### PR TITLE
Fix inconsistent Golang version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.0-alpine as build-env
+FROM golang:1.15-alpine as build-env
 RUN GO111MODULE=on go get -v github.com/projectdiscovery/nuclei/v2/cmd/nuclei
 
 FROM alpine:latest


### PR DESCRIPTION
Docker image is using Golang 1.16, while everything else in the code is using Golang 1.15. This could lead to inconsistencies between running Nuclei using the Docker Image and the release artifacts.