### PR TITLE
fix #1173: perform matching on all redirect responses instead of final

### DIFF
--- a/integration_tests/http/get-redirects-chain-headers.yaml
+++ b/integration_tests/http/get-redirects-chain-headers.yaml
@@ -1,0 +1,18 @@
+id: basic-get-redirects-chain-headers
+
+info:
+  name: Basic GET Redirects Request With Chain header
+  author: pdteam
+  severity: info
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    redirects: true
+    max-redirects: 3
+    matchers:
+      - type: word
+        part: header
+        words:
+          - "TestRedirectHeaderMatch"

--- a/integration_tests/http/get-redirects-chain-headers.yaml
+++ b/integration_tests/http/get-redirects-chain-headers.yaml
@@ -11,8 +11,13 @@ requests:
       - "{{BaseURL}}"
     redirects: true
     max-redirects: 3
+    matchers-condition: and
     matchers:
       - type: word
         part: header
         words:
           - "TestRedirectHeaderMatch"
+
+      - type: status
+        status:
+          - 302

--- a/v2/cmd/integration-test/http.go
+++ b/v2/cmd/integration-test/http.go
@@ -614,7 +614,7 @@ func (h *httpGetRedirectsChainHeaders) Execute(filePath string) error {
 		http.Redirect(w, r, "/final", http.StatusFound)
 	})
 	router.GET("/final", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
-		w.Write([]byte("ok"))
+		_, _ = w.Write([]byte("ok"))
 	})
 	ts := httptest.NewServer(router)
 	defer ts.Close()

--- a/v2/cmd/integration-test/integration-test.go
+++ b/v2/cmd/integration-test/integration-test.go
@@ -51,5 +51,5 @@ func main() {
 }
 
 func errIncorrectResultsCount(results []string) error {
-	return fmt.Errorf("incorrect number of results %s", strings.Join(results, "\n\t"))
+	return fmt.Errorf("incorrect number of results \n\t%s", strings.Join(results, "\n\t"))
 }

--- a/v2/pkg/protocols/http/request.go
+++ b/v2/pkg/protocols/http/request.go
@@ -445,7 +445,7 @@ func (request *Request) executeRequest(reqURL string, generatedRequest *generate
 		}
 		finalEvent := make(output.InternalEvent)
 
-		outputEvent := request.responseToDSLMap(resp, reqURL, matchedURL, tostring.UnsafeToString(dumpedRequest), tostring.UnsafeToString(response.fullResponse), tostring.UnsafeToString(response.body), tostring.UnsafeToString(response.headers), duration, generatedRequest.meta)
+		outputEvent := request.responseToDSLMap(response.resp, reqURL, matchedURL, tostring.UnsafeToString(dumpedRequest), tostring.UnsafeToString(response.fullResponse), tostring.UnsafeToString(response.body), tostring.UnsafeToString(response.headers), duration, generatedRequest.meta)
 		if i := strings.LastIndex(hostname, ":"); i != -1 {
 			hostname = hostname[:i]
 		}

--- a/v2/pkg/protocols/http/utils.go
+++ b/v2/pkg/protocols/http/utils.go
@@ -22,6 +22,7 @@ type redirectedResponse struct {
 	headers      []byte
 	body         []byte
 	fullResponse []byte
+	resp         *http.Response
 }
 
 // dumpResponseWithRedirectChain dumps a http response with the
@@ -41,6 +42,7 @@ func dumpResponseWithRedirectChain(resp *http.Response, body []byte) ([]redirect
 	respObj := redirectedResponse{
 		headers:      respData,
 		body:         body,
+		resp:         resp,
 		fullResponse: bytes.Join([][]byte{respData, body}, []byte{}),
 	}
 	if err := normalizeResponseBody(resp, &respObj); err != nil {
@@ -65,6 +67,7 @@ func dumpResponseWithRedirectChain(resp *http.Response, body []byte) ([]redirect
 		respObj := redirectedResponse{
 			headers:      respData,
 			body:         body,
+			resp:         redirectResp,
 			fullResponse: bytes.Join([][]byte{respData, body}, []byte{}),
 		}
 		if err := normalizeResponseBody(redirectResp, &respObj); err != nil {

--- a/v2/pkg/protocols/http/utils.go
+++ b/v2/pkg/protocols/http/utils.go
@@ -43,7 +43,7 @@ func dumpResponseWithRedirectChain(resp *http.Response, body []byte) ([]redirect
 		body:         body,
 		fullResponse: bytes.Join([][]byte{respData, body}, []byte{}),
 	}
-	if err := normalizeResponseBody(resp, respObj); err != nil {
+	if err := normalizeResponseBody(resp, &respObj); err != nil {
 		return nil, err
 	}
 	response = append(response, respObj)
@@ -67,7 +67,7 @@ func dumpResponseWithRedirectChain(resp *http.Response, body []byte) ([]redirect
 			body:         body,
 			fullResponse: bytes.Join([][]byte{respData, body}, []byte{}),
 		}
-		if err := normalizeResponseBody(redirectResp, respObj); err != nil {
+		if err := normalizeResponseBody(redirectResp, &respObj); err != nil {
 			return nil, err
 		}
 		response = append(response, respObj)
@@ -77,7 +77,7 @@ func dumpResponseWithRedirectChain(resp *http.Response, body []byte) ([]redirect
 }
 
 // normalizeResponseBody performs normalization on the http response object.
-func normalizeResponseBody(resp *http.Response, response redirectedResponse) error {
+func normalizeResponseBody(resp *http.Response, response *redirectedResponse) error {
 	var err error
 	// net/http doesn't automatically decompress the response body if an
 	// encoding has been specified by the user in the request so in case we have to


### PR DESCRIPTION
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->

Changed the HTTP execution logic so that the match on HTTP response is performed for all redirect chain response separately, with the final response being matched on first, and the chain of all the responses leading up to the final responses checked next.  

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)