### PR TITLE
Added sandboxed workflows feature + max time limit on workflow execution

### DIFF
--- a/v2/internal/runner/options.go
+++ b/v2/internal/runner/options.go
@@ -14,7 +14,8 @@ import (
 // the template requesting process.
 // nolint // false positive, options are allocated once and are necessary as is
 type Options struct {
-	Sandbox bool // Sandbox mode allows users to run isolated workflows with system commands disabled
+	MaxWorkflowDuration  int                    // MaxWorkflowDuration is the maximum time a workflow can run for a URL
+	Sandbox              bool                   // Sandbox mode allows users to run isolated workflows with system commands disabled
 	Debug                bool                   // Debug mode allows debugging request/responses for the engine
 	Silent               bool                   // Silent suppresses any extra text and only writes found URLs on screen.
 	Version              bool                   // Version specifies if we should just show version and exit
@@ -68,6 +69,7 @@ func ParseOptions() *Options {
 	options := &Options{}
 
 	flag.BoolVar(&options.Sandbox, "sandbox", false, "Run workflows in isolated sandbox mode")
+	flag.IntVar(&options.MaxWorkflowDuration, "workflow-duration", 10, "Max time for workflow run on single URL in minutes")
 	flag.StringVar(&options.Target, "target", "", "Target is a single target to scan using template")
 	flag.Var(&options.Templates, "t", "Template input dir/file/files to run on host. Can be used multiple times. Supports globbing.")
 	flag.Var(&options.ExcludedTemplates, "exclude", "Template input dir/file/files to exclude. Can be used multiple times. Supports globbing.")

--- a/v2/internal/runner/options.go
+++ b/v2/internal/runner/options.go
@@ -14,6 +14,7 @@ import (
 // the template requesting process.
 // nolint // false positive, options are allocated once and are necessary as is
 type Options struct {
+	Sandbox bool // Sandbox mode allows users to run isolated workflows with system commands disabled
 	Debug                bool                   // Debug mode allows debugging request/responses for the engine
 	Silent               bool                   // Silent suppresses any extra text and only writes found URLs on screen.
 	Version              bool                   // Version specifies if we should just show version and exit
@@ -66,6 +67,7 @@ func (m *multiStringFlag) Set(value string) error {
 func ParseOptions() *Options {
 	options := &Options{}
 
+	flag.BoolVar(&options.Sandbox, "sandbox", false, "Run workflows in isolated sandbox mode")
 	flag.StringVar(&options.Target, "target", "", "Target is a single target to scan using template")
 	flag.Var(&options.Templates, "t", "Template input dir/file/files to run on host. Can be used multiple times. Supports globbing.")
 	flag.Var(&options.ExcludedTemplates, "exclude", "Template input dir/file/files to exclude. Can be used multiple times. Supports globbing.")

--- a/v2/internal/runner/processor.go
+++ b/v2/internal/runner/processor.go
@@ -143,10 +143,19 @@ func (r *Runner) processWorkflowWithList(p *progress.Progress, workflow *workflo
 			defer wg.Done()
 
 			script := tengo.NewScript(logicBytes)
-			script.SetImports(stdlib.GetModuleMap(stdlib.AllModuleNames()...))
+			var moduleNames = []string{
+				"math",
+				"text",
+				"rand",
+				"fmt",
+				"json",
+				"base64",
+				"hex",
+				"enum",
+			}
+			script.SetImports(stdlib.GetModuleMap(moduleNames...))
 
 			variables := make(map[string]*workflows.NucleiVar)
-
 			for _, workflowTemplate := range *workflowTemplatesList {
 				name := workflowTemplate.Name
 				variable := &workflows.NucleiVar{Templates: workflowTemplate.Templates, URL: targetURL}


### PR DESCRIPTION
This PR adds some security features on top of nuclei workflow engine. The `sandbox` flag disables access to OS features which allow to execute commands, write to files, etc. The `workflow-duration` flag sets an upper limit on the duration of workflow execution for each URL preventing unlimited execution times.