### PR TITLE
Add support for port value to raw request templates.

### DIFF
--- a/v2/pkg/requests/http-request.go
+++ b/v2/pkg/requests/http-request.go
@@ -79,11 +79,27 @@ func (r *HTTPRequest) MakeHTTPRequest(baseURL string) (chan *CompiledHTTP, error
 	if err != nil {
 		return nil, err
 	}
-	hostname := parsed.Hostname()
+
+	hostname, port := parsed.Hostname(), parsed.Port()
+	portOrDefault := port
+	portWithColon := ""
+
+	if len(port) == 0 {
+		if strings.HasPrefix(baseURL, "https") {
+			portOrDefault = "443"
+		} else if strings.HasPrefix(baseURL, "http") {
+			portOrDefault = "80"
+		}
+	} else {
+		portWithColon = ":" + port
+	}
 
 	values := map[string]interface{}{
-		"BaseURL":  baseURL,
-		"Hostname": hostname,
+		"BaseURL":       baseURL,		// http(s)://host	http://host:9999
+		"Hostname":      hostname,		// host				host
+		"Port":          port,			// 					9999
+		"PortWithColon": portWithColon,	// 					:9999
+		"PortOrDefault": portOrDefault, // 80 (443)			9999
 	}
 
 	if len(r.Raw) > 0 {


### PR DESCRIPTION
This aims to fix #165 and also adds some variations to the `port` value so that templates are free to choose what better fits their use-case.

- add support for the `{{Port}}` default variable (can be empty)
- add `{{PortWithColon}}` variable, same as `{{Port}}` but prefixed with a colon character when valued
- add `{{PortOrDefault}}`, always valued, either with the supplied port or with a default port number based on the specified protocol (http/80, https/443).

Sample template:
```yaml
id: test-template

info:
  name: test-template
  author: pdteam
  severity: info


requests:
  - raw:
      - |
        POST / HTTP/1.1
        Host: {{Hostname}}:{{PortOrDefault}}
        User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:68.0) Gecko/20100101 Firefox/68.0

        body=testing
      - |
        POST / HTTP/1.1
        Host: {{Hostname}}{{PortWithColon}}
        User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:68.0) Gecko/20100101 Firefox/68.0

        body=testing
```

Both requests should be fine: in the first case, if no port is defined then `80` or `443` will be used while in the second case, whenever port is valued a semicolon will be prefixed to it automatically, else an empty value will have no effect.

NOTE: It should really be `ColonAndPort` but it doesn't feel natural to me although is technically more correct and `PortWithColonPrefix` is much longer 🤔 