### PR TITLE
add reqURL to json output

### DIFF
--- a/v2/pkg/executer/executer_http.go
+++ b/v2/pkg/executer/executer_http.go
@@ -537,7 +537,7 @@ func (e *HTTPExecuter) handleHTTP(reqURL string, request *requests.HTTPRequest, 
 				result.Meta = request.Meta
 				result.GotResults = true
 				result.Unlock()
-				e.writeOutputHTTP(request, resp, body, matcher, nil, result.Meta)
+				e.writeOutputHTTP(request, resp, body, matcher, nil, result.Meta, reqURL)
 			}
 		}
 	}
@@ -568,7 +568,7 @@ func (e *HTTPExecuter) handleHTTP(reqURL string, request *requests.HTTPRequest, 
 	// Write a final string of output if matcher type is
 	// AND or if we have extractors for the mechanism too.
 	if len(outputExtractorResults) > 0 || matcherCondition == matchers.ANDCondition {
-		e.writeOutputHTTP(request, resp, body, nil, outputExtractorResults, result.Meta)
+		e.writeOutputHTTP(request, resp, body, nil, outputExtractorResults, result.Meta, reqURL)
 		result.Lock()
 		result.GotResults = true
 		result.Unlock()

--- a/v2/pkg/executer/output_http.go
+++ b/v2/pkg/executer/output_http.go
@@ -12,7 +12,7 @@ import (
 )
 
 // writeOutputHTTP writes http output to streams
-func (e *HTTPExecuter) writeOutputHTTP(req *requests.HTTPRequest, resp *http.Response, body string, matcher *matchers.Matcher, extractorResults []string, meta map[string]interface{}) {
+func (e *HTTPExecuter) writeOutputHTTP(req *requests.HTTPRequest, resp *http.Response, body string, matcher *matchers.Matcher, extractorResults []string, meta map[string]interface{}, reqURL string) {
 	var URL string
 	if req.RawRequest != nil {
 		URL = req.RawRequest.FullURL
@@ -28,6 +28,7 @@ func (e *HTTPExecuter) writeOutputHTTP(req *requests.HTTPRequest, resp *http.Res
 		if !e.noMeta {
 			output["template"] = e.template.ID
 			output["type"] = "http"
+			output["host"] = reqURL
 			if len(meta) > 0 {
 				output["meta"] = meta
 			}


### PR DESCRIPTION
Hi guys. 
What about add reqURL to json output ?
Because right now we can't map target from target list ( when launch with `-l` flag  ) with json output.
It can be useful for automated tasks. I would like to know which targets from list are vulnerable. 

Before PR:
```
{"template":"go-debug-prof","type":"http","matched":"http://xxx.com:4999/debug/pprof/","severity":"info","author":""}
```

After PR:
```
{"type":"http","reqURL":"http://xxx.com","name":"GO debug prof","severity":"info","matched":"http://xxx.com:4999/debug/pprof/","template":"go-debug-prof"}
```
