### PR TITLE
[WIP] Fuzzing + DSL support in requests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.14
 require (
 	github.com/Knetic/govaluate v3.0.0+incompatible
 	github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535
+	github.com/elastic/go-lumber v0.1.0
 	github.com/karrick/godirwalk v1.15.6
 	github.com/miekg/dns v1.1.29
 	github.com/pkg/errors v0.9.1

--- a/go.mod
+++ b/go.mod
@@ -5,13 +5,12 @@ go 1.14
 require (
 	github.com/Knetic/govaluate v3.0.0+incompatible
 	github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535
-	github.com/elastic/go-lumber v0.1.0
 	github.com/karrick/godirwalk v1.15.6
 	github.com/miekg/dns v1.1.29
 	github.com/pkg/errors v0.9.1
 	github.com/projectdiscovery/gologger v1.0.0
 	github.com/projectdiscovery/retryabledns v1.0.4
 	github.com/projectdiscovery/retryablehttp-go v1.0.1
-	golang.org/x/net v0.0.0-20200501053045-e0ff5e5a1de5
-	gopkg.in/yaml.v2 v2.2.8
+	golang.org/x/net v0.0.0-20200513185701-a91f0712d120
+	gopkg.in/yaml.v2 v2.3.0
 )

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.14
 require (
 	github.com/Knetic/govaluate v3.0.0+incompatible
 	github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535
+	github.com/karrick/godirwalk v1.15.6
 	github.com/miekg/dns v1.1.29
 	github.com/pkg/errors v0.9.1
 	github.com/projectdiscovery/gologger v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/Knetic/govaluate v3.0.0+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8L
 github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535 h1:4daAzAu0S6Vi7/lbWECcX0j45yZReDZ56BQsrVBOEEY=
 github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/elastic/go-lumber v0.1.0 h1:HUjpyg36v2HoKtXlEC53EJ3zDFiDRn65d7B8dBHNius=
+github.com/elastic/go-lumber v0.1.0/go.mod h1:8YvjMIRYypWuPvpxx7WoijBYdbB7XIh/9FqSYQZTtxQ=
 github.com/karrick/godirwalk v1.15.6 h1:Yf2mmR8TJy+8Fa0SuQVto5SYap6IF7lNVX4Jdl8G1qA=
 github.com/karrick/godirwalk v1.15.6/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
 github.com/logrusorgru/aurora v0.0.0-20200102142835-e9ef32dff381 h1:bqDmpDG49ZRnB5PcgP0RXtQvnMSgIF14M7CBd2shtXs=

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,6 @@ github.com/Knetic/govaluate v3.0.0+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8L
 github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535 h1:4daAzAu0S6Vi7/lbWECcX0j45yZReDZ56BQsrVBOEEY=
 github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/elastic/go-lumber v0.1.0 h1:HUjpyg36v2HoKtXlEC53EJ3zDFiDRn65d7B8dBHNius=
-github.com/elastic/go-lumber v0.1.0/go.mod h1:8YvjMIRYypWuPvpxx7WoijBYdbB7XIh/9FqSYQZTtxQ=
 github.com/karrick/godirwalk v1.15.6 h1:Yf2mmR8TJy+8Fa0SuQVto5SYap6IF7lNVX4Jdl8G1qA=
 github.com/karrick/godirwalk v1.15.6/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
 github.com/logrusorgru/aurora v0.0.0-20200102142835-e9ef32dff381 h1:bqDmpDG49ZRnB5PcgP0RXtQvnMSgIF14M7CBd2shtXs=
@@ -30,8 +28,8 @@ golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190923162816-aa69164e4478/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20200501053045-e0ff5e5a1de5 h1:WQ8q63x+f/zpC8Ac1s9wLElVoHhm32p6tudrU72n1QA=
-golang.org/x/net v0.0.0-20200501053045-e0ff5e5a1de5/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
+golang.org/x/net v0.0.0-20200513185701-a91f0712d120 h1:EZ3cVSzKOlJxAd8e8YAJ7no8nNypTxexh/YE/xW3ZEY=
+golang.org/x/net v0.0.0-20200513185701-a91f0712d120/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -43,5 +41,5 @@ golang.org/x/tools v0.0.0-20191216052735-49a3e744a425/go.mod h1:TB2adYChydJhpapK
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
-gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
+gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/Knetic/govaluate v3.0.0+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8L
 github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535 h1:4daAzAu0S6Vi7/lbWECcX0j45yZReDZ56BQsrVBOEEY=
 github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/karrick/godirwalk v1.15.6 h1:Yf2mmR8TJy+8Fa0SuQVto5SYap6IF7lNVX4Jdl8G1qA=
+github.com/karrick/godirwalk v1.15.6/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
 github.com/logrusorgru/aurora v0.0.0-20200102142835-e9ef32dff381 h1:bqDmpDG49ZRnB5PcgP0RXtQvnMSgIF14M7CBd2shtXs=
 github.com/logrusorgru/aurora v0.0.0-20200102142835-e9ef32dff381/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=
 github.com/miekg/dns v1.1.29 h1:xHBEhR+t5RzcFJjBLJlax2daXOrTYtr9z4WdKEfWFzg=

--- a/internal/runner/banner.go
+++ b/internal/runner/banner.go
@@ -11,7 +11,7 @@ const banner = `
 `
 
 // Version is the current version of nuclei
-const Version = `1.1.4`
+const Version = `1.1.5`
 
 // showBanner is used to show the banner to the user
 func showBanner() {

--- a/internal/runner/banner.go
+++ b/internal/runner/banner.go
@@ -11,7 +11,7 @@ const banner = `
 `
 
 // Version is the current version of nuclei
-const Version = `1.1.3`
+const Version = `1.1.4`
 
 // showBanner is used to show the banner to the user
 func showBanner() {

--- a/pkg/executor/executer_http.go
+++ b/pkg/executor/executer_http.go
@@ -121,7 +121,7 @@ mainLoop:
 				// If the matcher has matched, and its an OR
 				// write the first output then move to next matcher.
 				if matcherCondition == matchers.ORCondition && len(e.httpRequest.Extractors) == 0 {
-					e.writeOutputHTTP(req, matcher, nil)
+					e.writeOutputHTTP(compiledRequest, matcher, nil)
 				}
 			}
 		}
@@ -142,7 +142,7 @@ mainLoop:
 		// Write a final string of output if matcher type is
 		// AND or if we have extractors for the mechanism too.
 		if len(e.httpRequest.Extractors) > 0 || matcherCondition == matchers.ANDCondition {
-			e.writeOutputHTTP(req, nil, extractorResults)
+			e.writeOutputHTTP(compiledRequest, nil, extractorResults)
 		}
 	}
 	return nil

--- a/pkg/executor/executer_http.go
+++ b/pkg/executor/executer_http.go
@@ -78,7 +78,11 @@ func (e *HTTPExecutor) ExecuteHTTP(URL string) error {
 
 	// Send the request to the target servers
 mainLoop:
-	for req := range compiledRequest {
+	for compiledRequest := range compiledRequest {
+		if compiledRequest.Error != nil {
+			return errors.Wrap(err, "could not make http request")
+		}
+		req := compiledRequest.Request
 		resp, err := e.httpClient.Do(req)
 		if err != nil {
 			if resp != nil {

--- a/pkg/executor/executer_http.go
+++ b/pkg/executor/executer_http.go
@@ -78,7 +78,7 @@ func (e *HTTPExecutor) ExecuteHTTP(URL string) error {
 
 	// Send the request to the target servers
 mainLoop:
-	for _, req := range compiledRequest {
+	for req := range compiledRequest {
 		resp, err := e.httpClient.Do(req)
 		if err != nil {
 			if resp != nil {

--- a/pkg/executor/executer_http.go
+++ b/pkg/executor/executer_http.go
@@ -99,6 +99,13 @@ mainLoop:
 		}
 		resp.Body.Close()
 
+		// net/http doesn't automatically decompress the response body if an encoding has been specified by the user in the request
+		// so in case we have to manually do it
+		data, err = requests.HandleDecompression(compiledRequest.Request, data)
+		if err != nil {
+			return errors.Wrap(err, "could not decompress http body")
+		}
+
 		// Convert response body from []byte to string with zero copy
 		body := unsafeToString(data)
 

--- a/pkg/executor/output_http.go
+++ b/pkg/executor/output_http.go
@@ -5,11 +5,11 @@ import (
 
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/nuclei/pkg/matchers"
-	"github.com/projectdiscovery/retryablehttp-go"
+	"github.com/projectdiscovery/nuclei/pkg/requests"
 )
 
 // writeOutputHTTP writes http output to streams
-func (e *HTTPExecutor) writeOutputHTTP(req *retryablehttp.Request, matcher *matchers.Matcher, extractorResults []string) {
+func (e *HTTPExecutor) writeOutputHTTP(req *requests.CompiledHTTP, matcher *matchers.Matcher, extractorResults []string) {
 	builder := &strings.Builder{}
 
 	builder.WriteRune('[')
@@ -21,7 +21,7 @@ func (e *HTTPExecutor) writeOutputHTTP(req *retryablehttp.Request, matcher *matc
 	builder.WriteString("] [http] ")
 
 	// Escape the URL by replacing all % with %%
-	URL := req.URL.String()
+	URL := req.Request.URL.String()
 	escapedURL := strings.Replace(URL, "%", "%%", -1)
 	builder.WriteString(escapedURL)
 
@@ -36,6 +36,18 @@ func (e *HTTPExecutor) writeOutputHTTP(req *retryablehttp.Request, matcher *matc
 		}
 		builder.WriteString("]")
 	}
+
+	// write meta if any
+	if len(req.Meta) > 0 {
+		builder.WriteString(" [")
+		var metas []string
+		for name, value := range req.Meta {
+			metas = append(metas, name+"="+value.(string))
+		}
+		builder.WriteString(strings.Join(metas, ","))
+		builder.WriteString("]")
+	}
+
 	builder.WriteRune('\n')
 
 	// Write output to screen as well as any output file

--- a/pkg/generators/attack.go
+++ b/pkg/generators/attack.go
@@ -1,0 +1,20 @@
+package generators
+
+// Type is type of attack
+type Type int
+
+const (
+	// Sniper attack - each variable replaced with values at a time
+	Sniper Type = iota + 1
+	// PitchFork attack - Each variable replaced with positional value in multiple wordlists
+	PitchFork
+	// ClusterBomb attack - Generate all possible combinations of values
+	ClusterBomb
+)
+
+// AttackTypes is an table for conversion of attack type from string.
+var AttackTypes = map[string]Type{
+	"sniper":      Sniper,
+	"pitchfork":   PitchFork,
+	"clusterbomb": ClusterBomb,
+}

--- a/pkg/generators/clusterbomb.go
+++ b/pkg/generators/clusterbomb.go
@@ -1,0 +1,50 @@
+package generators
+
+// ClusterbombGenerator Attack - Generate all possible combinations from an input map with all values listed
+// as slices of the same size
+func ClusterbombGenerator(payloads map[string][]string) (out chan map[string]interface{}) {
+	out = make(chan map[string]interface{})
+
+	// generator
+	go func() {
+		defer close(out)
+		var order []string
+		var parts [][]string
+		for name, wordlist := range payloads {
+			order = append(order, name)
+			parts = append(parts, wordlist)
+		}
+
+		var n = 1
+		for _, ar := range parts {
+			n *= len(ar)
+		}
+
+		var at = make([]int, len(parts))
+	loop:
+		for {
+			// increment position counters
+			for i := len(parts) - 1; i >= 0; i-- {
+				if at[i] > 0 && at[i] >= len(parts[i]) {
+					if i == 0 || (i == 1 && at[i-1] == len(parts[0])-1) {
+						break loop
+					}
+					at[i] = 0
+					at[i-1]++
+				}
+			}
+			// construct permutation
+			item := make(map[string]interface{})
+			for i, ar := range parts {
+				var p = at[i]
+				if p >= 0 && p < len(ar) {
+					item[order[i]] = ar[p]
+				}
+			}
+			out <- item
+			at[len(parts)-1]++
+		}
+	}()
+
+	return out
+}

--- a/pkg/generators/dsl.go
+++ b/pkg/generators/dsl.go
@@ -1,0 +1,103 @@
+package generators
+
+import (
+	"crypto/md5"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"html"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"github.com/Knetic/govaluate"
+)
+
+// HelperFunctions contains the dsl functions
+func HelperFunctions() (functions map[string]govaluate.ExpressionFunction) {
+	functions = make(map[string]govaluate.ExpressionFunction)
+	// strings
+	functions["len"] = func(args ...interface{}) (interface{}, error) {
+		length := len(args[0].(string))
+		return (float64)(length), nil
+	}
+	functions["toupper"] = func(args ...interface{}) (interface{}, error) {
+		return strings.ToUpper(args[0].(string)), nil
+	}
+	functions["tolower"] = func(args ...interface{}) (interface{}, error) {
+		return strings.ToLower(args[0].(string)), nil
+	}
+	functions["replace"] = func(args ...interface{}) (interface{}, error) {
+		return strings.Replace(args[0].(string), args[1].(string), args[2].(string), -1), nil
+	}
+	functions["trim"] = func(args ...interface{}) (interface{}, error) {
+		return strings.Trim(args[0].(string), args[2].(string)), nil
+	}
+	functions["trimleft"] = func(args ...interface{}) (interface{}, error) {
+		return strings.TrimLeft(args[0].(string), args[1].(string)), nil
+	}
+	functions["trimright"] = func(args ...interface{}) (interface{}, error) {
+		return strings.TrimRight(args[0].(string), args[1].(string)), nil
+	}
+	functions["trimspace"] = func(args ...interface{}) (interface{}, error) {
+		return strings.TrimSpace(args[0].(string)), nil
+	}
+	functions["trimprefix"] = func(args ...interface{}) (interface{}, error) {
+		return strings.TrimPrefix(args[0].(string), args[1].(string)), nil
+	}
+	functions["trimsuffix"] = func(args ...interface{}) (interface{}, error) {
+		return strings.TrimSuffix(args[0].(string), args[1].(string)), nil
+	}
+	functions["reverse"] = func(args ...interface{}) (interface{}, error) {
+		return reverseString(args[0].(string)), nil
+	}
+	// encoding
+	functions["base64"] = func(args ...interface{}) (interface{}, error) {
+		sEnc := base64.StdEncoding.EncodeToString([]byte(args[0].(string)))
+		return sEnc, nil
+	}
+	functions["base64_decode"] = func(args ...interface{}) (interface{}, error) {
+		sEnc := base64.StdEncoding.EncodeToString([]byte(args[0].(string)))
+		return sEnc, nil
+	}
+	functions["url_encode"] = func(args ...interface{}) (interface{}, error) {
+		return url.PathEscape(args[0].(string)), nil
+	}
+	functions["url_decode"] = func(args ...interface{}) (interface{}, error) {
+		return url.PathUnescape(args[0].(string))
+	}
+	functions["hex_encode"] = func(args ...interface{}) (interface{}, error) {
+		return hex.EncodeToString([]byte(args[0].(string))), nil
+	}
+	functions["hex_decode"] = func(args ...interface{}) (interface{}, error) {
+		hx, _ := hex.DecodeString(args[0].(string))
+		return string(hx), nil
+	}
+	functions["html_escape"] = func(args ...interface{}) (interface{}, error) {
+		return html.EscapeString(args[0].(string)), nil
+	}
+	functions["html_unescape"] = func(args ...interface{}) (interface{}, error) {
+		return html.UnescapeString(args[0].(string)), nil
+	}
+	// hashing
+	functions["md5"] = func(args ...interface{}) (interface{}, error) {
+		hash := md5.Sum([]byte(args[0].(string)))
+		return hex.EncodeToString(hash[:]), nil
+	}
+	functions["sha256"] = func(args ...interface{}) (interface{}, error) {
+		return sha256.Sum256([]byte(args[0].(string))), nil
+	}
+	// search
+	functions["contains"] = func(args ...interface{}) (interface{}, error) {
+		return strings.Contains(args[0].(string), args[1].(string)), nil
+	}
+	functions["regex"] = func(args ...interface{}) (interface{}, error) {
+		compiled, err := regexp.Compile(args[0].(string))
+		if err != nil {
+			return nil, err
+		}
+		return compiled.MatchString(args[1].(string)), nil
+	}
+
+	return
+}

--- a/pkg/generators/dsl.go
+++ b/pkg/generators/dsl.go
@@ -2,6 +2,7 @@ package generators
 
 import (
 	"crypto/md5"
+	"crypto/sha1"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
@@ -85,7 +86,14 @@ func HelperFunctions() (functions map[string]govaluate.ExpressionFunction) {
 		return hex.EncodeToString(hash[:]), nil
 	}
 	functions["sha256"] = func(args ...interface{}) (interface{}, error) {
-		return sha256.Sum256([]byte(args[0].(string))), nil
+		h := sha256.New()
+		h.Write([]byte(args[0].(string)))
+		return hex.EncodeToString(h.Sum(nil)), nil
+	}
+	functions["sha1"] = func(args ...interface{}) (interface{}, error) {
+		h := sha1.New()
+		h.Write([]byte(args[0].(string)))
+		return hex.EncodeToString(h.Sum(nil)), nil
 	}
 	// search
 	functions["contains"] = func(args ...interface{}) (interface{}, error) {

--- a/pkg/generators/pitchfork.go
+++ b/pkg/generators/pitchfork.go
@@ -1,0 +1,38 @@
+package generators
+
+// PitchforkGenerator Attack - Generate positional combinations from an input map with all values listed
+// as slices of the same size
+func PitchforkGenerator(payloads map[string][]string) (out chan map[string]interface{}) {
+	out = make(chan map[string]interface{})
+
+	size := 0
+
+	// check if all wordlists have the same size
+	for _, wordlist := range payloads {
+		if size == 0 {
+			size = len(wordlist)
+		}
+
+		if len(wordlist) != size {
+			//set size = 0 and exit the cycle
+			size = 0
+			break
+		}
+	}
+
+	// generator
+	go func() {
+		defer close(out)
+
+		for i := 0; i < size; i++ {
+			element := make(map[string]interface{})
+			for name, wordlist := range payloads {
+				element[name] = wordlist[i]
+			}
+
+			out <- element
+		}
+	}()
+
+	return out
+}

--- a/pkg/generators/sniper.go
+++ b/pkg/generators/sniper.go
@@ -1,0 +1,21 @@
+package generators
+
+// SniperGenerator Attack - Generate sequential combinations
+func SniperGenerator(payloads map[string][]string) (out chan map[string]interface{}) {
+	out = make(chan map[string]interface{})
+
+	// generator
+	go func() {
+		defer close(out)
+
+		for name, wordlist := range payloads {
+			for _, value := range wordlist {
+				element := CopyMapWithDefaultValue(payloads, "")
+				element[name] = value
+				out <- element
+			}
+		}
+	}()
+
+	return out
+}

--- a/pkg/generators/util.go
+++ b/pkg/generators/util.go
@@ -1,0 +1,108 @@
+package generators
+
+import (
+	"bufio"
+	"os"
+	"strings"
+)
+
+// LoadWordlists creating proper data structure
+func LoadWordlists(payloads map[string]string) map[string][]string {
+	wordlists := make(map[string][]string)
+	// load all wordlists
+	for name, filepath := range payloads {
+		wordlists[name] = LoadFile(filepath)
+	}
+
+	return wordlists
+}
+
+// LoadFile into slice of strings
+func LoadFile(filepath string) (lines []string) {
+	for line := range StreamFile(filepath) {
+		lines = append(lines, line)
+	}
+
+	return
+}
+
+// StreamFile content to a chan
+func StreamFile(filepath string) (content chan string) {
+	content = make(chan string)
+
+	go func() {
+		defer close(content)
+		file, err := os.Open(filepath)
+		if err != nil {
+			return
+		}
+		defer file.Close()
+
+		// yql filter applied
+		scanner := bufio.NewScanner(file)
+		for scanner.Scan() {
+			content <- scanner.Text()
+		}
+
+		if err := scanner.Err(); err != nil {
+			return
+		}
+	}()
+
+	return
+}
+
+// MergeMaps into a new one
+func MergeMaps(m1, m2 map[string]interface{}) (m map[string]interface{}) {
+	m = make(map[string]interface{})
+	for k, v := range m1 {
+		m[k] = v
+	}
+	for k, v := range m2 {
+		m[k] = v
+	}
+
+	return m
+}
+
+func reverseString(s string) string {
+	runes := []rune(s)
+	for i, j := 0, len(runes)-1; i < j; i, j = i+1, j-1 {
+		runes[i], runes[j] = runes[j], runes[i]
+	}
+	return string(runes)
+}
+
+// CopyMap creates a new copy of an existing map
+func CopyMap(originalMap map[string]interface{}) map[string]interface{} {
+	newMap := make(map[string]interface{})
+	for key, value := range originalMap {
+		newMap[key] = value
+	}
+	return newMap
+}
+
+// CopyMapWithDefaultValue creates a new copy of an existing map and set a default value
+func CopyMapWithDefaultValue(originalMap map[string][]string, defaultValue interface{}) map[string]interface{} {
+	newMap := make(map[string]interface{})
+	for key := range originalMap {
+		newMap[key] = defaultValue
+	}
+	return newMap
+}
+
+// StringContainsAnyMapItem verifies is a string contains any value of a map
+func StringContainsAnyMapItem(m map[string]interface{}, s string) bool {
+	for key := range m {
+		if strings.Contains(s, key) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// TrimDelimiters removes trailing brackets
+func TrimDelimiters(s string) string {
+	return strings.TrimSuffix(strings.TrimPrefix(s, "{{"), "}}")
+}

--- a/pkg/generators/util.go
+++ b/pkg/generators/util.go
@@ -106,3 +106,12 @@ func StringContainsAnyMapItem(m map[string]interface{}, s string) bool {
 func TrimDelimiters(s string) string {
 	return strings.TrimSuffix(strings.TrimPrefix(s, "{{"), "}}")
 }
+
+// FileExists checks if a file exists and is not a directory
+func FileExists(filename string) bool {
+	info, err := os.Stat(filename)
+	if os.IsNotExist(err) {
+		return false
+	}
+	return !info.IsDir()
+}

--- a/pkg/matchers/compile.go
+++ b/pkg/matchers/compile.go
@@ -1,15 +1,11 @@
 package matchers
 
 import (
-	"crypto/md5"
-	"crypto/sha256"
-	"encoding/base64"
-	"encoding/hex"
 	"fmt"
 	"regexp"
-	"strings"
 
 	"github.com/Knetic/govaluate"
+	"github.com/projectdiscovery/nuclei/pkg/generators"
 )
 
 // CompileMatchers performs the initial setup operation on a matcher
@@ -34,7 +30,7 @@ func (m *Matcher) CompileMatchers() error {
 
 	// Compile the dsl expressions
 	for _, dsl := range m.DSL {
-		compiled, err := govaluate.NewEvaluableExpressionWithFunctions(dsl, helperFunctions())
+		compiled, err := govaluate.NewEvaluableExpressionWithFunctions(dsl, generators.HelperFunctions())
 		if err != nil {
 			return fmt.Errorf("could not compile dsl: %s", dsl)
 		}
@@ -62,70 +58,4 @@ func (m *Matcher) CompileMatchers() error {
 		m.part = BodyPart
 	}
 	return nil
-}
-
-func helperFunctions() (functions map[string]govaluate.ExpressionFunction) {
-	functions = make(map[string]govaluate.ExpressionFunction)
-	// strings
-	functions["len"] = func(args ...interface{}) (interface{}, error) {
-		length := len(args[0].(string))
-		return (float64)(length), nil
-	}
-	functions["toupper"] = func(args ...interface{}) (interface{}, error) {
-		return strings.ToUpper(args[0].(string)), nil
-	}
-	functions["tolower"] = func(args ...interface{}) (interface{}, error) {
-		return strings.ToLower(args[0].(string)), nil
-	}
-	functions["replace"] = func(args ...interface{}) (interface{}, error) {
-		return strings.Replace(args[0].(string), args[1].(string), args[2].(string), -1), nil
-	}
-	functions["trim"] = func(args ...interface{}) (interface{}, error) {
-		return strings.Trim(args[0].(string), args[2].(string)), nil
-	}
-	functions["trimleft"] = func(args ...interface{}) (interface{}, error) {
-		return strings.TrimLeft(args[0].(string), args[1].(string)), nil
-	}
-	functions["trimright"] = func(args ...interface{}) (interface{}, error) {
-		return strings.TrimRight(args[0].(string), args[1].(string)), nil
-	}
-	functions["trimspace"] = func(args ...interface{}) (interface{}, error) {
-		return strings.TrimSpace(args[0].(string)), nil
-	}
-	functions["trimprefix"] = func(args ...interface{}) (interface{}, error) {
-		return strings.TrimPrefix(args[0].(string), args[1].(string)), nil
-	}
-	functions["trimsuffix"] = func(args ...interface{}) (interface{}, error) {
-		return strings.TrimSuffix(args[0].(string), args[1].(string)), nil
-	}
-	// encoding
-	functions["base64"] = func(args ...interface{}) (interface{}, error) {
-		sEnc := base64.StdEncoding.EncodeToString([]byte(args[0].(string)))
-		return sEnc, nil
-	}
-	functions["base64_decode"] = func(args ...interface{}) (interface{}, error) {
-		sEnc := base64.StdEncoding.EncodeToString([]byte(args[0].(string)))
-		return sEnc, nil
-	}
-	// hashing
-	functions["md5"] = func(args ...interface{}) (interface{}, error) {
-		hash := md5.Sum([]byte(args[0].(string)))
-		return hex.EncodeToString(hash[:]), nil
-	}
-	functions["sha256"] = func(args ...interface{}) (interface{}, error) {
-		return sha256.Sum256([]byte(args[0].(string))), nil
-	}
-	// search
-	functions["contains"] = func(args ...interface{}) (interface{}, error) {
-		return strings.Contains(args[0].(string), args[1].(string)), nil
-	}
-	functions["regex"] = func(args ...interface{}) (interface{}, error) {
-		compiled, err := regexp.Compile(args[0].(string))
-		if err != nil {
-			return nil, err
-		}
-		return compiled.MatchString(args[1].(string)), nil
-	}
-
-	return
 }

--- a/pkg/requests/util.go
+++ b/pkg/requests/util.go
@@ -1,8 +1,13 @@
 package requests
 
 import (
+	"bytes"
+	"compress/gzip"
 	"fmt"
+	"io/ioutil"
 	"strings"
+
+	"github.com/projectdiscovery/retryablehttp-go"
 )
 
 func newReplacer(values map[string]interface{}) *strings.Replacer {
@@ -13,4 +18,25 @@ func newReplacer(values map[string]interface{}) *strings.Replacer {
 	}
 
 	return strings.NewReplacer(replacerItems...)
+}
+
+// HandleDecompression if the user specified a custom encoding (as golang transport doesn't do this automatically)
+func HandleDecompression(r *retryablehttp.Request, bodyOrig []byte) (bodyDec []byte, err error) {
+	encodingHeader := strings.ToLower(r.Header.Get("Accept-Encoding"))
+	if encodingHeader == "gzip" {
+		gzipreader, err := gzip.NewReader(bytes.NewReader(bodyOrig))
+		if err != nil {
+			return bodyDec, err
+		}
+		defer gzipreader.Close()
+
+		bodyDec, err = ioutil.ReadAll(gzipreader)
+		if err != nil {
+			return bodyDec, err
+		}
+
+		return bodyDec, nil
+	}
+
+	return bodyOrig, nil
 }

--- a/pkg/templates/compile.go
+++ b/pkg/templates/compile.go
@@ -1,6 +1,7 @@
 package templates
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/projectdiscovery/nuclei/pkg/generators"
@@ -34,11 +35,19 @@ func ParseTemplate(file string) (*Template, error) {
 			request.SetMatchersCondition(condition)
 		}
 
+		// Set the attack type - used only in raw requests
 		attack, ok := generators.AttackTypes[request.AttackType]
 		if !ok {
 			request.SetAttackType(generators.Sniper)
 		} else {
 			request.SetAttackType(attack)
+		}
+
+		// Validate the payloads if any
+		for name, wordlist := range request.Payloads {
+			if !generators.FileExists(wordlist) {
+				return nil, fmt.Errorf("The %s file for payload %s does not exist", wordlist, name)
+			}
 		}
 
 		for _, matcher := range request.Matchers {

--- a/pkg/templates/compile.go
+++ b/pkg/templates/compile.go
@@ -3,6 +3,7 @@ package templates
 import (
 	"os"
 
+	"github.com/projectdiscovery/nuclei/pkg/generators"
 	"github.com/projectdiscovery/nuclei/pkg/matchers"
 	"gopkg.in/yaml.v2"
 )
@@ -31,6 +32,13 @@ func ParseTemplate(file string) (*Template, error) {
 			request.SetMatchersCondition(matchers.ANDCondition)
 		} else {
 			request.SetMatchersCondition(condition)
+		}
+
+		attack, ok := generators.AttackTypes[request.AttackType]
+		if !ok {
+			request.SetAttackType(generators.Sniper)
+		} else {
+			request.SetAttackType(attack)
 		}
 
 		for _, matcher := range request.Matchers {


### PR DESCRIPTION
- Added Intruder like functionalities (Sniper, Pitch Fork, Cluster Bomb)
- Added placeholders variables (like in burp) + DSL helper functions (similar to hackvector). This should solve #4 and extend it

As of now lot of code is redundant and it only works with raw requests with defined payloads, like the following one:

```
id: dummy-fuzz-raw-with-params

info:
  name: Dummy Raw Request
  author: mzack9999
  severity: none

requests:
  - payloads:
      param_a: /tmp/wordlist_a.txt
      param_b: /tmp/wordlist_b.txt
    attack: clusterbomb # Can be sniper, pitchfork, clusterbomb
    raw:
      - | 
          GET /path1/ HTTP/1.1
          User-Agent: {{param_a}}
          Host: {{Hostname}}
          AnotherHeader: {{base64(md5(param_a))}}
          Accept: */*

          {{html_escape(toupper(param_b))}}
      - | 
          GET /path2/ HTTP/1.1
          User-Agent: mz
          Host: {{Hostname}}
          Accept: a/b
    matchers:
      - type: word
        words: 
          - "anything"
```