### PR TITLE
Added support of historyData map to the all HTTP requests methods

### DIFF
--- a/v2/pkg/executer/executer_http.go
+++ b/v2/pkg/executer/executer_http.go
@@ -161,6 +161,7 @@ func (e *HTTPExecuter) ExecuteRaceRequest(reqURL string) *Result {
 	result := &Result{
 		Matches:     make(map[string]interface{}),
 		Extractions: make(map[string]interface{}),
+		historyData: make(map[string]interface{}),
 	}
 
 	dynamicvalues := make(map[string]interface{})
@@ -208,6 +209,7 @@ func (e *HTTPExecuter) ExecuteParallelHTTP(p *progress.Progress, reqURL string) 
 	result := &Result{
 		Matches:     make(map[string]interface{}),
 		Extractions: make(map[string]interface{}),
+		historyData: make(map[string]interface{}),
 	}
 
 	dynamicvalues := make(map[string]interface{})
@@ -264,6 +266,7 @@ func (e *HTTPExecuter) ExecuteTurboHTTP(reqURL string) *Result {
 	result := &Result{
 		Matches:     make(map[string]interface{}),
 		Extractions: make(map[string]interface{}),
+		historyData: make(map[string]interface{}),
 	}
 
 	dynamicvalues := make(map[string]interface{})
@@ -551,7 +554,9 @@ func (e *HTTPExecuter) handleHTTP(reqURL string, request *requests.HTTPRequest, 
 
 	var matchData map[string]interface{}
 	if payloads != nil {
+		result.Lock()
 		matchData = generators.MergeMaps(result.historyData, payloads)
+		result.Unlock()
 	}
 
 	// store for internal purposes the DSL matcher data


### PR DESCRIPTION
This PR adds support of historyData map to the all HTTP request methods.

**Problem**
In the commit https://github.com/projectdiscovery/nuclei/commit/b20742a1c8da83821451b6f5a977381e8582de2e was introduced new map named historyData to the Result structure in file https://github.com/projectdiscovery/nuclei/blob/master/v2/pkg/executer/executer_http.go#L758 . Unfortunately, creation of blank map for map historyData was realised only in **Result** structure initialisation in function **ExecuteHTTP** while three others (**ExecuteRaceRequest**, **ExecuteParallelHTTP**, **ExecuteTurboHTTP**) which are replacing **ExecuteHTTP** in some cases, still have nil pointer. This leads to errors while executing some of templates, ex. **fuzzing/wp-plugin-scan.yaml**:
<img width="1148" alt="error" src="https://user-images.githubusercontent.com/619735/105520015-31f2d580-5ceb-11eb-8aca-160004ccb81b.png">

**Solution**
I've added creation of blank historyData map to the functions **ExecuteRaceRequest**, **ExecuteParallelHTTP**, **ExecuteTurboHTTP**.  Also I added missing mutex locking and unlocking to the function **handleHTTP**.
