### PR TITLE
Network protocol support for nuclei

### DIFF
--- a/v2/internal/runner/config.go
+++ b/v2/internal/runner/config.go
@@ -93,28 +93,6 @@ func (r *Runner) readNucleiIgnoreFile() {
 	}
 }
 
-// checkIfInNucleiIgnore checks if a path falls under nuclei-ignore rules.
-func (r *Runner) checkIfInNucleiIgnore(item string) bool {
-	if r.templatesConfig == nil {
-		return false
-	}
-
-	for _, paths := range r.templatesConfig.IgnorePaths {
-		// If we have a path to ignore, check if it's in the item.
-		if paths[len(paths)-1] == '/' {
-			if strings.Contains(item, paths) {
-				return true
-			}
-			continue
-		}
-		// Check for file based extension in ignores
-		if strings.HasSuffix(item, paths) {
-			return true
-		}
-	}
-	return false
-}
-
 // getIgnoreFilePath returns the ignore file path for the runner
 func (r *Runner) getIgnoreFilePath() string {
 	defIgnoreFilePath := path.Join(r.templatesConfig.TemplatesDirectory, nucleiIgnoreFile)

--- a/v2/internal/runner/processor.go
+++ b/v2/internal/runner/processor.go
@@ -18,6 +18,7 @@ func (r *Runner) processTemplateWithList(template *templates.Template) bool {
 
 	r.hostMap.Scan(func(k, _ []byte) error {
 		URL := string(k)
+
 		wg.Add()
 		go func(URL string) {
 			defer wg.Done()

--- a/v2/internal/runner/runner.go
+++ b/v2/internal/runner/runner.go
@@ -16,6 +16,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v2/pkg/projectfile"
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/dns/dnsclientpool"
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/http/httpclientpool"
+	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/network/networkclientpool"
 	"github.com/projectdiscovery/nuclei/v2/pkg/templates"
 	"github.com/projectdiscovery/nuclei/v2/pkg/types"
 	"github.com/remeh/sizedwaitgroup"
@@ -275,6 +276,9 @@ func (r *Runner) initializeProtocols() error {
 		return err
 	}
 	if err := httpclientpool.Init(r.options); err != nil {
+		return err
+	}
+	if err := networkclientpool.Init(r.options); err != nil {
 		return err
 	}
 	return nil

--- a/v2/pkg/output/output.go
+++ b/v2/pkg/output/output.go
@@ -161,7 +161,6 @@ func (w *StandardWriter) Request(templateID, url, requestType string, err error)
 		return
 	}
 	w.traceMutex.Lock()
-	//nolint:errcheck // We don't need to do anything here
 	_ = w.traceFile.Write(data)
 	w.traceMutex.Unlock()
 }

--- a/v2/pkg/protocols/http/raw/raw.go
+++ b/v2/pkg/protocols/http/raw/raw.go
@@ -47,7 +47,6 @@ func Parse(request, baseURL string, unsafe bool) (*Request, error) {
 			break
 		}
 
-		//nolint:gomnd // this is not a magic number
 		p := strings.SplitN(line, ":", 2)
 		key = p[0]
 		if len(p) > 1 {

--- a/v2/pkg/protocols/network/executer.go
+++ b/v2/pkg/protocols/network/executer.go
@@ -1,0 +1,90 @@
+package network
+
+import (
+	"github.com/projectdiscovery/nuclei/v2/pkg/output"
+	"github.com/projectdiscovery/nuclei/v2/pkg/protocols"
+)
+
+// Executer executes a group of requests for a protocol
+type Executer struct {
+	requests []*Request
+	options  *protocols.ExecuterOptions
+}
+
+var _ protocols.Executer = &Executer{}
+
+// NewExecuter creates a new request executer for list of requests
+func NewExecuter(requests []*Request, options *protocols.ExecuterOptions) *Executer {
+	return &Executer{requests: requests, options: options}
+}
+
+// Compile compiles the execution generators preparing any requests possible.
+func (e *Executer) Compile() error {
+	for _, request := range e.requests {
+		err := request.Compile(e.options)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Requests returns the total number of requests the rule will perform
+func (e *Executer) Requests() int {
+	var count int
+	for _, request := range e.requests {
+		count += int(request.Requests())
+	}
+	return count
+}
+
+// Execute executes the protocol group and returns true or false if results were found.
+func (e *Executer) Execute(input string) (bool, error) {
+	var results bool
+
+	for _, req := range e.requests {
+		events, err := req.ExecuteWithResults(input, nil)
+		if err != nil {
+			return false, err
+		}
+		if events == nil {
+			return false, nil
+		}
+
+		// If we have a result field, we should add a result to slice.
+		for _, event := range events {
+			if event.OperatorsResult == nil {
+				continue
+			}
+
+			for _, result := range req.makeResultEvent(event) {
+				results = true
+				e.options.Output.Write(result)
+			}
+		}
+	}
+	return results, nil
+}
+
+// ExecuteWithResults executes the protocol requests and returns results instead of writing them.
+func (e *Executer) ExecuteWithResults(input string) ([]*output.InternalWrappedEvent, error) {
+	var results []*output.InternalWrappedEvent
+
+	for _, req := range e.requests {
+		events, err := req.ExecuteWithResults(input, nil)
+		if err != nil {
+			return nil, err
+		}
+		if events == nil {
+			return nil, nil
+		}
+		for _, event := range events {
+			if event.OperatorsResult == nil {
+				continue
+			}
+			event.Results = req.makeResultEvent(event)
+		}
+		results = append(results, events...)
+	}
+	return results, nil
+}

--- a/v2/pkg/protocols/network/network.go
+++ b/v2/pkg/protocols/network/network.go
@@ -20,7 +20,7 @@ type Request struct {
 	addressPort string
 
 	// Payload is the payload to send for the network request
-	Payload string `yaml:"payload"`
+	Inputs []*Input `yaml:"inputs"`
 	// ReadSize is the size of response to read (1024 if not provided by default)
 	ReadSize int `yaml:"read-size"`
 
@@ -31,6 +31,14 @@ type Request struct {
 	// cache any variables that may be needed for operation.
 	dialer  *fastdialer.Dialer
 	options *protocols.ExecuterOptions
+}
+
+// Input is the input to send on the network
+type Input struct {
+	// Data is the data to send as the input
+	Data string `yaml:"data"`
+	// Type is the type of input - hex, text.
+	Type string `yaml:"type"`
 }
 
 // Compile compiles the protocol request for further execution.

--- a/v2/pkg/protocols/network/network.go
+++ b/v2/pkg/protocols/network/network.go
@@ -1,0 +1,79 @@
+package network
+
+import (
+	"net"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/projectdiscovery/fastdialer/fastdialer"
+	"github.com/projectdiscovery/nuclei/v2/pkg/operators"
+	"github.com/projectdiscovery/nuclei/v2/pkg/protocols"
+	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/replacer"
+	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/network/networkclientpool"
+)
+
+// Request contains a Network protocol request to be made from a template
+type Request struct {
+	// Address is the address to send requests to (host:port combos generally)
+	Address     string `yaml:"address"`
+	addressHost string
+	addressPort string
+
+	// Payload is the payload to send for the network request
+	Payload string `yaml:"payload"`
+	// ReadSize is the size of response to read (1024 if not provided by default)
+	ReadSize int `yaml:"read-size"`
+
+	// Operators for the current request go here.
+	operators.Operators `yaml:",inline"`
+	CompiledOperators   *operators.Operators
+
+	// cache any variables that may be needed for operation.
+	dialer  *fastdialer.Dialer
+	options *protocols.ExecuterOptions
+}
+
+// Compile compiles the protocol request for further execution.
+func (r *Request) Compile(options *protocols.ExecuterOptions) error {
+	var err error
+	if strings.Contains(r.Address, ":") {
+		r.addressHost, r.addressPort, err = net.SplitHostPort(r.Address)
+		if err != nil {
+			return errors.Wrap(err, "could not parse address")
+		}
+	} else {
+		r.addressHost = r.Address
+	}
+
+	// Create a client for the class
+	client, err := networkclientpool.Get(options.Options, &networkclientpool.Configuration{})
+	if err != nil {
+		return errors.Wrap(err, "could not get network client")
+	}
+	r.dialer = client
+
+	if len(r.Matchers) > 0 || len(r.Extractors) > 0 {
+		compiled := &r.Operators
+		if err := compiled.Compile(); err != nil {
+			return errors.Wrap(err, "could not compile operators")
+		}
+		r.CompiledOperators = compiled
+	}
+	r.options = options
+	return nil
+}
+
+// Requests returns the total number of requests the YAML rule will perform
+func (r *Request) Requests() int {
+	return 1
+}
+
+// Make returns the request to be sent for the protocol
+func (r *Request) Make(data string) (string, error) {
+	replacer := replacer.New(map[string]interface{}{"Address": data})
+	address := replacer.Replace(r.addressHost)
+	if !strings.Contains(address, ":") {
+		address = net.JoinHostPort(address, r.addressPort)
+	}
+	return address, nil
+}

--- a/v2/pkg/protocols/network/networkclientpool/clientpool.go
+++ b/v2/pkg/protocols/network/networkclientpool/clientpool.go
@@ -1,0 +1,38 @@
+package networkclientpool
+
+import (
+	"github.com/pkg/errors"
+	"github.com/projectdiscovery/fastdialer/fastdialer"
+	"github.com/projectdiscovery/nuclei/v2/pkg/types"
+)
+
+var (
+	normalClient *fastdialer.Dialer
+)
+
+// Init initializes the clientpool implementation
+func Init(options *types.Options) error {
+	// Don't create clients if already created in past.
+	if normalClient != nil {
+		return nil
+	}
+	dialer, err := fastdialer.NewDialer(fastdialer.DefaultOptions)
+	if err != nil {
+		return errors.Wrap(err, "could not create dialer")
+	}
+	normalClient = dialer
+	return nil
+}
+
+// Configuration contains the custom configuration options for a client
+type Configuration struct{}
+
+// Hash returns the hash of the configuration to allow client pooling
+func (c *Configuration) Hash() string {
+	return ""
+}
+
+// Get creates or gets a client for the protocol based on custom configuration
+func Get(options *types.Options, configuration *Configuration) (*fastdialer.Dialer, error) {
+	return normalClient, nil
+}

--- a/v2/pkg/protocols/network/operators.go
+++ b/v2/pkg/protocols/network/operators.go
@@ -1,0 +1,108 @@
+package network
+
+import (
+	"github.com/projectdiscovery/nuclei/v2/pkg/operators/extractors"
+	"github.com/projectdiscovery/nuclei/v2/pkg/operators/matchers"
+	"github.com/projectdiscovery/nuclei/v2/pkg/output"
+	"github.com/projectdiscovery/nuclei/v2/pkg/types"
+)
+
+// Match matches a generic data response again a given matcher
+func (r *Request) Match(data map[string]interface{}, matcher *matchers.Matcher) bool {
+	partString := matcher.Part
+	switch partString {
+	case "body", "all", "":
+		partString = "data"
+	}
+
+	item, ok := data[partString]
+	if !ok {
+		return false
+	}
+	itemStr := types.ToString(item)
+
+	switch matcher.GetType() {
+	case matchers.SizeMatcher:
+		return matcher.Result(matcher.MatchSize(len(itemStr)))
+	case matchers.WordsMatcher:
+		return matcher.Result(matcher.MatchWords(itemStr))
+	case matchers.RegexMatcher:
+		return matcher.Result(matcher.MatchRegex(itemStr))
+	case matchers.BinaryMatcher:
+		return matcher.Result(matcher.MatchBinary(itemStr))
+	case matchers.DSLMatcher:
+		return matcher.Result(matcher.MatchDSL(data))
+	}
+	return false
+}
+
+// Extract performs extracting operation for a extractor on model and returns true or false.
+func (r *Request) Extract(data map[string]interface{}, extractor *extractors.Extractor) map[string]struct{} {
+	part, ok := data[extractor.Part]
+	if !ok {
+		return nil
+	}
+	partString := part.(string)
+
+	switch partString {
+	case "body", "all":
+		partString = "data"
+	}
+
+	item, ok := data[partString]
+	if !ok {
+		return nil
+	}
+	itemStr := types.ToString(item)
+
+	switch extractor.GetType() {
+	case extractors.RegexExtractor:
+		return extractor.ExtractRegex(itemStr)
+	case extractors.KValExtractor:
+		return extractor.ExtractKval(data)
+	}
+	return nil
+}
+
+// responseToDSLMap converts a DNS response to a map for use in DSL matching
+func (r *Request) responseToDSLMap(req, resp string, host, matched string) output.InternalEvent {
+	data := make(output.InternalEvent, 4)
+
+	// Some data regarding the request metadata
+	data["host"] = host
+	data["matched"] = matched
+	if r.options.Options.JSONRequests {
+		data["request"] = req
+	}
+	data["data"] = resp
+	return data
+}
+
+// makeResultEvent creates a result event from internal wrapped event
+func (r *Request) makeResultEvent(wrapped *output.InternalWrappedEvent) []*output.ResultEvent {
+	results := make([]*output.ResultEvent, 0, len(wrapped.OperatorsResult.Matches)+1)
+
+	data := output.ResultEvent{
+		TemplateID:       r.options.TemplateID,
+		Info:             r.options.TemplateInfo,
+		Type:             "network",
+		Host:             wrapped.InternalEvent["host"].(string),
+		Matched:          wrapped.InternalEvent["matched"].(string),
+		ExtractedResults: wrapped.OperatorsResult.OutputExtracts,
+	}
+	if r.options.Options.JSONRequests {
+		data.Request = wrapped.InternalEvent["request"].(string)
+		data.Response = wrapped.InternalEvent["data"].(string)
+	}
+
+	// If we have multiple matchers with names, write each of them separately.
+	if len(wrapped.OperatorsResult.Matches) > 0 {
+		for k := range wrapped.OperatorsResult.Matches {
+			data.MatcherName = k
+			results = append(results, &data)
+		}
+	} else {
+		results = append(results, &data)
+	}
+	return results
+}

--- a/v2/pkg/protocols/network/request.go
+++ b/v2/pkg/protocols/network/request.go
@@ -1,0 +1,96 @@
+package network
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/projectdiscovery/gologger"
+	"github.com/projectdiscovery/nuclei/v2/pkg/output"
+	"github.com/projectdiscovery/nuclei/v2/pkg/protocols"
+)
+
+var _ protocols.Request = &Request{}
+
+// ExecuteWithResults executes the protocol requests and returns results instead of writing them.
+func (r *Request) ExecuteWithResults(input string, metadata output.InternalEvent) ([]*output.InternalWrappedEvent, error) {
+	address, err := getAddress(input)
+	if err != nil {
+		r.options.Output.Request(r.options.TemplateID, input, "network", err)
+		r.options.Progress.DecrementRequests(1)
+		return nil, errors.Wrap(err, "could not get address from url")
+	}
+
+	// Compile each request for the template based on the URL
+	actualAddress, err := r.Make(address)
+	if err != nil {
+		r.options.Output.Request(r.options.TemplateID, address, "network", err)
+		r.options.Progress.DecrementRequests(1)
+		return nil, errors.Wrap(err, "could not build request")
+	}
+
+	conn, err := r.dialer.Dial(context.Background(), "tcp", actualAddress)
+	if err != nil {
+		r.options.Output.Request(r.options.TemplateID, address, "network", err)
+		r.options.Progress.DecrementRequests(1)
+		return nil, errors.Wrap(err, "could not connect to server request")
+	}
+	defer conn.Close()
+	conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+
+	_, err = conn.Write([]byte(r.Payload))
+	if err != nil {
+		r.options.Output.Request(r.options.TemplateID, address, "network", err)
+		r.options.Progress.DecrementRequests(1)
+		return nil, errors.Wrap(err, "could not write request to server")
+	}
+	r.options.Progress.IncrementRequests()
+
+	r.options.Output.Request(r.options.TemplateID, actualAddress, "network", err)
+	gologger.Verbose().Msgf("[%s] Sent Network request to %s", r.options.TemplateID, actualAddress)
+
+	if r.options.Options.Debug {
+		gologger.Info().Str("address", actualAddress).Msgf("[%s] Dumped Network request for %s", r.options.TemplateID, actualAddress)
+		fmt.Fprintf(os.Stderr, "%s\n", r.Payload)
+	}
+
+	bufferSize := 1024
+	if r.ReadSize != 0 {
+		bufferSize = r.ReadSize
+	}
+	buffer := make([]byte, bufferSize)
+	n, _ := conn.Read(buffer)
+	resp := string(buffer[:n])
+
+	if r.options.Options.Debug {
+		gologger.Debug().Msgf("[%s] Dumped Network response for %s", r.options.TemplateID, actualAddress)
+		fmt.Fprintf(os.Stderr, "%s\n", resp)
+	}
+	ouputEvent := r.responseToDSLMap(r.Payload, resp, input, actualAddress)
+
+	event := []*output.InternalWrappedEvent{{InternalEvent: ouputEvent}}
+	if r.CompiledOperators != nil {
+		result, ok := r.Operators.Execute(ouputEvent, r.Match, r.Extract)
+		if !ok {
+			return nil, nil
+		}
+		event[0].OperatorsResult = result
+	}
+	return event, nil
+}
+
+// getAddress returns the address of the host to make request to
+func getAddress(toTest string) (string, error) {
+	if strings.Contains(toTest, "://") {
+		parsed, err := url.Parse(toTest)
+		if err != nil {
+			return "", err
+		}
+		toTest = parsed.Host
+	}
+	return toTest, nil
+}

--- a/v2/pkg/protocols/network/request.go
+++ b/v2/pkg/protocols/network/request.go
@@ -41,7 +41,7 @@ func (r *Request) ExecuteWithResults(input string, metadata output.InternalEvent
 
 		output, err := r.executeAddress(actualAddress, address, input)
 		if err != nil {
-			gologger.Error().Msgf("Could not make network request for %s: %s\n", actualAddress, err)
+			gologger.Verbose().Lable("ERR").Msgf("Could not make network request for %s: %s\n", actualAddress, err)
 			continue
 		}
 		outputs = append(outputs, output...)

--- a/v2/pkg/templates/compile.go
+++ b/v2/pkg/templates/compile.go
@@ -49,15 +49,6 @@ func Parse(file string, options *protocols.ExecuterOptions) (*Template, error) {
 	}
 
 	// Compile the requests found
-	for _, request := range template.RequestsDNS {
-		template.TotalRequests += request.Requests()
-	}
-	for _, request := range template.RequestsHTTP {
-		template.TotalRequests += request.Requests()
-	}
-	for _, request := range template.RequestsNetwork {
-		template.TotalRequests += request.Requests()
-	}
 	if len(template.RequestsDNS) > 0 {
 		template.Executer = dns.NewExecuter(template.RequestsDNS, options)
 		err = template.Executer.Compile()
@@ -70,13 +61,10 @@ func Parse(file string, options *protocols.ExecuterOptions) (*Template, error) {
 		template.Executer = network.NewExecuter(template.RequestsNetwork, options)
 		err = template.Executer.Compile()
 	}
+	template.TotalRequests += template.Executer.Requests()
+
 	if err != nil {
 		return nil, errors.Wrap(err, "could not compile request")
-	}
-	if template.Executer != nil {
-		if err := template.Executer.Compile(); err != nil {
-			return nil, errors.Wrap(err, "could not compile template executer")
-		}
 	}
 	return template, nil
 }

--- a/v2/pkg/templates/templates.go
+++ b/v2/pkg/templates/templates.go
@@ -4,6 +4,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols"
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/dns"
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/http"
+	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/network"
 	"github.com/projectdiscovery/nuclei/v2/pkg/workflows"
 )
 
@@ -17,6 +18,8 @@ type Template struct {
 	RequestsHTTP []*http.Request `yaml:"requests,omitempty"`
 	// RequestsDNS contains the dns request to make in the template
 	RequestsDNS []*dns.Request `yaml:"dns,omitempty"`
+	// RequestsNetwork contains the network request to make in the template
+	RequestsNetwork []*network.Request `yaml:"network,omitempty"`
 	// Workflows is a yaml based workflow declaration code.
 	workflows.Workflow `yaml:",inline"`
 	CompiledWorkflow   *workflows.Workflow

--- a/v2/pkg/workflows/execute_test.go
+++ b/v2/pkg/workflows/execute_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestWorkflowsSimple(t *testing.T) {
 	workflow := &Workflow{Workflows: []*WorkflowTemplate{
-		{executer: &mockExecuter{result: true}},
+		{Executer: &mockExecuter{result: true}},
 	}}
 
 	matched, err := workflow.RunWorkflow("https://test.com")
@@ -21,10 +21,10 @@ func TestWorkflowsSimple(t *testing.T) {
 func TestWorkflowsSimpleMultiple(t *testing.T) {
 	var firstInput, secondInput string
 	workflow := &Workflow{Workflows: []*WorkflowTemplate{
-		{executer: &mockExecuter{result: true, executeHook: func(input string) {
+		{Executer: &mockExecuter{result: true, executeHook: func(input string) {
 			firstInput = input
 		}}},
-		{executer: &mockExecuter{result: true, executeHook: func(input string) {
+		{Executer: &mockExecuter{result: true, executeHook: func(input string) {
 			secondInput = input
 		}}},
 	}}
@@ -40,11 +40,11 @@ func TestWorkflowsSimpleMultiple(t *testing.T) {
 func TestWorkflowsSubtemplates(t *testing.T) {
 	var firstInput, secondInput string
 	workflow := &Workflow{Workflows: []*WorkflowTemplate{
-		{executer: &mockExecuter{result: true, executeHook: func(input string) {
+		{Executer: &mockExecuter{result: true, executeHook: func(input string) {
 			firstInput = input
 		}},
 			Subtemplates: []*WorkflowTemplate{
-				{executer: &mockExecuter{result: true, executeHook: func(input string) {
+				{Executer: &mockExecuter{result: true, executeHook: func(input string) {
 					secondInput = input
 				}}},
 			}},
@@ -61,11 +61,11 @@ func TestWorkflowsSubtemplates(t *testing.T) {
 func TestWorkflowsSubtemplatesNoMatch(t *testing.T) {
 	var firstInput, secondInput string
 	workflow := &Workflow{Workflows: []*WorkflowTemplate{
-		{executer: &mockExecuter{result: false, executeHook: func(input string) {
+		{Executer: &mockExecuter{result: false, executeHook: func(input string) {
 			firstInput = input
 		}},
 			Subtemplates: []*WorkflowTemplate{
-				{executer: &mockExecuter{result: true, executeHook: func(input string) {
+				{Executer: &mockExecuter{result: true, executeHook: func(input string) {
 					secondInput = input
 				}}},
 			}},
@@ -82,7 +82,7 @@ func TestWorkflowsSubtemplatesNoMatch(t *testing.T) {
 func TestWorkflowsSubtemplatesWithMatcher(t *testing.T) {
 	var firstInput, secondInput string
 	workflow := &Workflow{Workflows: []*WorkflowTemplate{
-		{executer: &mockExecuter{result: true, executeHook: func(input string) {
+		{Executer: &mockExecuter{result: true, executeHook: func(input string) {
 			firstInput = input
 		}, outputs: []*output.InternalWrappedEvent{
 			{OperatorsResult: &operators.Result{
@@ -92,7 +92,7 @@ func TestWorkflowsSubtemplatesWithMatcher(t *testing.T) {
 		}},
 			Matchers: []*Matcher{
 				{Name: "tomcat", Subtemplates: []*WorkflowTemplate{
-					{executer: &mockExecuter{result: true, executeHook: func(input string) {
+					{Executer: &mockExecuter{result: true, executeHook: func(input string) {
 						secondInput = input
 					}}},
 				}},
@@ -111,7 +111,7 @@ func TestWorkflowsSubtemplatesWithMatcher(t *testing.T) {
 func TestWorkflowsSubtemplatesWithMatcherNoMatch(t *testing.T) {
 	var firstInput, secondInput string
 	workflow := &Workflow{Workflows: []*WorkflowTemplate{
-		{executer: &mockExecuter{result: true, executeHook: func(input string) {
+		{Executer: &mockExecuter{result: true, executeHook: func(input string) {
 			firstInput = input
 		}, outputs: []*output.InternalWrappedEvent{
 			{OperatorsResult: &operators.Result{
@@ -121,7 +121,7 @@ func TestWorkflowsSubtemplatesWithMatcherNoMatch(t *testing.T) {
 		}},
 			Matchers: []*Matcher{
 				{Name: "apache", Subtemplates: []*WorkflowTemplate{
-					{executer: &mockExecuter{result: true, executeHook: func(input string) {
+					{Executer: &mockExecuter{result: true, executeHook: func(input string) {
 						secondInput = input
 					}}},
 				}},


### PR DESCRIPTION
This PR picks off from PR #396 adding support for network protocol based templating in nuclei.

```yaml
id: memcached-stats

info:
  name: Memcached stats disclosure
  author: ice3man
  severity: low

network:
  - payload: "stats\r\n\r\nquit\r\n\r\n"
    address: "{{Address}}:11211"
    matchers:
      - type: word
        words:
          - "STAT "
 ```

Example run on a vulnerable host - 

```
                      __     _
     ____  __  _______/ /__  (_)
    / __ \/ / / / ___/ / _ \/ /
   / / / / /_/ / /__/ /  __/ /
  /_/ /_/\__,_/\___/_/\___/_/   v2.2.1-dev

                projectdiscovery.io

[WRN] Use with caution. You are responsible for your actions
[WRN] Developers assume no liability and are not responsible for any misuse or damage.
[INF] Loading templates...
[INF] [memcached-stats] Memcached stats disclosure (@ice3man) [low]
[INF] Using 1 rules (1 templates, 0 workflows)
[INF] [memcached-stats] Dumped Network request for xx.xx.xx.xx:11211 address=xx.xx.xx.xx:11211
stats

quit


[DBG] [memcached-stats] Dumped Network response for xx.xx.xx.xx:11211
STAT pid 3956
STAT uptime 107490
STAT time 1609320292
STAT version 1.2.6
STAT pointer_size 32
STAT curr_items 0
STAT total_items 0
STAT bytes 0
STAT curr_connections 3
STAT total_connections 59
STAT connection_structures 6
STAT cmd_get 0
STAT cmd_set 0
STAT get_hits 0
STAT get_misses 0
STAT evictions 0
STAT bytes_read 1496
STAT bytes_written 8221
STAT limit_maxbytes 0
STAT threads 1
END
ERROR

[memcached-stats] [network] [low] xx.xx.xx.xx:11211
```