### PR TITLE
Add output results color highlighting (fix #175)

### DIFF
--- a/v2/pkg/executer/executer_dns.go
+++ b/v2/pkg/executer/executer_dns.go
@@ -3,8 +3,10 @@ package executer
 import (
 	"bufio"
 	"fmt"
+	"github.com/logrusorgru/aurora"
 	"github.com/projectdiscovery/nuclei/v2/internal/progress"
 	"os"
+	"regexp"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -26,6 +28,10 @@ type DNSExecuter struct {
 	dnsRequest  *requests.DNSRequest
 	writer      *bufio.Writer
 	outputMutex *sync.Mutex
+
+	coloredOutput	bool
+	colorizer		aurora.Aurora
+	decolorizer		*regexp.Regexp
 }
 
 // DefaultResolvers contains the list of resolvers known to be trusted.
@@ -43,6 +49,10 @@ type DNSOptions struct {
 	Template   *templates.Template
 	DNSRequest *requests.DNSRequest
 	Writer     *bufio.Writer
+
+	ColoredOutput	bool
+	Colorizer		aurora.Aurora
+	Decolorizer		*regexp.Regexp
 }
 
 // NewDNSExecuter creates a new DNS executer from a template
@@ -58,6 +68,9 @@ func NewDNSExecuter(options *DNSOptions) *DNSExecuter {
 		dnsRequest:  options.DNSRequest,
 		writer:      options.Writer,
 		outputMutex: &sync.Mutex{},
+		coloredOutput:   options.ColoredOutput,
+		colorizer:       options.Colorizer,
+		decolorizer:     options.Decolorizer,
 	}
 	return executer
 }

--- a/v2/pkg/executer/executer_http.go
+++ b/v2/pkg/executer/executer_http.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"crypto/tls"
 	"fmt"
+	"github.com/logrusorgru/aurora"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -11,6 +12,7 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"os"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -39,6 +41,10 @@ type HTTPExecuter struct {
 	outputMutex     *sync.Mutex
 	customHeaders   requests.CustomHeaders
 	CookieJar       *cookiejar.Jar
+
+	coloredOutput	bool
+	colorizer		aurora.Aurora
+	decolorizer		*regexp.Regexp
 }
 
 // HTTPOptions contains configuration options for the HTTP executer.
@@ -56,6 +62,9 @@ type HTTPOptions struct {
 	CustomHeaders   requests.CustomHeaders
 	CookieReuse     bool
 	CookieJar       *cookiejar.Jar
+	ColoredOutput	bool
+	Colorizer		aurora.Aurora
+	Decolorizer		*regexp.Regexp
 }
 
 // NewHTTPExecuter creates a new HTTP executer from a template
@@ -95,6 +104,9 @@ func NewHTTPExecuter(options *HTTPOptions) (*HTTPExecuter, error) {
 		writer:          options.Writer,
 		customHeaders:   options.CustomHeaders,
 		CookieJar:       options.CookieJar,
+		coloredOutput:   options.ColoredOutput,
+		colorizer:       options.Colorizer,
+		decolorizer:     options.Decolorizer,
 	}
 
 	return executer, nil

--- a/v2/pkg/executer/output_dns.go
+++ b/v2/pkg/executer/output_dns.go
@@ -42,13 +42,17 @@ func (e *DNSExecuter) writeOutputDNS(domain string, matcher *matchers.Matcher, e
 	}
 
 	builder := &strings.Builder{}
+	colorizer := e.colorizer
+
 	builder.WriteRune('[')
-	builder.WriteString(e.template.ID)
+	builder.WriteString(colorizer.BrightGreen(e.template.ID).String())
 	if matcher != nil && len(matcher.Name) > 0 {
 		builder.WriteString(":")
-		builder.WriteString(matcher.Name)
+		builder.WriteString(colorizer.BrightGreen(matcher.Name).Bold().String())
 	}
-	builder.WriteString("] [dns] ")
+	builder.WriteString("] [")
+	builder.WriteString(colorizer.BrightBlue("dns").String())
+	builder.WriteString("] ")
 
 	builder.WriteString(domain)
 
@@ -56,7 +60,7 @@ func (e *DNSExecuter) writeOutputDNS(domain string, matcher *matchers.Matcher, e
 	if len(extractorResults) > 0 {
 		builder.WriteString(" [")
 		for i, result := range extractorResults {
-			builder.WriteString(result)
+			builder.WriteString(colorizer.BrightCyan(result).String())
 			if i != len(extractorResults)-1 {
 				builder.WriteRune(',')
 			}
@@ -71,6 +75,9 @@ func (e *DNSExecuter) writeOutputDNS(domain string, matcher *matchers.Matcher, e
 
 	if e.writer != nil {
 		e.outputMutex.Lock()
+		if e.coloredOutput {
+			message = e.decolorizer.ReplaceAllString(message, "")
+		}
 		e.writer.WriteString(message)
 		e.outputMutex.Unlock()
 	}

--- a/v2/pkg/executer/output_http.go
+++ b/v2/pkg/executer/output_http.go
@@ -62,14 +62,17 @@ func (e *HTTPExecuter) writeOutputHTTP(req *requests.HttpRequest, resp *http.Res
 	}
 
 	builder := &strings.Builder{}
+	colorizer := e.colorizer
 
 	builder.WriteRune('[')
-	builder.WriteString(e.template.ID)
+	builder.WriteString(colorizer.BrightGreen(e.template.ID).String())
 	if matcher != nil && len(matcher.Name) > 0 {
 		builder.WriteString(":")
-		builder.WriteString(matcher.Name)
+		builder.WriteString(colorizer.BrightGreen(matcher.Name).Bold().String())
 	}
-	builder.WriteString("] [http] ")
+	builder.WriteString("] [")
+	builder.WriteString(colorizer.BrightBlue("http").String())
+	builder.WriteString("] ")
 
 	// Escape the URL by replacing all % with %%
 	escapedURL := strings.Replace(URL, "%", "%%", -1)
@@ -79,7 +82,7 @@ func (e *HTTPExecuter) writeOutputHTTP(req *requests.HttpRequest, resp *http.Res
 	if len(extractorResults) > 0 {
 		builder.WriteString(" [")
 		for i, result := range extractorResults {
-			builder.WriteString(result)
+			builder.WriteString(colorizer.BrightCyan(result).String())
 			if i != len(extractorResults)-1 {
 				builder.WriteRune(',')
 			}
@@ -92,7 +95,7 @@ func (e *HTTPExecuter) writeOutputHTTP(req *requests.HttpRequest, resp *http.Res
 		builder.WriteString(" [")
 		var metas []string
 		for name, value := range req.Meta {
-			metas = append(metas, name+"="+value.(string))
+			metas = append(metas, colorizer.BrightYellow(name).Bold().String()+"="+ colorizer.BrightYellow(value.(string)).String() )
 		}
 		builder.WriteString(strings.Join(metas, ","))
 		builder.WriteString("]")
@@ -106,6 +109,9 @@ func (e *HTTPExecuter) writeOutputHTTP(req *requests.HttpRequest, resp *http.Res
 
 	if e.writer != nil {
 		e.outputMutex.Lock()
+		if e.coloredOutput {
+			message = e.decolorizer.ReplaceAllString(message, "")
+		}
 		e.writer.WriteString(message)
 		e.outputMutex.Unlock()
 	}


### PR DESCRIPTION
This is an initial implementation of adding color highlighting to the output results:
![image](https://user-images.githubusercontent.com/819314/88739343-9f59eb00-d13a-11ea-940b-27e67621b70f.png)

Let me know if you have better ideas on how to avoid building multiple strings with and without color escape codes: this one is implemented by decolorizing file output (if colored output is active).