### PR TITLE
[proposal] Support matchers inheritance

### DIFF
--- a/v2/go.mod
+++ b/v2/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/d5/tengo/v2 v2.6.0
 	github.com/google/go-github/v32 v32.1.0
+	github.com/imdario/mergo v0.3.10
 	github.com/json-iterator/go v1.1.10
 	github.com/karrick/godirwalk v1.15.6
 	github.com/logrusorgru/aurora v2.0.3+incompatible

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -22,6 +22,8 @@ github.com/google/go-github/v32 v32.1.0/go.mod h1:rIEpZD9CTDQwDK9GDrtMTycQNA4JU3
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/imdario/mergo v0.3.10 h1:6q5mVkdH/vYmqngx7kZQTjJ5HRsx+ImorDIEQ+beJgc=
+github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/json-iterator/go v1.1.10 h1:Kz6Cvnvv2wGdaG/V8yMvfkmNiXq9Ya2KUv4rouJJr68=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/karrick/godirwalk v1.15.6 h1:Yf2mmR8TJy+8Fa0SuQVto5SYap6IF7lNVX4Jdl8G1qA=

--- a/v2/pkg/matchers/matchers.go
+++ b/v2/pkg/matchers/matchers.go
@@ -13,8 +13,8 @@ type Matcher struct {
 	// matcherType is the internal type of the matcher
 	matcherType MatcherType
 
-	// Extends is the name of another matcher to use as a template, any other additional field will have
-	// precedence and will overwrite the template's ones
+	// Extends is the name of another matcher to use as a template, any additionally defined field will not be
+	// overridden by the template's ones
 	Extends string `yaml:"extends,omitempty"`
 	// Whether this matcher has been extended already
 	extended bool

--- a/v2/pkg/matchers/matchers.go
+++ b/v2/pkg/matchers/matchers.go
@@ -16,6 +16,8 @@ type Matcher struct {
 	// Extends is the name of another matcher to use as a template, any other additional field will have
 	// precedence and will overwrite the template's ones
 	Extends string `yaml:"extends,omitempty"`
+	// Whether this matcher has been extended already
+	extended bool
 	// Name is matcher Name
 	Name string `yaml:"name,omitempty"`
 	// Status are the acceptable status codes for the response
@@ -116,4 +118,14 @@ var PartTypes = map[string]Part{
 // GetPart returns the part of the matcher
 func (m *Matcher) GetPart() Part {
 	return m.part
+}
+
+// NeedsExtension returns whether this matcher needs to be extended
+func (m *Matcher) NeedsExtension() bool {
+	return m.Extends != "" && !m.extended
+}
+
+// SetExtended marks this Matcher as being extended and resolved
+func (m *Matcher) SetExtended() {
+	m.extended = true
 }

--- a/v2/pkg/matchers/matchers.go
+++ b/v2/pkg/matchers/matchers.go
@@ -13,6 +13,9 @@ type Matcher struct {
 	// matcherType is the internal type of the matcher
 	matcherType MatcherType
 
+	// Extends is the name of another matcher name to use as a template, any other additional field will have
+	// precedence and will overwrite the template's ones
+	Extends string `yaml:"extends,omitempty"`
 	// Name is matcher Name
 	Name string `yaml:"name,omitempty"`
 	// Status are the acceptable status codes for the response

--- a/v2/pkg/matchers/matchers.go
+++ b/v2/pkg/matchers/matchers.go
@@ -13,7 +13,7 @@ type Matcher struct {
 	// matcherType is the internal type of the matcher
 	matcherType MatcherType
 
-	// Extends is the name of another matcher name to use as a template, any other additional field will have
+	// Extends is the name of another matcher to use as a template, any other additional field will have
 	// precedence and will overwrite the template's ones
 	Extends string `yaml:"extends,omitempty"`
 	// Name is matcher Name

--- a/v2/pkg/templates/compile.go
+++ b/v2/pkg/templates/compile.go
@@ -14,7 +14,7 @@ import (
 )
 
 // extendMatcher tries to use the matcher as specified in the Matcher.Extends field as the base for this matcher: any
-// additionally defined field will have precedence and will overwrite the template's ones.
+// additionally defined field will not be overridden by the template's ones.
 func extendMatcher(allMatchers map[string]*matchers.Matcher, matcher *matchers.Matcher) error {
 	if referenced, found := allMatchers[matcher.Extends]; found {
 		if referenced.NeedsExtension() {


### PR DESCRIPTION
Not sure if there could be any interest on this, but while i was playing with matchers I noticed there isn't a way to avoid duplicating them if a group of requests need the same matcher. I played with it a bit and come up with the idea of matchers inheritance: before throwing my tests in the bin i just decided to actually make them into a proposal.

For example, the `files/wadl-files.yaml` template defines both `GET` and `OPTIONS` requests to be performed, but the matchers have to be duplicated:

```yaml
requests:
  - method: GET
    path:
      - "{{BaseURL}}/application.wadl"
      ...
    matchers:
      - name: http-get
        type: word
        words:
          - "This is simplified WADL with user and core resources only"
          - "\"http://jersey.java.net/\""
          - "http://wadl.dev.java.net/2009/02"
        condition: or
        part: body

  - method: OPTIONS
    path:
      - "{{BaseURL}}/"
      ...
    matchers:
      - name: http-options
        type: word
        words:
          - "This is simplified WADL with user and core resources only"
          - "\"http://jersey.java.net/\""
          - "http://wadl.dev.java.net/2009/02"
        condition: or
        part: body
```

To avoid this and ease other tasks with matcher writing, i added support for matchers to actually be able to _extends_ another matcher by specifying it in an optional `extends` field, so the above template could be simplified to:
```yaml
requests:
  - method: GET
    path:
      - "{{BaseURL}}/application.wadl"
      ...
    matchers:
      - name: http-get
        type: word
        words:
          - "This is simplified WADL with user and core resources only"
          - "\"http://jersey.java.net/\""
          - "http://wadl.dev.java.net/2009/02"
        condition: or
        part: body

  - method: OPTIONS
    path:
      - "{{BaseURL}}/"
      ...
    matchers:
      - extends: http-get
        name: http-options

```

Note this also works when a matcher is extending from a matcher that extends from a matcher and so on, so this is a valid definition too:
```yaml
requests:
  - method: GET
    path:
      - "{{BaseURL}}/application.wadl"
      ...
    matchers:
      - name: http-get
        type: word
        words:
          - "This is simplified WADL with user and core resources only"
          - "\"http://jersey.java.net/\""
          - "http://wadl.dev.java.net/2009/02"
        condition: or
        part: body

  - method: GET
    path:
      - "{{BaseURL}}/z"
    matchers:
      - extends: http-options
        name: ztest

  - method: OPTIONS
    path:
      - "{{BaseURL}}/"
      ..
    matchers:
      - extends: http-get
        name: http-options
```
