### PR TITLE
Dockerfile fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,9 @@ FROM alpine
 
 RUN mkdir /app
 RUN adduser -S -D -H -h /app appuser
-USER appuser
 COPY --from=builder /app/v2/cmd/nuclei/nuclei /app
+RUN chown appuser -R /app
+USER appuser
 
 WORKDIR /app
-CMD ["./nuclei"]
+ENTRYPOINT ["/app/nuclei"]


### PR DESCRIPTION
I fixed the Dockerfile. It wasn't (fully) working for me anymore since the last pull (permission denied when running with -update-templates). Reason to that was a too-low-privileged user. The only things I did giving the user `appuser` the permissions to change/create files/folders in the `/app` folder. Also I fixed up the entrypoint since you'd have to type `docker run -it --rm projectdiscovery/nuclei ./nuclei` otherwise (which is a no-go in my eyes).
Cheers!