### PR TITLE
chore: push docker tags too

### DIFF
--- a/.github/workflows/dockerhub-push.yml
+++ b/.github/workflows/dockerhub-push.yml
@@ -5,13 +5,15 @@ on:
   release:
     types: [published]
 jobs:
-  build:
+  update:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
     - name: Publish to Dockerhub Registry
+      pre: echo ::save-state name=RELEASE_VERSION::$(echo ${GITHUB_REF:10})
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
         name: projectdiscovery/nuclei
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
+        tags: "latest,${{ env.STATE_RELEASE_VERSION }}"


### PR DESCRIPTION
Hi, thanks for nuclei, would be great to also push tagged versions to Docker Hub

This would make it according to https://github.com/elgohr/Publish-Docker-Github-Action#tags
