### PR TITLE
Read response from http2 or http3

### DIFF
--- a/v2/pkg/protocols/offlinehttp/read_response.go
+++ b/v2/pkg/protocols/offlinehttp/read_response.go
@@ -4,13 +4,22 @@ import (
 	"bufio"
 	"errors"
 	"net/http"
+	"regexp"
 	"strings"
 )
 
 // readResponseFromString reads a raw http response from a string.
 func readResponseFromString(data string) (*http.Response, error) {
 	var final string
+	noMinor := regexp.MustCompile(`HTTP\/[0-9] `)
+
 	if strings.HasPrefix(data, "HTTP/") {
+		// Go could not parse http version with no minor version
+		if noMinor.MatchString(data) {
+			// add minor version
+			data = strings.Replace(data, "HTTP/2", "HTTP/2.0", 1)
+			data = strings.Replace(data, "HTTP/3", "HTTP/3.0", 1)
+		}
 		final = data
 	} else {
 		lastIndex := strings.LastIndex(data, "HTTP/")
@@ -18,6 +27,11 @@ func readResponseFromString(data string) (*http.Response, error) {
 			return nil, errors.New("malformed raw http response")
 		}
 		final = data[lastIndex:] // choose last http/ in case of it being later.
+
+		if noMinor.MatchString(final) {
+			final = strings.ReplaceAll(final, "HTTP/2", "HTTP/2.0")
+			final = strings.ReplaceAll(final, "HTTP/3", "HTTP/3.0")
+		}
 	}
 	return http.ReadResponse(bufio.NewReader(strings.NewReader(final)), nil)
 }

--- a/v2/pkg/protocols/offlinehttp/read_response_test.go
+++ b/v2/pkg/protocols/offlinehttp/read_response_test.go
@@ -49,6 +49,62 @@ Server: Google Frontend
 		require.Equal(t, "Google Frontend", resp.Header.Get("Server"), "could not get correct headers")
 	})
 
+	t.Run("response-http2-without-minor-version", func(t *testing.T) {
+		data := `HTTP/2 200 OK
+Age: 0
+Cache-Control: public, max-age=600
+Content-Type: text/html
+Server: Google Frontend
+
+<!DOCTYPE html>
+<html>
+<head>
+<title>Firing Range</title>
+</head>
+<body>
+   <h1>Version 0.48</h1>
+   <h1>What is the Firing Range?</h1>
+   <p>
+</body>
+</body>
+</html>`
+		resp, err := readResponseFromString(data)
+		require.Nil(t, err, "could not read response from string")
+
+		respData, err := ioutil.ReadAll(resp.Body)
+		require.Nil(t, err, "could not read response body")
+		require.Equal(t, expectedBody, string(respData), "could not get correct parsed body")
+		require.Equal(t, "Google Frontend", resp.Header.Get("Server"), "could not get correct headers")
+	})
+
+	t.Run("response-http2-with-minor-version", func(t *testing.T) {
+		data := `HTTP/2.0 200 OK
+Age: 0
+Cache-Control: public, max-age=600
+Content-Type: text/html
+Server: Google Frontend
+
+<!DOCTYPE html>
+<html>
+<head>
+<title>Firing Range</title>
+</head>
+<body>
+   <h1>Version 0.48</h1>
+   <h1>What is the Firing Range?</h1>
+   <p>
+</body>
+</body>
+</html>`
+		resp, err := readResponseFromString(data)
+		require.Nil(t, err, "could not read response from string")
+
+		respData, err := ioutil.ReadAll(resp.Body)
+		require.Nil(t, err, "could not read response body")
+		require.Equal(t, expectedBody, string(respData), "could not get correct parsed body")
+		require.Equal(t, "Google Frontend", resp.Header.Get("Server"), "could not get correct headers")
+	})
+
 	t.Run("request-response", func(t *testing.T) {
 		data := `GET http://public-firing-range.appspot.com/ HTTP/1.1
 Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9
@@ -82,4 +138,39 @@ Server: Google Frontend
 		require.Equal(t, expectedBody, string(respData), "could not get correct parsed body")
 		require.Equal(t, "Google Frontend", resp.Header.Get("Server"), "could not get correct headers")
 	})
+
+	t.Run("request-response-without-minor-version", func(t *testing.T) {
+		data := `GET http://public-firing-range.appspot.com/ HTTP/1.1
+Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9
+Accept-Encoding: gzip, deflate
+Upgrade-Insecure-Requests: 1
+User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 11_1_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.96 Safari/537.36
+
+HTTP/2 200 OK
+Age: 0
+Cache-Control: public, max-age=600
+Content-Type: text/html
+Server: Google Frontend
+
+<!DOCTYPE html>
+<html>
+<head>
+<title>Firing Range</title>
+</head>
+<body>
+   <h1>Version 0.48</h1>
+   <h1>What is the Firing Range?</h1>
+   <p>
+</body>
+</body>
+</html>`
+		resp, err := readResponseFromString(data)
+		require.Nil(t, err, "could not read response from string")
+
+		respData, err := ioutil.ReadAll(resp.Body)
+		require.Nil(t, err, "could not read response body")
+		require.Equal(t, expectedBody, string(respData), "could not get correct parsed body")
+		require.Equal(t, "Google Frontend", resp.Header.Get("Server"), "could not get correct headers")
+	})
+
 }


### PR DESCRIPTION
Go `http.ParseHTTPVersion()` could not parse http version without minor version, like HTTP/2 or HTTP/3.
So in this PR, I add a minor version if the response doesn't include minor version in HTTP response.

this PR related to https://github.com/projectdiscovery/nuclei/issues/1067