### PR TITLE
Support for multiple fingerprints in single template #25

### DIFF
--- a/pkg/matchers/matchers.go
+++ b/pkg/matchers/matchers.go
@@ -20,6 +20,8 @@ type Matcher struct {
 	// Regex are the regex pattern required to be present in the response
 	Regex []string `yaml:"regex,omitempty"`
 	// regexCompiled is the compiled variant
+	// Matcher Name to be displayed in result output.
+	Name string `yaml:"name,omitempty"`
 	regexCompiled []*regexp.Regexp
 
 	// Condition is the optional condition between two matcher variables


### PR DESCRIPTION
## Support for multiple fingerprints in single template 

- Implementation for multiple matchers in template was already here but `runner.sendRequest` returned after first matcher fail. This PR makes sure that all matchers are checked.

- Adding an optional name attribute to matchers to uniquely identify which matcher is used while printing result.

This is very useful in order to reduce the noise of multiple requests when it could be achieved with one:
  - Subdomain takeovers fingerprinting cc https://github.com/projectdiscovery/nuclei/issues/25
  - Fingerprinting web servers, reverse proxy, CMS, frameworks (See https://github.com/projectdiscovery/nuclei-templates/pull/45)

## Examples

 - Reverse proxy:
<img width="372" alt="Screenshot_2020-04-22_at_14_43_52" src="https://user-images.githubusercontent.com/5072452/79987256-7546bc00-84ad-11ea-9037-6b9bbe03fc41.png">

 - CMS
<img width="372" alt="Screenshot_2020-04-22_at_15_11_47" src="https://user-images.githubusercontent.com/5072452/79987338-8f809a00-84ad-11ea-938e-2cab9db29c01.png">

- Web Frameworks

<img width="372" alt="Screenshot_2020-04-22_at_15_20_43" src="https://user-images.githubusercontent.com/5072452/79987453-b939c100-84ad-11ea-9c0d-bbb6afb418eb.png">

- No name matcher (retro-compatibility check)
<img width="372" alt="Screenshot_2020-04-22_at_15_30_40" src="https://user-images.githubusercontent.com/5072452/79988103-8d6b0b00-84ae-11ea-85f8-e5f77fbe374b.png">



## Issue 

https://github.com/projectdiscovery/nuclei//issues/25