### PR TITLE
Fixed error reporting on update templates

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -50,7 +50,7 @@ func New(options *Options) (*Runner, error) {
 	}
 
 	if err := runner.updateTemplates(); err != nil {
-		gologger.Warningf("Could not update templates: %s\n", err)
+		gologger.Labelf("Could not update templates: %s\n", err)
 	}
 
 	if options.TemplateList {

--- a/internal/runner/update.go
+++ b/internal/runner/update.go
@@ -118,13 +118,13 @@ func (r *Runner) updateTemplates() error {
 	}
 
 	if version.EQ(oldVersion) {
-		gologger.Labelf("Latest version of nuclei-templates installed: v%s\n", oldVersion.String())
+		gologger.Infof("Your nuclei-templates are up to date: v%s\n", oldVersion.String())
 		return r.writeConfiguration(r.templatesConfig)
 	}
 
 	if version.GT(oldVersion) {
 		if !r.options.UpdateTemplates {
-			gologger.Labelf("You're using outdated nuclei-templates. Latest v%s\n", version.String())
+			gologger.Labelf("Your current nuclei-templates v%s are outdated. Latest is v%s\n", oldVersion, version.String())
 			return r.writeConfiguration(r.templatesConfig)
 		}
 


### PR DESCRIPTION
Currently templates update errors are not being reported if it is not in verbose mode.