### PR TITLE
Removed "Loaded template" in favour of "Loading templates..."

### DIFF
--- a/v2/internal/runner/runner.go
+++ b/v2/internal/runner/runner.go
@@ -205,7 +205,7 @@ func hasMatchingSeverity(templateSeverity string, allowedSeverities []string) bo
 
 func (r *Runner) logTemplateLoaded(id, name, author, severity string) {
 	// Display the message for the template
-	message := fmt.Sprintf("[%s] Loaded template %s (%s)",
+	message := fmt.Sprintf("[%s] %s (%s)",
 		r.colorizer.BrightBlue(id).String(), r.colorizer.Bold(name).String(), r.colorizer.BrightYellow("@"+author).String())
 	if severity != "" {
 		message += " [" + r.colorizer.Yellow(severity).String() + "]"
@@ -221,6 +221,7 @@ func (r *Runner) getParsedTemplatesFor(templatePaths []string, severities string
 	allSeverities := strings.Split(severities, ",")
 	filterBySeverity := len(severities) > 0
 
+	gologger.Infof("Loading templates...")
 	for _, match := range templatePaths {
 		t, err := r.parse(match)
 		switch t.(type) {


### PR DESCRIPTION
`Loaded template` it's a bit noisy and redundant, a single `Loading templates...` before template paths iteration looks much better.

Before:

![noisy](https://user-images.githubusercontent.com/10209695/91012572-9992e080-e5e6-11ea-87a8-fdf177978e60.png)

After:

![clean](https://user-images.githubusercontent.com/10209695/91012610-a4e60c00-e5e6-11ea-8f46-82e4adb2b53d.png)
