### PR TITLE
Update executer_http.go

### DIFF
--- a/v2/pkg/executer/executer_http.go
+++ b/v2/pkg/executer/executer_http.go
@@ -549,7 +549,7 @@ func (e *HTTPExecuter) handleHTTP(reqURL string, request *requests.HTTPRequest, 
 
 	headers := headersToString(resp.Header)
 
-	var matchData map[string]interface{}
+	matchData := make(map[string]interface{})
 	if payloads != nil {
 		matchData = generators.MergeMaps(result.historyData, payloads)
 	}


### PR DESCRIPTION
using make to prevent writing in a nil map and runtime panic