### PR TITLE
Fix erroring out behaviour on unevaulable expressions

### DIFF
--- a/v2/pkg/protocols/common/expressions/expressions.go
+++ b/v2/pkg/protocols/common/expressions/expressions.go
@@ -26,11 +26,11 @@ func Evaluate(data string, base map[string]interface{}) (string, error) {
 
 		compiled, err := govaluate.NewEvaluableExpressionWithFunctions(expr, dsl.HelperFunctions())
 		if err != nil {
-			return "", err
+			continue
 		}
 		result, err := compiled.Evaluate(base)
 		if err != nil {
-			return "", err
+			continue
 		}
 		dynamicValues[expr] = result // convert x(<payload_name>) => <x-representation>
 	}

--- a/v2/pkg/protocols/common/expressions/expressions_test.go
+++ b/v2/pkg/protocols/common/expressions/expressions_test.go
@@ -16,6 +16,7 @@ func TestEvaluate(t *testing.T) {
 		{input: "test", expected: "test", extra: map[string]interface{}{}},
 		{input: "{{hex_encode(Item)}}", expected: "50494e47", extra: map[string]interface{}{"Item": "PING"}},
 		{input: "{{hex_encode(Item)}}\r\n", expected: "50494e47\r\n", extra: map[string]interface{}{"Item": "PING"}},
+		{input: "{{someTestData}}{{hex_encode('PING')}}", expected: "{{someTestData}}50494e47", extra: map[string]interface{}{}},
 	}
 	for _, item := range items {
 		value, err := Evaluate(item.input, item.extra)


### PR DESCRIPTION
Fixed nuclei engine from erroring out if it is unable to evaluate a Request Payload Expression.