### PR TITLE
Prepare nuclei for to containerized model

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "nuclei-templates"]
+	path = nuclei-templates
+	url = git@github.com:projectdiscovery/nuclei-templates.git
+	branch = master

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM golang:1.13.10-alpine3.11
+RUN mkdir /nuclei
+ADD . /nuclei
+WORKDIR /nuclei
+RUN go build -o nuclei /nuclei/cmd/nuclei/main.go
+ENTRYPOINT ["/nuclei/nuclei"]

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -12,6 +12,7 @@ import (
 type Options struct {
 	Templates string // Signature specifies the template/templates to use
 	Targets   string // Targets specifies the targets to scan using templates.
+	Target    string // Target specifies the target to scan using templates.
 	Threads   int    // Thread controls the number of concurrent requests to make.
 	Timeout   int    // Timeout is the seconds to wait for a response from the server.
 	Retries   int    // Retries is the number of times to retry the request
@@ -30,6 +31,7 @@ func ParseOptions() *Options {
 
 	flag.StringVar(&options.Templates, "t", "", "Template input file/files to run on host")
 	flag.StringVar(&options.Targets, "l", "", "List of URLs to run templates on")
+	flag.StringVar(&options.Target, "u", "", "URL to run templates on")
 	flag.StringVar(&options.Output, "o", "", "File to write output to (optional)")
 	flag.BoolVar(&options.Silent, "silent", false, "Show only results in output")
 	flag.BoolVar(&options.Version, "version", false, "Show version of nuclei")

--- a/internal/runner/validate.go
+++ b/internal/runner/validate.go
@@ -18,7 +18,7 @@ func (options *Options) validateOptions() error {
 		return errors.New("no template/templates provided")
 	}
 
-	if options.Targets == "" && !options.Stdin {
+	if !(options.Targets == "" || options.Target == "") && !options.Stdin {
 		return errors.New("no target input provided")
 	}
 	return nil


### PR DESCRIPTION
- add a Dockerfile
- add nuclei-templates submodule
- add a `Target` parameter to pass URL (example: `nuclei -u https://foodles.co -t "/nuclei/nuclei-templates/files/*.yaml"`)