### PR TITLE
[WIP] File support add to nuclei

### DIFF
--- a/v2/pkg/operators/operators.go
+++ b/v2/pkg/operators/operators.go
@@ -56,7 +56,7 @@ type Result struct {
 	// OutputExtracts is the list of extracts to be displayed on screen.
 	OutputExtracts []string
 	// DynamicValues contains any dynamic values to be templated
-	DynamicValues map[string]string
+	DynamicValues map[string]interface{}
 	// PayloadValues contains payload values provided by user. (Optional)
 	PayloadValues map[string]interface{}
 }
@@ -75,7 +75,7 @@ func (r *Operators) Execute(data map[string]interface{}, match MatchFunc, extrac
 	result := &Result{
 		Matches:       make(map[string]struct{}),
 		Extracts:      make(map[string][]string),
-		DynamicValues: make(map[string]string),
+		DynamicValues: make(map[string]interface{}),
 	}
 	for _, matcher := range r.Matchers {
 		// Check if the matcher matched

--- a/v2/pkg/protocols/common/tostring/tostring.go
+++ b/v2/pkg/protocols/common/tostring/tostring.go
@@ -1,0 +1,8 @@
+package tostring
+
+import "unsafe"
+
+// UnsafeToString converts byte slice to string with zero allocations
+func UnsafeToString(bs []byte) string {
+	return *(*string)(unsafe.Pointer(&bs))
+}

--- a/v2/pkg/protocols/file/executer.go
+++ b/v2/pkg/protocols/file/executer.go
@@ -1,0 +1,90 @@
+package file
+
+import (
+	"github.com/projectdiscovery/nuclei/v2/pkg/output"
+	"github.com/projectdiscovery/nuclei/v2/pkg/protocols"
+)
+
+// Executer executes a group of requests for a protocol
+type Executer struct {
+	requests []*Request
+	options  *protocols.ExecuterOptions
+}
+
+var _ protocols.Executer = &Executer{}
+
+// NewExecuter creates a new request executer for list of requests
+func NewExecuter(requests []*Request, options *protocols.ExecuterOptions) *Executer {
+	return &Executer{requests: requests, options: options}
+}
+
+// Compile compiles the execution generators preparing any requests possible.
+func (e *Executer) Compile() error {
+	for _, request := range e.requests {
+		err := request.Compile(e.options)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Requests returns the total number of requests the rule will perform
+func (e *Executer) Requests() int {
+	var count int
+	for _, request := range e.requests {
+		count += request.Requests()
+	}
+	return count
+}
+
+// Execute executes the protocol group and returns true or false if results were found.
+func (e *Executer) Execute(input string) (bool, error) {
+	var results bool
+
+	for _, req := range e.requests {
+		events, err := req.ExecuteWithResults(input, nil)
+		if err != nil {
+			return false, err
+		}
+		if events == nil {
+			return false, nil
+		}
+
+		// If we have a result field, we should add a result to slice.
+		for _, event := range events {
+			if event.OperatorsResult == nil {
+				continue
+			}
+
+			for _, result := range req.makeResultEvent(event) {
+				results = true
+				e.options.Output.Write(result)
+			}
+		}
+	}
+	return results, nil
+}
+
+// ExecuteWithResults executes the protocol requests and returns results instead of writing them.
+func (e *Executer) ExecuteWithResults(input string) ([]*output.InternalWrappedEvent, error) {
+	var results []*output.InternalWrappedEvent
+
+	for _, req := range e.requests {
+		events, err := req.ExecuteWithResults(input, nil)
+		if err != nil {
+			return nil, err
+		}
+		if events == nil {
+			return nil, nil
+		}
+		for _, event := range events {
+			if event.OperatorsResult == nil {
+				continue
+			}
+			event.Results = req.makeResultEvent(event)
+		}
+		results = append(results, events...)
+	}
+	return results, nil
+}

--- a/v2/pkg/protocols/file/file.go
+++ b/v2/pkg/protocols/file/file.go
@@ -1,0 +1,73 @@
+package file
+
+import (
+	"github.com/pkg/errors"
+	"github.com/projectdiscovery/nuclei/v2/pkg/operators"
+	"github.com/projectdiscovery/nuclei/v2/pkg/protocols"
+)
+
+// Request contains a File matching mechanism for local disk operations.
+type Request struct {
+	// MaxSize is the maximum size of the file to run request on.
+	// By default, nuclei will process 5MB files and not go more than that.
+	// It can be set to much lower or higher depending on use.
+	MaxSize int `yaml:"max-size"`
+	// NoRecursive specifies whether to not do recursive checks if folders are provided.
+	NoRecursive bool `yaml:"no-recursive"`
+	// Extensions is the list of extensions to perform matching on.
+	Extensions []string `yaml:"extensions"`
+	// ExtensionAllowlist is the list of file extensions to enforce allowing.
+	ExtensionAllowlist []string `yaml:"allowlist"`
+	// ExtensionDenylist is the list of file extensions to deny during matching.
+	ExtensionDenylist []string `yaml:"denylist"`
+
+	// Operators for the current request go here.
+	operators.Operators `yaml:",inline"`
+	CompiledOperators   *operators.Operators
+
+	// cache any variables that may be needed for operation.
+	options           *protocols.ExecuterOptions
+	extensions        map[string]struct{}
+	extensionDenylist map[string]struct{}
+}
+
+// defaultDenylist is the default list of extensions to be denied
+var defaultDenylist = []string{".3g2", ".3gp", ".7z", ".apk", ".arj", ".avi", ".axd", ".bmp", ".css", ".csv", ".deb", ".dll", ".doc", ".drv", ".eot", ".exe", ".flv", ".gif", ".gifv", ".gz", ".h264", ".ico", ".iso", ".jar", ".jpeg", ".jpg", ".lock", ".m4a", ".m4v", ".map", ".mkv", ".mov", ".mp3", ".mp4", ".mpeg", ".mpg", ".msi", ".ogg", ".ogm", ".ogv", ".otf", ".pdf", ".pkg", ".png", ".ppt", ".psd", ".rar", ".rm", ".rpm", ".svg", ".swf", ".sys", ".tar.gz", ".tar", ".tif", ".tiff", ".ttf", ".txt", ".vob", ".wav", ".webm", ".wmv", ".woff", ".woff2", ".xcf", ".xls", ".xlsx", ".zip"}
+
+// Compile compiles the protocol request for further execution.
+func (r *Request) Compile(options *protocols.ExecuterOptions) error {
+	if len(r.Matchers) > 0 || len(r.Extractors) > 0 {
+		compiled := &r.Operators
+		if err := compiled.Compile(); err != nil {
+			return errors.Wrap(err, "could not compile operators")
+		}
+		r.CompiledOperators = compiled
+	}
+	// By default use 5mb as max size to read.
+	if r.MaxSize == 0 {
+		r.MaxSize = 5 * 1024 * 1024
+	}
+	r.options = options
+
+	r.extensions = make(map[string]struct{})
+	r.extensionDenylist = make(map[string]struct{})
+
+	for _, extension := range r.Extensions {
+		r.extensions[extension] = struct{}{}
+	}
+	for _, extension := range defaultDenylist {
+		r.extensionDenylist[extension] = struct{}{}
+	}
+	for _, extension := range r.ExtensionDenylist {
+		r.extensionDenylist[extension] = struct{}{}
+	}
+	for _, extension := range r.ExtensionAllowlist {
+		delete(r.extensionDenylist, extension)
+	}
+	return nil
+}
+
+// Requests returns the total number of requests the YAML rule will perform
+func (r *Request) Requests() int {
+	return 1
+}

--- a/v2/pkg/protocols/file/file.go
+++ b/v2/pkg/protocols/file/file.go
@@ -28,6 +28,7 @@ type Request struct {
 	// cache any variables that may be needed for operation.
 	options           *protocols.ExecuterOptions
 	extensions        map[string]struct{}
+	allExtensions     bool
 	extensionDenylist map[string]struct{}
 }
 
@@ -53,7 +54,11 @@ func (r *Request) Compile(options *protocols.ExecuterOptions) error {
 	r.extensionDenylist = make(map[string]struct{})
 
 	for _, extension := range r.Extensions {
-		r.extensions[extension] = struct{}{}
+		if extension == "*" {
+			r.allExtensions = true
+		} else {
+			r.extensions[extension] = struct{}{}
+		}
 	}
 	for _, extension := range defaultDenylist {
 		r.extensionDenylist[extension] = struct{}{}

--- a/v2/pkg/protocols/file/find.go
+++ b/v2/pkg/protocols/file/find.go
@@ -1,0 +1,117 @@
+package file
+
+import (
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/karrick/godirwalk"
+	"github.com/pkg/errors"
+	"github.com/projectdiscovery/gologger"
+)
+
+// getInputPaths parses the specified input paths and returns a compiled
+// list of finished absolute paths to the files evaluating any allowlist, denylist,
+// glob, file or folders, etc.
+func (r *Request) getInputPaths(target string, callback func(string)) error {
+	processed := make(map[string]struct{})
+
+	// Template input includes a wildcard
+	if strings.Contains(target, "*") {
+		err := r.findGlobPathMatches(target, processed, callback)
+		if err != nil {
+			return errors.Wrap(err, "could not find glob matches")
+		}
+		return nil
+	}
+
+	// Template input is either a file or a directory
+	file, err := r.findFileMatches(target, processed, callback)
+	if err != nil {
+		return errors.Wrap(err, "could not find file")
+	}
+	if file {
+		return nil
+	}
+
+	// Recursively walk down the Templates directory and run all
+	// the template file checks
+	err = r.findDirectoryMatches(target, processed, callback)
+	if err != nil {
+		return errors.Wrap(err, "could not find directory matches")
+	}
+	return nil
+}
+
+// findGlobPathMatches returns the matched files from a glob path
+func (r *Request) findGlobPathMatches(absPath string, processed map[string]struct{}, callback func(string)) error {
+	matches, err := filepath.Glob(absPath)
+	if err != nil {
+		return errors.Errorf("wildcard found, but unable to glob: %s\n", err)
+	}
+	for _, match := range matches {
+		if !r.validatePath(match) {
+			continue
+		}
+		if _, ok := processed[match]; !ok {
+			processed[match] = struct{}{}
+			callback(match)
+		}
+	}
+	return nil
+}
+
+// findFileMatches finds if a path is an absolute file. If the path
+// is a file, it returns true otherwise false with no errors.
+func (r *Request) findFileMatches(absPath string, processed map[string]struct{}, callback func(string)) (bool, error) {
+	info, err := os.Stat(absPath)
+	if err != nil {
+		return false, err
+	}
+	if !info.Mode().IsRegular() {
+		return false, nil
+	}
+	if _, ok := processed[absPath]; !ok {
+		processed[absPath] = struct{}{}
+		callback(absPath)
+	}
+	return true, nil
+}
+
+// findDirectoryMatches finds matches for templates from a directory
+func (r *Request) findDirectoryMatches(absPath string, processed map[string]struct{}, callback func(string)) error {
+	err := godirwalk.Walk(absPath, &godirwalk.Options{
+		Unsorted: true,
+		ErrorCallback: func(fsPath string, err error) godirwalk.ErrorAction {
+			return godirwalk.SkipNode
+		},
+		Callback: func(path string, d *godirwalk.Dirent) error {
+			if !r.validatePath(path) {
+				return nil
+			}
+			if _, ok := processed[path]; !ok {
+				callback(path)
+				processed[path] = struct{}{}
+			}
+			return nil
+		},
+	})
+	return err
+}
+
+// validatePath validates a file path for blacklist and whitelist options
+func (r *Request) validatePath(item string) bool {
+	extension := path.Ext(item)
+	if len(r.extensions) > 0 {
+		if _, ok := r.extensions[extension]; ok {
+			return true
+		}
+		return false
+	}
+	if _, ok := r.extensionDenylist[extension]; ok {
+		gologger.Verbose().Msgf("Ignoring path %s due to denylist item %s\n", item, extension)
+		return false
+	}
+	return true
+}

--- a/v2/pkg/protocols/file/find.go
+++ b/v2/pkg/protocols/file/find.go
@@ -103,7 +103,7 @@ func (r *Request) findDirectoryMatches(absPath string, processed map[string]stru
 // validatePath validates a file path for blacklist and whitelist options
 func (r *Request) validatePath(item string) bool {
 	extension := path.Ext(item)
-	if len(r.extensions) > 0 {
+	if len(r.extensions) > 0 && !r.allExtensions {
 		if _, ok := r.extensions[extension]; ok {
 			return true
 		}

--- a/v2/pkg/protocols/file/operators.go
+++ b/v2/pkg/protocols/file/operators.go
@@ -1,0 +1,104 @@
+package file
+
+import (
+	"github.com/projectdiscovery/nuclei/v2/pkg/operators/extractors"
+	"github.com/projectdiscovery/nuclei/v2/pkg/operators/matchers"
+	"github.com/projectdiscovery/nuclei/v2/pkg/output"
+	"github.com/projectdiscovery/nuclei/v2/pkg/types"
+)
+
+// Match matches a generic data response again a given matcher
+func (r *Request) Match(data map[string]interface{}, matcher *matchers.Matcher) bool {
+	partString := matcher.Part
+	switch partString {
+	case "body", "all", "":
+		partString = "raw"
+	}
+
+	item, ok := data[partString]
+	if !ok {
+		return false
+	}
+	itemStr := types.ToString(item)
+
+	switch matcher.GetType() {
+	case matchers.SizeMatcher:
+		return matcher.Result(matcher.MatchSize(len(itemStr)))
+	case matchers.WordsMatcher:
+		return matcher.Result(matcher.MatchWords(itemStr))
+	case matchers.RegexMatcher:
+		return matcher.Result(matcher.MatchRegex(itemStr))
+	case matchers.BinaryMatcher:
+		return matcher.Result(matcher.MatchBinary(itemStr))
+	case matchers.DSLMatcher:
+		return matcher.Result(matcher.MatchDSL(data))
+	}
+	return false
+}
+
+// Extract performs extracting operation for a extractor on model and returns true or false.
+func (r *Request) Extract(data map[string]interface{}, extractor *extractors.Extractor) map[string]struct{} {
+	part, ok := data[extractor.Part]
+	if !ok {
+		return nil
+	}
+	partString := part.(string)
+
+	switch partString {
+	case "body", "all", "":
+		partString = "raw"
+	}
+
+	item, ok := data[partString]
+	if !ok {
+		return nil
+	}
+	itemStr := types.ToString(item)
+
+	switch extractor.GetType() {
+	case extractors.RegexExtractor:
+		return extractor.ExtractRegex(itemStr)
+	case extractors.KValExtractor:
+		return extractor.ExtractKval(data)
+	}
+	return nil
+}
+
+// responseToDSLMap converts a DNS response to a map for use in DSL matching
+func (r *Request) responseToDSLMap(raw string, host, matched string) output.InternalEvent {
+	data := make(output.InternalEvent, 3)
+
+	// Some data regarding the request metadata
+	data["host"] = host
+	data["matched"] = matched
+	data["raw"] = raw
+	return data
+}
+
+// makeResultEvent creates a result event from internal wrapped event
+func (r *Request) makeResultEvent(wrapped *output.InternalWrappedEvent) []*output.ResultEvent {
+	results := make([]*output.ResultEvent, 0, len(wrapped.OperatorsResult.Matches)+1)
+
+	data := output.ResultEvent{
+		TemplateID:       r.options.TemplateID,
+		Info:             r.options.TemplateInfo,
+		Type:             "file",
+		Host:             wrapped.InternalEvent["host"].(string),
+		Matched:          wrapped.InternalEvent["matched"].(string),
+		ExtractedResults: wrapped.OperatorsResult.OutputExtracts,
+	}
+	if r.options.Options.JSONRequests {
+		data.Response = wrapped.InternalEvent["raw"].(string)
+	}
+
+	// If we have multiple matchers with names, write each of them separately.
+	if len(wrapped.OperatorsResult.Matches) > 0 {
+		for k := range wrapped.OperatorsResult.Matches {
+			data.MatcherName = k
+			results = append(results, &data)
+		}
+	} else {
+		results = append(results, &data)
+	}
+	return results
+}

--- a/v2/pkg/protocols/file/request.go
+++ b/v2/pkg/protocols/file/request.go
@@ -1,0 +1,70 @@
+package file
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/projectdiscovery/gologger"
+	"github.com/projectdiscovery/nuclei/v2/pkg/output"
+	"github.com/projectdiscovery/nuclei/v2/pkg/protocols"
+	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/tostring"
+)
+
+var _ protocols.Request = &Request{}
+
+// ExecuteWithResults executes the protocol requests and returns results instead of writing them.
+func (r *Request) ExecuteWithResults(input string, metadata output.InternalEvent) ([]*output.InternalWrappedEvent, error) {
+	var events []*output.InternalWrappedEvent
+
+	err := r.getInputPaths(input, func(data string) {
+		file, err := os.Open(data)
+		if err != nil {
+			gologger.Error().Msgf("Could not open file path %s: %s\n", data, err)
+			return
+		}
+		defer file.Close()
+
+		stat, err := file.Stat()
+		if err != nil {
+			gologger.Error().Msgf("Could not stat file path %s: %s\n", data, err)
+			return
+		}
+		if stat.Size() >= int64(r.MaxSize) {
+			gologger.Verbose().Msgf("Could not process path %s: exceeded max size\n", data)
+			return
+		}
+
+		buffer, err := ioutil.ReadAll(file)
+		if err != nil {
+			gologger.Error().Msgf("Could not read file path %s: %s\n", data, err)
+			return
+		}
+		dataStr := tostring.UnsafeToString(buffer)
+
+		if r.options.Options.Debug {
+			gologger.Info().Msgf("[%s] Dumped file request for %s", r.options.TemplateID, data)
+			fmt.Fprintf(os.Stderr, "%s\n", dataStr)
+		}
+		gologger.Verbose().Msgf("[%s] Sent file request to %s", r.options.TemplateID, data)
+		ouputEvent := r.responseToDSLMap(dataStr, input, data)
+
+		event := []*output.InternalWrappedEvent{{InternalEvent: ouputEvent}}
+		if r.CompiledOperators != nil {
+			result, ok := r.Operators.Execute(ouputEvent, r.Match, r.Extract)
+			if !ok {
+				return
+			}
+			event[0].OperatorsResult = result
+		}
+		events = append(events, event...)
+	})
+	if err != nil {
+		r.options.Output.Request(r.options.TemplateID, input, "file", err)
+		r.options.Progress.DecrementRequests(1)
+		return nil, errors.Wrap(err, "could not send file request")
+	}
+	r.options.Progress.IncrementRequests()
+	return events, nil
+}

--- a/v2/pkg/protocols/http/request.go
+++ b/v2/pkg/protocols/http/request.go
@@ -18,6 +18,7 @@ import (
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/nuclei/v2/pkg/output"
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/generators"
+	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/tostring"
 	"github.com/projectdiscovery/rawhttp"
 	"github.com/remeh/sizedwaitgroup"
 	"go.uber.org/multierr"
@@ -346,7 +347,7 @@ func (e *Request) executeRequest(reqURL string, request *generatedRequest, dynam
 	if request.request != nil {
 		matchedURL = request.request.URL.String()
 	}
-	ouputEvent := e.responseToDSLMap(resp, reqURL, matchedURL, unsafeToString(dumpedRequest), unsafeToString(dumpedResponse), unsafeToString(data), headersToString(resp.Header), duration, request.meta)
+	ouputEvent := e.responseToDSLMap(resp, reqURL, matchedURL, tostring.UnsafeToString(dumpedRequest), tostring.UnsafeToString(dumpedResponse), tostring.UnsafeToString(data), headersToString(resp.Header), duration, request.meta)
 
 	event := []*output.InternalWrappedEvent{{InternalEvent: ouputEvent}}
 	if e.CompiledOperators != nil {

--- a/v2/pkg/protocols/http/request.go
+++ b/v2/pkg/protocols/http/request.go
@@ -197,6 +197,12 @@ func (e *Request) ExecuteWithResults(reqURL string, dynamicValues map[string]int
 		if err != nil {
 			requestErr = multierr.Append(requestErr, err)
 		} else {
+			// Add the extracts to the dynamic values if any.
+			for _, o := range output {
+				if o.OperatorsResult != nil {
+					dynamicValues = generators.MergeMaps(dynamicValues, o.OperatorsResult.DynamicValues)
+				}
+			}
 			outputs = append(outputs, output...)
 		}
 		e.options.Progress.IncrementRequests()

--- a/v2/pkg/protocols/http/utils.go
+++ b/v2/pkg/protocols/http/utils.go
@@ -7,16 +7,10 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"strings"
-	"unsafe"
 
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/generators"
 	"github.com/projectdiscovery/rawhttp"
 )
-
-// unsafeToString converts byte slice to string with zero allocations
-func unsafeToString(bs []byte) string {
-	return *(*string)(unsafe.Pointer(&bs))
-}
 
 // headersToString converts http headers to string
 func headersToString(headers http.Header) string {

--- a/v2/pkg/templates/templates.go
+++ b/v2/pkg/templates/templates.go
@@ -3,6 +3,7 @@ package templates
 import (
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols"
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/dns"
+	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/file"
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/http"
 	"github.com/projectdiscovery/nuclei/v2/pkg/workflows"
 )
@@ -17,6 +18,8 @@ type Template struct {
 	RequestsHTTP []*http.Request `yaml:"requests,omitempty"`
 	// RequestsDNS contains the dns request to make in the template
 	RequestsDNS []*dns.Request `yaml:"dns,omitempty"`
+	// RequestsFile contains the file request to make in the template
+	RequestsFile []*file.Request `yaml:"file,omitempty"`
 	// Workflows is a yaml based workflow declaration code.
 	workflows.Workflow `yaml:",inline"`
 	CompiledWorkflow   *workflows.Workflow


### PR DESCRIPTION
Sample template - 

```yaml
id: test-file

info:
  name: File based test template
  author: ice3man
  severity: low

file:
    # extensions is the master level flag that ovverides allowlist and denylist.
    # use extension when the pattern to match is highly specific to a file type, for
    # example when you are writing checks to detect secrets in a language like php, etc.
  - extensions: [".go"]

    # allowlist removes an item from the denylist. both default and user provided 
    # denylist can be overwriten by using an allowlist value. For example, to allow .css
    # to be scanned along with all other extensions, which is in the default denylist can be done
    # by uncommenting the next line adding .css to the allowlist.
    #allowlist: [".css"] 
    
    # denylist adds an extension to the denylist which will not be scanned by nuclei. Nuclei
    # has a comprehensive denylist which can be extended as per user's choice.
    #denylist: [".go"]
    matchers:
      - type: word
        words:
          - "Workflows"
  ```