### PR TITLE
[WIP] Potential fix for #304 allowing multiple matches from and extractor

### DIFF
--- a/pkg/executer/executer_http.go
+++ b/pkg/executer/executer_http.go
@@ -129,7 +129,6 @@ func (e *HTTPExecuter) ExecuteHTTP(ctx context.Context, p progress.IProgress, re
 	result.Matches = make(map[string]interface{})
 	result.Extractions = make(map[string]interface{})
 	dynamicvalues := make(map[string]interface{})
-	dynvars := make(map[string][]string)
 
 	// verify if the URL is already being processed
 	if e.bulkHTTPRequest.HasGenerator(reqURL) {
@@ -149,7 +148,7 @@ func (e *HTTPExecuter) ExecuteHTTP(ctx context.Context, p progress.IProgress, re
 			return
 		}
 
-		dynvars, err = e.handleHTTP(reqURL, httpRequest, dynamicvalues, &result)
+		dynvars, err := e.handleHTTP(reqURL, httpRequest, &result)
 		if err != nil {
 			result.Error = errors.Wrap(err, "could not handle http request")
 
@@ -175,7 +174,7 @@ func (e *HTTPExecuter) ExecuteHTTP(ctx context.Context, p progress.IProgress, re
 						return
 					}
 
-					dynvars, err = e.handleHTTP(reqURL, httpRequest, dynamicvalues, &result)
+					_, err = e.handleHTTP(reqURL, httpRequest, &result)
 					if err != nil {
 						result.Error = errors.Wrap(err, "could not handle http request")
 
@@ -196,7 +195,7 @@ func (e *HTTPExecuter) ExecuteHTTP(ctx context.Context, p progress.IProgress, re
 	return result
 }
 
-func (e *HTTPExecuter) handleHTTP(reqURL string, request *requests.HTTPRequest, dynamicvalues map[string]interface{}, result *Result) (map[string][]string, error) {
+func (e *HTTPExecuter) handleHTTP(reqURL string, request *requests.HTTPRequest, result *Result) (map[string][]string, error) {
 	dynvars := make(map[string][]string)
 	e.setCustomHeaders(request)
 	req := request.Request

--- a/pkg/executer/executer_http.go
+++ b/pkg/executer/executer_http.go
@@ -196,7 +196,7 @@ func (e *HTTPExecuter) ExecuteHTTP(ctx context.Context, p progress.IProgress, re
 	return result
 }
 
-func (e *HTTPExecuter) handleHTTP(reqURL string, request *requests.HTTPRequest, dynamicvalues map[string]interface{}, result *Result) (error, map[string][]string) {
+func (e *HTTPExecuter) handleHTTP(reqURL string, request *requests.HTTPRequest, dynamicvalues map[string]interface{}, result *Result) (map[string][]string, error) {
 	dynvars := make(map[string][]string)
 	e.setCustomHeaders(request)
 	req := request.Request


### PR DESCRIPTION
Potential fix for #304 allowing multiple matches from and extractor to iterate the same RAW request.

To allow extractors to contain multiple values and iterate the same RAW request.

This request requires more testing than I can do myself and as such is created as WIP.

The idea is to allow a template as such:

```yaml
requests:
  - raw:
    - |
      GET /robots.txt HTTP/1.1
      Host: {{Hostname}}
      User-Agent: Mozilla/5.0 (X11; Fedora; Linux x86_64; rv:80.0) Gecko/20100101 Firefox/80.0
      Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
      Accept-Language: en-US,en;q=0.5
    - |
      GET{{endpoint}} HTTP/1.1
      Host: {{Hostname}}
      User-Agent: Mozilla/5.0 (X11; Fedora; Linux x86_64; rv:80.0) Gecko/20100101 Firefox/80.0
      Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
      Accept-Language: en-US,en;q=0.5
    
    extractors:
      - type: regex
        name: endpoint
        part: body
        internal: true
        regex:
          - '(?m:(\s/[[:alpha:]]+[[:graph:]]+))'
```

And have the following match:

```
/foo
/bar
/foo-bar
```
result in 3 GET requests using the same RAW per above:
```
      GET{{endpoint}} HTTP/1.1
      Host: {{Hostname}}
      User-Agent: Mozilla/5.0 (X11; Fedora; Linux x86_64; rv:80.0) Gecko/20100101 Firefox/80.0
      Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
      Accept-Language: en-US,en;q=0.5
```

Cheers!
/ Casper