### PR TITLE
Fix minor issue where a dangling comma can cause any severity to match

### DIFF
--- a/v2/internal/runner/runner.go
+++ b/v2/internal/runner/runner.go
@@ -191,7 +191,7 @@ func isNewPath(path string, pathMap map[string]bool) bool {
 
 func hasMatchingSeverity(templateSeverity string, allowedSeverities []string) bool {
 	for _, s := range allowedSeverities {
-		if strings.HasPrefix(templateSeverity, s) {
+		if s != "" && strings.HasPrefix(templateSeverity, s) {
 			return true
 		}
 	}


### PR DESCRIPTION
Very minor fix for a border case that can occur when specifying severities and not paying attention to the comma-without-spaces format, ie. `-severity info, high` will cause any template to match.