### PR TITLE
Fix missing IP in the JSON when URLs contain hostname:port

### DIFF
--- a/v2/pkg/protocols/http/request.go
+++ b/v2/pkg/protocols/http/request.go
@@ -372,6 +372,9 @@ func (r *Request) executeRequest(reqURL string, request *generatedRequest, previ
 	finalEvent := make(output.InternalEvent)
 
 	outputEvent := r.responseToDSLMap(resp, reqURL, matchedURL, tostring.UnsafeToString(dumpedRequest), tostring.UnsafeToString(dumpedResponse), tostring.UnsafeToString(data), headersToString(resp.Header), duration, request.meta)
+	if i := strings.LastIndex(hostname, ":"); i != -1 {
+		hostname = hostname[:i]
+	}
 	outputEvent["ip"] = httpclientpool.Dialer.GetDialedIP(hostname)
 	outputEvent["redirect-chain"] = tostring.UnsafeToString(redirectedResponse)
 	for k, v := range previous {


### PR DESCRIPTION
This is to fix a bug where the IP is not included in the JSON output when URLs contain a port number.
I'm not a Go expert so the code I came up with may not be the best. Feel free to fix the bug with your own code, i won't be offended :)

### Env to reproduce
branch: dev
commit: `2b602ebe`
go version: go1.14.15 linux/amd64

Create a `urls.txt` file with an URL containing a port number. I used `http://scanme.insecure.org:80/` in the below example.

### Actual result
```console
$ nuclei -t technologies/tech-detect.yaml -l urls.txt -json 2>/dev/null  | jq
{
  "templateID": "tech-detect",
  "info": {
    "severity": "info",
    "name": "Wappalyzer Technology Detection",
    "author": "hakluke"
  },
  "matcher_name": "apache",
  "type": "http",
  "host": "http://scanme.insecure.org:80/",
  "matched": "http://scanme.insecure.org:80/",
  "timestamp": "2021-04-23T22:30:51.374378136+10:00"
}
```
Notice the JSON missing the `"ip"` field.

### Expected result
```console
$ nuclei -t technologies/tech-detect.yaml -l urls.txt -json 2>/dev/null  | jq
{
  "templateID": "tech-detect",
  "info": {
    "name": "Wappalyzer Technology Detection",
    "author": "hakluke",
    "severity": "info"
  },
  "matcher_name": "apache",
  "type": "http",
  "host": "http://scanme.insecure.org:80/",
  "matched": "http://scanme.insecure.org:80/",
  "ip": "45.33.49.119",
  "timestamp": "2021-04-23T22:31:53.875996064+10:00"
}
```
Notice the `"ip"` field is correctly included now.
