### PR TITLE
Support Raw Base64 Encoding for Deserialization Helpers

### DIFF
--- a/v2/pkg/protocols/common/helpers/deserialization/java.go
+++ b/v2/pkg/protocols/common/helpers/deserialization/java.go
@@ -58,6 +58,8 @@ func gadgetEncodingHelper(returnData []byte, encoding string) string {
 			return ""
 		}
 		return urlsafeBase64Encode(buffer.Bytes())
+	case "base64":
+		return base64.StdEncoding.EncodeToString(returnData)
 	default:
 		return urlsafeBase64Encode(returnData)
 	}

--- a/v2/pkg/protocols/common/helpers/deserialization/java.go
+++ b/v2/pkg/protocols/common/helpers/deserialization/java.go
@@ -58,7 +58,7 @@ func gadgetEncodingHelper(returnData []byte, encoding string) string {
 			return ""
 		}
 		return urlsafeBase64Encode(buffer.Bytes())
-	case "base64":
+	case "base64-raw":
 		return base64.StdEncoding.EncodeToString(returnData)
 	default:
 		return urlsafeBase64Encode(returnData)


### PR DESCRIPTION
For https://github.com/projectdiscovery/nuclei-templates/pull/2540, I have noticed issues where the default base64 and url-encoding (urlsafeBase64Encode method) will break the deserialization gadget.

This PR adds a small helper to support raw base64 encoding. It does not perform the url encoding like the default option.

I'd like to say this is an issue with padding in the deserialization payloads. This helper appears to create more reliable results for CVE-2015-7450.

This will impact the following template: https://github.com/projectdiscovery/nuclei-templates/blob/master/iot/qvisdvr-deserialization-rce.yaml. Ideally that template could be re-verified with this PR, but otherwise the helper used could be changed to `"base64-url"` or similar. Alternatively this PR be changed to modify `"base64"` to `"base64-raw"`.