### PR TITLE
Added value sharing to workflows

### DIFF
--- a/v2/pkg/core/execute.go
+++ b/v2/pkg/core/execute.go
@@ -5,6 +5,7 @@ import (
 	"go.uber.org/atomic"
 
 	"github.com/projectdiscovery/gologger"
+	"github.com/projectdiscovery/nuclei/v2/pkg/output"
 	"github.com/projectdiscovery/nuclei/v2/pkg/templates"
 	"github.com/projectdiscovery/nuclei/v2/pkg/templates/types"
 )
@@ -57,7 +58,7 @@ func (e *Engine) ExecuteWithOpts(templatesList []*templates.Template, target Inp
 
 // processSelfContainedTemplates execute a self-contained template.
 func (e *Engine) executeSelfContainedTemplateWithInput(template *templates.Template, results *atomic.Bool) {
-	match, err := template.Executer.Execute("")
+	match, err := template.Executer.Execute("", make(output.InternalEvent), make(output.InternalEvent))
 	if err != nil {
 		gologger.Warning().Msgf("[%s] Could not execute step: %s\n", e.executerOpts.Colorizer.BrightBlue(template.ID), err)
 	}
@@ -84,7 +85,7 @@ func (e *Engine) executeModelWithInput(templateType types.ProtocolType, template
 			case types.WorkflowProtocol:
 				match = e.executeWorkflow(value, template.CompiledWorkflow)
 			default:
-				match, err = template.Executer.Execute(value)
+				match, err = template.Executer.Execute(value, make(output.InternalEvent), make(output.InternalEvent))
 			}
 			if err != nil {
 				gologger.Warning().Msgf("[%s] Could not execute step: %s\n", e.executerOpts.Colorizer.BrightBlue(template.ID), err)

--- a/v2/pkg/core/workflow_execute.go
+++ b/v2/pkg/core/workflow_execute.go
@@ -161,7 +161,10 @@ func (e *Engine) executeWorkflowStepMatchers(workflowArgs *runWorkflowStepArgs) 
 					workflowArgs.swg.Add()
 
 					go func(subtemplate *workflows.WorkflowTemplate) {
-						if err := e.runWorkflowStep(workflowArgs); err != nil {
+						copy := workflowArgs.Copy()
+						copy.template = subtemplate
+
+						if err := e.runWorkflowStep(copy); err != nil {
 							gologger.Warning().Msgf("[%s] Could not execute workflow step: %s\n", subtemplate.Template, err)
 						}
 						workflowArgs.swg.Done()
@@ -187,7 +190,10 @@ func (e *Engine) executeWorkflowStepSubtemplates(workflowArgs *runWorkflowStepAr
 		workflowArgs.swg.Add()
 
 		go func(template *workflows.WorkflowTemplate) {
-			if err := e.runWorkflowStep(workflowArgs); err != nil {
+			copy := workflowArgs.Copy()
+			copy.template = template
+
+			if err := e.runWorkflowStep(copy); err != nil {
 				gologger.Warning().Msgf("[%s] Could not execute workflow step: %s\n", template.Template, err)
 			}
 			workflowArgs.swg.Done()

--- a/v2/pkg/core/workflow_execute.go
+++ b/v2/pkg/core/workflow_execute.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/nuclei/v2/pkg/output"
+	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/generators"
 	"github.com/projectdiscovery/nuclei/v2/pkg/workflows"
 )
 
@@ -16,8 +17,17 @@ func (e *Engine) executeWorkflow(input string, w *workflows.Workflow) bool {
 	swg := sizedwaitgroup.New(w.Options.Options.TemplateThreads)
 	for _, template := range w.Workflows {
 		swg.Add()
+
 		func(template *workflows.WorkflowTemplate) {
-			if err := e.runWorkflowStep(template, input, results, &swg, w); err != nil {
+			if err := e.runWorkflowStep(&runWorkflowStepArgs{
+				template:      template,
+				input:         input,
+				results:       results,
+				swg:           &swg,
+				w:             w,
+				previous:      make(output.InternalEvent),
+				dynamicValues: make(output.InternalEvent),
+			}); err != nil {
 				gologger.Warning().Msgf("[%s] Could not execute workflow step: %s\n", template.Template, err)
 			}
 			swg.Done()
@@ -27,102 +37,160 @@ func (e *Engine) executeWorkflow(input string, w *workflows.Workflow) bool {
 	return results.Load()
 }
 
+// runWorkflowStepArgs are the arguments for workflow template execution
+type runWorkflowStepArgs struct {
+	template      *workflows.WorkflowTemplate
+	input         string
+	results       *atomic.Bool
+	swg           *sizedwaitgroup.SizedWaitGroup
+	w             *workflows.Workflow
+	previous      output.InternalEvent
+	dynamicValues output.InternalEvent
+}
+
+// Copy returns a copy of the runWorkflowStepArgs structure
+func (r *runWorkflowStepArgs) Copy() *runWorkflowStepArgs {
+	return &runWorkflowStepArgs{
+		template:      r.template,
+		input:         r.input,
+		results:       r.results,
+		swg:           r.swg,
+		w:             r.w,
+		previous:      r.previous,
+		dynamicValues: r.dynamicValues,
+	}
+}
+
 // runWorkflowStep runs a workflow step for the workflow. It executes the workflow
 // in a recursive manner running all subtemplates and matchers.
-func (e *Engine) runWorkflowStep(template *workflows.WorkflowTemplate, input string, results *atomic.Bool, swg *sizedwaitgroup.SizedWaitGroup, w *workflows.Workflow) error {
+func (e *Engine) runWorkflowStep(workflowArgs *runWorkflowStepArgs) error {
 	var firstMatched bool
 	var err error
 	var mainErr error
+	var finalEvent output.InternalEvent
 
-	if len(template.Matchers) == 0 {
-		for _, executer := range template.Executers {
-			executer.Options.Progress.AddToTotal(int64(executer.Executer.Requests()))
-
-			// Don't print results with subtemplates, only print results on template.
-			if len(template.Subtemplates) > 0 {
-				err = executer.Executer.ExecuteWithResults(input, func(result *output.InternalWrappedEvent) {
-					if result.OperatorsResult == nil {
-						return
-					}
-					if len(result.Results) > 0 {
-						firstMatched = true
-					}
-				})
-			} else {
-				var matched bool
-				matched, err = executer.Executer.Execute(input)
-				if matched {
-					firstMatched = true
-				}
-			}
-			if err != nil {
-				if w.Options.HostErrorsCache != nil {
-					if w.Options.HostErrorsCache.CheckError(err) {
-						w.Options.HostErrorsCache.MarkFailed(input)
-					}
-				}
-				if len(template.Executers) == 1 {
-					mainErr = err
-				} else {
-					gologger.Warning().Msgf("[%s] Could not execute workflow step: %s\n", template.Template, err)
-				}
-				continue
-			}
+	if len(workflowArgs.template.Matchers) == 0 {
+		if firstMatched, finalEvent, err = e.executeWorkflowStepNoMatchers(workflowArgs); err != nil {
+			mainErr = err
+		}
+		if workflowArgs.template.CaptureValues {
+			workflowArgs.dynamicValues = finalEvent
 		}
 	}
-	if len(template.Subtemplates) == 0 {
-		results.CAS(false, firstMatched)
+	if len(workflowArgs.template.Subtemplates) == 0 {
+		workflowArgs.results.CAS(false, firstMatched)
 	}
-	if len(template.Matchers) > 0 {
-		for _, executer := range template.Executers {
-			executer.Options.Progress.AddToTotal(int64(executer.Executer.Requests()))
+	if len(workflowArgs.template.Matchers) > 0 {
+		if err := e.executeWorkflowStepMatchers(workflowArgs); err != nil {
+			mainErr = err
+		}
+	}
+	if len(workflowArgs.template.Subtemplates) > 0 && (firstMatched || workflowArgs.template.CaptureValues) {
+		e.executeWorkflowStepSubtemplates(workflowArgs)
+	}
+	return mainErr
+}
 
-			err := executer.Executer.ExecuteWithResults(input, func(event *output.InternalWrappedEvent) {
-				if event.OperatorsResult == nil {
+// executeWorkflowStepNoMatchers executes workflow step for condition with no matchers.
+func (e *Engine) executeWorkflowStepNoMatchers(workflowArgs *runWorkflowStepArgs) (bool, output.InternalEvent, error) {
+	var firstMatched bool
+	var err error
+	finalEvent := workflowArgs.dynamicValues
+	var mainErr error
+
+	for _, executer := range workflowArgs.template.Executers {
+		executer.Options.Progress.AddToTotal(int64(executer.Executer.Requests()))
+
+		// Don't print results with subtemplates, only print results on template.
+		if len(workflowArgs.template.Subtemplates) > 0 {
+			err = executer.Executer.ExecuteWithResults(workflowArgs.input, finalEvent, workflowArgs.previous, func(result *output.InternalWrappedEvent) {
+				if result.OperatorsResult == nil {
 					return
 				}
-
-				for _, matcher := range template.Matchers {
-					_, matchOK := event.OperatorsResult.Matches[matcher.Name]
-					_, extractOK := event.OperatorsResult.Extracts[matcher.Name]
-					if !matchOK && !extractOK {
-						continue
-					}
-
-					for _, subtemplate := range matcher.Subtemplates {
-						swg.Add()
-
-						go func(subtemplate *workflows.WorkflowTemplate) {
-							if err := e.runWorkflowStep(subtemplate, input, results, swg, w); err != nil {
-								gologger.Warning().Msgf("[%s] Could not execute workflow step: %s\n", subtemplate.Template, err)
-							}
-							swg.Done()
-						}(subtemplate)
-					}
+				if len(result.Results) > 0 {
+					firstMatched = true
+				}
+				if len(result.OperatorsResult.DynamicValues) > 0 && workflowArgs.template.CaptureValues {
+					finalEvent = generators.MergeMaps(finalEvent, result.OperatorsResult.DynamicValues)
 				}
 			})
-			if err != nil {
-				if len(template.Executers) == 1 {
-					mainErr = err
-				} else {
-					gologger.Warning().Msgf("[%s] Could not execute workflow step: %s\n", template.Template, err)
-				}
-				continue
+		} else {
+			var matched bool
+			matched, err = executer.Executer.Execute(workflowArgs.input, finalEvent, workflowArgs.previous)
+			if matched {
+				firstMatched = true
 			}
 		}
-		return mainErr
-	}
-	if len(template.Subtemplates) > 0 && firstMatched {
-		for _, subtemplate := range template.Subtemplates {
-			swg.Add()
-
-			go func(template *workflows.WorkflowTemplate) {
-				if err := e.runWorkflowStep(template, input, results, swg, w); err != nil {
-					gologger.Warning().Msgf("[%s] Could not execute workflow step: %s\n", template.Template, err)
+		if err != nil {
+			if workflowArgs.w.Options.HostErrorsCache != nil {
+				if workflowArgs.w.Options.HostErrorsCache.CheckError(err) {
+					workflowArgs.w.Options.HostErrorsCache.MarkFailed(workflowArgs.input)
 				}
-				swg.Done()
-			}(subtemplate)
+			}
+			if len(workflowArgs.template.Executers) == 1 {
+				mainErr = err
+			} else {
+				gologger.Warning().Msgf("[%s] Could not execute workflow step: %s\n", workflowArgs.template.Template, err)
+			}
+			continue
+		}
+	}
+	return firstMatched, finalEvent, mainErr
+}
+
+// executeWorkflowStepMatchers executes workflow step for condition with matchers
+func (e *Engine) executeWorkflowStepMatchers(workflowArgs *runWorkflowStepArgs) error {
+	var mainErr error
+
+	for _, executer := range workflowArgs.template.Executers {
+		executer.Options.Progress.AddToTotal(int64(executer.Executer.Requests()))
+
+		err := executer.Executer.ExecuteWithResults(workflowArgs.input, workflowArgs.dynamicValues, workflowArgs.previous, func(event *output.InternalWrappedEvent) {
+			if event.OperatorsResult == nil {
+				return
+			}
+
+			for _, matcher := range workflowArgs.template.Matchers {
+				_, matchOK := event.OperatorsResult.Matches[matcher.Name]
+				_, extractOK := event.OperatorsResult.Extracts[matcher.Name]
+				if !matchOK && !extractOK {
+					continue
+				}
+
+				for _, subtemplate := range matcher.Subtemplates {
+					workflowArgs.swg.Add()
+
+					go func(subtemplate *workflows.WorkflowTemplate) {
+						if err := e.runWorkflowStep(workflowArgs); err != nil {
+							gologger.Warning().Msgf("[%s] Could not execute workflow step: %s\n", subtemplate.Template, err)
+						}
+						workflowArgs.swg.Done()
+					}(subtemplate)
+				}
+			}
+		})
+		if err != nil {
+			if len(workflowArgs.template.Executers) == 1 {
+				mainErr = err
+			} else {
+				gologger.Warning().Msgf("[%s] Could not execute workflow step: %s\n", workflowArgs.template.Template, err)
+			}
+			continue
 		}
 	}
 	return mainErr
+}
+
+// executeWorkflowStepSubtemplates executes workflow step for condition with subtemplates
+func (e *Engine) executeWorkflowStepSubtemplates(workflowArgs *runWorkflowStepArgs) {
+	for _, subtemplate := range workflowArgs.template.Subtemplates {
+		workflowArgs.swg.Add()
+
+		go func(template *workflows.WorkflowTemplate) {
+			if err := e.runWorkflowStep(workflowArgs); err != nil {
+				gologger.Warning().Msgf("[%s] Could not execute workflow step: %s\n", template.Template, err)
+			}
+			workflowArgs.swg.Done()
+		}(subtemplate)
+	}
 }

--- a/v2/pkg/core/workflow_execute_test.go
+++ b/v2/pkg/core/workflow_execute_test.go
@@ -177,7 +177,7 @@ func (m *mockExecuter) Requests() int {
 }
 
 // Execute executes the protocol group and  returns true or false if results were found.
-func (m *mockExecuter) Execute(input string) (bool, error) {
+func (m *mockExecuter) Execute(input string, a, b output.InternalEvent) (bool, error) {
 	if m.executeHook != nil {
 		m.executeHook(input)
 	}
@@ -185,7 +185,7 @@ func (m *mockExecuter) Execute(input string) (bool, error) {
 }
 
 // ExecuteWithResults executes the protocol requests and returns results instead of writing them.
-func (m *mockExecuter) ExecuteWithResults(input string, callback protocols.OutputEventCallback) error {
+func (m *mockExecuter) ExecuteWithResults(input string, a, b output.InternalEvent, callback protocols.OutputEventCallback) error {
 	if m.executeHook != nil {
 		m.executeHook(input)
 	}

--- a/v2/pkg/core/workflow_execute_test.go
+++ b/v2/pkg/core/workflow_execute_test.go
@@ -165,33 +165,23 @@ func TestWorkflowsSubtemplatesWithCaptureValues(t *testing.T) {
 
 	var gotValues output.InternalEvent
 	var firstInput string
-	workflow := &workflows.Workflow{
-		Options: &protocols.ExecuterOptions{
-			Options: &types.Options{TemplateThreads: 10},
-		},
-		Workflows: []*workflows.WorkflowTemplate{
-			{
-				Executers: []*workflows.ProtocolExecuterPair{{
-					Executer: &mockExecuter{result: true, executeHook: func(input string, values output.InternalEvent) {
-						firstInput = input
-					}, outputs: []*output.InternalWrappedEvent{
-						{OperatorsResult: &operators.Result{
-							DynamicValues: map[string]interface{}{"value": "test"},
-						}},
-					}}, Options: &protocols.ExecuterOptions{Progress: progressBar}}},
-				CaptureValues: true,
-				Subtemplates: []*workflows.WorkflowTemplate{
-					{
-						Executers: []*workflows.ProtocolExecuterPair{
-							{
-								Executer: &mockExecuter{result: false, executeHook: func(input string, values output.InternalEvent) {
-									gotValues = values
-								}}, Options: &protocols.ExecuterOptions{Progress: progressBar}}},
-					},
-				},
-			},
-		},
-	}
+	workflow := &workflows.Workflow{Options: &protocols.ExecuterOptions{
+		Options: &types.Options{TemplateThreads: 10},
+	}, Workflows: []*workflows.WorkflowTemplate{{
+		Executers: []*workflows.ProtocolExecuterPair{{
+			Executer: &mockExecuter{result: true, executeHook: func(input string, values output.InternalEvent) {
+				firstInput = input
+			}, outputs: []*output.InternalWrappedEvent{
+				{OperatorsResult: &operators.Result{
+					DynamicValues: map[string]interface{}{"value": "test"},
+				}},
+			}}, Options: &protocols.ExecuterOptions{Progress: progressBar}}},
+		CaptureValues: true, Subtemplates: []*workflows.WorkflowTemplate{{
+			Executers: []*workflows.ProtocolExecuterPair{{Executer: &mockExecuter{result: false, executeHook: func(input string, values output.InternalEvent) {
+				gotValues = values
+			}}, Options: &protocols.ExecuterOptions{Progress: progressBar}}},
+		}},
+	}}}
 
 	engine := &Engine{}
 	_ = engine.executeWorkflow("https://test.com", workflow)

--- a/v2/pkg/protocols/common/executer/executer.go
+++ b/v2/pkg/protocols/common/executer/executer.go
@@ -42,11 +42,9 @@ func (e *Executer) Requests() int {
 }
 
 // Execute executes the protocol group and returns true or false if results were found.
-func (e *Executer) Execute(input string) (bool, error) {
+func (e *Executer) Execute(input string, dynamicValues, previous output.InternalEvent) (bool, error) {
 	var results bool
 
-	dynamicValues := make(map[string]interface{})
-	previous := make(map[string]interface{})
 	for _, req := range e.requests {
 		err := req.ExecuteWithResults(input, dynamicValues, previous, func(event *output.InternalWrappedEvent) {
 			ID := req.GetID()
@@ -86,10 +84,7 @@ func (e *Executer) Execute(input string) (bool, error) {
 }
 
 // ExecuteWithResults executes the protocol requests and returns results instead of writing them.
-func (e *Executer) ExecuteWithResults(input string, callback protocols.OutputEventCallback) error {
-	dynamicValues := make(map[string]interface{})
-	previous := make(map[string]interface{})
-
+func (e *Executer) ExecuteWithResults(input string, dynamicValues, previous output.InternalEvent, callback protocols.OutputEventCallback) error {
 	for _, req := range e.requests {
 		req := req
 

--- a/v2/pkg/protocols/protocols.go
+++ b/v2/pkg/protocols/protocols.go
@@ -28,9 +28,9 @@ type Executer interface {
 	// Requests returns the total number of requests the rule will perform
 	Requests() int
 	// Execute executes the protocol group and returns true or false if results were found.
-	Execute(input string) (bool, error)
+	Execute(input string, dynamicValues, previous output.InternalEvent) (bool, error)
 	// ExecuteWithResults executes the protocol requests and returns results instead of writing them.
-	ExecuteWithResults(input string, callback OutputEventCallback) error
+	ExecuteWithResults(input string, dynamicValues, previous output.InternalEvent, callback OutputEventCallback) error
 }
 
 // ExecuterOptions contains the configuration options for executer clients

--- a/v2/pkg/templates/cluster.go
+++ b/v2/pkg/templates/cluster.go
@@ -141,11 +141,9 @@ func (e *Executer) Requests() int {
 }
 
 // Execute executes the protocol group and returns true or false if results were found.
-func (e *Executer) Execute(input string) (bool, error) {
+func (e *Executer) Execute(input string, dynamicValues, previous output.InternalEvent) (bool, error) {
 	var results bool
 
-	previous := make(map[string]interface{})
-	dynamicValues := make(map[string]interface{})
 	err := e.requests.ExecuteWithResults(input, dynamicValues, previous, func(event *output.InternalWrappedEvent) {
 		for _, operator := range e.operators {
 			result, matched := operator.operator.Execute(event.InternalEvent, e.requests.Match, e.requests.Extract, e.options.Options.Debug || e.options.Options.DebugResponse)
@@ -175,9 +173,8 @@ func (e *Executer) Execute(input string) (bool, error) {
 }
 
 // ExecuteWithResults executes the protocol requests and returns results instead of writing them.
-func (e *Executer) ExecuteWithResults(input string, callback protocols.OutputEventCallback) error {
-	dynamicValues := make(map[string]interface{})
-	err := e.requests.ExecuteWithResults(input, dynamicValues, nil, func(event *output.InternalWrappedEvent) {
+func (e *Executer) ExecuteWithResults(input string, dynamicValues, previous output.InternalEvent, callback protocols.OutputEventCallback) error {
+	err := e.requests.ExecuteWithResults(input, dynamicValues, previous, func(event *output.InternalWrappedEvent) {
 		for _, operator := range e.operators {
 			result, matched := operator.operator.Execute(event.InternalEvent, e.requests.Match, e.requests.Extract, e.options.Options.Debug || e.options.Options.DebugResponse)
 			if matched && result != nil {

--- a/v2/pkg/workflows/workflows.go
+++ b/v2/pkg/workflows/workflows.go
@@ -25,6 +25,9 @@ type WorkflowTemplate struct {
 	//     value: "\"misconfigurations/aem\""
 	Template string `yaml:"template,omitempty" jsonschema:"title=template/directory to execute,description=Template or directory to execute as part of workflow"`
 	// description: |
+	//    CaptureValues enables capturing of values from ran templates
+	CaptureValues bool `yaml:"capture-values,omitempty" jsonschema:"title=capture values from templates,description=Enable capturing of values from templates"`
+	// description: |
 	//    Tags to run templates based on.
 	Tags stringslice.StringSlice `yaml:"tags,omitempty" jsonschema:"title=tags to execute,description=Tags to run template based on"`
 	// description: |


### PR DESCRIPTION
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->


workflow.yaml

```yaml
id: value-sharing-workflow
info:
  name: Value Sharing Test
  author: pdteam
  severity: info

workflows:
  - template: test1.yaml
    cookie-reuse: true
    subtemplates:
      - template: test2.yaml
```

test1.yaml
```yaml
id: test-valuesharing-1

info:
  name: test-valuesharing-1
  author: pdteam
  severity: info

requests:
  - path:
      - https://example.com
    extractors:
      - type: regex
        part: body
        name: extracted
        regex:
          - 'href="(.*)"'
        group: 1
        internal: true
```

test2.yaml

```yaml
id: test-valuesharing-2

info:
  name: test-valuesharing-2
  author: pdteam
  severity: info

requests:
  - path:
      - https://example.com/?got={{extracted}}
```

Example run - 

```
✘ ./nuclei -w workflow.yaml -u https://example.com -debug

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   2.5.4-dev

                projectdiscovery.io

[WRN] Use with caution. You are responsible for your actions.
[WRN] Developers assume no liability and are not responsible for any misuse or damage.
[INF] Using Nuclei Engine 2.5.4-dev (development)
[INF] Using Nuclei Templates 8.6.8 (latest)
[INF] Using Interactsh Server https://interactsh.com
[INF] Workflows loaded for scan: 1
[INF] [test-valuesharing-1] Dumped HTTP request for https://example.com

GET / HTTP/1.1
Host: example.com
User-Agent: Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1866.237 Safari/537.36
Connection: close
Accept: */*
Accept-Language: en
Accept-Encoding: gzip

[DBG] [test-valuesharing-1] Dumped HTTP response for https://example.com

HTTP/1.1 200 OK
Connection: close
Accept-Ranges: bytes
Age: 573000
Cache-Control: max-age=604800
Content-Type: text/html; charset=UTF-8
Date: Thu, 02 Dec 2021 10:50:36 GMT
Etag: "3147526947+ident"
Expires: Thu, 09 Dec 2021 10:50:36 GMT
Last-Modified: Thu, 17 Oct 2019 07:18:26 GMT
Server: ECS (sab/573F)
Vary: Accept-Encoding
X-Cache: HIT

<!doctype html>
<html>
<head>
    <title>Example Domain</title>

    <meta charset="utf-8" />
    <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
    <meta name="viewport" content="width=device-width, initial-scale=1" />
    <style type="text/css">
    body {
        background-color: #f0f0f2;
        margin: 0;
        padding: 0;
        font-family: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
        
    }
    div {
        width: 600px;
        margin: 5em auto;
        padding: 2em;
        background-color: #fdfdff;
        border-radius: 0.5em;
        box-shadow: 2px 3px 7px 2px rgba(0,0,0,0.02);
    }
    a:link, a:visited {
        color: #38488f;
        text-decoration: none;
    }
    @media (max-width: 700px) {
        div {
            margin: 0 auto;
            width: auto;
        }
    }
    </style>    
</head>

<body>
<div>
    <h1>Example Domain</h1>
    <p>This domain is for use in illustrative examples in documents. You may use this
    domain in literature without prior coordination or asking for permission.</p>
    <p><a href="https://www.iana.org/domains/example">More information...</a></p>
</div>
</body>
</html>
[INF] [test-valuesharing-2] Dumped HTTP request for https://example.com

GET /?got=https://www.iana.org/domains/example HTTP/1.1
Host: example.com
User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2919.83 Safari/537.36
Connection: close
Accept: */*
Accept-Language: en
Accept-Encoding: gzip

[DBG] [test-valuesharing-2] Dumped HTTP response for https://example.com/?got=https://www.iana.org/domains/example

HTTP/1.1 200 OK
Connection: close
Age: 501720
Cache-Control: max-age=604800
Content-Type: text/html; charset=UTF-8
Date: Thu, 02 Dec 2021 10:50:37 GMT
Etag: "3147526947+gzip"
Expires: Thu, 09 Dec 2021 10:50:37 GMT
Last-Modified: Thu, 17 Oct 2019 07:18:26 GMT
Server: ECS (sab/56BA)
Vary: Accept-Encoding
X-Cache: HIT

<!doctype html>
<html>
<head>
    <title>Example Domain</title>

    <meta charset="utf-8" />
    <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
    <meta name="viewport" content="width=device-width, initial-scale=1" />
    <style type="text/css">
    body {
        background-color: #f0f0f2;
        margin: 0;
        padding: 0;
        font-family: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
        
    }
    div {
        width: 600px;
        margin: 5em auto;
        padding: 2em;
        background-color: #fdfdff;
        border-radius: 0.5em;
        box-shadow: 2px 3px 7px 2px rgba(0,0,0,0.02);
    }
    a:link, a:visited {
        color: #38488f;
        text-decoration: none;
    }
    @media (max-width: 700px) {
        div {
            margin: 0 auto;
            width: auto;
        }
    }
    </style>    
</head>

<body>
<div>
    <h1>Example Domain</h1>
    <p>This domain is for use in illustrative examples in documents. You may use this
    domain in literature without prior coordination or asking for permission.</p>
    <p><a href="https://www.iana.org/domains/example">More information...</a></p>
</div>
</body>
</html>
[INF] No results found. Better luck next time!
```

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)