### PR TITLE
Added negative matchers support closing #163

### DIFF
--- a/v2/pkg/matchers/match.go
+++ b/v2/pkg/matchers/match.go
@@ -12,39 +12,39 @@ import (
 func (m *Matcher) Match(resp *http.Response, body, headers string) bool {
 	switch m.matcherType {
 	case StatusMatcher:
-		return m.matchStatusCode(resp.StatusCode)
+		return m.isNegative(m.matchStatusCode(resp.StatusCode))
 	case SizeMatcher:
-		return m.matchSizeCode(len(body))
+		return m.isNegative(m.matchSizeCode(len(body)))
 	case WordsMatcher:
 		// Match the parts as required for word check
 		if m.part == BodyPart {
-			return m.matchWords(body)
+			return m.isNegative(m.matchWords(body))
 		} else if m.part == HeaderPart {
-			return m.matchWords(headers)
+			return m.isNegative(m.matchWords(headers))
 		} else {
-			return m.matchWords(headers) || m.matchWords(body)
+			return m.isNegative(m.matchWords(headers) || m.matchWords(body))
 		}
 	case RegexMatcher:
 		// Match the parts as required for regex check
 		if m.part == BodyPart {
-			return m.matchRegex(body)
+			return m.isNegative(m.matchRegex(body))
 		} else if m.part == HeaderPart {
-			return m.matchRegex(headers)
+			return m.isNegative(m.matchRegex(headers))
 		} else {
-			return m.matchRegex(headers) || m.matchRegex(body)
+			return m.isNegative(m.matchRegex(headers) || m.matchRegex(body))
 		}
 	case BinaryMatcher:
 		// Match the parts as required for binary characters check
 		if m.part == BodyPart {
-			return m.matchBinary(body)
+			return m.isNegative(m.matchBinary(body))
 		} else if m.part == HeaderPart {
-			return m.matchBinary(headers)
+			return m.isNegative(m.matchBinary(headers))
 		} else {
-			return m.matchBinary(headers) || m.matchBinary(body)
+			return m.isNegative(m.matchBinary(headers) || m.matchBinary(body))
 		}
 	case DSLMatcher:
 		// Match complex query
-		return m.matchDSL(httpToMap(resp, body, headers))
+		return m.isNegative(m.matchDSL(httpToMap(resp, body, headers)))
 	}
 	return false
 }

--- a/v2/pkg/matchers/matchers.go
+++ b/v2/pkg/matchers/matchers.go
@@ -45,6 +45,10 @@ type Matcher struct {
 	Part string `yaml:"part,omitempty"`
 	// part is the part of the request to match
 	part Part
+
+	// Negative specifies if the match should be reversed
+	// It will only match if the condition is not true.
+	Negative bool `yaml:"negative,omitempty"`
 }
 
 // MatcherType is the type of the matcher specified
@@ -113,4 +117,13 @@ var PartTypes = map[string]Part{
 // GetPart returns the part of the matcher
 func (m *Matcher) GetPart() Part {
 	return m.part
+}
+
+// isNegative reverts the results of the match if the matcher
+// is of type negative.
+func (m *Matcher) isNegative(data bool) bool {
+	if m.Negative {
+		return !data
+	}
+	return data
 }


### PR DESCRIPTION
Matchers can now be specified as negative by using `negative: true` flag in matcher block.