### PR TITLE
Fixed stdin input parsing bug causing nuclei to hang

### DIFF
--- a/v2/internal/runner/options.go
+++ b/v2/internal/runner/options.go
@@ -71,9 +71,8 @@ func hasStdin() bool {
 		return false
 	}
 
-	isPipedFromChrDev := (stat.Mode() & os.ModeCharDevice) == 0
+	isPipedFromChrDev := (stat.Mode() & os.ModeCharDevice) != 0
 	isPipedFromFIFO := (stat.Mode() & os.ModeNamedPipe) != 0
-
 	return isPipedFromChrDev || isPipedFromFIFO
 }
 


### PR DESCRIPTION
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->

There was a typo in the stdin parsing which resulted in nuclei trying to read stdin which caused it to get stuck when spawned as child process in some cases.

This should hopefully fix #1274 (tested) and #1265 (untested, to be tested)

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)