### PR TITLE
Don't add Host header if unsafe is true

### DIFF
--- a/v2/pkg/protocols/http/raw/raw.go
+++ b/v2/pkg/protocols/http/raw/raw.go
@@ -110,9 +110,9 @@ func Parse(request, baseURL string, unsafe bool) (*Request, error) {
 	}
 	rawRequest.FullURL = fmt.Sprintf("%s://%s%s", parsedURL.Scheme, strings.TrimSpace(hostURL), rawRequest.Path)
 
-	// If raw request doesn't have a Host header
-	// this will be generated from the parsed baseURL
-	if rawRequest.Headers["Host"] == "" {
+	// If raw request doesn't have a Host header and isn't marked unsafe,
+	// this will generate the Host header from the parsed baseURL
+	if !unsafe && rawRequest.Headers["Host"] == "" {
 		rawRequest.Headers["Host"] = hostURL
 	}
 


### PR DESCRIPTION
Do not add Host header if `unsafe: true` is set.

This will prevent nuclei from adding it when the template author doesn’t want it, but add it if if missing from a `safe` raw request.

Templates using raw requests without Host header were modified in projectdiscovery/nuclei-templates#2784
