### PR TITLE
Add option for redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ This will display help for the tool. Here are all the switches it supports.
 | -o       | File to save output result (optional)                 | nuclei -o output.txt       |
 | -silent  | Show only found results in output                     | nuclei -silent             |
 | -retries | Number of times to retry a failed request (default 1) | nuclei -retries 1          |
+| -redirect| Number of times to redirect a request (default 0)     | nuclei -redirect 0         |
 | -timeout | Seconds to wait before timeout (default 5)            | nuclei -timeout 5          |
 | -v       | Show Verbose output                                   | nuclei -v                  |
 | -version | Show version of nuclei                                | nuclei -version            |

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -15,6 +15,7 @@ type Options struct {
 	Threads   int    // Thread controls the number of concurrent requests to make.
 	Timeout   int    // Timeout is the seconds to wait for a response from the server.
 	Retries   int    // Retries is the number of times to retry the request
+	Redirect  int    // Redirect is the number of consecutive time to redirect the request on 301/302/303/307/308.
 	Output    string // Output is the file to write found subdomains to.
 	Silent    bool   // Silent suppresses any extra text and only writes found URLs on screen.
 	Version   bool   // Version specifies if we should just show version and exit
@@ -38,6 +39,7 @@ func ParseOptions() *Options {
 	flag.IntVar(&options.Threads, "c", 10, "Number of concurrent requests to make")
 	flag.IntVar(&options.Timeout, "timeout", 5, "Time to wait in seconds before timeout")
 	flag.IntVar(&options.Retries, "retries", 1, "Number of times to retry a failed request")
+	flag.IntVar(&options.Redirect, "redirect", 0, "Number of consecutive redirection")
 
 	flag.Parse()
 

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -53,8 +53,11 @@ func New(options *Options) (*Runner, error) {
 			DisableKeepAlives: true,
 		},
 		Timeout: time.Duration(options.Timeout) * time.Second,
-		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
-			return http.ErrUseLastResponse
+		CheckRedirect: func(_ *http.Request, redirCount []*http.Request) error {
+			if len(redirCount) > options.Redirect {
+				return http.ErrUseLastResponse
+        	}
+			return nil
 		},
 	}, retryablehttpOptions)
 	client.CheckRetry = retryablehttp.HostSprayRetryPolicy()


### PR DESCRIPTION
## Adding Redirect option

This PR adds redirection option to Nuclei using the `redirect` option. Default value is 0 which leaves it as it was before.

## Usage
 
```bash
nuclei -t path/to-template -redirect 1
```
## References

https://golang.org/pkg/net/http/#Client.Get

## Note

This is very useful in many cases, as a lot of time I've seen:
  - `/path` => `/path/` 
  - `/path` => `/path?foo=bar`

I've been using this branch successfully with https://github.com/projectdiscovery/nuclei-templates/pull/41.

## Issues
https://github.com/projectdiscovery/nuclei/issues/21
https://github.com/projectdiscovery/nuclei/issues/10