### PR TITLE
Fix PANIC: assignment to entry in nil map in executor_http.go

### DIFF
--- a/v2/pkg/executer/executer_http.go
+++ b/v2/pkg/executer/executer_http.go
@@ -209,6 +209,7 @@ func (e *HTTPExecuter) ExecuteParallelHTTP(p *progress.Progress, reqURL string) 
 	result := &Result{
 		Matches:     make(map[string]interface{}),
 		Extractions: make(map[string]interface{}),
+		historyData: make(map[string]interface{}),
 	}
 
 	dynamicvalues := make(map[string]interface{})
@@ -265,6 +266,7 @@ func (e *HTTPExecuter) ExecuteTurboHTTP(reqURL string) *Result {
 	result := &Result{
 		Matches:     make(map[string]interface{}),
 		Extractions: make(map[string]interface{}),
+		historyData: make(map[string]interface{}),
 	}
 
 	dynamicvalues := make(map[string]interface{})

--- a/v2/pkg/executer/executer_http.go
+++ b/v2/pkg/executer/executer_http.go
@@ -161,6 +161,7 @@ func (e *HTTPExecuter) ExecuteRaceRequest(reqURL string) *Result {
 	result := &Result{
 		Matches:     make(map[string]interface{}),
 		Extractions: make(map[string]interface{}),
+		historyData: make(map[string]interface{}),
 	}
 
 	dynamicvalues := make(map[string]interface{})


### PR DESCRIPTION
Writing to a nil map causes panic on line 567 when reqURL is written to result.histroryData