### PR TITLE
Refactor: err is always nil

### DIFF
--- a/v2/pkg/protocols/http/httpclientpool/clientpool.go
+++ b/v2/pkg/protocols/http/httpclientpool/clientpool.go
@@ -104,9 +104,6 @@ func wrappedGet(options *types.Options, configuration *Configuration) (*retryabl
 	if Dialer == nil {
 		Dialer = protocolstate.Dialer
 	}
-	if err != nil {
-		return nil, errors.Wrap(err, "could not create dialer")
-	}
 
 	hash := configuration.Hash()
 	poolMutex.RLock()

--- a/v2/pkg/protocols/http/httpclientpool/clientpool.go
+++ b/v2/pkg/protocols/http/httpclientpool/clientpool.go
@@ -24,7 +24,7 @@ import (
 )
 
 var (
-	// Dialer is a copy of the fatdialer from protocolstate
+	// Dialer is a copy of the fastdialer from protocolstate
 	Dialer *fastdialer.Dialer
 
 	rawhttpClient *rawhttp.Client
@@ -96,7 +96,7 @@ func Get(options *types.Options, configuration *Configuration) (*retryablehttp.C
 	return wrappedGet(options, configuration)
 }
 
-// wrappedGet wraps a get operation without normal cliet check
+// wrappedGet wraps a get operation without normal client check
 func wrappedGet(options *types.Options, configuration *Configuration) (*retryablehttp.Client, error) {
 	var proxyURL *url.URL
 	var err error


### PR DESCRIPTION
Condition is always `false`,  because  `err` is always  `nil`