### PR TITLE
Fix #191 - Add support for severity filtering

### DIFF
--- a/v2/internal/progress/progress.go
+++ b/v2/internal/progress/progress.go
@@ -74,7 +74,7 @@ func NewProgress(noColor bool, active bool) IProgress {
 }
 
 // Creates and returns a progress bar that tracks all the progress.
-func (p *Progress) InitProgressbar(hostCount int64, templateCount int, requestCount int64) {
+func (p *Progress) InitProgressbar(hostCount int64, rulesCount int, requestCount int64) {
 	if p.bar != nil {
 		panic("A global progressbar is already present.")
 	}
@@ -83,8 +83,8 @@ func (p *Progress) InitProgressbar(hostCount int64, templateCount int, requestCo
 
 	barName := color.Sprintf(
 		color.Cyan("%d %s, %d %s"),
-		color.Bold(color.Cyan(templateCount)),
-		pluralize(int64(templateCount), "template", "templates"),
+		color.Bold(color.Cyan(rulesCount)),
+		pluralize(int64(rulesCount), "rule", "rules"),
 		color.Bold(color.Cyan(hostCount)),
 		pluralize(hostCount, "host", "hosts"))
 

--- a/v2/internal/runner/options.go
+++ b/v2/internal/runner/options.go
@@ -13,6 +13,7 @@ import (
 type Options struct {
 	Debug              bool                   // Debug mode allows debugging request/responses for the engine
 	Templates          multiStringFlag        // Signature specifies the template/templates to use
+	Severity 		   string 				  // Filter templates based on their severity and only run the matching ones.
 	Target             string                 // Target is a single URL/Domain to scan usng a template
 	Targets            string                 // Targets specifies the targets to scan using templates.
 	Threads            int                    // Thread controls the number of concurrent requests to make.
@@ -52,6 +53,7 @@ func ParseOptions() *Options {
 
 	flag.StringVar(&options.Target, "target", "", "Target is a single target to scan using template")
 	flag.Var(&options.Templates, "t", "Template input file/files to run on host. Can be used multiple times.")
+	flag.StringVar(&options.Severity, "severity", "", "Filter templates based on their severity and only run the matching ones. Comma-separated values can be used to specify multiple severities.")
 	flag.StringVar(&options.Targets, "l", "", "List of URLs to run templates on")
 	flag.StringVar(&options.Output, "o", "", "File to write output to (optional)")
 	flag.StringVar(&options.ProxyURL, "proxy-url", "", "URL of the proxy server")

--- a/v2/internal/runner/runner.go
+++ b/v2/internal/runner/runner.go
@@ -218,7 +218,7 @@ func (r *Runner) getParsedTemplatesFor(templatePaths []string, severities string
 			if !filterBySeverity || hasMatchingSeverity(sev, allSeverities) {
 				parsedTemplates = append(parsedTemplates, template)
 			} else {
-				gologger.Infof("Excluding template %s due to severity filter (%s not in [%s])", id, sev, severities)
+				gologger.Warningf("Excluding template %s due to severity filter (%s not in [%s])", id, sev, severities)
 			}
 		case *workflows.Workflow:
 			workflow := t.(*workflows.Workflow)


### PR DESCRIPTION
This should close #191 by permitting to specify one or more severity filters such as `-severity informative` or `-severity high,critical`, the latter as a comma-separated list of values (without spaces).

Severity matches when the template-defined severity has a prefix as the one supplied with `-severity`, so that both `-severity info` and -`severity informative` works.