### PR TITLE
Defaults to an OR condition when no matchers-condition is specified in the rule

### DIFF
--- a/pkg/templates/compile.go
+++ b/pkg/templates/compile.go
@@ -35,7 +35,7 @@ func Parse(file string) (*Template, error) {
 		// Get the condition between the matchers
 		condition, ok := matchers.ConditionTypes[request.MatchersCondition]
 		if !ok {
-			request.SetMatchersCondition(matchers.ANDCondition)
+			request.SetMatchersCondition(matchers.ORCondition)
 		} else {
 			request.SetMatchersCondition(condition)
 		}
@@ -73,7 +73,7 @@ func Parse(file string) (*Template, error) {
 		// Get the condition between the matchers
 		condition, ok := matchers.ConditionTypes[request.MatchersCondition]
 		if !ok {
-			request.SetMatchersCondition(matchers.ANDCondition)
+			request.SetMatchersCondition(matchers.ORCondition)
 		} else {
 			request.SetMatchersCondition(condition)
 		}


### PR DESCRIPTION
According to the [templates writing guide](https://github.com/projectdiscovery/nuclei-templates/blob/master/GUIDE.md#multiple-matchers) an `OR` condition should be used when not specified by a `matchers-condition` definition, but an `AND` condition is applied by default instead.