### PR TITLE
Add case-insensitive option to template

### DIFF
--- a/integration_tests/http/get-case-insensitive.yaml
+++ b/integration_tests/http/get-case-insensitive.yaml
@@ -1,0 +1,16 @@
+id: basic-get-case-insensitive
+
+info:
+  name: Basic GET Request
+  author: pdteam
+  severity: info
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    matchers:
+      - type: word
+        case-insensitive: true
+        words:
+          - "ThIS is TEsT MAtcHEr TExT"

--- a/v2/cmd/integration-test/http.go
+++ b/v2/cmd/integration-test/http.go
@@ -15,24 +15,26 @@ import (
 )
 
 var httpTestcases = map[string]testutils.TestCase{
-	"http/get-headers.yaml":           &httpGetHeaders{},
-	"http/get-query-string.yaml":      &httpGetQueryString{},
-	"http/get-redirects.yaml":         &httpGetRedirects{},
-	"http/get.yaml":                   &httpGet{},
-	"http/post-body.yaml":             &httpPostBody{},
-	"http/post-json-body.yaml":        &httpPostJSONBody{},
-	"http/post-multipart-body.yaml":   &httpPostMultipartBody{},
-	"http/raw-cookie-reuse.yaml":      &httpRawCookieReuse{},
-	"http/raw-dynamic-extractor.yaml": &httpRawDynamicExtractor{},
-	"http/raw-get-query.yaml":         &httpRawGetQuery{},
-	"http/raw-get.yaml":               &httpRawGet{},
-	"http/raw-payload.yaml":           &httpRawPayload{},
-	"http/raw-post-body.yaml":         &httpRawPostBody{},
-	"http/raw-unsafe-request.yaml":    &httpRawUnsafeRequest{},
-	"http/request-condition.yaml":     &httpRequestCondition{},
-	"http/request-condition-new.yaml": &httpRequestCondition{},
-	"http/interactsh.yaml":            &httpInteractshRequest{},
-	"http/self-contained.yaml":        &httpRequestSelContained{},
+	"http/get-headers.yaml":                        &httpGetHeaders{},
+	"http/get-query-string.yaml":                   &httpGetQueryString{},
+	"http/get-redirects.yaml":                      &httpGetRedirects{},
+	"http/get.yaml":                                &httpGet{},
+	"http/post-body.yaml":                          &httpPostBody{},
+	"http/post-json-body.yaml":                     &httpPostJSONBody{},
+	"http/post-multipart-body.yaml":                &httpPostMultipartBody{},
+	"http/raw-cookie-reuse.yaml":                   &httpRawCookieReuse{},
+	"http/raw-dynamic-extractor.yaml":              &httpRawDynamicExtractor{},
+	"http/raw-get-query.yaml":                      &httpRawGetQuery{},
+	"http/raw-get.yaml":                            &httpRawGet{},
+	"http/raw-payload.yaml":                        &httpRawPayload{},
+	"http/raw-post-body.yaml":                      &httpRawPostBody{},
+	"http/raw-unsafe-request.yaml":                 &httpRawUnsafeRequest{},
+	"http/request-condition.yaml":                  &httpRequestCondition{},
+	"http/request-condition-new.yaml":              &httpRequestCondition{},
+	"http/interactsh.yaml":                         &httpInteractshRequest{},
+	"http/self-contained.yaml":                     &httpRequestSelContained{},
+	"http/get-case-insensitive.yaml":               &httpGetCaseInsensitive{},
+	"http/get.yaml,http/get-case-insensitive.yaml": &httpGetCaseInsensitiveCluster{},
 }
 
 type httpInteractshRequest struct{}
@@ -549,6 +551,50 @@ func (h *httpRequestSelContained) Execute(filePath string) error {
 		return routerErr
 	}
 	if len(results) != 1 {
+		return errIncorrectResultsCount(results)
+	}
+	return nil
+}
+
+type httpGetCaseInsensitive struct{}
+
+// Execute executes a test case and returns an error if occurred
+func (h *httpGetCaseInsensitive) Execute(filePath string) error {
+	router := httprouter.New()
+	router.GET("/", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+		fmt.Fprintf(w, "THIS IS TEST MATCHER TEXT")
+	})
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+
+	results, err := testutils.RunNucleiTemplateAndGetResults(filePath, ts.URL, debug)
+	if err != nil {
+		return err
+	}
+	if len(results) != 1 {
+		return errIncorrectResultsCount(results)
+	}
+	return nil
+}
+
+type httpGetCaseInsensitiveCluster struct{}
+
+// Execute executes a test case and returns an error if occurred
+func (h *httpGetCaseInsensitiveCluster) Execute(filesPath string) error {
+	router := httprouter.New()
+	router.GET("/", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+		fmt.Fprintf(w, "This is test matcher text")
+	})
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+
+	files := strings.Split(filesPath, ",")
+
+	results, err := testutils.RunNucleiTemplateAndGetResults(files[0], ts.URL, debug, "-t", files[1])
+	if err != nil {
+		return err
+	}
+	if len(results) != 2 {
 		return errIncorrectResultsCount(results)
 	}
 	return nil

--- a/v2/pkg/operators/extractors/compile.go
+++ b/v2/pkg/operators/extractors/compile.go
@@ -46,5 +46,15 @@ func (e *Extractor) CompileExtractors() error {
 	if e.Part == "" {
 		e.Part = "body"
 	}
+
+	if e.CaseInsensitive {
+		if e.Type != "kval" {
+			return fmt.Errorf("case-insensitive flag is supported only for 'kval' extractors (not '%s')", e.Type)
+		}
+		for i := range e.KVal {
+			e.KVal[i] = strings.ToLower(e.KVal[i])
+		}
+	}
+
 	return nil
 }

--- a/v2/pkg/operators/extractors/extract.go
+++ b/v2/pkg/operators/extractors/extract.go
@@ -34,8 +34,18 @@ func (e *Extractor) ExtractRegex(corpus string) map[string]struct{} {
 
 // ExtractKval extracts key value pairs from a data map
 func (e *Extractor) ExtractKval(data map[string]interface{}) map[string]struct{} {
-	results := make(map[string]struct{})
+	if e.CaseInsensitive {
+		inputData := data
+		data = make(map[string]interface{}, len(inputData))
+		for k, v := range inputData {
+			if s, ok := v.(string); ok {
+				v = strings.ToLower(s)
+			}
+			data[strings.ToLower(k)] = v
+		}
+	}
 
+	results := make(map[string]struct{})
 	for _, k := range e.KVal {
 		item, ok := data[k]
 		if !ok {

--- a/v2/pkg/operators/extractors/extractors.go
+++ b/v2/pkg/operators/extractors/extractors.go
@@ -105,6 +105,13 @@ type Extractor struct {
 	//   Internal, when set to true will allow using the value extracted
 	//   in the next request for some protocols (like HTTP).
 	Internal bool `yaml:"internal,omitempty" jsonschema:"title=mark extracted value for internal variable use,description=Internal when set to true will allow using the value extracted in the next request for some protocols"`
+
+	// description: |
+	//   CaseInsensitive enables case-insensitive extractions. Default is false.
+	// values:
+	//   - false
+	//   - true
+	CaseInsensitive bool `yaml:"case-insensitive,omitempty" jsonschema:"title=use case insensitive extract,description=use case insensitive extract"`
 }
 
 // ExtractorType is the type of the extractor specified

--- a/v2/pkg/operators/matchers/compile.go
+++ b/v2/pkg/operators/matchers/compile.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/Knetic/govaluate"
 
@@ -59,6 +60,15 @@ func (m *Matcher) CompileMatchers() error {
 		}
 	} else {
 		m.condition = ORCondition
+	}
+
+	if m.CaseInsensitive {
+		if m.Type != "word" {
+			return fmt.Errorf("case-insensitive flag is supported only for 'word' matchers (not '%s')", m.Type)
+		}
+		for i := range m.Words {
+			m.Words[i] = strings.ToLower(m.Words[i])
+		}
 	}
 	return nil
 }

--- a/v2/pkg/operators/matchers/match.go
+++ b/v2/pkg/operators/matchers/match.go
@@ -42,6 +42,10 @@ func (m *Matcher) MatchSize(length int) bool {
 
 // MatchWords matches a word check against a corpus.
 func (m *Matcher) MatchWords(corpus string, dynamicValues map[string]interface{}) (bool, []string) {
+	if m.CaseInsensitive {
+		corpus = strings.ToLower(corpus)
+	}
+
 	var matchedWords []string
 	// Iterate over all the words accepted as valid
 	for i, word := range m.Words {

--- a/v2/pkg/operators/matchers/matchers.go
+++ b/v2/pkg/operators/matchers/matchers.go
@@ -105,6 +105,12 @@ type Matcher struct {
 	// values:
 	//   - "hex"
 	Encoding string `yaml:"encoding,omitempty" jsonschema:"title=encoding for word field,description=Optional encoding for the word fields,enum=hex"`
+	// description: |
+	//   CaseInsensitive enables case-insensitive matches. Default is false.
+	// values:
+	//   - false
+	//   - true
+	CaseInsensitive bool `yaml:"case-insensitive,omitempty" jsonschema:"title=use case insensitive match,description=use case insensitive match"`
 
 	// cached data for the compiled matcher
 	condition     ConditionType

--- a/v2/pkg/protocols/dns/operators.go
+++ b/v2/pkg/protocols/dns/operators.go
@@ -16,13 +16,7 @@ import (
 
 // Match matches a generic data response again a given matcher
 func (request *Request) Match(data map[string]interface{}, matcher *matchers.Matcher) (bool, []string) {
-	partString := matcher.Part
-	switch partString {
-	case "body", "all", "":
-		partString = "raw"
-	}
-
-	item, ok := data[partString]
+	item, ok := request.getMatchPart(matcher.Part, data)
 	if !ok {
 		return false, []string{}
 	}
@@ -50,25 +44,32 @@ func (request *Request) Match(data map[string]interface{}, matcher *matchers.Mat
 
 // Extract performs extracting operation for an extractor on model and returns true or false.
 func (request *Request) Extract(data map[string]interface{}, extractor *extractors.Extractor) map[string]struct{} {
-	part := extractor.Part
+	item, ok := request.getMatchPart(extractor.Part, data)
+	if !ok {
+		return nil
+	}
+
+	switch extractor.GetType() {
+	case extractors.RegexExtractor:
+		return extractor.ExtractRegex(types.ToString(item))
+	case extractors.KValExtractor:
+		return extractor.ExtractKval(data)
+	}
+	return nil
+}
+
+func (request *Request) getMatchPart(part string, data output.InternalEvent) (interface{}, bool) {
 	switch part {
-	case "body", "all":
+	case "body", "all", "":
 		part = "raw"
 	}
 
 	item, ok := data[part]
 	if !ok {
-		return nil
+		return "", false
 	}
-	itemStr := types.ToString(item)
 
-	switch extractor.GetType() {
-	case extractors.RegexExtractor:
-		return extractor.ExtractRegex(itemStr)
-	case extractors.KValExtractor:
-		return extractor.ExtractKval(data)
-	}
-	return nil
+	return item, true
 }
 
 // responseToDSLMap converts a DNS response to a map for use in DSL matching

--- a/v2/pkg/protocols/file/operators.go
+++ b/v2/pkg/protocols/file/operators.go
@@ -16,17 +16,10 @@ import (
 
 // Match matches a generic data response again a given matcher
 func (request *Request) Match(data map[string]interface{}, matcher *matchers.Matcher) (bool, []string) {
-	partString := matcher.Part
-	switch partString {
-	case "body", "all", "data", "":
-		partString = "raw"
-	}
-
-	item, ok := data[partString]
+	itemStr, ok := request.getMatchPart(matcher.Part, data)
 	if !ok {
 		return false, []string{}
 	}
-	itemStr := types.ToString(item)
 
 	switch matcher.GetType() {
 	case matchers.SizeMatcher:
@@ -45,17 +38,10 @@ func (request *Request) Match(data map[string]interface{}, matcher *matchers.Mat
 
 // Extract performs extracting operation for an extractor on model and returns true or false.
 func (request *Request) Extract(data map[string]interface{}, extractor *extractors.Extractor) map[string]struct{} {
-	partString := extractor.Part
-	switch partString {
-	case "body", "all", "data", "":
-		partString = "raw"
-	}
-
-	item, ok := data[partString]
+	itemStr, ok := request.getMatchPart(extractor.Part, data)
 	if !ok {
 		return nil
 	}
-	itemStr := types.ToString(item)
 
 	switch extractor.GetType() {
 	case extractors.RegexExtractor:
@@ -64,6 +50,21 @@ func (request *Request) Extract(data map[string]interface{}, extractor *extracto
 		return extractor.ExtractKval(data)
 	}
 	return nil
+}
+
+func (request *Request) getMatchPart(part string, data output.InternalEvent) (string, bool) {
+	switch part {
+	case "body", "all", "data", "":
+		part = "raw"
+	}
+
+	item, ok := data[part]
+	if !ok {
+		return "", false
+	}
+	itemStr := types.ToString(item)
+
+	return itemStr, true
 }
 
 // responseToDSLMap converts a file response to a map for use in DSL matching

--- a/v2/pkg/protocols/file/operators_test.go
+++ b/v2/pkg/protocols/file/operators_test.go
@@ -105,6 +105,26 @@ func TestFileOperatorMatch(t *testing.T) {
 		require.False(t, isMatched, "could match invalid response matcher")
 		require.Equal(t, []string{}, matched)
 	})
+
+	t.Run("caseInsensitive", func(t *testing.T) {
+		resp := "TEST-DATA\r\n1.1.1.1\r\n"
+		event := request.responseToDSLMap(resp, "one.one.one.one", "one.one.one.one")
+		require.Len(t, event, 6, "could not get correct number of items in dsl map")
+		require.Equal(t, resp, event["raw"], "could not get correct resp")
+
+		matcher := &matchers.Matcher{
+			Part:            "raw",
+			Type:            "word",
+			Words:           []string{"TeSt-DaTA"},
+			CaseInsensitive: true,
+		}
+		err = matcher.CompileMatchers()
+		require.Nil(t, err, "could not compile matcher")
+
+		isMatched, matched := request.Match(event, matcher)
+		require.True(t, isMatched, "could not match valid response")
+		require.Equal(t, []string{"test-data"}, matched)
+	})
 }
 
 func TestFileOperatorExtract(t *testing.T) {

--- a/v2/pkg/protocols/headless/operators.go
+++ b/v2/pkg/protocols/headless/operators.go
@@ -14,17 +14,10 @@ import (
 
 // Match matches a generic data response again a given matcher
 func (request *Request) Match(data map[string]interface{}, matcher *matchers.Matcher) (bool, []string) {
-	partString := matcher.Part
-	switch partString {
-	case "body", "resp", "":
-		partString = "data"
-	}
-
-	item, ok := data[partString]
+	itemStr, ok := request.getMatchPart(matcher.Part, data)
 	if !ok {
 		return false, []string{}
 	}
-	itemStr := types.ToString(item)
 
 	switch matcher.GetType() {
 	case matchers.SizeMatcher:
@@ -43,17 +36,10 @@ func (request *Request) Match(data map[string]interface{}, matcher *matchers.Mat
 
 // Extract performs extracting operation for an extractor on model and returns true or false.
 func (request *Request) Extract(data map[string]interface{}, extractor *extractors.Extractor) map[string]struct{} {
-	partString := extractor.Part
-	switch partString {
-	case "body", "resp", "":
-		partString = "data"
-	}
-
-	item, ok := data[partString]
+	itemStr, ok := request.getMatchPart(extractor.Part, data)
 	if !ok {
 		return nil
 	}
-	itemStr := types.ToString(item)
 
 	switch extractor.GetType() {
 	case extractors.RegexExtractor:
@@ -62,6 +48,21 @@ func (request *Request) Extract(data map[string]interface{}, extractor *extracto
 		return extractor.ExtractKval(data)
 	}
 	return nil
+}
+
+func (request *Request) getMatchPart(part string, data output.InternalEvent) (string, bool) {
+	switch part {
+	case "body", "resp", "":
+		part = "data"
+	}
+
+	item, ok := data[part]
+	if !ok {
+		return "", false
+	}
+	itemStr := types.ToString(item)
+
+	return itemStr, true
 }
 
 // responseToDSLMap converts a headless response to a map for use in DSL matching

--- a/v2/pkg/protocols/http/operators.go
+++ b/v2/pkg/protocols/http/operators.go
@@ -17,7 +17,7 @@ import (
 
 // Match matches a generic data response again a given matcher
 func (request *Request) Match(data map[string]interface{}, matcher *matchers.Matcher) (bool, []string) {
-	item, ok := getMatchPart(matcher.Part, data)
+	item, ok := request.getMatchPart(matcher.Part, data)
 	if !ok {
 		return false, []string{}
 	}
@@ -57,7 +57,7 @@ func getStatusCode(data map[string]interface{}) (int, bool) {
 
 // Extract performs extracting operation for an extractor on model and returns true or false.
 func (request *Request) Extract(data map[string]interface{}, extractor *extractors.Extractor) map[string]struct{} {
-	item, ok := getMatchPart(extractor.Part, data)
+	item, ok := request.getMatchPart(extractor.Part, data)
 	if !ok {
 		return nil
 	}
@@ -75,7 +75,7 @@ func (request *Request) Extract(data map[string]interface{}, extractor *extracto
 }
 
 // getMatchPart returns the match part honoring "all" matchers + others.
-func getMatchPart(part string, data output.InternalEvent) (string, bool) {
+func (request *Request) getMatchPart(part string, data output.InternalEvent) (string, bool) {
 	if part == "header" {
 		part = "all_headers"
 	}

--- a/v2/pkg/protocols/http/operators_test.go
+++ b/v2/pkg/protocols/http/operators_test.go
@@ -117,6 +117,21 @@ func TestHTTPOperatorMatch(t *testing.T) {
 		require.False(t, isMatched, "could match invalid response matcher")
 		require.Equal(t, []string{}, matched)
 	})
+
+	t.Run("caseInsensitive", func(t *testing.T) {
+		matcher := &matchers.Matcher{
+			Part:            "body",
+			Type:            "word", // only applies to word
+			Words:           []string{"EXAMPLE DOMAIN"},
+			CaseInsensitive: true,
+		}
+		err = matcher.CompileMatchers()
+		require.Nil(t, err, "could not compile matcher")
+
+		isMatched, matched := request.Match(event, matcher)
+		require.True(t, isMatched, "could not match valid response")
+		require.Equal(t, []string{"example domain"}, matched)
+	})
 }
 
 func TestHTTPOperatorExtract(t *testing.T) {
@@ -214,6 +229,22 @@ func TestHTTPOperatorExtract(t *testing.T) {
 			require.Greater(t, len(data), 0, "could not extractor json valid response")
 			require.Equal(t, map[string]struct{}{"{\"batter\":[{\"id\":\"1001\",\"type\":\"Regular\"},{\"id\":\"1002\",\"type\":\"Chocolate\"},{\"id\":\"1003\",\"type\":\"Blueberry\"},{\"id\":\"1004\",\"type\":\"Devil's Food\"}]}": {}}, data, "could not extract correct json data")
 		})
+	})
+
+	t.Run("caseInsensitive", func(t *testing.T) {
+		event["body"] = exampleResponseBody
+
+		extractor := &extractors.Extractor{
+			Type:            "kval",
+			KVal:            []string{"TEST_HEADER"}, // only applies to KVal
+			CaseInsensitive: true,
+		}
+		err = extractor.CompileExtractors()
+		require.Nil(t, err, "could not compile kval extractor")
+
+		data := request.Extract(event, extractor)
+		require.Greater(t, len(data), 0, "could not extractor kval valid response")
+		require.Equal(t, map[string]struct{}{"test-response": {}}, data, "could not extract correct kval data")
 	})
 }
 

--- a/v2/pkg/protocols/network/operators.go
+++ b/v2/pkg/protocols/network/operators.go
@@ -14,17 +14,10 @@ import (
 
 // Match matches a generic data response again a given matcher
 func (request *Request) Match(data map[string]interface{}, matcher *matchers.Matcher) (bool, []string) {
-	partString := matcher.Part
-	switch partString {
-	case "body", "all", "":
-		partString = "data"
-	}
-
-	item, ok := data[partString]
+	itemStr, ok := request.getMatchPart(matcher.Part, data)
 	if !ok {
 		return false, []string{}
 	}
-	itemStr := types.ToString(item)
 
 	switch matcher.GetType() {
 	case matchers.SizeMatcher:
@@ -43,17 +36,10 @@ func (request *Request) Match(data map[string]interface{}, matcher *matchers.Mat
 
 // Extract performs extracting operation for an extractor on model and returns true or false.
 func (request *Request) Extract(data map[string]interface{}, extractor *extractors.Extractor) map[string]struct{} {
-	partString := extractor.Part
-	switch partString {
-	case "body", "all", "":
-		partString = "data"
-	}
-
-	item, ok := data[partString]
+	itemStr, ok := request.getMatchPart(extractor.Part, data)
 	if !ok {
 		return nil
 	}
-	itemStr := types.ToString(item)
 
 	switch extractor.GetType() {
 	case extractors.RegexExtractor:
@@ -62,6 +48,21 @@ func (request *Request) Extract(data map[string]interface{}, extractor *extracto
 		return extractor.ExtractKval(data)
 	}
 	return nil
+}
+
+func (request *Request) getMatchPart(part string, data output.InternalEvent) (string, bool) {
+	switch part {
+	case "body", "all", "":
+		part = "data"
+	}
+
+	item, ok := data[part]
+	if !ok {
+		return "", false
+	}
+	itemStr := types.ToString(item)
+
+	return itemStr, true
 }
 
 // responseToDSLMap converts a network response to a map for use in DSL matching

--- a/v2/pkg/protocols/network/operators_test.go
+++ b/v2/pkg/protocols/network/operators_test.go
@@ -103,6 +103,25 @@ func TestNetworkOperatorMatch(t *testing.T) {
 		require.False(t, isMatched, "could match invalid response matcher")
 		require.Equal(t, []string{}, matched)
 	})
+
+	t.Run("caseInsensitive", func(t *testing.T) {
+		matcher := &matchers.Matcher{
+			Part:            "body",
+			Type:            "word",
+			Words:           []string{"rESp-DAta"},
+			CaseInsensitive: true,
+		}
+		err = matcher.CompileMatchers()
+		require.Nil(t, err, "could not compile matcher")
+
+		req := "TEST-DATA\r\n"
+		resp := "RESP-DATA\r\nSTAT \r\n"
+		event := request.responseToDSLMap(req, resp, "one.one.one.one", "one.one.one.one", "TEST")
+
+		isMatched, matched := request.Match(event, matcher)
+		require.True(t, isMatched, "could not match valid response")
+		require.Equal(t, []string{"resp-data"}, matched)
+	})
 }
 
 func TestNetworkOperatorExtract(t *testing.T) {


### PR DESCRIPTION
In this PR I tried to implement case-insensitive matches (#261).
I added this support for the following protocols: `http`, `dns`, `file`, `headless`, `network`.

Although this solution implements the feature, it has several drawbacks:
1. It requires that matchers should also be defined in lowercase
2. for extractors, the result will be returned in lowercase

Are these drawbacks critical to fix or current solution is enough? I think fixing them will require significant refactoring.
Do I need to add more tests? So far I have added a single test for the http protocol.