### PR TITLE
Added group capturing in backward compatible way

### DIFF
--- a/pkg/extractors/extract.go
+++ b/pkg/extractors/extract.go
@@ -54,13 +54,15 @@ func (e *Extractor) ExtractDNS(msg *dns.Msg) map[string]struct{} {
 func (e *Extractor) extractRegex(corpus string) map[string]struct{} {
 	results := make(map[string]struct{})
 
+	groupPlusOne := e.RegexGroup + 1
 	for _, regex := range e.regexCompiled {
-		matches := regex.FindAllString(corpus, -1)
+		matches := regex.FindAllStringSubmatch(corpus, -1)
 		for _, match := range matches {
-			results[match] = struct{}{}
+			if len(match) >= groupPlusOne {
+				results[match[e.RegexGroup]] = struct{}{}
+			}
 		}
 	}
-
 	return results
 }
 

--- a/pkg/extractors/extractors.go
+++ b/pkg/extractors/extractors.go
@@ -13,6 +13,8 @@ type Extractor struct {
 
 	// Regex are the regex pattern required to be present in the response
 	Regex []string `yaml:"regex"`
+	// RegexGroup specifies a group to extract from the regex
+	RegexGroup int `yaml:"group"`
 	// regexCompiled is the compiled variant
 	regexCompiled []*regexp.Regexp
 
@@ -25,7 +27,6 @@ type Extractor struct {
 	Part string `yaml:"part,omitempty"`
 	// part is the part of the request to match
 	part Part
-
 	// Internal defines if this is used internally
 	Internal bool `yaml:"internal,omitempty"`
 }


### PR DESCRIPTION
```yaml
    extractors:
      - type: regex
        part: body
        group: 1
        regex: 
          - 'value="(.*)"'
```

By specifying the group, a single group can be extracted. If no groups are passed, by default the entire match is returned.