### PR TITLE
[issue] 995 - YAML Unmarshal error in reporting template

### DIFF
--- a/v2/cmd/nuclei/issue-tracker-config.yaml
+++ b/v2/cmd/nuclei/issue-tracker-config.yaml
@@ -1,15 +1,9 @@
-# Severities
-#   1) Info
-#   2) Low
-#   3) Medium
-#   4) High
-#   5) Critical
 # to specify which severities should be reported
 #allow-list:
-#  severity: [4, 5]
+#  severity: "critical, high"
 # to specify which severities should be excluded from reporting
 #deny-list:
-#  severity: [1, 2, 3]
+#  severity: "info, low, medium"
 #allow-list:
 #  severity: high,critical
 #deny-list:

--- a/v2/cmd/nuclei/issue-tracker-config.yaml
+++ b/v2/cmd/nuclei/issue-tracker-config.yaml
@@ -5,11 +5,11 @@
 #   4) High
 #   5) Critical
 # to specify which severities should be reported
-allow-list:
-  severity: [4, 5]
+#allow-list:
+#  severity: [4, 5]
 # to specify which severities should be excluded from reporting
-deny-list:
-  severity: [1, 2, 3]
+#deny-list:
+#  severity: [1, 2, 3]
 #allow-list:
 #  severity: high,critical
 #deny-list:

--- a/v2/cmd/nuclei/issue-tracker-config.yaml
+++ b/v2/cmd/nuclei/issue-tracker-config.yaml
@@ -1,3 +1,15 @@
+# Severities
+#   1) Info
+#   2) Low
+#   3) Medium
+#   4) High
+#   5) Critical
+# to specify which severities should be reported
+allow-list:
+  severity: [4, 5]
+# to specify which severities should be excluded from reporting
+deny-list:
+  severity: [1, 2, 3]
 #allow-list:
 #  severity: high,critical
 #deny-list:

--- a/v2/cmd/nuclei/issue-tracker-config.yaml
+++ b/v2/cmd/nuclei/issue-tracker-config.yaml
@@ -4,10 +4,6 @@
 # to specify which severities should be excluded from reporting
 #deny-list:
 #  severity: "info, low, medium"
-#allow-list:
-#  severity: high,critical
-#deny-list:
-#  severity: low
 
 # github contains configuration options for github issue tracker
 #github: 

--- a/v2/internal/severity/misc.go
+++ b/v2/internal/severity/misc.go
@@ -11,6 +11,18 @@ func (severities Severities) String() string {
 	return strings.Join(severities.ToStringArray(), ", ")
 }
 
+func (severities *Severities) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var marshalledSeverities string
+	if err := unmarshal(&marshalledSeverities); err != nil {
+		return err
+	}
+
+	if err := severities.Set(marshalledSeverities); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (severities *Severities) Set(value string) error {
 	inputSeverities := toStringSlice(value)
 


### PR DESCRIPTION
This is fix of issue mentioned in https://github.com/projectdiscovery/nuclei/issues/995 
Recent change (RES-84 # Improve Nuclei CLI interface) updated the way, how severities are treated inside nuclei. This caused an error in `issue-tracker-config.yaml`, the default version cannot be unmarshaled.

![image](https://user-images.githubusercontent.com/2551605/131871128-4a6289eb-a6e9-454a-9f6d-297669d79b2c.png)

This is caused by the fact, that the severities are stored in `reporting.go`

```go
// Filter filters the received event and decides whether to perform
// reporting for it or not.
type Filter struct {
	Severities severity.Severities `yaml:"severity"`
	Tags       model.StringSlice   `yaml:"tags"`
}
```

Severities are defined in `misc.go` as
```go
type Severities []Severity
```

This file does not use any `UnmarshalYAML` method and the Severity is custom type with const ints.
Therefore, the quick fix might be simple update of the YAML template to contain an array of integers.

![image](https://user-images.githubusercontent.com/2551605/131872263-1334358d-66e7-4772-bd62-f61246e4f5d3.png)

Because it is not very user friendly, I decided to implement `UnmarshalYAML` inside misc.go, which solves the issue.

![image](https://user-images.githubusercontent.com/2551605/131872451-0baf6671-380c-488a-bc34-89ad0ea23ba9.png)
