### PR TITLE
Enhance hexdump content highlighting

### DIFF
--- a/v2/pkg/protocols/common/helpers/responsehighlighter/hexdump.go
+++ b/v2/pkg/protocols/common/helpers/responsehighlighter/hexdump.go
@@ -77,7 +77,13 @@ func highlightHexSection(hexDump HighlightableHexDump, snippetToColor string) Hi
 func highlightAsciiSection(hexDump HighlightableHexDump, snippetToColor string) HighlightableHexDump {
 	var snippetCharactersMatchPattern string
 	for _, v := range snippetToColor {
-		snippetCharactersMatchPattern += fmt.Sprintf(`(%s\n*)`, regexp.QuoteMeta(string(v)))
+		var value string
+		if IsASCIIPrintable(v) {
+			value = regexp.QuoteMeta(string(v))
+		} else {
+			value = "."
+		}
+		snippetCharactersMatchPattern += fmt.Sprintf(`(%s\n*)`, value)
 	}
 
 	hexDump.ascii = highlight(hexDump.ascii, snippetCharactersMatchPattern, func(v string) string {
@@ -105,6 +111,10 @@ func highlight(values []string, snippetCharactersMatchPattern string, replaceToF
 	return strings.Split(rows, "\n")
 }
 
+func HasBinaryContent(input string) bool {
+	return !IsASCII(input)
+}
+
 // IsASCII tests whether a string consists only of ASCII characters or not
 func IsASCII(input string) bool {
 	for i := 0; i < len(input); i++ {
@@ -113,4 +123,8 @@ func IsASCII(input string) bool {
 		}
 	}
 	return true
+}
+
+func IsASCIIPrintable(input rune) bool {
+	return input > 32 && input < unicode.MaxASCII
 }

--- a/v2/pkg/protocols/dns/request.go
+++ b/v2/pkg/protocols/dns/request.go
@@ -65,22 +65,22 @@ func (request *Request) ExecuteWithResults(input string, metadata /*TODO review 
 
 	event := eventcreator.CreateEvent(request, outputEvent, request.options.Options.Debug || request.options.Options.DebugResponse)
 
-	debug(event, request, domain, response.String())
+	dumpResponse(event, request.options, response.String(), domain)
 
 	callback(event)
 	return nil
 }
 
-func debug(event *output.InternalWrappedEvent, request *Request, domain string, response string) {
-	if request.options.Options.Debug || request.options.Options.DebugResponse {
-		gologger.Debug().Msgf("[%s] Dumped DNS response for %s\n", request.options.TemplateID, domain)
-
+func dumpResponse(event *output.InternalWrappedEvent, requestOptions *protocols.ExecuterOptions, response string, domain string) {
+	cliOptions := requestOptions.Options
+	if cliOptions.Debug || cliOptions.DebugResponse {
 		hexDump := false
-		if !responsehighlighter.IsASCII(response) {
+		if responsehighlighter.HasBinaryContent(response) {
 			hexDump = true
 			response = hex.Dump([]byte(response))
 		}
-		gologger.Print().Msgf("%s", responsehighlighter.Highlight(event.OperatorsResult, response, request.options.Options.NoColor, hexDump))
+		highlightedResponse := responsehighlighter.Highlight(event.OperatorsResult, response, cliOptions.NoColor, hexDump)
+		gologger.Debug().Msgf("[%s] Dumped DNS response for %s\n\n%s", requestOptions.TemplateID, domain, highlightedResponse)
 	}
 }
 

--- a/v2/pkg/protocols/headless/request.go
+++ b/v2/pkg/protocols/headless/request.go
@@ -67,15 +67,16 @@ func (request *Request) ExecuteWithResults(inputURL string, metadata, previous o
 
 	event := eventcreator.CreateEvent(request, outputEvent, request.options.Options.Debug || request.options.Options.DebugResponse)
 
-	debug(event, request, responseBody, inputURL)
+	dumpResponse(event, request.options, responseBody, inputURL)
 
 	callback(event)
 	return nil
 }
 
-func debug(event *output.InternalWrappedEvent, request *Request, responseBody string, input string) {
-	if request.options.Options.Debug || request.options.Options.DebugResponse {
-		gologger.Debug().Msgf("[%s] Dumped Headless response for %s\n", request.options.TemplateID, input)
-		gologger.Print().Msgf("%s", responsehighlighter.Highlight(event.OperatorsResult, responseBody, request.options.Options.NoColor, false))
+func dumpResponse(event *output.InternalWrappedEvent, requestOptions *protocols.ExecuterOptions, responseBody string, input string) {
+	cliOptions := requestOptions.Options
+	if cliOptions.Debug || cliOptions.DebugResponse {
+		highlightedResponse := responsehighlighter.Highlight(event.OperatorsResult, responseBody, cliOptions.NoColor, false)
+		gologger.Debug().Msgf("[%s] Dumped Headless response for %s\n\n%s", requestOptions.TemplateID, input, highlightedResponse)
 	}
 }

--- a/v2/pkg/protocols/http/request.go
+++ b/v2/pkg/protocols/http/request.go
@@ -511,7 +511,7 @@ func (request *Request) executeRequest(reqURL string, generatedRequest *generate
 		internalWrappedEvent.OperatorsResult.PayloadValues = generatedRequest.meta
 	})
 
-	debug(request, formedURL, redirectedResponse, responseContentType, event)
+	dumpResponse(event, request.options, redirectedResponse, formedURL, responseContentType)
 
 	callback(event)
 	return nil
@@ -534,26 +534,33 @@ func (request *Request) setCustomHeaders(req *generatedRequest) {
 
 const CRLF = "\r\n"
 
-func debug(request *Request, formedURL string, redirectedResponse []byte, responseContentType string, event *output.InternalWrappedEvent) {
-	if request.options.Options.Debug || request.options.Options.DebugResponse {
-		hexDump := false
+func dumpResponse(event *output.InternalWrappedEvent, requestOptions *protocols.ExecuterOptions, redirectedResponse []byte, formedURL string, responseContentType string) {
+	cliOptions := requestOptions.Options
+	if cliOptions.Debug || cliOptions.DebugResponse {
 		response := string(redirectedResponse)
 
-		var headers string
-		if responseContentType == "" || responseContentType == "application/octet-stream" || (responseContentType == "application/x-www-form-urlencoded" && responsehighlighter.IsASCII(response)) {
-			hexDump = true
-			responseLines := strings.Split(response, CRLF)
-			for i, value := range responseLines {
-				headers += value + CRLF
-				if value == "" {
-					response = hex.Dump([]byte(strings.Join(responseLines[i+1:], "")))
-					break
-				}
-			}
+		var highlightedResult string
+		if responseContentType == "application/octet-stream" || ((responseContentType == "" || responseContentType == "application/x-www-form-urlencoded") && responsehighlighter.HasBinaryContent(response)) {
+			highlightedResult = createResponseHexDump(event, response, cliOptions.NoColor)
+		} else {
+			highlightedResult = responsehighlighter.Highlight(event.OperatorsResult, response, cliOptions.NoColor, false)
 		}
-		logMessageHeader := fmt.Sprintf("[%s] Dumped HTTP response for %s\n", request.options.TemplateID, formedURL)
 
-		gologger.Debug().Msgf("%s\n%s", logMessageHeader, responsehighlighter.Highlight(event.OperatorsResult, headers, request.options.Options.NoColor, false))
-		gologger.Print().Msgf("%s", responsehighlighter.Highlight(event.OperatorsResult, response, request.options.Options.NoColor, hexDump))
+		gologger.Debug().Msgf("[%s] Dumped HTTP response for %s\n\n%s", requestOptions.TemplateID, formedURL, highlightedResult)
+	}
+}
+
+func createResponseHexDump(event *output.InternalWrappedEvent, response string, noColor bool) string {
+	CRLFs := CRLF + CRLF
+	headerEndIndex := strings.Index(response, CRLFs) + len(CRLFs)
+	if headerEndIndex > 0 {
+		headers := response[0:headerEndIndex]
+		responseBodyHexDump := hex.Dump([]byte(response[headerEndIndex:]))
+
+		highlightedHeaders := responsehighlighter.Highlight(event.OperatorsResult, headers, noColor, false)
+		highlightedResponse := responsehighlighter.Highlight(event.OperatorsResult, responseBodyHexDump, noColor, true)
+		return fmt.Sprintf("%s\n%s", highlightedHeaders, highlightedResponse)
+	} else {
+		return responsehighlighter.Highlight(event.OperatorsResult, hex.Dump([]byte(response)), noColor, true)
 	}
 }

--- a/v2/pkg/protocols/network/request.go
+++ b/v2/pkg/protocols/network/request.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/projectdiscovery/gologger"
+	"github.com/projectdiscovery/nuclei/v2/pkg/operators"
 	"github.com/projectdiscovery/nuclei/v2/pkg/output"
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols"
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/expressions"
@@ -189,9 +190,8 @@ func (request *Request) executeRequestWithPayloads(actualAddress, address, input
 	request.options.Progress.IncrementRequests()
 
 	if request.options.Options.Debug || request.options.Options.DebugRequests {
-		gologger.Info().Str("address", actualAddress).Msgf("[%s] Dumped Network request for %s\n", request.options.TemplateID, actualAddress)
 		requestBytes := []byte(reqBuilder.String())
-		gologger.Print().Msgf("%s", hex.Dump(requestBytes))
+		gologger.Debug().Str("address", actualAddress).Msgf("[%s] Dumped Network request for %s\n%s", request.options.TemplateID, actualAddress, hex.Dump(requestBytes))
 		if request.options.Options.VerboseVerbose {
 			gologger.Print().Msgf("\nCompact HEX view:\n%s", hex.EncodeToString(requestBytes))
 		}
@@ -277,26 +277,35 @@ func (request *Request) executeRequestWithPayloads(actualAddress, address, input
 		})
 	}
 
-	debug(event, request, response, actualAddress)
+	dumpResponse(event, request.options, response, actualAddress)
 
 	return nil
 }
 
-func debug(event *output.InternalWrappedEvent, request *Request, response string, actualAddress string) {
-	if request.options.Options.Debug || request.options.Options.DebugResponse {
-		gologger.Debug().Msgf("[%s] Dumped Network response for %s\n", request.options.TemplateID, actualAddress)
+func dumpResponse(event *output.InternalWrappedEvent, requestOptions *protocols.ExecuterOptions, response string, actualAddress string) {
+	cliOptions := requestOptions.Options
+	if cliOptions.Debug || cliOptions.DebugResponse {
 		requestBytes := []byte(response)
-		gologger.Print().Msgf("%s", responsehighlighter.Highlight(event.OperatorsResult, hex.Dump(requestBytes), request.options.Options.NoColor, true))
-		if request.options.Options.VerboseVerbose {
-			var allMatches []string
-			for _, namedMatch := range event.OperatorsResult.Matches {
-				for _, matchElement := range namedMatch {
-					allMatches = append(allMatches, hex.EncodeToString([]byte(matchElement)))
-				}
-			}
-			event.OperatorsResult.Matches["compact"] = allMatches
-			gologger.Print().Msgf("\nCompact HEX view:\n%s", responsehighlighter.Highlight(event.OperatorsResult, hex.EncodeToString([]byte(response)), request.options.Options.NoColor, false))
+		highlightedResponse := responsehighlighter.Highlight(event.OperatorsResult, hex.Dump(requestBytes), cliOptions.NoColor, true)
+		gologger.Debug().Msgf("[%s] Dumped Network response for %s\n\n%s", requestOptions.TemplateID, actualAddress, highlightedResponse)
+
+		if cliOptions.VerboseVerbose {
+			displayCompactHexView(event, response, cliOptions.NoColor)
 		}
+	}
+}
+
+func displayCompactHexView(event *output.InternalWrappedEvent, response string, noColor bool) {
+	operatorsResult := event.OperatorsResult
+	if operatorsResult != nil {
+		var allMatches []string
+		for _, namedMatch := range operatorsResult.Matches {
+			for _, matchElement := range namedMatch {
+				allMatches = append(allMatches, hex.EncodeToString([]byte(matchElement)))
+			}
+		}
+		tempOperatorResult := &operators.Result{Matches: map[string][]string{"matchesInHex": allMatches}}
+		gologger.Print().Msgf("\nCompact HEX view:\n%s", responsehighlighter.Highlight(tempOperatorResult, hex.EncodeToString([]byte(response)), noColor, false))
 	}
 }
 


### PR DESCRIPTION
The ASCII column in the hex dump shows non-printable ASCII characters as a `.` character, so in order to enable proper highlighting, those characters has to be replaced in the generated regex as well.

Example:
* regex: `SSH-2-OpenSSH_.*`
* input: `SSH-2.0-OpenSSH_7.4\r\n...`

Since SSH header terminates in `\r\n`, the regex will match everything up until `\r`. The `\r` character is shown as `.` in the hex dump's ASCII column, hence the content will not be found.

Before the fix the ASCII part was not highlighted:
![image](https://user-images.githubusercontent.com/13679401/139727131-a9a262ce-daff-4a35-b571-9d0ab22b41ec.png)

Continuation of https://github.com/projectdiscovery/nuclei/pull/1203