### PR TITLE
docker workflow improvements

### DIFF
--- a/.github/workflows/dockerhub-push.yml
+++ b/.github/workflows/dockerhub-push.yml
@@ -1,8 +1,10 @@
 name: 🌥 Docker Push
 
 on:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: ["🎉 Release Binary"]
+    types:
+      - completed
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This update will ensure that the most recent release tag is pushed to dockerhub rather than the older one, since both workflows were previously executing at the same time, resulting in the older tag being selected.