### PR TITLE
feat(#1080): Added hexdump view to network request responses

### DIFF
--- a/v2/pkg/protocols/common/helpers/responsehighlighter/hexdump.go
+++ b/v2/pkg/protocols/common/helpers/responsehighlighter/hexdump.go
@@ -1,0 +1,137 @@
+package responsehighlighter
+
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import (
+	"encoding/hex"
+	"errors"
+	"io"
+	"strings"
+)
+
+// HexDump returns a string that contains a hex dump of the given data. The format
+// of the hex dump matches the output of `hexdump -C` on the command line.
+func HexDump(data []byte) string {
+	if len(data) == 0 {
+		return ""
+	}
+
+	var buf strings.Builder
+	// Dumper will write 79 bytes per complete 16 byte chunk, and at least
+	// 64 bytes for whatever remains. Round the allocation up, since only a
+	// maximum of 15 bytes will be wasted.
+	buf.Grow((1 + ((len(data) - 1) / 16)) * 79)
+
+	dumper := &dumper{w: &buf}
+	dumper.Write(data)
+	dumper.Close()
+	return buf.String()
+}
+
+type dumper struct {
+	w          io.Writer
+	rightChars [18]byte
+	buf        [14]byte
+	used       int  // number of bytes in the current line
+	n          uint // number of bytes, total
+	closed     bool
+}
+
+func toChar(b byte) byte {
+	if b < 32 || b > 126 {
+		return '.'
+	}
+	return b
+}
+
+func (h *dumper) Write(data []byte) (n int, err error) {
+	if h.closed {
+		return 0, errors.New("encoding/hex: dumper closed")
+	}
+
+	// Output lines look like:
+	// 00000010  2e 2f 30 31 32 33 34 35 36 37 38 39 3a 3b 3c 3d  |./0123456789:;<=|
+	// ^ offset                                                    ^ ASCII of line.
+	// The only change is the extra space after 8th byte has been removed.
+	for i := range data {
+		if h.used == 0 {
+			// At the beginning of a line we print the current
+			// offset in hex.
+			h.buf[0] = byte(h.n >> 24)
+			h.buf[1] = byte(h.n >> 16)
+			h.buf[2] = byte(h.n >> 8)
+			h.buf[3] = byte(h.n)
+			hex.Encode(h.buf[4:], h.buf[:4])
+			h.buf[12] = ' '
+			h.buf[13] = ' '
+			_, err = h.w.Write(h.buf[4:])
+			if err != nil {
+				return
+			}
+		}
+		hex.Encode(h.buf[:], data[i:i+1])
+		h.buf[2] = ' '
+		l := 3
+		if h.used == 15 {
+			// At the end of the line there's an extra space and
+			// the bar for the right column.
+			h.buf[3] = ' '
+			h.buf[4] = '|'
+			l = 5
+		}
+		_, err = h.w.Write(h.buf[:l])
+		if err != nil {
+			return
+		}
+		n++
+		h.rightChars[h.used] = toChar(data[i])
+		h.used++
+		h.n++
+		if h.used == 16 {
+			h.rightChars[16] = '|'
+			h.rightChars[17] = '\n'
+			_, err = h.w.Write(h.rightChars[:])
+			if err != nil {
+				return
+			}
+			h.used = 0
+		}
+	}
+	return
+}
+
+func (h *dumper) Close() (err error) {
+	// See the comments in Write() for the details of this format.
+	if h.closed {
+		return
+	}
+	h.closed = true
+	if h.used == 0 {
+		return
+	}
+	h.buf[0] = ' '
+	h.buf[1] = ' '
+	h.buf[2] = ' '
+	h.buf[3] = ' '
+	h.buf[4] = '|'
+	nBytes := h.used
+	for h.used < 16 {
+		l := 3
+		if h.used == 7 {
+			l = 4
+		} else if h.used == 15 {
+			l = 5
+		}
+		_, err = h.w.Write(h.buf[:l])
+		if err != nil {
+			return
+		}
+		h.used++
+	}
+	h.rightChars[nBytes] = '|'
+	h.rightChars[nBytes+1] = '\n'
+	_, err = h.w.Write(h.rightChars[:nBytes+2])
+	return
+}

--- a/v2/pkg/protocols/common/helpers/responsehighlighter/hexdump.go
+++ b/v2/pkg/protocols/common/helpers/responsehighlighter/hexdump.go
@@ -25,7 +25,7 @@ func HexDump(data []byte) string {
 	buf.Grow((1 + ((len(data) - 1) / 16)) * 79)
 
 	dumper := &dumper{w: &buf}
-	dumper.Write(data)
+	_, _ = dumper.Write(data)
 	dumper.Close()
 	return buf.String()
 }

--- a/v2/pkg/protocols/common/helpers/responsehighlighter/response_highlighter.go
+++ b/v2/pkg/protocols/common/helpers/responsehighlighter/response_highlighter.go
@@ -1,6 +1,7 @@
 package responsehighlighter
 
 import (
+	"encoding/hex"
 	"strconv"
 	"strings"
 
@@ -11,12 +12,16 @@ import (
 
 var colorizer = aurora.NewAurora(true)
 
-func Highlight(operatorResult *operators.Result, response string, noColor bool) string {
+func Highlight(operatorResult *operators.Result, response string, noColor, hexdump bool) string {
 	result := response
 	if operatorResult != nil && !noColor {
 		for _, matches := range operatorResult.Matches {
 			if len(matches) > 0 {
 				for _, currentMatch := range matches {
+					if hexdump {
+						currentMatchEncoded := chunkSplit(hex.EncodeToString([]byte(currentMatch)), 2, " ")
+						result = strings.ReplaceAll(result, currentMatchEncoded, colorizer.Green(currentMatchEncoded).String())
+					}
 					result = strings.ReplaceAll(result, currentMatch, colorizer.Green(currentMatch).String())
 				}
 			}
@@ -32,4 +37,27 @@ func CreateStatusCodeSnippet(response string, statusCode int) string {
 		return response[:strings.Index(response, strStatusCode)+len(strStatusCode)]
 	}
 	return ""
+}
+
+// chunkSplit splits a string into smaller chunks
+func chunkSplit(body string, chunklen uint, end string) string {
+	if end == "" {
+		end = "\r\n"
+	}
+	runes, erunes := []rune(body), []rune(end)
+	l := uint(len(runes))
+	if l <= 1 || l < chunklen {
+		return body + end
+	}
+	ns := make([]rune, 0, len(runes)+len(erunes))
+	var i uint
+	for i = 0; i < l; i += chunklen {
+		if i+chunklen > l {
+			ns = append(ns, runes[i:]...)
+		} else {
+			ns = append(ns, runes[i:i+chunklen]...)
+		}
+		ns = append(ns, erunes...)
+	}
+	return string(ns)
 }

--- a/v2/pkg/protocols/dns/request.go
+++ b/v2/pkg/protocols/dns/request.go
@@ -66,7 +66,7 @@ func (request *Request) ExecuteWithResults(input string, metadata /*TODO review 
 
 	if request.options.Options.Debug || request.options.Options.DebugResponse {
 		gologger.Debug().Msgf("[%s] Dumped DNS response for %s", request.options.TemplateID, domain)
-		gologger.Print().Msgf("%s", responsehighlighter.Highlight(event.OperatorsResult, resp.String(), request.options.Options.NoColor))
+		gologger.Print().Msgf("%s", responsehighlighter.Highlight(event.OperatorsResult, resp.String(), request.options.Options.NoColor, false))
 	}
 
 	callback(event)

--- a/v2/pkg/protocols/file/request.go
+++ b/v2/pkg/protocols/file/request.go
@@ -61,7 +61,7 @@ func (request *Request) ExecuteWithResults(input string, metadata /*TODO review 
 
 			if request.options.Options.Debug || request.options.Options.DebugResponse {
 				gologger.Info().Msgf("[%s] Dumped file request for %s", request.options.TemplateID, filePath)
-				gologger.Print().Msgf("%s", responsehighlighter.Highlight(event.OperatorsResult, dataStr, request.options.Options.NoColor))
+				gologger.Print().Msgf("%s", responsehighlighter.Highlight(event.OperatorsResult, dataStr, request.options.Options.NoColor, false))
 			}
 
 			callback(event)

--- a/v2/pkg/protocols/headless/request.go
+++ b/v2/pkg/protocols/headless/request.go
@@ -69,7 +69,7 @@ func (request *Request) ExecuteWithResults(input string, metadata, previous outp
 
 	if request.options.Options.Debug || request.options.Options.DebugResponse {
 		gologger.Debug().Msgf("[%s] Dumped Headless response for %s", request.options.TemplateID, input)
-		gologger.Print().Msgf("%s", responsehighlighter.Highlight(event.OperatorsResult, responseBody, request.options.Options.NoColor))
+		gologger.Print().Msgf("%s", responsehighlighter.Highlight(event.OperatorsResult, responseBody, request.options.Options.NoColor, false))
 	}
 
 	callback(event)

--- a/v2/pkg/protocols/http/request.go
+++ b/v2/pkg/protocols/http/request.go
@@ -511,7 +511,7 @@ func (request *Request) executeRequest(reqURL string, generatedRequest *generate
 
 	if request.options.Options.Debug || request.options.Options.DebugResponse {
 		gologger.Info().Msgf("[%s] Dumped HTTP response for %s\n\n", request.options.TemplateID, formedURL)
-		gologger.Print().Msgf("%s", responsehighlighter.Highlight(event.OperatorsResult, string(redirectedResponse), request.options.Options.NoColor))
+		gologger.Print().Msgf("%s", responsehighlighter.Highlight(event.OperatorsResult, string(redirectedResponse), request.options.Options.NoColor, false))
 	}
 
 	callback(event)

--- a/v2/pkg/protocols/network/request.go
+++ b/v2/pkg/protocols/network/request.go
@@ -191,7 +191,7 @@ func (request *Request) executeRequestWithPayloads(actualAddress, address, input
 	if request.options.Options.Debug || request.options.Options.DebugRequests {
 		requestOutput := reqBuilder.String()
 		gologger.Info().Str("address", actualAddress).Msgf("[%s] Dumped Network request for %s", request.options.TemplateID, actualAddress)
-		gologger.Print().Msgf("%s\nHexdump: \n%s", requestOutput, hex.Dump([]byte(requestOutput)))
+		gologger.Print().Msgf("%s\nHexdump: \n%s", requestOutput, responsehighlighter.HexDump([]byte(requestOutput)))
 	}
 
 	request.options.Output.Request(request.options.TemplateID, actualAddress, "network", err)
@@ -276,7 +276,7 @@ func (request *Request) executeRequestWithPayloads(actualAddress, address, input
 
 	if request.options.Options.Debug || request.options.Options.DebugResponse {
 		gologger.Debug().Msgf("[%s] Dumped Network response for %s", request.options.TemplateID, actualAddress)
-		gologger.Print().Msgf("%s\nHexdump: \n%s", response, responsehighlighter.Highlight(event.OperatorsResult, hex.Dump([]byte(response)), request.options.Options.NoColor, true))
+		gologger.Print().Msgf("%s\nHexdump: \n%s", response, responsehighlighter.Highlight(event.OperatorsResult, responsehighlighter.HexDump([]byte(response)), request.options.Options.NoColor, true))
 	}
 
 	return nil

--- a/v2/pkg/protocols/network/request.go
+++ b/v2/pkg/protocols/network/request.go
@@ -191,7 +191,7 @@ func (request *Request) executeRequestWithPayloads(actualAddress, address, input
 	if request.options.Options.Debug || request.options.Options.DebugRequests {
 		requestOutput := reqBuilder.String()
 		gologger.Info().Str("address", actualAddress).Msgf("[%s] Dumped Network request for %s", request.options.TemplateID, actualAddress)
-		gologger.Print().Msgf("%s\nHex: %s", requestOutput, hex.EncodeToString([]byte(requestOutput)))
+		gologger.Print().Msgf("%s\nHexdump: \n%s", requestOutput, hex.Dump([]byte(requestOutput)))
 	}
 
 	request.options.Output.Request(request.options.TemplateID, actualAddress, "network", err)
@@ -276,7 +276,7 @@ func (request *Request) executeRequestWithPayloads(actualAddress, address, input
 
 	if request.options.Options.Debug || request.options.Options.DebugResponse {
 		gologger.Debug().Msgf("[%s] Dumped Network response for %s", request.options.TemplateID, actualAddress)
-		gologger.Print().Msgf("%s\nHex: %s", response, responsehighlighter.Highlight(event.OperatorsResult, hex.EncodeToString([]byte(response)), request.options.Options.NoColor))
+		gologger.Print().Msgf("%s\nHexdump: \n%s", response, responsehighlighter.Highlight(event.OperatorsResult, hex.Dump([]byte(response)), request.options.Options.NoColor, true))
 	}
 
 	return nil


### PR DESCRIPTION
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->
This PR Closes #1080 by adding a hexdump view for network request and response.

![image](https://user-images.githubusercontent.com/22318055/138853933-f1e180ac-f2a8-4897-8de4-4df4b9072171.png)


## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)