### PR TITLE
Fixed SIGSEGV if no templates config exists

### DIFF
--- a/v2/internal/runner/config.go
+++ b/v2/internal/runner/config.go
@@ -102,6 +102,9 @@ func (r *Runner) readNucleiIgnoreFile() {
 
 // checkIfInNucleiIgnore checks if a path falls under nuclei-ignore rules.
 func (r *Runner) checkIfInNucleiIgnore(item string) bool {
+	if r.templatesConfig == nil {
+		return false
+	}
 	for _, paths := range r.templatesConfig.ignorePaths {
 		// If we have a path to ignore, check if it's in the item.
 		if paths[len(paths)-1] == '/' {


### PR DESCRIPTION
```
$ go run main.go -target http://localhost:3000 -t /home/vzamanillo/nuclei-templates/cves
                       __     _
     ____  __  _______/ /__  (_)
    / __ \/ / / / ___/ / _ \/ /
   / / / / /_/ / /__/ /  __/ /
  /_/ /_/\__,_/\___/_/\___/_/   v2.1

		projectdiscovery.io

[WRN] Use with caution. You are responsible for your actions
[WRN] Developers assume no liability and are not responsible for any misuse or damage.
[WRN] nuclei-templates are not installed, use update-templates flag.
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0x9d2713]

goroutine 1 [running]:
github.com/projectdiscovery/nuclei/v2/internal/runner.(*Runner).checkIfInNucleiIgnore(0xc0001d0100, 0xc0001e41e0, 0x45, 0x1)
	/home/vzamanillo/go/src/github.com/projectdiscovery/nuclei/v2/internal/runner/config.go:118 +0x33
github.com/projectdiscovery/nuclei/v2/internal/runner.(*Runner).getTemplatesFor.func1(0xc0001e41e0, 0x45, 0xc0001c9a40, 0xc0001d9780, 0x4f0cc2)
	/home/vzamanillo/go/src/github.com/projectdiscovery/nuclei/v2/internal/runner/runner.go:345 +0xbb
github.com/karrick/godirwalk.walk(0xc0001e41e0, 0x45, 0xc0001c9a40, 0xc0001d9be0, 0x45, 0xc0001bab60)
	/home/vzamanillo/go/pkg/mod/github.com/karrick/godirwalk@v1.15.6/walk.go:218 +0x69
github.com/karrick/godirwalk.walk(0x7fffd27b1c5f, 0x32, 0xc0001c9a10, 0xc0001d9be0, 0x0, 0x0)
	/home/vzamanillo/go/pkg/mod/github.com/karrick/godirwalk@v1.15.6/walk.go:279 +0x424
github.com/karrick/godirwalk.Walk(0x7fffd27b1c5f, 0x32, 0xc0001d9be0, 0x32, 0xc0001d9ca8)
	/home/vzamanillo/go/pkg/mod/github.com/karrick/godirwalk@v1.15.6/walk.go:204 +0x238
github.com/projectdiscovery/nuclei/v2/internal/runner.(*Runner).getTemplatesFor(0xc0001d0100, 0xc0001c16c0, 0x1, 0x1, 0x0, 0x0, 0x15)
	/home/vzamanillo/go/src/github.com/projectdiscovery/nuclei/v2/internal/runner/runner.go:342 +0xb5e
github.com/projectdiscovery/nuclei/v2/internal/runner.(*Runner).RunEnumeration(0xc0001d0100)
	/home/vzamanillo/go/src/github.com/projectdiscovery/nuclei/v2/internal/runner/runner.go:382 +0x62
main.main()
	/home/vzamanillo/go/src/github.com/projectdiscovery/nuclei/v2/cmd/nuclei/main.go:17 +0x9f
exit status 2

```