### PR TITLE
[FEATURE] Implementation of custom Exporter/Tracker

### DIFF
--- a/v2/pkg/reporting/reporting.go
+++ b/v2/pkg/reporting/reporting.go
@@ -98,6 +98,10 @@ type Client struct {
 
 // New creates a new nuclei issue tracker reporting client
 func New(options *Options, db string) (*Client, error) {
+	if options == nil {
+		return nil, errors.New("no options passed")
+	}
+
 	if options.AllowList != nil {
 		options.AllowList.Compile()
 	}
@@ -141,12 +145,23 @@ func New(options *Options, db string) (*Client, error) {
 		}
 		client.exporters = append(client.exporters, exporter)
 	}
+
 	storage, err := dedupe.New(db)
 	if err != nil {
 		return nil, err
 	}
 	client.dedupe = storage
 	return client, nil
+}
+
+// RegisterTracker registers a custom tracker to the reporter
+func (c *Client) RegisterTracker(tracker Tracker) {
+	c.trackers = append(c.trackers, tracker)
+}
+
+// RegisterExporter registers a custom exporter to the reporter
+func (c *Client) RegisterExporter(exporter Exporter) {
+	c.exporters = append(c.exporters, exporter)
 }
 
 // Close closes the issue tracker reporting client


### PR DESCRIPTION
The following PR introduces two new functions under the `reporting` package.

**Features**
- RegisterTracker to allow for custom trackers to be implemented beyond Jira/Github/Gitlab
- RegisterExporter to allow for custom exporters to be implemented beyond Sarif/Disk

**Bug Fixes**
- If `nil` is passed to `reporting.New` it would crash due to nil references

**Use Case**

Beyond a CLI implementation, these two functions add the ability for additional trackers to be registered without being directly supported by Nuclei. This allows for users to implement a custom reporting platform without needing support in the core package