### PR TITLE
Integration with Jira Standalone server

### DIFF
--- a/v2/cmd/nuclei/issue-tracker-config.yaml
+++ b/v2/cmd/nuclei/issue-tracker-config.yaml
@@ -32,14 +32,16 @@
 #  issue-label: ""
 
 # jira contains configuration options for jira issue tracker
-#jira: 
+#jira:
+#  # Cloud is the boolean which tells if Jira instance is running in the cloud or on-prem version is used
+#  cloud: true
 #  # URL is the jira application url
 #  url: ""
-#  # account-id is the account-id of the jira user
+#  # account-id is the account-id of the jira user or username in case of on-prem Jira
 #  account-id: ""
 #  # email is the email of the user for jira instance
 #  email: ""
-#  # token is the token for jira instance.
+#  # token is the token for jira instance or password in case of on-prem Jira
 #  token: ""
 #  # project-name is the name of the project.
 #  project-name: ""


### PR DESCRIPTION
The current implementation does not work very well with non-Cloud version of Jira.  See details below:
I am a newbie in golang - please let me know, if there is any need to update the proposed behavior.

**Description**
We are using the on-premise version of Jira server (v8.13.2#813002) and the Jira reporting feature does not work correctly. The RestAPI for the on-prem version is different then the Jira Cloud instance. Set an example in our release, the jira account does not have any accountId and login via email does not work.

![image](https://user-images.githubusercontent.com/2551605/120795837-4d43dc00-c53a-11eb-8893-69bf3558d4b2.png)

The fix requires to use the username instead of it. 
Once the fix UI is correctly authorized, the next issue is with the creation of the new issue. The field `reporter` is not recognized by the RestAPI and it requires to use `Name` instead of the `AccountID`

![image](https://user-images.githubusercontent.com/2551605/120796131-bcb9cb80-c53a-11eb-9b2f-31ced27474a8.png)
![image](https://user-images.githubusercontent.com/2551605/120796242-e4a92f00-c53a-11eb-923d-93359f2ce5f9.png)


**Nuclei version**
Tested on the latested dev version of the nuclei. The same behavior even on v2.3.7. 