### PR TITLE
Support Authorization Header for Self-Hosted Interactsh Servers 

### DIFF
--- a/v2/cmd/nuclei/main.go
+++ b/v2/cmd/nuclei/main.go
@@ -110,7 +110,7 @@ on extensive configurability, massive extensibility and ease of use.`)
 	createGroup(flagSet, "interactsh", "interactsh",
 		flagSet.BoolVar(&options.NoInteractsh, "no-interactsh", false, "do not use interactsh server for blind interaction polling"),
 		flagSet.StringVar(&options.InteractshURL, "interactsh-url", "https://interact.sh", "self-hosted Interactsh Server URL"),
-
+		flagSet.StringVar(&options.InteractshAuth, "interactsh-auth", "", "authorization header for self-hosted interactsh server"),
 		flagSet.IntVar(&options.InteractionsCacheSize, "interactions-cache-size", 5000, "number of requests to keep in the interactions cache"),
 		flagSet.IntVar(&options.InteractionsEviction, "interactions-eviction", 60, "number of seconds to wait before evicting requests from cache"),
 		flagSet.IntVar(&options.InteractionsPollDuration, "interactions-poll-duration", 5, "number of seconds to wait before each interaction poll request"),

--- a/v2/internal/runner/runner.go
+++ b/v2/internal/runner/runner.go
@@ -245,6 +245,7 @@ func New(options *types.Options) (*Runner, error) {
 	if !options.NoInteractsh {
 		interactshClient, err := interactsh.New(&interactsh.Options{
 			ServerURL:      options.InteractshURL,
+			Authorization:  options.InteractshAuth,
 			CacheSize:      int64(options.InteractionsCacheSize),
 			Eviction:       time.Duration(options.InteractionsEviction) * time.Second,
 			ColldownPeriod: time.Duration(options.InteractionsColldownPeriod) * time.Second,

--- a/v2/pkg/protocols/common/interactsh/interactsh.go
+++ b/v2/pkg/protocols/common/interactsh/interactsh.go
@@ -48,6 +48,8 @@ var (
 type Options struct {
 	// ServerURL is the URL of the interactsh server.
 	ServerURL string
+	// Authorization is the Authorization header value
+	Authorization string
 	// CacheSize is the numbers of requests to keep track of at a time.
 	// Older items are discarded in LRU manner in favor of new requests.
 	CacheSize int64
@@ -80,6 +82,7 @@ func New(options *Options) (*Client, error) {
 
 	interactsh, err := client.New(&client.Options{
 		ServerURL:         options.ServerURL,
+		Token:             options.Authorization,
 		PersistentSession: false,
 	})
 	if err != nil {

--- a/v2/pkg/types/types.go
+++ b/v2/pkg/types/types.go
@@ -37,6 +37,8 @@ type Options struct {
 	ProjectPath string
 	// InteractshURL is the URL for the interactsh server.
 	InteractshURL string
+	// Interactsh Authorization header value for self-hosted servers
+	InteractshAuth string
 	// Target URLs/Domains to scan using a template
 	Targets goflags.StringSlice
 	// TargetsFilePath specifies the targets from a file to scan using templates.


### PR DESCRIPTION
The current interactsh flags for nuclei don't provide a way to provide an `Authorization` header.

This is required for self-hosted interactsh servers that require an authorization token.

This PR adds a flag to accept this input and passes it to the client library when creating the interactsh client.

---
If interactsh-token is a better flag name, then let me know and it can be changed.
