### PR TITLE
exclude etags with tags param

### DIFF
--- a/v2/pkg/templates/compile.go
+++ b/v2/pkg/templates/compile.go
@@ -49,14 +49,12 @@ func Parse(filePath string, options protocols.ExecuterOptions) (*Template, error
 	if !ok {
 		templateTags = ""
 	}
-	matchWithTags := false
 	if len(options.Options.Tags) > 0 {
 		if err := matchTemplateWithTags(types.ToString(templateTags), types.ToString(template.Info["severity"]), options.Options.Tags); err != nil {
 			return nil, fmt.Errorf("tags filter not matched %s", templateTags)
 		}
-		matchWithTags = true
 	}
-	if len(options.Options.ExcludeTags) > 0 && !matchWithTags {
+	if len(options.Options.ExcludeTags) > 0 {
 		if err := matchTemplateWithTags(types.ToString(templateTags), types.ToString(template.Info["severity"]), options.Options.ExcludeTags); err == nil {
 			return nil, fmt.Errorf("exclude-tags filter matched %s", templateTags)
 		}


### PR DESCRIPTION
Now if the tags and etags flags are used simultaneously they will work as the user expects.

It was:
```
❯ nuclei -tags wordpress -etags log  -l wp_urls.txt 2>&1| grep 'Using '
[INF] Using 50 rules (50 templates, 0 workflows)
```

Became:
```
❯  ./nuclei -tags wordpress -etags log  -l wp_urls.txt 2>&1| grep 'Using '
[INF] Using 47 rules (47 templates, 0 workflows)
```

Resolve #729 