### PR TITLE
Fixing typo in variable name while validating template payloads

### DIFF
--- a/v2/pkg/protocols/common/generators/generators.go
+++ b/v2/pkg/protocols/common/generators/generators.go
@@ -37,7 +37,7 @@ func New(payloads map[string]interface{}, attackType AttackType, templatePath st
 	}
 
 	generator := &PayloadGenerator{}
-	if err := generator.validate(payloads, templatePath); err != nil {
+	if err := generator.validate(payloadsFinal, templatePath); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
## Proposed changes
This PR fixes a copy-paste typo in templates validation logic


## Checklist
- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)