### PR TITLE
Trim paths info from released binary

### DIFF
--- a/v2/.goreleaser.yml
+++ b/v2/.goreleaser.yml
@@ -26,6 +26,9 @@ builds:
   binary: '{{ .ProjectName }}'
   main: cmd/nuclei/main.go
 
+  flags:
+    - -trimpath
+
 archives:
 - format: zip
   replacements:


### PR DESCRIPTION
## Proposed changes
This PR trims path info from released binary. It's not necessary to strip symbol table + debug info as goreleaser add those flags by default during the build process.

## Checklist
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)