### PR TITLE
Update README.md to reflect proxy auth scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ This will display help for the tool. Here are all the switches it supports.
 | -timeout          | Seconds to wait before timeout (default 5)            | nuclei -timeout 5                                  |
 | -v                | Show Verbose output                                   | nuclei -v                                          |
 | -version          | Show version of nuclei                                | nuclei -version                                    |
-| -proxy-url        | Proxy URL                                             | nuclei -proxy-url http://this.is.a.proxy:8080      |
-| -proxy-socks-url  | Proxy Socks URL                                       | nuclei -proxy-socks-url this.is.a.proxy.socks:9050 |
+| -proxy-url        | Proxy URL                                             | nuclei -proxy-url http://user:pass@this.is.a.proxy:8080      |
+| -proxy-socks-url  | Proxy Socks URL                                       | nuclei -proxy-socks-url socks5://user:pass@this.is.a.proxy.socks:9050 |
 
 
 # Installation Instructions


### PR DESCRIPTION
Reflect the new proxy auth scheme into switches. Proxy URL schema allows the use of authentication with a combination of `username:password`.

HTTP/s proxy URL schema:
`nuclei -proxy-url http://proxyuser:proxypass@host.proxy:8080`

Socks5 proxy schema:
`nuclei -proxy-socks-url socks5://proxyuser:proxypass@host.proxy.socks:8080`

Authentication `proxyuser:proxypass` is totally optional, depending on whether the proxy requires authentication or not.