### PR TITLE
Add error log option

### DIFF
--- a/v2/cmd/nuclei/main.go
+++ b/v2/cmd/nuclei/main.go
@@ -139,6 +139,7 @@ on extensive configurability, massive extensibility and ease of use.`)
 		flagSet.StringVarP(&options.ProxyURL, "proxy-url", "proxy", "", "URL of the HTTP proxy server"),
 		flagSet.StringVar(&options.ProxySocksURL, "proxy-socks-url", "", "URL of the SOCKS proxy server"),
 		flagSet.StringVarP(&options.TraceLogFile, "trace-log", "tlog", "", "file to write sent requests trace log"),
+		flagSet.StringVarP(&options.ErrorLogFile, "error-log", "elog", "", "file to write sent requests error log"),
 		flagSet.BoolVar(&options.Version, "version", false, "show nuclei version"),
 		flagSet.BoolVarP(&options.Verbose, "verbose", "v", false, "show verbose output"),
 		flagSet.BoolVar(&options.VerboseVerbose, "vv", false, "display templates loaded for scan"),

--- a/v2/internal/runner/runner.go
+++ b/v2/internal/runner/runner.go
@@ -215,7 +215,7 @@ func New(options *types.Options) (*Runner, error) {
 	}
 
 	// Create the output file if asked
-	outputWriter, err := output.NewStandardWriter(!options.NoColor, options.NoMeta, options.NoTimestamp, options.JSON, options.JSONRequests, options.Output, options.TraceLogFile)
+	outputWriter, err := output.NewStandardWriter(!options.NoColor, options.NoMeta, options.NoTimestamp, options.JSON, options.JSONRequests, options.Output, options.TraceLogFile, options.ErrorLogFile)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not create output file")
 	}

--- a/v2/pkg/output/file_output_writer.go
+++ b/v2/pkg/output/file_output_writer.go
@@ -2,11 +2,13 @@ package output
 
 import (
 	"os"
+	"sync"
 )
 
 // fileWriter is a concurrent file based output writer.
 type fileWriter struct {
 	file *os.File
+	mu   sync.Mutex
 }
 
 // NewFileOutputWriter creates a new buffered writer for a file
@@ -20,6 +22,8 @@ func newFileOutputWriter(file string) (*fileWriter, error) {
 
 // WriteString writes an output to the underlying file
 func (w *fileWriter) Write(data []byte) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
 	if _, err := w.file.Write(data); err != nil {
 		return err
 	}
@@ -29,6 +33,8 @@ func (w *fileWriter) Write(data []byte) error {
 
 // Close closes the underlying writer flushing everything to disk
 func (w *fileWriter) Close() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
 	//nolint:errcheck // we don't care whether sync failed or succeeded.
 	w.file.Sync()
 	return w.file.Close()

--- a/v2/pkg/output/file_output_writer.go
+++ b/v2/pkg/output/file_output_writer.go
@@ -21,14 +21,16 @@ func newFileOutputWriter(file string) (*fileWriter, error) {
 }
 
 // WriteString writes an output to the underlying file
-func (w *fileWriter) Write(data []byte) error {
+func (w *fileWriter) Write(data []byte) (int, error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	if _, err := w.file.Write(data); err != nil {
-		return err
+		return 0, err
 	}
-	_, err := w.file.Write([]byte("\n"))
-	return err
+	if _, err := w.file.Write([]byte("\n")); err != nil {
+		return 0, err
+	}
+	return len(data) + 1, nil
 }
 
 // Close closes the underlying writer flushing everything to disk

--- a/v2/pkg/output/output.go
+++ b/v2/pkg/output/output.go
@@ -174,23 +174,23 @@ func (w *StandardWriter) Write(event *ResultEvent) error {
 	return nil
 }
 
-// JSONTraceRequest is a trace log request written to file
-type JSONTraceRequest struct {
-	ID    string `json:"id"`
-	URL   string `json:"url"`
-	Error string `json:"error"`
-	Type  string `json:"type"`
+// JSONLogRequest is a trace/error log request written to file
+type JSONLogRequest struct {
+	Template string `json:"template"`
+	Input    string `json:"input"`
+	Error    string `json:"error"`
+	Type     string `json:"type"`
 }
 
 // Request writes a log the requests trace log
-func (w *StandardWriter) Request(templateID, url, requestType string, requestErr error) {
+func (w *StandardWriter) Request(templatePath, input, requestType string, requestErr error) {
 	if w.traceFile == nil && w.errorFile == nil {
 		return
 	}
-	request := &JSONTraceRequest{
-		ID:   templateID,
-		URL:  url,
-		Type: requestType,
+	request := &JSONLogRequest{
+		Template: templatePath,
+		Input:    input,
+		Type:     requestType,
 	}
 	if requestErr != nil {
 		request.Error = requestErr.Error()

--- a/v2/pkg/output/output.go
+++ b/v2/pkg/output/output.go
@@ -3,7 +3,6 @@ package output
 import (
 	"os"
 	"regexp"
-	"sync"
 	"time"
 
 	"github.com/pkg/errors"
@@ -39,11 +38,8 @@ type StandardWriter struct {
 	noMetadata     bool
 	aurora         aurora.Aurora
 	outputFile     *fileWriter
-	outputMutex    *sync.Mutex
 	traceFile      *fileWriter
-	traceMutex     *sync.Mutex
 	errorFile      *fileWriter
-	errorMutex     *sync.Mutex
 	severityColors func(severity.Severity) string
 }
 
@@ -134,11 +130,8 @@ func NewStandardWriter(colors, noMetadata, noTimestamp, json, jsonReqResp bool, 
 		noTimestamp:    noTimestamp,
 		aurora:         auroraColorizer,
 		outputFile:     outputFile,
-		outputMutex:    &sync.Mutex{},
 		traceFile:      traceOutput,
-		traceMutex:     &sync.Mutex{},
 		errorFile:      errorOutput,
-		errorMutex:     &sync.Mutex{},
 		severityColors: colorizer.New(auroraColorizer),
 	}
 	return writer, nil
@@ -205,15 +198,11 @@ func (w *StandardWriter) Request(templatePath, input, requestType string, reques
 	}
 
 	if w.traceFile != nil {
-		w.traceMutex.Lock()
 		_ = w.traceFile.Write(data)
-		w.traceMutex.Unlock()
 	}
 
 	if requestErr != nil && w.errorFile != nil {
-		w.errorMutex.Lock()
 		_ = w.errorFile.Write(data)
-		w.errorMutex.Unlock()
 	}
 }
 

--- a/v2/pkg/output/output.go
+++ b/v2/pkg/output/output.go
@@ -16,6 +16,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v2/pkg/model"
 	"github.com/projectdiscovery/nuclei/v2/pkg/model/types/severity"
 	"github.com/projectdiscovery/nuclei/v2/pkg/operators"
+	"github.com/projectdiscovery/nuclei/v2/pkg/utils"
 )
 
 // Writer is an interface which writes output to somewhere for nuclei events.
@@ -192,8 +193,8 @@ func (w *StandardWriter) Request(templatePath, input, requestType string, reques
 		Input:    input,
 		Type:     requestType,
 	}
-	if requestErr != nil {
-		request.Error = requestErr.Error()
+	if unwrappedErr := utils.UnwrapError(requestErr); unwrappedErr != nil {
+		request.Error = unwrappedErr.Error()
 	} else {
 		request.Error = "none"
 	}

--- a/v2/pkg/output/output_test.go
+++ b/v2/pkg/output/output_test.go
@@ -1,0 +1,59 @@
+package output
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStandardWriterRequest(t *testing.T) {
+	t.Run("WithoutTraceAndError", func(t *testing.T) {
+		w, err := NewStandardWriter(false, false, false, false, false, "", "", "")
+		require.NoError(t, err)
+		require.NotPanics(t, func() {
+			w.Request("path", "input", "http", nil)
+			w.Close()
+		})
+	})
+
+	t.Run("TraceAndErrorWithoutError", func(t *testing.T) {
+		traceWriter := &testWriteCloser{}
+		errorWriter := &testWriteCloser{}
+
+		w, err := NewStandardWriter(false, false, false, false, false, "", "", "")
+		w.traceFile = traceWriter
+		w.errorFile = errorWriter
+		require.NoError(t, err)
+		w.Request("path", "input", "http", nil)
+
+		require.Equal(t, `{"template":"path","input":"input","error":"none","type":"http"}`, traceWriter.String())
+		require.Empty(t, errorWriter.String())
+	})
+
+	t.Run("ErrorWithWrappedError", func(t *testing.T) {
+		errorWriter := &testWriteCloser{}
+
+		w, err := NewStandardWriter(false, false, false, false, false, "", "", "")
+		w.errorFile = errorWriter
+		require.NoError(t, err)
+		w.Request(
+			"misconfiguration/tcpconfig.yaml",
+			"https://example.com/tcpconfig.html",
+			"http",
+			fmt.Errorf("GET https://example.com/tcpconfig.html/tcpconfig.html giving up after 2 attempts: %w", errors.New("context deadline exceeded (Client.Timeout exceeded while awaiting headers)")),
+		)
+
+		require.Equal(t, `{"template":"misconfiguration/tcpconfig.yaml","input":"https://example.com/tcpconfig.html","error":"context deadline exceeded (Client.Timeout exceeded while awaiting headers)","type":"http"}`, errorWriter.String())
+	})
+}
+
+type testWriteCloser struct {
+	strings.Builder
+}
+
+func (w testWriteCloser) Close() error {
+	return nil
+}

--- a/v2/pkg/protocols/dns/request.go
+++ b/v2/pkg/protocols/dns/request.go
@@ -28,7 +28,7 @@ func (request *Request) ExecuteWithResults(input string, metadata /*TODO review 
 	// Compile each request for the template based on the URL
 	compiledRequest, err := request.Make(domain)
 	if err != nil {
-		request.options.Output.Request(request.options.TemplateID, domain, "dns", err)
+		request.options.Output.Request(request.options.TemplatePath, domain, "dns", err)
 		request.options.Progress.IncrementFailedRequestsBy(1)
 		return errors.Wrap(err, "could not build request")
 	}
@@ -46,7 +46,7 @@ func (request *Request) ExecuteWithResults(input string, metadata /*TODO review 
 	// Send the request to the target servers
 	resp, err := request.dnsClient.Do(compiledRequest)
 	if err != nil {
-		request.options.Output.Request(request.options.TemplateID, domain, "dns", err)
+		request.options.Output.Request(request.options.TemplatePath, domain, "dns", err)
 		request.options.Progress.IncrementFailedRequestsBy(1)
 	}
 	if resp == nil {
@@ -54,7 +54,7 @@ func (request *Request) ExecuteWithResults(input string, metadata /*TODO review 
 	}
 	request.options.Progress.IncrementRequests()
 
-	request.options.Output.Request(request.options.TemplateID, domain, "dns", err)
+	request.options.Output.Request(request.options.TemplatePath, domain, "dns", err)
 	gologger.Verbose().Msgf("[%s] Sent DNS request to %s", request.options.TemplateID, domain)
 
 	outputEvent := request.responseToDSLMap(compiledRequest, resp, input, input)

--- a/v2/pkg/protocols/file/request.go
+++ b/v2/pkg/protocols/file/request.go
@@ -69,7 +69,7 @@ func (request *Request) ExecuteWithResults(input string, metadata /*TODO review 
 	})
 	wg.Wait()
 	if err != nil {
-		request.options.Output.Request(request.options.TemplateID, input, "file", err)
+		request.options.Output.Request(request.options.TemplatePath, input, "file", err)
 		request.options.Progress.IncrementFailedRequestsBy(1)
 		return errors.Wrap(err, "could not send file request")
 	}

--- a/v2/pkg/protocols/headless/request.go
+++ b/v2/pkg/protocols/headless/request.go
@@ -20,7 +20,7 @@ var _ protocols.Request = &Request{}
 func (request *Request) ExecuteWithResults(input string, metadata, previous output.InternalEvent /*TODO review unused parameter*/, callback protocols.OutputEventCallback) error {
 	instance, err := request.options.Browser.NewInstance()
 	if err != nil {
-		request.options.Output.Request(request.options.TemplateID, input, "headless", err)
+		request.options.Output.Request(request.options.TemplatePath, input, "headless", err)
 		request.options.Progress.IncrementFailedRequestsBy(1)
 		return errors.Wrap(err, "could get html element")
 	}
@@ -28,19 +28,19 @@ func (request *Request) ExecuteWithResults(input string, metadata, previous outp
 
 	parsed, err := url.Parse(input)
 	if err != nil {
-		request.options.Output.Request(request.options.TemplateID, input, "headless", err)
+		request.options.Output.Request(request.options.TemplatePath, input, "headless", err)
 		request.options.Progress.IncrementFailedRequestsBy(1)
 		return errors.Wrap(err, "could get html element")
 	}
 	out, page, err := instance.Run(parsed, request.Steps, time.Duration(request.options.Options.PageTimeout)*time.Second)
 	if err != nil {
-		request.options.Output.Request(request.options.TemplateID, input, "headless", err)
+		request.options.Output.Request(request.options.TemplatePath, input, "headless", err)
 		request.options.Progress.IncrementFailedRequestsBy(1)
 		return errors.Wrap(err, "could get html element")
 	}
 	defer page.Close()
 
-	request.options.Output.Request(request.options.TemplateID, input, "headless", nil)
+	request.options.Output.Request(request.options.TemplatePath, input, "headless", nil)
 	request.options.Progress.IncrementRequests()
 	gologger.Verbose().Msgf("Sent Headless request to %s", input)
 

--- a/v2/pkg/protocols/http/request.go
+++ b/v2/pkg/protocols/http/request.go
@@ -356,7 +356,7 @@ func (request *Request) executeRequest(reqURL string, generatedRequest *generate
 			_, _ = io.CopyN(ioutil.Discard, resp.Body, drainReqSize)
 			resp.Body.Close()
 		}
-		request.options.Output.Request(request.options.TemplateID, formedURL, "http", err)
+		request.options.Output.Request(request.options.TemplatePath, formedURL, "http", err)
 		request.options.Progress.IncrementErrorsBy(1)
 
 		// If we have interactsh markers and request times out, still send
@@ -394,7 +394,7 @@ func (request *Request) executeRequest(reqURL string, generatedRequest *generate
 	}
 
 	gologger.Verbose().Msgf("[%s] Sent HTTP request to %s", request.options.TemplateID, formedURL)
-	request.options.Output.Request(request.options.TemplateID, formedURL, "http", err)
+	request.options.Output.Request(request.options.TemplatePath, formedURL, "http", err)
 
 	duration := time.Since(timeStart)
 

--- a/v2/pkg/protocols/network/request.go
+++ b/v2/pkg/protocols/network/request.go
@@ -36,7 +36,7 @@ func (request *Request) ExecuteWithResults(input string, metadata /*TODO review 
 		address, err = getAddress(input)
 	}
 	if err != nil {
-		request.options.Output.Request(request.options.TemplateID, input, "network", err)
+		request.options.Output.Request(request.options.TemplatePath, input, "network", err)
 		request.options.Progress.IncrementFailedRequestsBy(1)
 		return errors.Wrap(err, "could not get address from url")
 	}
@@ -65,7 +65,7 @@ func (request *Request) ExecuteWithResults(input string, metadata /*TODO review 
 func (request *Request) executeAddress(actualAddress, address, input string, shouldUseTLS bool, previous output.InternalEvent, callback protocols.OutputEventCallback) error {
 	if !strings.Contains(actualAddress, ":") {
 		err := errors.New("no port provided in network protocol request")
-		request.options.Output.Request(request.options.TemplateID, address, "network", err)
+		request.options.Output.Request(request.options.TemplatePath, address, "network", err)
 		request.options.Progress.IncrementFailedRequestsBy(1)
 		return err
 	}
@@ -113,7 +113,7 @@ func (request *Request) executeRequestWithPayloads(actualAddress, address, input
 		conn, err = request.dialer.Dial(context.Background(), "tcp", actualAddress)
 	}
 	if err != nil {
-		request.options.Output.Request(request.options.TemplateID, address, "network", err)
+		request.options.Output.Request(request.options.TemplatePath, address, "network", err)
 		request.options.Progress.IncrementFailedRequestsBy(1)
 		return errors.Wrap(err, "could not connect to server request")
 	}
@@ -143,7 +143,7 @@ func (request *Request) executeRequestWithPayloads(actualAddress, address, input
 			data = []byte(input.Data)
 		}
 		if err != nil {
-			request.options.Output.Request(request.options.TemplateID, address, "network", err)
+			request.options.Output.Request(request.options.TemplatePath, address, "network", err)
 			request.options.Progress.IncrementFailedRequestsBy(1)
 			return errors.Wrap(err, "could not write request to server")
 		}
@@ -151,7 +151,7 @@ func (request *Request) executeRequestWithPayloads(actualAddress, address, input
 
 		finalData, dataErr := expressions.EvaluateByte(data, payloads)
 		if dataErr != nil {
-			request.options.Output.Request(request.options.TemplateID, address, "network", dataErr)
+			request.options.Output.Request(request.options.TemplatePath, address, "network", dataErr)
 			request.options.Progress.IncrementFailedRequestsBy(1)
 			return errors.Wrap(dataErr, "could not evaluate template expressions")
 		}
@@ -162,7 +162,7 @@ func (request *Request) executeRequestWithPayloads(actualAddress, address, input
 			return nil
 		}
 		if _, err := conn.Write(finalData); err != nil {
-			request.options.Output.Request(request.options.TemplateID, address, "network", err)
+			request.options.Output.Request(request.options.TemplatePath, address, "network", err)
 			request.options.Progress.IncrementFailedRequestsBy(1)
 			return errors.Wrap(err, "could not write request to server")
 		}
@@ -194,7 +194,7 @@ func (request *Request) executeRequestWithPayloads(actualAddress, address, input
 		gologger.Print().Msgf("%s\nHex: %s", requestOutput, hex.EncodeToString([]byte(requestOutput)))
 	}
 
-	request.options.Output.Request(request.options.TemplateID, actualAddress, "network", err)
+	request.options.Output.Request(request.options.TemplatePath, actualAddress, "network", err)
 	gologger.Verbose().Msgf("Sent TCP request to %s", actualAddress)
 
 	bufferSize := 1024
@@ -225,7 +225,7 @@ func (request *Request) executeRequestWithPayloads(actualAddress, address, input
 				buf := make([]byte, bufferSize)
 				nBuf, err := conn.Read(buf)
 				if err != nil && !os.IsTimeout(err) {
-					request.options.Output.Request(request.options.TemplateID, address, "network", err)
+					request.options.Output.Request(request.options.TemplatePath, address, "network", err)
 					closeTimer(readInterval)
 					return errors.Wrap(err, "could not read from server")
 				}
@@ -238,7 +238,7 @@ func (request *Request) executeRequestWithPayloads(actualAddress, address, input
 		final = make([]byte, bufferSize)
 		n, err = conn.Read(final)
 		if err != nil && err != io.EOF {
-			request.options.Output.Request(request.options.TemplateID, address, "network", err)
+			request.options.Output.Request(request.options.TemplatePath, address, "network", err)
 			return errors.Wrap(err, "could not read from server")
 		}
 		responseBuilder.Write(final[:n])

--- a/v2/pkg/protocols/offlinehttp/request.go
+++ b/v2/pkg/protocols/offlinehttp/request.go
@@ -91,7 +91,7 @@ func (request *Request) ExecuteWithResults(input string, metadata /*TODO review 
 	})
 	wg.Wait()
 	if err != nil {
-		request.options.Output.Request(request.options.TemplateID, input, "file", err)
+		request.options.Output.Request(request.options.TemplatePath, input, "file", err)
 		request.options.Progress.IncrementFailedRequestsBy(1)
 		return errors.Wrap(err, "could not send file request")
 	}

--- a/v2/pkg/types/types.go
+++ b/v2/pkg/types/types.go
@@ -57,6 +57,8 @@ type Options struct {
 	TemplatesDirectory string
 	// TraceLogFile specifies a file to write with the trace of all requests
 	TraceLogFile string
+	// ErrorLogFile specifies a file to write with the errors of all requests
+	ErrorLogFile string
 	// ReportingDB is the db for report storage as well as deduplication
 	ReportingDB string
 	// ReportingConfig is the config file for nuclei reporting module

--- a/v2/pkg/utils/utils.go
+++ b/v2/pkg/utils/utils.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"errors"
 	"strings"
 )
 
@@ -10,4 +11,15 @@ func IsBlank(value string) bool {
 
 func IsNotBlank(value string) bool {
 	return !IsBlank(value)
+}
+
+func UnwrapError(err error) error {
+	for { // get the last wrapped error
+		unwrapped := errors.Unwrap(err)
+		if unwrapped == nil {
+			break
+		}
+		err = unwrapped
+	}
+	return err
 }

--- a/v2/pkg/utils/utils_test.go
+++ b/v2/pkg/utils/utils_test.go
@@ -1,0 +1,21 @@
+package utils
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnwrapError(t *testing.T) {
+	require.Equal(t, nil, UnwrapError(nil))
+
+	errOne := fmt.Errorf("error one")
+	require.Equal(t, errOne, UnwrapError(errOne))
+
+	errTwo := fmt.Errorf("error with error: %w", errOne)
+	require.Equal(t, errOne, UnwrapError(errTwo))
+
+	errThree := fmt.Errorf("error with error: %w", errTwo)
+	require.Equal(t, errOne, UnwrapError(errThree))
+}


### PR DESCRIPTION
## Proposed changes

Implements error log feature (#1187)

Original issue checklist:
- [x] Updating id to template-path to include template path information instead of id (https://github.com/projectdiscovery/nuclei/commit/933ed2429d533f7d78ce30df4eee51ade0313be9, https://github.com/projectdiscovery/nuclei/commit/463c1c0142968de19e97c9d18667acc1c74bbf71)
- [x] Updating url JSON field input to make it uniform for all types of template (https://github.com/projectdiscovery/nuclei/commit/933ed2429d533f7d78ce30df4eee51ade0313be9)
- [x] Updating HTTP and FILE type error to include only final error information (https://github.com/projectdiscovery/nuclei/commit/1eb0378952b576db290fa15fc87fc6904ace13e5)

Differences from the original issue:
- The absolute path to the template is displayed, not the relative path as in the example. Does this need to be fixed?
- I made the original error message for all protocols since it can be done uniformly in one place. Also, I am doing recursive `Unwrap` to get the last wrapped error. I don't know how bad it is.
- I also did some refactoring to improve the testability of outputs. This is done in the last three commits (https://github.com/projectdiscovery/nuclei/commit/cd2db280bfd5469f5984d1d3f1bb96828cbdb6c8, https://github.com/projectdiscovery/nuclei/commit/b8ebbc27f5a11f6d5edd74a5415bc0041893850e, https://github.com/projectdiscovery/nuclei/commit/bccc8e921b9aa640fd244f9d149ace0723e704ab). If it's unnecessary, I can remove it.

Example of output:
```
$ echo "https://exxmple.com/tcpconfig.html" | ./nuclei -t misconfiguration/tcpconfig.yaml -error-log error.log
$ cat error.log | jq                                                                                                               
{
  "template": "/home/zerodivisi0n/nuclei-templates/misconfiguration/tcpconfig.yaml",
  "input": "https://exxmple.com/tcpconfig.html/tcpconfig.html",
  "error": "no address found for host",
  "type": "http"
}
```

## Checklist

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)