### PR TITLE
Enriched verbose request mesages

### DIFF
--- a/pkg/executer/executer_dns.go
+++ b/pkg/executer/executer_dns.go
@@ -116,7 +116,7 @@ func (e *DNSExecuter) ExecuteDNS(p progress.IProgress, reqURL string) (result Re
 
 	p.Update()
 
-	gologger.Verbosef("Sent DNS request to %s\n", "dns-request", reqURL)
+	gologger.Verbosef("Sent for [%s] to %s\n", "dns-request", e.template.ID, reqURL)
 
 	if e.debug {
 		gologger.Infof("Dumped DNS response for %s (%s)\n\n", reqURL, e.template.ID)

--- a/pkg/executer/executer_http.go
+++ b/pkg/executer/executer_http.go
@@ -162,7 +162,7 @@ func (e *HTTPExecuter) ExecuteHTTP(ctx context.Context, p progress.IProgress, re
 		remaining--
 	}
 
-	gologger.Verbosef("Sent HTTP request to %s\n", "http-request", reqURL)
+	gologger.Verbosef("Sent for [%s] to %s\n", "http-request", e.template.ID, reqURL)
 
 	return result
 }


### PR DESCRIPTION
The message "Sent `Type` request to" is redundant and noisy and does not provide any useful information, we enriched it adding the template id.