### PR TITLE
Add an auto configure option for templates

### DIFF
--- a/pkg/executor/executer_http.go
+++ b/pkg/executor/executer_http.go
@@ -68,8 +68,11 @@ func NewHTTPExecutor(options *HTTPOptions) (*HTTPExecutor, error) {
 	return executer, nil
 }
 
+// ConfigureAutoType makes HTTP request to random URLs to configure what a 404 looks like
 func (e *HTTPExecutor) ConfigureAutoType(URL string) error {
-	compiledConfigRequest, err := e.httpRequest.MakeHTTPRequestForAutoConfigure(URL)
+	// Create config requests
+	compiledConfigRequest, err := e.httpRequest.MakeHTTPRequestForAutoConfigure(URL, 16)
+	compiledConfigRequest, err = e.httpRequest.MakeHTTPRequestForAutoConfigure(URL, 32)
 	if err != nil {
 		return errors.Wrap(err, "could not make auto configure http request")
 	}
@@ -95,6 +98,13 @@ func (e *HTTPExecutor) ConfigureAutoType(URL string) error {
 
 				// Convert response body from []byte to string with zero copy
 				body := unsafeToString(data)
+
+				// Don't add duplicate response sizes
+				for _, size := range matcher.Size {
+					if size == len(body) {
+						continue
+					}
+				}
 
 				matcher.Size = append(matcher.Size, len(body))
 				matcher.Status = append(matcher.Status, resp.StatusCode)

--- a/pkg/executor/executer_http.go
+++ b/pkg/executor/executer_http.go
@@ -79,6 +79,9 @@ func (e *HTTPExecutor) ConfigureAutoType(URL string) error {
 
 	for _, matcher := range e.httpRequest.Matchers {
 		if matcher.Type == "auto" {
+			matcher.Size = nil
+			matcher.Status = nil
+
 			for _, req := range compiledConfigRequest {
 				resp, err := e.httpClient.Do(req)
 				if err != nil {

--- a/pkg/matchers/match.go
+++ b/pkg/matchers/match.go
@@ -55,6 +55,11 @@ func (m *Matcher) Match(resp *http.Response, body, headers string) bool {
 		// Match complex query
 		return m.matchDSL(httpToMap(resp, body, headers))
 	case AutoMatcher:
+		// Match on status code, negate since that's an indicator of 404
+		if len(m.Size) > 1 {
+			return !m.matchStatusCode(resp.StatusCode)
+		}
+		// Match on status code and size (404 indicators had same response size), negate result
 		return !m.matchStatusCode(resp.StatusCode) && !m.matchSizeCode(len(body))
 	}
 	return false

--- a/pkg/matchers/match.go
+++ b/pkg/matchers/match.go
@@ -54,6 +54,8 @@ func (m *Matcher) Match(resp *http.Response, body, headers string) bool {
 	case DSLMatcher:
 		// Match complex query
 		return m.matchDSL(httpToMap(resp, body, headers))
+	case AutoMatcher:
+		return !m.matchStatusCode(resp.StatusCode) && !m.matchSizeCode(len(body))
 	}
 	return false
 }

--- a/pkg/matchers/matchers.go
+++ b/pkg/matchers/matchers.go
@@ -63,6 +63,8 @@ const (
 	SizeMatcher
 	// DSLMatcher matches based upon dsl syntax
 	DSLMatcher
+	// AutoMatcher matches based on auto configuration
+	AutoMatcher
 )
 
 // MatcherTypes is an table for conversion of matcher type from string.
@@ -73,6 +75,7 @@ var MatcherTypes = map[string]MatcherType{
 	"regex":  RegexMatcher,
 	"binary": BinaryMatcher,
 	"dsl":    DSLMatcher,
+	"auto":   AutoMatcher,
 }
 
 // ConditionType is the type of condition for matcher

--- a/pkg/requests/http-request.go
+++ b/pkg/requests/http-request.go
@@ -72,6 +72,36 @@ func (r *HTTPRequest) MakeHTTPRequest(baseURL string) ([]*retryablehttp.Request,
 	return r.makeHTTPRequestFromModel(baseURL, values)
 }
 
+func (r *HTTPRequest) MakeHTTPRequestForAutoConfigure(baseURL string) (requests []*retryablehttp.Request, err error) {
+	parsed, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, err
+	}
+	hostname := parsed.Hostname()
+
+	values := map[string]interface{}{
+		"BaseURL":  baseURL,
+		"Hostname": hostname,
+	}
+
+	urlTo404 := baseURL + "/" + randSeq(16)
+
+	// Build a request on the specified URL
+	req, err := http.NewRequest(r.Method, urlTo404, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	request, err := r.fillRequest(req, values)
+	if err != nil {
+		return nil, err
+	}
+
+	requests = append(requests, request)
+
+	return
+}
+
 // MakeHTTPRequestFromModel creates a *http.Request from a request template
 func (r *HTTPRequest) makeHTTPRequestFromModel(baseURL string, values map[string]interface{}) (requests []*retryablehttp.Request, err error) {
 	replacer := newReplacer(values)

--- a/pkg/requests/http-request.go
+++ b/pkg/requests/http-request.go
@@ -72,7 +72,8 @@ func (r *HTTPRequest) MakeHTTPRequest(baseURL string) ([]*retryablehttp.Request,
 	return r.makeHTTPRequestFromModel(baseURL, values)
 }
 
-func (r *HTTPRequest) MakeHTTPRequestForAutoConfigure(baseURL string) (requests []*retryablehttp.Request, err error) {
+// Create HTTP requests for auto configuration
+func (r *HTTPRequest) MakeHTTPRequestForAutoConfigure(baseURL string, seqSize int) (requests []*retryablehttp.Request, err error) {
 	parsed, err := url.Parse(baseURL)
 	if err != nil {
 		return nil, err
@@ -84,7 +85,8 @@ func (r *HTTPRequest) MakeHTTPRequestForAutoConfigure(baseURL string) (requests 
 		"Hostname": hostname,
 	}
 
-	urlTo404 := baseURL + "/" + randSeq(16)
+	// Create URL with a random path that will indicate a 404
+	urlTo404 := baseURL + "/" + randSeq(seqSize)
 
 	// Build a request on the specified URL
 	req, err := http.NewRequest(r.Method, urlTo404, nil)

--- a/pkg/requests/util.go
+++ b/pkg/requests/util.go
@@ -2,6 +2,7 @@ package requests
 
 import (
 	"fmt"
+	"math/rand"
 	"strings"
 )
 
@@ -13,4 +14,13 @@ func newReplacer(values map[string]interface{}) *strings.Replacer {
 	}
 
 	return strings.NewReplacer(replacerItems...)
+}
+
+func randSeq(n int) string {
+	var letters = []rune("abcdefghijklmnopqrstuvwxyz0987654321")
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(b)
 }


### PR DESCRIPTION
Hello, I wrote some code to solve issue #78. This adds a match type for templates `auto`.

The way this works is by requesting two random paths on each target, then configuring the matcher to only match paths that don't indicate a 404 (based on either status or status AND response size). 

Here's an example of a template that can be used...

```
id: auto-test

info:
  name: Auto-Configuration Test
  author: michael1026
  severity: low

requests:
  - method: GET
    path:
      - "{{BaseURL}}/test123"
      - "{{BaseURL}}/hacktivity"
      - "{{BaseURL}}/doesntexist"
      - "{{BaseURL}}/admin"
      - "{{BaseURL}}/user"
      - "{{BaseURL}}/login"
      - "{{BaseURL}}/api"
    matchers:
      - type: auto
```

This probably needs some tweaking as I haven't really written Go before and I haven't contributed to this project in the past.