### PR TITLE
Fix can't set user agent in templates

### DIFF
--- a/v2/pkg/protocols/http/build_request.go
+++ b/v2/pkg/protocols/http/build_request.go
@@ -114,11 +114,11 @@ func (r *requestGenerator) makeHTTPRequestFromModel(ctx context.Context, data st
 
 // makeHTTPRequestFromRaw creates a *http.Request from a raw request
 func (r *requestGenerator) makeHTTPRequestFromRaw(ctx context.Context, baseURL, data string, values, payloads map[string]interface{}) (*generatedRequest, error) {
-	return r.handleRawWithPaylods(ctx, data, baseURL, values, payloads)
+	return r.handleRawWithPayloads(ctx, data, baseURL, values, payloads)
 }
 
-// handleRawWithPaylods handles raw requests along with paylaods
-func (r *requestGenerator) handleRawWithPaylods(ctx context.Context, rawRequest, baseURL string, values, generatorValues map[string]interface{}) (*generatedRequest, error) {
+// handleRawWithPayloads handles raw requests along with payloads
+func (r *requestGenerator) handleRawWithPayloads(ctx context.Context, rawRequest, baseURL string, values, generatorValues map[string]interface{}) (*generatedRequest, error) {
 	// Combine the template payloads along with base
 	// request values.
 	finalValues := generators.MergeMaps(generatorValues, values)

--- a/v2/pkg/protocols/http/build_request.go
+++ b/v2/pkg/protocols/http/build_request.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/corpix/uarand"
 	"github.com/pkg/errors"
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/expressions"
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/generators"
@@ -182,7 +183,7 @@ func (r *requestGenerator) fillRequest(req *http.Request, values map[string]inte
 	if r.request.Body != "" {
 		req.Body = ioutil.NopCloser(strings.NewReader(r.request.Body))
 	}
-	setHeader(req, "User-Agent", "Nuclei - Open-source project (github.com/projectdiscovery/nuclei)")
+	setHeader(req, "User-Agent", uarand.GetRandom())
 
 	// Only set these headers on non raw requests
 	if len(r.request.Raw) == 0 {

--- a/v2/pkg/protocols/http/http.go
+++ b/v2/pkg/protocols/http/http.go
@@ -3,7 +3,6 @@ package http
 import (
 	"strings"
 
-	"github.com/corpix/uarand"
 	"github.com/pkg/errors"
 	"github.com/projectdiscovery/nuclei/v2/pkg/operators"
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols"
@@ -101,10 +100,6 @@ func (r *Request) Compile(options *protocols.ExecuterOptions) error {
 			continue
 		}
 		r.customHeaders[parts[0]] = strings.TrimSpace(parts[1])
-	}
-	// Add User-Agent value randomly to the customHeaders slice if `random-agent` flag is given
-	if _, ok := r.customHeaders["User-Agent"]; !ok {
-		r.customHeaders["User-Agent"] = uarand.GetRandom()
 	}
 
 	if r.Body != "" && !strings.Contains(r.Body, "\r\n") {


### PR DESCRIPTION
Hi there,

I noticed that from nuclei [2.3.3](https://github.com/projectdiscovery/nuclei/releases/tag/v2.3.3), random-agent flag is removed and it will be set as default. However, due to adding random user agents with a wrong condition check (https://github.com/projectdiscovery/nuclei/blob/master/v2/pkg/protocols/http/http.go#L105), user agents in templates will be ignored even if they had been provided. I think this is important because some exploits require this header (ex: https://github.com/projectdiscovery/nuclei-templates/blob/master/vulnerabilities/other/rce-shellshock-user-agent.yaml). 

You can confirm this bug by using this template:

```yaml
id: test

info:
  name: Test
  author: yabeow
  severity: medium

requests:
  - raw:
      - |
        GET /1 HTTP/1.1
        Host: {{Hostname}}
        User-Agent: this_will_be_replaced_with_a_random_user_agent
```

Run this template with this command: `nuclei -t ~/Desktop/test.yaml --target https://enmwdhvsuyx2h.x.pipedream.net -debug`

```

                       __     _
     ____  __  _______/ /__  (_)
    / __ \/ / / / ___/ / _ \/ /
   / / / / /_/ / /__/ /  __/ /
  /_/ /_/\__,_/\___/_/\___/_/   v2.3.4

                projectdiscovery.io

[WRN] Use with caution. You are responsible for your actions
[WRN] Developers assume no liability and are not responsible for any misuse or damage.
[WRN] nuclei-templates are not installed (or indexed), use update-templates flag.
[INF] Loading templates...
[INF] [test] Test (@yabeow) [medium]
[INF] Loading workflows...
[INF] Using 1 rules (1 templates, 0 workflows)
[INF] [test] Dumped HTTP request for https://enmwdhvsuyx2h.x.pipedream.net

GET /1 HTTP/1.1
Host: enmwdhvsuyx2h.x.pipedream.net
User-Agent: Mozilla/5.0 (X11; OpenBSD i386) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.125 Safari/537.36
Connection: close
Accept-Encoding: gzip
```
