### PR TITLE
[enhancement] matcher with binary rule capability

### DIFF
--- a/pkg/matchers/matchers.go
+++ b/pkg/matchers/matchers.go
@@ -19,6 +19,8 @@ type Matcher struct {
 	Words []string `yaml:"words,omitempty"`
 	// Regex are the regex pattern required to be present in the response
 	Regex []string `yaml:"regex,omitempty"`
+	// Binary are the binary characters required to be present in the response
+	Binary []string `yaml:"binary,omitempty"`
 	// regexCompiled is the compiled variant
 	regexCompiled []*regexp.Regexp
 
@@ -45,6 +47,8 @@ const (
 	WordsMatcher MatcherType = iota + 1
 	// RegexMatcher matches responses with regexes
 	RegexMatcher
+	// BinaryMatcher matches responses with words
+	BinaryMatcher MatcherType = iota + 2
 	// StatusMatcher matches responses with status codes
 	StatusMatcher
 	// SizeMatcher matches responses with response size
@@ -57,6 +61,7 @@ var MatcherTypes = map[string]MatcherType{
 	"size":   SizeMatcher,
 	"word":   WordsMatcher,
 	"regex":  RegexMatcher,
+	"binary": BinaryMatcher,
 }
 
 // ConditionType is the type of condition for matcher


### PR DESCRIPTION
# Context

I thought that a matcher with binary rule capability could be interesting like Yara rules.
It's useful to match binary files such as archives.
In fact, the need to develop a dedicated matcher comes from the native utf-8 encoding from Golang.
I wanted to bypass the issue that I can't match characters such a: `\x8a` because Golang automatically handles it as `\xc2\x8a`.


So finally, after contribution #31, you can now invoke a binary matcher to handle hexadecimal rules.

## Example
Take a look at this template https://github.com/projectdiscovery/nuclei-templates/pull/42.
To resume, it enhances the capability to use hexadecimal input.
```
matchers:
      - type: binary
        binary:
        - "504B0304" # zip
        - "425A68" # bz2
        condition: or
        part: body
```

# Proposed Changes
- add a matcher named binary (BinaryMatcher)