### PR TITLE
Add severity label to GitHub reporter - Issue#822

### DIFF
--- a/v2/pkg/reporting/trackers/github/github.go
+++ b/v2/pkg/reporting/trackers/github/github.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 
 	"golang.org/x/oauth2"
@@ -57,11 +58,12 @@ func New(options *Options) (*Integration, error) {
 func (i *Integration) CreateIssue(event *output.ResultEvent) error {
 	summary := format.Summary(event)
 	description := format.MarkdownDescription(event)
+	severityLabel := fmt.Sprintf("Severity: %s", event.Info.SeverityHolder.Severity.String())
 
 	req := &github.IssueRequest{
 		Title:     &summary,
 		Body:      &description,
-		Labels:    &[]string{i.options.IssueLabel},
+		Labels:    &[]string{i.options.IssueLabel, severityLabel},
 		Assignees: &[]string{i.options.Username},
 	}
 	_, _, err := i.client.Issues.Create(context.Background(), i.options.Owner, i.options.ProjectName, req)


### PR DESCRIPTION
Include a severity label when creating a GitHub issue.

This is my first time contributing to this project so I wasn't sure if the string formatting should go here or in the format package. I'm happy to change things around if needed 👍 

Tested on a private repo and this is the output.
![image](https://user-images.githubusercontent.com/72813848/133782431-689a73d0-3311-4f55-ac41-408e136710ff.png)

Thanks,