### PR TITLE
Adding unixtime functionality with seconds offset

### DIFF
--- a/v2/pkg/operators/common/dsl/dsl.go
+++ b/v2/pkg/operators/common/dsl/dsl.go
@@ -224,6 +224,15 @@ var functions = map[string]govaluate.ExpressionFunction{
 		}
 		return rand.Intn(max-min) + min, nil
 	},
+	"unixtime": func(args ...interface{}) (interface{}, error) {
+		seconds := 0
+		if len(args) >= 1 {
+			seconds = int(args[0].(float64))
+		}
+		now := time.Now()
+		offset := now.Add(time.Duration(seconds) * time.Second)
+		return offset.Unix(), nil
+	},
 	// Time Functions
 	"waitfor": func(args ...interface{}) (interface{}, error) {
 		seconds := args[0].(float64)


### PR DESCRIPTION
Hi,
This is a simple functionality to generate epoch timestamps with dynamic offset.
I will upload, when the responsible disclosure procedure will end, the nuclei template of a vulnerability regarding an open source project that uses this feature.
Further features could be to extend to date and nano epoch formats.
Hope this helps, thanks in advance.