### PR TITLE
Fixing templates bundle unzip on windows

### DIFF
--- a/v2/go.mod
+++ b/v2/go.mod
@@ -65,7 +65,7 @@ require (
 	moul.io/http2curl v1.0.0
 )
 
-require github.com/projectdiscovery/folderutil v0.0.0-20211203091551-e81604e6940e
+require github.com/projectdiscovery/folderutil v0.0.0-20211206150108-b4e7ea80f36e
 
 require (
 	git.mills.io/prologic/smtpd v0.0.0-20210710122116-a525b76c287a // indirect

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -599,6 +599,8 @@ github.com/projectdiscovery/folderutil v0.0.0-20210804143510-68474319fd84 h1:+Vq
 github.com/projectdiscovery/folderutil v0.0.0-20210804143510-68474319fd84/go.mod h1:BMqXH4jNGByVdE2iLtKvc/6XStaiZRuCIaKv1vw9PnI=
 github.com/projectdiscovery/folderutil v0.0.0-20211203091551-e81604e6940e h1:ozfSeEc5j1f7NCEZAiAskP/KYfBD/TzPmFTIfh+CEwE=
 github.com/projectdiscovery/folderutil v0.0.0-20211203091551-e81604e6940e/go.mod h1:BMqXH4jNGByVdE2iLtKvc/6XStaiZRuCIaKv1vw9PnI=
+github.com/projectdiscovery/folderutil v0.0.0-20211206150108-b4e7ea80f36e h1:RJJuYyuwskYtzZi2gziy6SE/b7saWEzyskaA252E0VY=
+github.com/projectdiscovery/folderutil v0.0.0-20211206150108-b4e7ea80f36e/go.mod h1:BMqXH4jNGByVdE2iLtKvc/6XStaiZRuCIaKv1vw9PnI=
 github.com/projectdiscovery/goflags v0.0.7/go.mod h1:Jjwsf4eEBPXDSQI2Y+6fd3dBumJv/J1U0nmpM+hy2YY=
 github.com/projectdiscovery/goflags v0.0.8-0.20211028121123-edf02bc05b1a h1:EzwVm8i4zmzqZX55vrDtyfogwHh8AAZ3cWCJe4fEduk=
 github.com/projectdiscovery/goflags v0.0.8-0.20211028121123-edf02bc05b1a/go.mod h1:Jjwsf4eEBPXDSQI2Y+6fd3dBumJv/J1U0nmpM+hy2YY=

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -595,8 +595,6 @@ github.com/projectdiscovery/fileutil v0.0.0-20210914153648-31f843feaad4/go.mod h
 github.com/projectdiscovery/fileutil v0.0.0-20210926202739-6050d0acf73c/go.mod h1:U+QCpQnX8o2N2w0VUGyAzjM3yBAe4BKedVElxiImsx0=
 github.com/projectdiscovery/fileutil v0.0.0-20210928100737-cab279c5d4b5 h1:2dbm7UhrAKnccZttr78CAmG768sSCd+MBn4ayLVDeqA=
 github.com/projectdiscovery/fileutil v0.0.0-20210928100737-cab279c5d4b5/go.mod h1:U+QCpQnX8o2N2w0VUGyAzjM3yBAe4BKedVElxiImsx0=
-github.com/projectdiscovery/folderutil v0.0.0-20211206102047-d6bf8e7490ff h1:ci7/Pq9xvrVFb94jeARYb45oSzs85NWG+Fxp/kjgHVc=
-github.com/projectdiscovery/folderutil v0.0.0-20211206102047-d6bf8e7490ff/go.mod h1:BMqXH4jNGByVdE2iLtKvc/6XStaiZRuCIaKv1vw9PnI=
 github.com/projectdiscovery/folderutil v0.0.0-20211206150108-b4e7ea80f36e h1:RJJuYyuwskYtzZi2gziy6SE/b7saWEzyskaA252E0VY=
 github.com/projectdiscovery/folderutil v0.0.0-20211206150108-b4e7ea80f36e/go.mod h1:BMqXH4jNGByVdE2iLtKvc/6XStaiZRuCIaKv1vw9PnI=
 github.com/projectdiscovery/goflags v0.0.7/go.mod h1:Jjwsf4eEBPXDSQI2Y+6fd3dBumJv/J1U0nmpM+hy2YY=

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -595,10 +595,6 @@ github.com/projectdiscovery/fileutil v0.0.0-20210914153648-31f843feaad4/go.mod h
 github.com/projectdiscovery/fileutil v0.0.0-20210926202739-6050d0acf73c/go.mod h1:U+QCpQnX8o2N2w0VUGyAzjM3yBAe4BKedVElxiImsx0=
 github.com/projectdiscovery/fileutil v0.0.0-20210928100737-cab279c5d4b5 h1:2dbm7UhrAKnccZttr78CAmG768sSCd+MBn4ayLVDeqA=
 github.com/projectdiscovery/fileutil v0.0.0-20210928100737-cab279c5d4b5/go.mod h1:U+QCpQnX8o2N2w0VUGyAzjM3yBAe4BKedVElxiImsx0=
-github.com/projectdiscovery/folderutil v0.0.0-20210804143510-68474319fd84 h1:+VqGxv8ywpIHwGGSCOcGn/q5kkuB6F1AZtY42I8VnXc=
-github.com/projectdiscovery/folderutil v0.0.0-20210804143510-68474319fd84/go.mod h1:BMqXH4jNGByVdE2iLtKvc/6XStaiZRuCIaKv1vw9PnI=
-github.com/projectdiscovery/folderutil v0.0.0-20211203091551-e81604e6940e h1:ozfSeEc5j1f7NCEZAiAskP/KYfBD/TzPmFTIfh+CEwE=
-github.com/projectdiscovery/folderutil v0.0.0-20211203091551-e81604e6940e/go.mod h1:BMqXH4jNGByVdE2iLtKvc/6XStaiZRuCIaKv1vw9PnI=
 github.com/projectdiscovery/folderutil v0.0.0-20211206150108-b4e7ea80f36e h1:RJJuYyuwskYtzZi2gziy6SE/b7saWEzyskaA252E0VY=
 github.com/projectdiscovery/folderutil v0.0.0-20211206150108-b4e7ea80f36e/go.mod h1:BMqXH4jNGByVdE2iLtKvc/6XStaiZRuCIaKv1vw9PnI=
 github.com/projectdiscovery/goflags v0.0.7/go.mod h1:Jjwsf4eEBPXDSQI2Y+6fd3dBumJv/J1U0nmpM+hy2YY=

--- a/v2/internal/runner/update.go
+++ b/v2/internal/runner/update.go
@@ -24,6 +24,7 @@ import (
 	"github.com/olekukonko/tablewriter"
 	"github.com/pkg/errors"
 
+	"github.com/projectdiscovery/folderutil"
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/nuclei-updatecheck-api/client"
 	"github.com/projectdiscovery/nuclei/v2/pkg/catalog/config"
@@ -401,7 +402,9 @@ func calculateTemplateAbsolutePath(zipFilePath, configuredTemplateDirectory stri
 		return "", true, nil
 	}
 
-	directoryPathChunks := strings.Split(directory, string(os.PathSeparator))
+	pathInfo, _ := folderutil.NewPathInfo(directory)
+
+	directoryPathChunks := pathInfo.Parts
 	relativeDirectoryPathWithoutZipRoot := filepath.Join(directoryPathChunks[1:]...)
 
 	if strings.HasPrefix(relativeDirectoryPathWithoutZipRoot, ".") {

--- a/v2/internal/runner/update.go
+++ b/v2/internal/runner/update.go
@@ -402,10 +402,17 @@ func calculateTemplateAbsolutePath(zipFilePath, configuredTemplateDirectory stri
 		return "", true, nil
 	}
 
-	pathInfo, _ := folderutil.NewPathInfo(directory)
-
-	directoryPathChunks := pathInfo.Parts
-	relativeDirectoryPathWithoutZipRoot := filepath.Join(directoryPathChunks[1:]...)
+	var (
+		directoryPathChunks                 []string
+		relativeDirectoryPathWithoutZipRoot string
+	)
+	if folderutil.IsUnixOS() {
+		directoryPathChunks = strings.Split(directory, string(os.PathSeparator))
+	} else if folderutil.IsWindowsOS() {
+		pathInfo, _ := folderutil.NewPathInfo(directory)
+		directoryPathChunks = pathInfo.Parts
+	}
+	relativeDirectoryPathWithoutZipRoot = filepath.Join(directoryPathChunks[1:]...)
 
 	if strings.HasPrefix(relativeDirectoryPathWithoutZipRoot, ".") {
 		return "", true, nil

--- a/v2/pkg/protocols/common/generators/validate.go
+++ b/v2/pkg/protocols/common/generators/validate.go
@@ -28,21 +28,10 @@ func (g *PayloadGenerator) validate(payloads map[string]interface{}, templatePat
 
 			changed := false
 
-			var dir string
-			if folderutil.IsWindowsOS() {
-				dir, payloadType = filepath.Split(filepath.Join(templatePath, payloadType))
-			} else {
-				dir, _ = filepath.Split(templatePath)
-			}
+			dir, _ := filepath.Split(templatePath)
+			templatePathInfo, _ := folderutil.NewPathInfo(dir)
+			payloadPathsToProbe, _ := templatePathInfo.MeshWith(payloadType)
 
-			templatePathInfo, err := folderutil.NewPathInfo(dir)
-			if err != nil {
-				return err
-			}
-			payloadPathsToProbe, err := templatePathInfo.MeshWith(payloadType)
-			if err != nil {
-				return err
-			}
 			for _, payloadPath := range payloadPathsToProbe {
 				if fileExists(payloadPath) {
 					payloads[name] = payloadPath


### PR DESCRIPTION
## Proposed changes
This PR fixes the `nuclei-templates` unzip operation improving subdirectory handling via [folderutils](https://github.com/projectdiscovery/folderutil)


## Checklist
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)