### PR TITLE
Update From Binary steps to use flag that returns good exit code

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Download latest binary from https://github.com/projectdiscovery/nuclei/releases
 
 ▶ tar -xzvf nuclei-linux-amd64.tar.gz
 ▶ mv nuclei /usr/local/bin/
-▶ nuclei -h
+▶ nuclei -version
 ```
 
 ### From Source


### PR DESCRIPTION
`nuclei -h` returns 2 as an exit code. Why not provide a valid test that is `-e` friendly? 