### PR TITLE
Adding race condition test

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -29,3 +29,8 @@ jobs:
       - name: Build
         run: go build .
         working-directory: v2/cmd/nuclei/
+      
+      # At the bottom for known issue on OSX - https://github.com/projectdiscovery/nuclei/issues/1309
+      - name: Race Condition Tests
+        run: go build -race .
+        working-directory: v2/cmd/nuclei/


### PR DESCRIPTION
## Proposed changes
This PR adds support for race condition tests. The check is at the bottom of the github workflow due to a known issue of the go compiler on OSX (ref: https://github.com/projectdiscovery/nuclei/issues/1309). Multi-OS support is covered by https://github.com/projectdiscovery/nuclei/pull/1347

## Checklist
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)