### PR TITLE
NkxxkN/multiple requests per template

### DIFF
--- a/pkg/requests/requests.go
+++ b/pkg/requests/requests.go
@@ -64,7 +64,12 @@ func (r *Request) MakeRequest(baseURL string) ([]*retryablehttp.Request, error) 
 
 		// Set the header values requested
 		for header, value := range r.Headers {
-			req.Header.Set(header, value)
+			t := fasttemplate.New(value, "{{", "}}")
+			val := t.ExecuteString(map[string]interface{}{
+				"BaseURL":  baseURL,
+				"Hostname": hostname,
+			})
+			req.Header.Set(header, val)
 		}
 
 		// Set some headers only if the header wasn't supplied by the user

--- a/pkg/templates/templates.go
+++ b/pkg/templates/templates.go
@@ -10,7 +10,7 @@ type Template struct {
 	ID string `yaml:"id"`
 	// Info contains information about the template
 	Info Info `yaml:"info"`
-	// Request contains the request to make in the template
+	// Request contains the requests to make in the template
 	Requests []*requests.Request `yaml:"requests"`
 }
 


### PR DESCRIPTION
## Description

This PR adds:
 -  Support for multiple requests per templates. Particularly useful for CORS template.
 - Support for configurable headers with BaseURL and Hostname. Also useful for CORS template.

## References

[CORS Template](https://github.com/projectdiscovery/nuclei-templates/pull/49)

## Note

I struggled a bit with the go concurrency and I know that this is a sensitive subject in go. You don't want to mess up with it 😄so make sure to particularly review this part while reviewing the PR. From my testing I think we are good but better be safe than sorry.


