### PR TITLE
Added severity to match output message

### DIFF
--- a/internal/runner/processor.go
+++ b/internal/runner/processor.go
@@ -64,7 +64,7 @@ func (r *Runner) processTemplateWithList(ctx context.Context, p progress.IProgre
 			JSONRequests:    r.options.JSONRequests,
 			CookieReuse:     value.CookieReuse,
 			ColoredOutput:   !r.options.NoColor,
-			Colorizer:       r.colorizer,
+			Colorizer:       &r.colorizer,
 			Decolorizer:     r.decolorizer,
 		})
 	}
@@ -217,7 +217,7 @@ func (r *Runner) preloadWorkflowTemplates(p progress.IProgress, workflow *workfl
 					JSONRequests:  r.options.JSONRequests,
 					CookieJar:     jar,
 					ColoredOutput: !r.options.NoColor,
-					Colorizer:     r.colorizer,
+					Colorizer:     &r.colorizer,
 					Decolorizer:   r.decolorizer,
 				}
 			} else if len(t.RequestsDNS) > 0 {

--- a/internal/runner/templates.go
+++ b/internal/runner/templates.go
@@ -8,21 +8,10 @@ import (
 	"strings"
 
 	"github.com/karrick/godirwalk"
-	"github.com/logrusorgru/aurora"
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/nuclei/v2/pkg/templates"
 	"github.com/projectdiscovery/nuclei/v2/pkg/workflows"
 )
-
-const fgOrange uint8 = 208
-
-var severityMap = map[string]string{
-	"info":     aurora.Blue("info").String(),
-	"low":      aurora.Green("low").String(),
-	"medium":   aurora.Yellow("medium").String(),
-	"high":     aurora.Index(fgOrange, "high").String(),
-	"critical": aurora.Red("critical").String(),
-}
 
 // getTemplatesFor parses the specified input template definitions and returns a list of unique, absolute template paths.
 func (r *Runner) getTemplatesFor(definitions []string) []string {
@@ -193,12 +182,12 @@ func (r *Runner) parseTemplateFile(file string) (interface{}, error) {
 func (r *Runner) templateLogMsg(id, name, author, severity string) string {
 	// Display the message for the template
 	message := fmt.Sprintf("[%s] %s (%s)",
-		r.colorizer.BrightBlue(id).String(),
-		r.colorizer.Bold(name).String(),
-		r.colorizer.BrightYellow("@"+author).String())
+		r.colorizer.Colorizer.BrightBlue(id).String(),
+		r.colorizer.Colorizer.Bold(name).String(),
+		r.colorizer.Colorizer.BrightYellow("@"+author).String())
 
 	if severity != "" {
-		message += " [" + severityMap[strings.ToLower(severity)] + "]"
+		message += " [" + r.colorizer.GetColorizedSeverity(severity) + "]"
 	}
 
 	return message
@@ -234,12 +223,11 @@ func (r *Runner) listAvailableTemplates() {
 		r.templatesConfig.CurrentVersion,
 		r.templatesConfig.TemplatesDirectory,
 	)
-	r.colorizer = aurora.NewAurora(true)
 	err := directoryWalker(
 		r.templatesConfig.TemplatesDirectory,
 		func(path string, d *godirwalk.Dirent) error {
 			if d.IsDir() && path != r.templatesConfig.TemplatesDirectory {
-				gologger.Silentf("\n%s:\n\n", r.colorizer.Bold(r.colorizer.BgBrightBlue(d.Name())).String())
+				gologger.Silentf("\n%s:\n\n", r.colorizer.Colorizer.Bold(r.colorizer.Colorizer.BgBrightBlue(d.Name())).String())
 			} else if strings.HasSuffix(path, ".yaml") {
 				r.logAvailableTemplate(path)
 			}

--- a/pkg/colorizer/colorizer.go
+++ b/pkg/colorizer/colorizer.go
@@ -1,0 +1,42 @@
+package colorizer
+
+import (
+	"strings"
+
+	"github.com/logrusorgru/aurora"
+)
+
+const (
+	fgOrange  uint8  = 208
+	undefined string = "undefined"
+)
+
+// NucleiColorizer contains the severity color mapping
+type NucleiColorizer struct {
+	Colorizer   aurora.Aurora
+	SeverityMap map[string]string
+}
+
+// NewNucleiColorizer initializes the new nuclei colorizer
+func NewNucleiColorizer(colorizer aurora.Aurora) *NucleiColorizer {
+	return &NucleiColorizer{
+		Colorizer: colorizer,
+		SeverityMap: map[string]string{
+			"info":     colorizer.Blue("info").String(),
+			"low":      colorizer.Green("low").String(),
+			"medium":   colorizer.Yellow("medium").String(),
+			"high":     colorizer.Index(fgOrange, "high").String(),
+			"critical": colorizer.Red("critical").String(),
+		},
+	}
+}
+
+// GetColorizedSeverity returns the colorized severity string
+func (r *NucleiColorizer) GetColorizedSeverity(severity string) string {
+	sev := r.SeverityMap[strings.ToLower(severity)]
+	if sev == "" {
+		return undefined
+	}
+
+	return sev
+}

--- a/pkg/executer/executer_dns.go
+++ b/pkg/executer/executer_dns.go
@@ -5,11 +5,11 @@ import (
 	"os"
 	"regexp"
 
-	"github.com/logrusorgru/aurora"
 	"github.com/pkg/errors"
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/nuclei/v2/internal/bufwriter"
 	"github.com/projectdiscovery/nuclei/v2/internal/progress"
+	"github.com/projectdiscovery/nuclei/v2/pkg/colorizer"
 	"github.com/projectdiscovery/nuclei/v2/pkg/matchers"
 	"github.com/projectdiscovery/nuclei/v2/pkg/requests"
 	"github.com/projectdiscovery/nuclei/v2/pkg/templates"
@@ -29,7 +29,7 @@ type DNSExecuter struct {
 	dnsRequest    *requests.DNSRequest
 	writer        *bufwriter.Writer
 
-	colorizer   aurora.Aurora
+	colorizer   colorizer.NucleiColorizer
 	decolorizer *regexp.Regexp
 }
 
@@ -51,7 +51,7 @@ type DNSOptions struct {
 	DNSRequest    *requests.DNSRequest
 	Writer        *bufwriter.Writer
 
-	Colorizer   aurora.Aurora
+	Colorizer   colorizer.NucleiColorizer
 	Decolorizer *regexp.Regexp
 }
 

--- a/pkg/executer/executer_http.go
+++ b/pkg/executer/executer_http.go
@@ -16,12 +16,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/logrusorgru/aurora"
-
 	"github.com/pkg/errors"
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/nuclei/v2/internal/bufwriter"
 	"github.com/projectdiscovery/nuclei/v2/internal/progress"
+	"github.com/projectdiscovery/nuclei/v2/pkg/colorizer"
 	"github.com/projectdiscovery/nuclei/v2/pkg/matchers"
 	"github.com/projectdiscovery/nuclei/v2/pkg/requests"
 	"github.com/projectdiscovery/nuclei/v2/pkg/templates"
@@ -49,7 +48,7 @@ type HTTPExecuter struct {
 	customHeaders   requests.CustomHeaders
 	CookieJar       *cookiejar.Jar
 
-	colorizer   aurora.Aurora
+	colorizer   colorizer.NucleiColorizer
 	decolorizer *regexp.Regexp
 }
 
@@ -69,7 +68,7 @@ type HTTPOptions struct {
 	ProxySocksURL   string
 	CustomHeaders   requests.CustomHeaders
 	CookieJar       *cookiejar.Jar
-	Colorizer       aurora.Aurora
+	Colorizer       *colorizer.NucleiColorizer
 	Decolorizer     *regexp.Regexp
 }
 
@@ -114,7 +113,7 @@ func NewHTTPExecuter(options *HTTPOptions) (*HTTPExecuter, error) {
 		customHeaders:   options.CustomHeaders,
 		CookieJar:       options.CookieJar,
 		coloredOutput:   options.ColoredOutput,
-		colorizer:       options.Colorizer,
+		colorizer:       *options.Colorizer,
 		decolorizer:     options.Decolorizer,
 	}
 

--- a/pkg/executer/output_dns.go
+++ b/pkg/executer/output_dns.go
@@ -57,16 +57,23 @@ func (e *DNSExecuter) writeOutputDNS(domain string, req, resp *dns.Msg, matcher 
 	colorizer := e.colorizer
 
 	builder.WriteRune('[')
-	builder.WriteString(colorizer.BrightGreen(e.template.ID).String())
+	builder.WriteString(colorizer.Colorizer.BrightGreen(e.template.ID).String())
 
 	if matcher != nil && len(matcher.Name) > 0 {
 		builder.WriteString(":")
-		builder.WriteString(colorizer.BrightGreen(matcher.Name).Bold().String())
+		builder.WriteString(colorizer.Colorizer.BrightGreen(matcher.Name).Bold().String())
 	}
 
 	builder.WriteString("] [")
-	builder.WriteString(colorizer.BrightBlue("dns").String())
+	builder.WriteString(colorizer.Colorizer.BrightBlue("dns").String())
 	builder.WriteString("] ")
+
+	if e.template.Info.Severity != "" {
+		builder.WriteString("[")
+		builder.WriteString(colorizer.GetColorizedSeverity(e.template.Info.Severity))
+		builder.WriteString("] ")
+	}
+
 	builder.WriteString(domain)
 
 	// If any extractors, write the results
@@ -74,7 +81,7 @@ func (e *DNSExecuter) writeOutputDNS(domain string, req, resp *dns.Msg, matcher 
 		builder.WriteString(" [")
 
 		for i, result := range extractorResults {
-			builder.WriteString(colorizer.BrightCyan(result).String())
+			builder.WriteString(colorizer.Colorizer.BrightCyan(result).String())
 
 			if i != len(extractorResults)-1 {
 				builder.WriteRune(',')

--- a/pkg/executer/output_http.go
+++ b/pkg/executer/output_http.go
@@ -73,16 +73,22 @@ func (e *HTTPExecuter) writeOutputHTTP(req *requests.HTTPRequest, resp *http.Res
 	colorizer := e.colorizer
 
 	builder.WriteRune('[')
-	builder.WriteString(colorizer.BrightGreen(e.template.ID).String())
+	builder.WriteString(colorizer.Colorizer.BrightGreen(e.template.ID).String())
 
 	if matcher != nil && len(matcher.Name) > 0 {
 		builder.WriteString(":")
-		builder.WriteString(colorizer.BrightGreen(matcher.Name).Bold().String())
+		builder.WriteString(colorizer.Colorizer.BrightGreen(matcher.Name).Bold().String())
 	}
 
 	builder.WriteString("] [")
-	builder.WriteString(colorizer.BrightBlue("http").String())
+	builder.WriteString(colorizer.Colorizer.BrightBlue("http").String())
 	builder.WriteString("] ")
+
+	if e.template.Info.Severity != "" {
+		builder.WriteString("[")
+		builder.WriteString(colorizer.GetColorizedSeverity(e.template.Info.Severity))
+		builder.WriteString("] ")
+	}
 
 	// Escape the URL by replacing all % with %%
 	escapedURL := strings.ReplaceAll(URL, "%", "%%")
@@ -93,7 +99,7 @@ func (e *HTTPExecuter) writeOutputHTTP(req *requests.HTTPRequest, resp *http.Res
 		builder.WriteString(" [")
 
 		for i, result := range extractorResults {
-			builder.WriteString(colorizer.BrightCyan(result).String())
+			builder.WriteString(colorizer.Colorizer.BrightCyan(result).String())
 
 			if i != len(extractorResults)-1 {
 				builder.WriteRune(',')
@@ -110,7 +116,7 @@ func (e *HTTPExecuter) writeOutputHTTP(req *requests.HTTPRequest, resp *http.Res
 		var metas []string
 
 		for name, value := range req.Meta {
-			metas = append(metas, colorizer.BrightYellow(name).Bold().String()+"="+colorizer.BrightYellow(value.(string)).String())
+			metas = append(metas, colorizer.Colorizer.BrightYellow(name).Bold().String()+"="+colorizer.Colorizer.BrightYellow(value.(string)).String())
 		}
 
 		builder.WriteString(strings.Join(metas, ","))

--- a/pkg/workflows/var.go
+++ b/pkg/workflows/var.go
@@ -9,6 +9,7 @@ import (
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/nuclei/v2/internal/progress"
 	"github.com/projectdiscovery/nuclei/v2/pkg/atomicboolean"
+	"github.com/projectdiscovery/nuclei/v2/pkg/colorizer"
 	"github.com/projectdiscovery/nuclei/v2/pkg/executer"
 	"github.com/projectdiscovery/nuclei/v2/pkg/generators"
 )
@@ -76,7 +77,7 @@ func (n *NucleiVar) Call(args ...tengo.Object) (ret tengo.Object, err error) {
 				template.HTTPOptions.BulkHTTPRequest = request
 
 				if template.HTTPOptions.Colorizer == nil {
-					template.HTTPOptions.Colorizer = aurora.NewAurora(true)
+					template.HTTPOptions.Colorizer = colorizer.NewNucleiColorizer(aurora.NewAurora(true))
 				}
 
 				httpExecuter, err := executer.NewHTTPExecuter(template.HTTPOptions)


### PR DESCRIPTION
- Implements a new `NucleiColorizer` to colorize all nuclei messages (included severity).
- Fixes `severity` color is always colorized even with `nocolor` flag.