### PR TITLE
Stop at first match support for HTTP requests

### DIFF
--- a/v2/pkg/protocols/http/http.go
+++ b/v2/pkg/protocols/http/http.go
@@ -161,6 +161,9 @@ type Request struct {
 	//
 	//   This allows matching on them later for multi-request conditions.
 	ReqCondition bool `yaml:"req-condition,omitempty" jsonschema:"title=preserve request history,description=Automatically assigns numbers to requests and preserves their history"`
+	// description: |
+	//   StopAtFirstMatch stops the execution of the requests as soon as a match is found.
+	StopAtFirstMatch bool `yaml:"stop-at-first-match,omitempty" jsonschema:"title=stop at first match,description=Stop the execution after a match is found"`
 }
 
 // GetID returns the unique ID of the request if any.

--- a/v2/pkg/protocols/http/request.go
+++ b/v2/pkg/protocols/http/request.go
@@ -249,7 +249,7 @@ func (r *Request) ExecuteWithResults(reqURL string, dynamicValues, previous outp
 		requestCount++
 		r.options.Progress.IncrementRequests()
 
-		if request.original.options.Options.StopAtFirstMatch && gotOutput {
+		if (request.original.options.Options.StopAtFirstMatch || r.StopAtFirstMatch) && gotOutput {
 			r.options.Progress.IncrementErrorsBy(int64(generator.Total()))
 			break
 		}


### PR DESCRIPTION
```yaml
id: test-stop-at-first-match

info:
  name: test-stop-at-first-match
  author: pdteam
  severity: info

requests:
  - method: GET
    path:
      - "{{BaseURL}}/a"
      - "{{BaseURL}}/b"
      - "{{BaseURL}}/c"
      - "{{BaseURL}}/d"
      - "{{BaseURL}}/e"
    stop-at-first-match: true
    matchers-condition: and
    matchers:
      - type: word
        words:
          - HTML
 ```