### PR TITLE
change values precedence to prioritise default nuclei values

### DIFF
--- a/v2/pkg/protocols/http/build_request.go
+++ b/v2/pkg/protocols/http/build_request.go
@@ -69,7 +69,7 @@ func (r *requestGenerator) Make(baseURL string, dynamicValues map[string]interfa
 
 	// merge with env vars
 	if r.options.Options.EnvironmentVariables {
-		values = generators.MergeMaps(values, generators.EnvVars())
+		values = generators.MergeMaps(generators.EnvVars(), values)
 	}
 
 	// If data contains \n it's a raw request, process it like raw. Else


### PR DESCRIPTION
This PR ensures to prioritize nuclei **Global** variable over **ENV** variable when the same variable name is used with `env-vars` flag.

Example template:-

```yaml
id: basic-example

info:
  name: Test HTTP Template
  author: pdteam
  severity: info

requests:
  - method: GET
    path:
      - "{{BaseURL}}/"
    headers:
      Origin: '{{Hostname}}'

    matchers:
      - type: word
        words:
          - "This is test matcher text"
```

```diff
echo https://example.com | ./nuclei -t test.yaml -debug-req -env-vars


[INF] [basic-example] Dumped HTTP request for https://example.com

GET / HTTP/1.1
Host: example.com
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2656.18 Safari/537.36
Connection: close
Accept: */*
Accept-Language: en
+ Origin: example.com
Accept-Encoding: gzip
```

```diff
echo https://example.com | nuclei -t test.yaml -debug-req -env-vars

[INF] [basic-example] Dumped HTTP request for https://example.com

GET / HTTP/1.1
Host: example.com
User-Agent: Mozilla/5.0 (Windows NT 10.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.114 Safari/537.36
Connection: close
Accept: */*
Accept-Language: en
- Origin: TEST-TOKEN
Accept-Encoding: gzip
```