### PR TITLE
Same-name-headers are chunked into 1 line when matching

### DIFF
--- a/pkg/executer/http_utils.go
+++ b/pkg/executer/http_utils.go
@@ -37,7 +37,9 @@ func headersToString(headers http.Header) string {
 			builder.WriteString(value)
 
 			if i != len(values)-1 {
-				builder.WriteRune(',')
+				builder.WriteRune('\n')
+				builder.WriteString(header)
+				builder.WriteString(": ")
 			}
 		}
 


### PR DESCRIPTION
Referencing the comments on the NTLM template PR [here](https://github.com/projectdiscovery/nuclei-templates/pull/329#issuecomment-689581892), [here](https://github.com/projectdiscovery/nuclei-templates/pull/329#issuecomment-689583174) and lastly [here](https://github.com/projectdiscovery/nuclei-templates/pull/329#issuecomment-689587550) I've changed the appending of `,` to a newline and the header name.

The issue at hand was with the response of a `GET /` when the server requires NTLM (probably the same with basic?) authentication. The server responds as such:
```
...
WWW-Authentication: Negotiate
WWW-Authentication: NTLM
...
```
And when using `,` the matcher receives
```
Www-Authenticate: Negotiate,NTLM
```
Instead of
```
Www-Authenticate: Negotiate
Www-Authenticate: NTLM
```

While it's possible to create a matcher for this, it is not true to the returned headers and could create more confusion.

/ Casper