### PR TITLE
Fix 180 - Add support for template exclusions

### DIFF
--- a/v2/internal/runner/options.go
+++ b/v2/internal/runner/options.go
@@ -13,6 +13,7 @@ import (
 type Options struct {
 	Debug              bool                   // Debug mode allows debugging request/responses for the engine
 	Templates          multiStringFlag        // Signature specifies the template/templates to use
+	ExcludedTemplates  multiStringFlag        // Signature specifies the template/templates to exclude
 	Target             string                 // Target is a single URL/Domain to scan usng a template
 	Targets            string                 // Targets specifies the targets to scan using templates.
 	Threads            int                    // Thread controls the number of concurrent requests to make.
@@ -51,7 +52,8 @@ func ParseOptions() *Options {
 	options := &Options{}
 
 	flag.StringVar(&options.Target, "target", "", "Target is a single target to scan using template")
-	flag.Var(&options.Templates, "t", "Template input file/files to run on host. Can be used multiple times.")
+	flag.Var(&options.Templates, "t", "Template input dir/file/files to run on host. Can be used multiple times. Supports globbing.")
+	flag.Var(&options.ExcludedTemplates, "exclude", "Template input dir/file/files to exclude. Can be used multiple times. Supports globbing.")
 	flag.StringVar(&options.Targets, "l", "", "List of URLs to run templates on")
 	flag.StringVar(&options.Output, "o", "", "File to write output to (optional)")
 	flag.StringVar(&options.ProxyURL, "proxy-url", "", "URL of the proxy server")

--- a/v2/internal/runner/runner.go
+++ b/v2/internal/runner/runner.go
@@ -189,15 +189,14 @@ func isNewPath(path string, pathMap map[string]bool) bool {
 	return true
 }
 
-// RunEnumeration sets up the input layer for giving input nuclei.
-// binary and runs the actual enumeration
-func (r *Runner) RunEnumeration() {
+// getTemplatesFor parses the specified input template definitions and returns a list of unique, absolute template paths.
+func (r *Runner) getTemplatesFor(definitions []string) []string {
 	// keeps track of processed dirs and files
 	processed := make(map[string]bool)
 	allTemplates := []string{}
 
 	// parses user input, handle file/directory cases and produce a list of unique templates
-	for _, t := range r.options.Templates {
+	for _, t := range definitions {
 		var absPath string
 		var err error
 
@@ -292,6 +291,15 @@ func (r *Runner) RunEnumeration() {
 			}
 		}
 	}
+
+	return allTemplates
+}
+
+// RunEnumeration sets up the input layer for giving input nuclei.
+// binary and runs the actual enumeration
+func (r *Runner) RunEnumeration() {
+	// resolves input templates
+	allTemplates := r.getTemplatesFor(r.options.Templates)
 
 	// 0 matches means no templates were found in directory
 	if len(allTemplates) == 0 {


### PR DESCRIPTION
This aims to close #180.

Refactored the code to permit reuse of the template resolution logic: templates can be excluded with `-exclude` and it accepts the same kind of input as `-t`, so globbing is also supported there.