### PR TITLE
Ensuring internal keyword has priority over response headers in internal map

### DIFF
--- a/v2/pkg/protocols/offlinehttp/operators.go
+++ b/v2/pkg/protocols/offlinehttp/operators.go
@@ -98,6 +98,13 @@ func (request *Request) responseToDSLMap(resp *http.Response, host, matched, raw
 	for k, v := range extra {
 		data[k] = v
 	}
+	for _, cookie := range resp.Cookies() {
+		data[strings.ToLower(cookie.Name)] = cookie.Value
+	}
+	for k, v := range resp.Header {
+		k = strings.ToLower(strings.TrimSpace(k))
+		data[k] = strings.Join(v, " ")
+	}
 
 	data["path"] = host
 	data["matched"] = matched
@@ -106,13 +113,6 @@ func (request *Request) responseToDSLMap(resp *http.Response, host, matched, raw
 	data["content_length"] = resp.ContentLength
 	data["status_code"] = resp.StatusCode
 	data["body"] = body
-	for _, cookie := range resp.Cookies() {
-		data[strings.ToLower(cookie.Name)] = cookie.Value
-	}
-	for k, v := range resp.Header {
-		k = strings.ToLower(strings.TrimSpace(k))
-		data[k] = strings.Join(v, " ")
-	}
 	data["all_headers"] = headers
 	data["duration"] = duration.Seconds()
 	data["template-id"] = request.options.TemplateID


### PR DESCRIPTION
This PR refactors the code to ensure that internal keyword values in the status map have priority over the fields populated from the response headers. The original issue was already fixed, but it was still present in the offline http module.