### PR TITLE
Fix #235 - issue where 'all' scope requires matches in both html parts

### DIFF
--- a/v2/pkg/matchers/match.go
+++ b/v2/pkg/matchers/match.go
@@ -22,10 +22,7 @@ func (m *Matcher) Match(resp *http.Response, body, headers string) bool {
 		} else if m.part == HeaderPart {
 			return m.matchWords(headers)
 		} else {
-			if !m.matchWords(headers) {
-				return false
-			}
-			return m.matchWords(body)
+			return m.matchWords(headers) || m.matchWords(body)
 		}
 	case RegexMatcher:
 		// Match the parts as required for regex check
@@ -34,10 +31,7 @@ func (m *Matcher) Match(resp *http.Response, body, headers string) bool {
 		} else if m.part == HeaderPart {
 			return m.matchRegex(headers)
 		} else {
-			if m.matchRegex(headers) {
-				return true
-			}
-			return m.matchRegex(body)
+			return m.matchRegex(headers) || m.matchRegex(body)
 		}
 	case BinaryMatcher:
 		// Match the parts as required for binary characters check
@@ -46,10 +40,7 @@ func (m *Matcher) Match(resp *http.Response, body, headers string) bool {
 		} else if m.part == HeaderPart {
 			return m.matchBinary(headers)
 		} else {
-			if !m.matchBinary(headers) {
-				return false
-			}
-			return m.matchBinary(body)
+			return m.matchBinary(headers) || m.matchBinary(body)
 		}
 	case DSLMatcher:
 		// Match complex query


### PR DESCRIPTION
This should fix #235, WordsMatcher with 'all' part currently requires that the word matches in both html parts (header and body), same case with BinaryMatcher.
https://github.com/projectdiscovery/nuclei/blob/bdb3321f5fe78f255af6c52f05bc49211380e0b3/v2/pkg/matchers/match.go#L18-L29

Taking 'all' part as scope where to match, i've changed the behavior to require one word match in at least one html part. (RegexMatcher current behavior)
