### PR TITLE
Raw request hostname

### DIFF
--- a/v2/pkg/protocols/http/raw/raw.go
+++ b/v2/pkg/protocols/http/raw/raw.go
@@ -112,11 +112,11 @@ func Parse(request, baseURL string, unsafe bool) (*Request, error) {
 		rawRequest.Path = parts[1]
 	}
 
-	hostURL := parsedURL.Host
+	hostURL := rawRequest.Headers["Host"]
 	if strings.HasSuffix(parsedURL.Path, "/") && strings.HasPrefix(rawRequest.Path, "/") {
 		parsedURL.Path = strings.TrimSuffix(parsedURL.Path, "/")
 	}
-	if parsedURL.Path != rawRequest.Path {
+	if parsedURL.Path != rawRequest.Path && hostURL == parsedURL.Host {
 		rawRequest.Path = fmt.Sprintf("%s%s", parsedURL.Path, rawRequest.Path)
 	}
 	if strings.HasSuffix(rawRequest.Path, "//") {


### PR DESCRIPTION
## Proposed changes

The change: replace the  hardcoded "hostURL"= URL provided in current nuclei call with what the nuclei template actually wants to pick.

Details:
Currently the Raw package ignores the "Host" header and uses the baseurl provided in the list. If the template wants to specify a host header it should be followed. 
EG:
1st raw request:
I check a website to see if it returns okta token. I use the baseurl provided in this case
2nd raw request:
I want to check against okta to see if the okta token is valid

This is also the  solution to https://github.com/projectdiscovery/nuclei/issues/1289 ,  https://github.com/projectdiscovery/nuclei/pull/1293 ,
https://github.com/projectdiscovery/nuclei/pull/1294 ,
and
https://github.com/projectdiscovery/nuclei/pull/1299

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works---> I tested it locally and it works
- [x] I have added necessary documentation (if appropriate)