### PR TITLE
fix no result found problem with and condition

### DIFF
--- a/v2/pkg/executer/executer_dns.go
+++ b/v2/pkg/executer/executer_dns.go
@@ -148,6 +148,7 @@ func (e *DNSExecuter) ExecuteDNS(p progress.IProgress, URL string) (result Resul
 	// AND or if we have extractors for the mechanism too.
 	if len(e.dnsRequest.Extractors) > 0 || matcherCondition == matchers.ANDCondition {
 		e.writeOutputDNS(domain, nil, extractorResults)
+		result.GotResults = true
 	}
 
 	return


### PR DESCRIPTION
There seems to be a problem with the AND extractor and DNS queries. The output file is deleted after the run, as nuclei thinks nothing was found.
![Screenshot 2020-08-04 um 15 08 01](https://user-images.githubusercontent.com/199681/89297947-f264fe00-d664-11ea-87fe-059736c0718b.png)
 