### PR TITLE
Better error handling for return value of helper http library

### DIFF
--- a/v2/pkg/protocols/http/request.go
+++ b/v2/pkg/protocols/http/request.go
@@ -99,15 +99,15 @@ func (request *Request) executeParallelHTTP(reqURL string, dynamicValues output.
 	mutex := &sync.Mutex{}
 	for {
 		generatedHttpRequest, err := generator.Make(reqURL, dynamicValues)
-		if err == io.EOF {
-			break
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			request.options.Progress.IncrementFailedRequestsBy(int64(generator.Total()))
+			return err
 		}
 		if reqURL == "" {
 			reqURL = generatedHttpRequest.URL()
-		}
-		if err != nil {
-			request.options.Progress.IncrementFailedRequestsBy(int64(generator.Total()))
-			return err
 		}
 		swg.Add()
 		go func(httpRequest *generatedRequest) {
@@ -162,18 +162,17 @@ func (request *Request) executeTurboHTTP(reqURL string, dynamicValues, previous 
 	mutex := &sync.Mutex{}
 	for {
 		generatedHttpRequest, err := generator.Make(reqURL, dynamicValues)
-		if err == io.EOF {
-			break
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			request.options.Progress.IncrementFailedRequestsBy(int64(generator.Total()))
+			return err
 		}
 		if reqURL == "" {
 			reqURL = generatedHttpRequest.URL()
 		}
-		if err != nil {
-			request.options.Progress.IncrementFailedRequestsBy(int64(generator.Total()))
-			return err
-		}
 		generatedHttpRequest.pipelinedClient = pipeClient
-
 		swg.Add()
 		go func(httpRequest *generatedRequest) {
 			defer swg.Done()
@@ -216,17 +215,16 @@ func (request *Request) ExecuteWithResults(reqURL string, dynamicValues, previou
 		hasInteractMarkers := interactsh.HasMatchers(request.CompiledOperators)
 
 		generatedHttpRequest, err := generator.Make(reqURL, dynamicValues)
-		if err == io.EOF {
-			break
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			request.options.Progress.IncrementFailedRequestsBy(int64(generator.Total()))
+			return err
 		}
 		if reqURL == "" {
 			reqURL = generatedHttpRequest.URL()
 		}
-		if err != nil {
-			request.options.Progress.IncrementFailedRequestsBy(int64(generator.Total()))
-			return err
-		}
-
 		request.dynamicValues = generatedHttpRequest.dynamicValues
 		// Check if hosts just keep erroring
 		if request.options.HostErrorsCache != nil && request.options.HostErrorsCache.Check(reqURL) {


### PR DESCRIPTION
## Proposed changes

This PR improves handling of the error value returned from `Make` function in `pkg/protocols/http/build_request.go` avoiding nil pointer crashes

## Checklist
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)