### PR TITLE
fix #1303: speed regression due to missing goroutine in executer

### DIFF
--- a/v2/pkg/core/execute.go
+++ b/v2/pkg/core/execute.go
@@ -39,15 +39,17 @@ func (e *Engine) ExecuteWithOpts(templatesList []*templates.Template, target Inp
 		}
 
 		wg.Add()
-		switch {
-		case template.SelfContained:
-			// Self Contained requests are executed here separately
-			e.executeSelfContainedTemplateWithInput(template, results)
-		default:
-			// All other request types are executed here
-			e.executeModelWithInput(templateType, template, target, results)
-		}
-		wg.Done()
+		go func(tpl *templates.Template) {
+			switch {
+			case tpl.SelfContained:
+				// Self Contained requests are executed here separately
+				e.executeSelfContainedTemplateWithInput(tpl, results)
+			default:
+				// All other request types are executed here
+				e.executeModelWithInput(templateType, tpl, target, results)
+			}
+			wg.Done()
+		}(template)
 	}
 	e.workPool.Wait()
 	return results


### PR DESCRIPTION
Fixed speed regression introduced in dev due to missing go() statement when executing template input

## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->


## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)