### PR TITLE
Adding support for CLI/Env variables in network requests

### DIFF
--- a/v2/pkg/protocols/common/generators/options.go
+++ b/v2/pkg/protocols/common/generators/options.go
@@ -1,0 +1,20 @@
+package generators
+
+import (
+	"github.com/projectdiscovery/nuclei/v2/pkg/types"
+)
+
+// BuildPayloadFromOptions returns a map with the payloads provided via CLI
+func BuildPayloadFromOptions(options *types.Options) map[string]interface{} {
+	m := make(map[string]interface{})
+	// merge with vars
+	if !options.Vars.IsEmpty() {
+		m = MergeMaps(m, options.Vars.AsMap())
+	}
+
+	// merge with env vars
+	if options.EnvironmentVariables {
+		m = MergeMaps(EnvVars(), m)
+	}
+	return m
+}

--- a/v2/pkg/protocols/http/build_request.go
+++ b/v2/pkg/protocols/http/build_request.go
@@ -60,17 +60,10 @@ func (r *requestGenerator) Make(baseURL string, dynamicValues map[string]interfa
 	if !isRawRequest && strings.HasSuffix(parsed.Path, "/") && strings.Contains(data, "{{BaseURL}}/") {
 		trailingSlash = true
 	}
-	values := generators.MergeMaps(dynamicValues, generateVariables(parsed, trailingSlash))
-
-	// merge with vars
-	if !r.options.Options.Vars.IsEmpty() {
-		values = generators.MergeMaps(values, r.options.Options.Vars.AsMap())
-	}
-
-	// merge with env vars
-	if r.options.Options.EnvironmentVariables {
-		values = generators.MergeMaps(generators.EnvVars(), values)
-	}
+	values := generators.MergeMaps(
+		generators.MergeMaps(dynamicValues, generateVariables(parsed, trailingSlash)),
+		generators.BuildPayloadFromOptions(r.request.options.Options),
+	)
 
 	// If data contains \n it's a raw request, process it like raw. Else
 	// continue with the template based request flow.

--- a/v2/pkg/protocols/network/request.go
+++ b/v2/pkg/protocols/network/request.go
@@ -59,6 +59,8 @@ func (request *Request) executeAddress(actualAddress, address, input string, sho
 		return err
 	}
 
+	payloads := generators.BuildPayloadFromOptions(request.options.Options)
+
 	if request.generator != nil {
 		iterator := request.generator.NewIterator()
 
@@ -67,12 +69,13 @@ func (request *Request) executeAddress(actualAddress, address, input string, sho
 			if !ok {
 				break
 			}
+			value = generators.MergeMaps(value, payloads)
 			if err := request.executeRequestWithPayloads(actualAddress, address, input, shouldUseTLS, value, previous, callback); err != nil {
 				return err
 			}
 		}
 	} else {
-		value := make(map[string]interface{})
+		value := generators.MergeMaps(map[string]interface{}{}, payloads)
 		if err := request.executeRequestWithPayloads(actualAddress, address, input, shouldUseTLS, value, previous, callback); err != nil {
 			return err
 		}
@@ -86,6 +89,7 @@ func (request *Request) executeRequestWithPayloads(actualAddress, address, input
 		conn     net.Conn
 		err      error
 	)
+
 	request.dynamicValues = generators.MergeMaps(payloads, map[string]interface{}{"Hostname": address})
 
 	if host, _, splitErr := net.SplitHostPort(actualAddress); splitErr == nil {


### PR DESCRIPTION
Before
```
$ nuclei -debug -u null -t network.yaml -var token="EXAMPLE"
...
AUTH PLAIN {{token}}
```

After:
```
$ nuclei -debug -u null -t network.yaml -var token="EXAMPLE"
...
AUTH PLAIN EXAMPLE
```