### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Download latest binary from https://github.com/projectdiscovery/nuclei/releases
 nuclei requires **go1.14+** to install successfully. Run the following command to get the repo -
 
 ```sh
-▶ GO111MODULE=auto go get -u -v github.com/projectdiscovery/nuclei/v2/cmd/nuclei
+▶ GO111MODULE=auto go get -u -v github.com/projectdiscovery/nuclei/cmd/nuclei
 ```
 
 ### From Github


### PR DESCRIPTION
Removed "v2" from the build from source command `GO111MODULE=auto go get -u -v github.com/projectdiscovery/nuclei/v2/cmd/nuclei`