### PR TITLE
Rate limit per target

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,5 +19,6 @@ require (
 	github.com/stretchr/testify v1.5.1
 	github.com/vbauerster/mpb/v5 v5.2.4
 	golang.org/x/net v0.0.0-20200707034311-ab3426394381
+	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e
 	gopkg.in/yaml.v2 v2.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -81,6 +81,8 @@ golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae h1:Ih9Yo4hSPImZOpfGuA4bR/ORKTAbhZo2AbWNRCnevdo=
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e h1:EHBhcS0mlXEAVwNyO2dLfjToGsyY4j24pTs2ScHnX7s=
+golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20191216052735-49a3e744a425/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -79,7 +79,7 @@ func ParseOptions() *Options {
 	flag.BoolVar(&options.JSONRequests, "json-requests", false, "Write requests/responses for matches in JSON output")
 	flag.BoolVar(&options.EnableProgressBar, "pbar", false, "Enable the progress bar")
 	flag.BoolVar(&options.TemplateList, "tl", false, "List available templates")
-	flag.IntVar(&options.RateLimit, "rl", 0, "Rate-Limit of requests per specified target") // 0 as default to turn the flag "off"
+	flag.IntVar(&options.RateLimit, "rl", 9999999, "Rate-Limit of requests per specified target") // 9999999 to avoid limiting
 
 	flag.Parse()
 

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -38,6 +38,7 @@ type Options struct {
 	ProxySocksURL      string                 // ProxySocksURL is the URL for the proxy socks server
 	CustomHeaders      requests.CustomHeaders // Custom global headers
 	TemplatesDirectory string                 // TemplatesDirectory is the directory to use for storing templates
+	RateLimit          int                    // Rate-Limit of requests per specified target
 }
 
 type multiStringFlag []string
@@ -78,6 +79,7 @@ func ParseOptions() *Options {
 	flag.BoolVar(&options.JSONRequests, "json-requests", false, "Write requests/responses for matches in JSON output")
 	flag.BoolVar(&options.EnableProgressBar, "pbar", false, "Enable the progress bar")
 	flag.BoolVar(&options.TemplateList, "tl", false, "List available templates")
+	flag.IntVar(&options.RateLimit, "rl", 0, "Rate-Limit of requests per specified target") // 0 as default to turn the flag "off"
 
 	flag.Parse()
 

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -10,6 +10,9 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"time"
+
+	"golang.org/x/time/rate"
 
 	"github.com/logrusorgru/aurora"
 	"github.com/projectdiscovery/gologger"
@@ -237,6 +240,8 @@ func (r *Runner) RunEnumeration() {
 		gologger.Errorf("Could not find any valid input URLs.")
 	} else if totalRequests > 0 || hasWorkflows {
 		ctx := context.Background()
+		// Limiter that will add to the tokenbucket every second and set the max size to -rl flag
+		rateLimit := rate.NewLimiter(rate.Every(1*time.Second), r.options.RateLimit)
 		// tracks global progress and captures stdout/stderr until p.Wait finishes
 		p := r.progress
 		p.InitProgressbar(r.inputCount, templateCount, totalRequests)
@@ -245,6 +250,10 @@ func (r *Runner) RunEnumeration() {
 			wgtemplates.Add(1)
 			go func(template interface{}) {
 				defer wgtemplates.Done()
+				err := rateLimit.Wait(ctx)
+				if err != nil {
+					gologger.Errorf("Issue with rate-limit")
+				}
 				switch tt := template.(type) {
 				case *templates.Template:
 					for _, request := range tt.RequestsDNS {


### PR DESCRIPTION
Introducing `-rl` flag for controlling `rate-limiting` of client requests per second.
The Limiter is based on the `rate.Limiter` and appended to the `runner` per target. Illustrative testing done here:  
  
```
... Just showing amount of templates below ...
[INF] Using 142 rules (142 templates, 0 workflows)
...
[cgn@localhost nuclei]$ date; ./nuclei -target some_single_target -t ../nuclei-templates/cves/ -t ../nuclei-templates/files/ -t ../nuclei-templates/generic-detections/ -rl 120 -silent; date
lør 12 sep 17:25:52 CEST 2020
lør 12 sep 17:26:14 CEST 2020
[cgn@localhost nuclei]$ date; ./nuclei -target some_single_target -t ../nuclei-templates/cves/ -t ../nuclei-templates/files/ -t ../nuclei-templates/generic-detections/ -rl 170 -silent; date
lør 12 sep 17:26:29 CEST 2020
lør 12 sep 17:26:29 CEST 2020
[cgn@localhost nuclei]$ date; ./nuclei -target some_single_target -t ../nuclei-templates/cves/ -t ../nuclei-templates/files/ -t ../nuclei-templates/generic-detections/ -rl 90 -silent; date
lør 12 sep 17:26:53 CEST 2020
lør 12 sep 17:27:45 CEST 2020
```
And with multiple targets:
```
[cgn@localhost nuclei]$ wc -l targets.txt 
193 targets.txt
[cgn@localhost nuclei]$ date; ./nuclei -l targets.txt -t ../nuclei-templates/cves/ -t ../nuclei-templates/files/ -t ../nuclei-templates/generic-detections/ -rl 120 -silent; date
lør 12 sep 17:36:20 CEST 2020
lør 12 sep 17:36:42 CEST 2020
[cgn@localhost nuclei]$ date; ./nuclei -l targets.txt -t ../nuclei-templates/cves/ -t ../nuclei-templates/files/ -t ../nuclei-templates/generic-detections/ -rl 170 -silent; date
lør 12 sep 17:42:39 CEST 2020
lør 12 sep 17:42:39 CEST 2020
[cgn@localhost nuclei]$ date; ./nuclei -l targets.txt -t ../nuclei-templates/cves/ -t ../nuclei-templates/files/ -t ../nuclei-templates/generic-detections/ -rl 90 -silent; date
lør 12 sep 17:42:44 CEST 2020
lør 12 sep 17:43:36 CEST 2020
```
And without specifying `-rl` the default limit is set to `9999999` to avoid limiting.
```
[cgn@localhost nuclei]$ date; ./nuclei -l targets.txt -t ../nuclei-templates/cves/ -t ../nuclei-templates/files/ -t ../nuclei-templates/generic-detections/ -silent; date
lør 12 sep 17:44:05 CEST 2020
lør 12 sep 17:44:06 CEST 2020
```

Let me know what you think.

**Edit:** The overall goal is to be able to control the amount of requests per second per target. Ideally this would lead to:  
1 target with `-rl 10` -> total of 10 requests per second  
10 targets with `-rl 10` -> total of 100 requests per second 

This would make it easier to honor rate-limits on BugBounty programs.

Most of the testing has been conducted as such:
```
[cgn@localhost nuclei]$ subfinder -silent -d "large_BB_program.com" -oD . -o large_BB_program.txt
[cgn@localhost nuclei]$ sed -i 's/^/https:\/\//g' large_BB_program.txt
[cgn@localhost nuclei]$ nuclei -l large_BB_program.txt -t ../nuclei-templates/security-misconfiguration/ -pba -silent
... observe r/s
[cgn@localhost nuclei]$ nuclei -l large_BB_program.txt -t ../nuclei-templates/security-misconfiguration/ -pba -silent -rl 20
... observe r/s
[cgn@localhost nuclei]$ nuclei -target $(head -1 large_BB_program.txt) -t ../nuclei-templates/security-misconfiguration/ -pba -silent
... observe r/s
[cgn@localhost nuclei]$ nuclei -target $(head -1 large_BB_program.txt) -t ../nuclei-templates/security-misconfiguration/ -pba -silent -rl 20
... observe r/s
```

Cheers!
/ Casper


