### PR TITLE
Making extractors as reusable variables

### DIFF
--- a/v2/pkg/operators/operators.go
+++ b/v2/pkg/operators/operators.go
@@ -178,13 +178,13 @@ func (operators *Operators) Execute(data map[string]interface{}, match MatchFunc
 		for match := range extract(data, extractor) {
 			extractorResults = append(extractorResults, match)
 
-			if extractor.Internal {
-				if data, ok := result.DynamicValues[extractor.Name]; !ok {
-					result.DynamicValues[extractor.Name] = []string{match}
-				} else {
-					result.DynamicValues[extractor.Name] = append(data, match)
-				}
+			if data, ok := result.DynamicValues[extractor.Name]; !ok {
+				result.DynamicValues[extractor.Name] = []string{match}
 			} else {
+				result.DynamicValues[extractor.Name] = append(data, match)
+			}
+
+			if !extractor.Internal {
 				result.OutputExtracts = append(result.OutputExtracts, match)
 			}
 		}

--- a/v2/pkg/operators/operators.go
+++ b/v2/pkg/operators/operators.go
@@ -214,9 +214,6 @@ func (operators *Operators) Execute(data map[string]interface{}, match MatchFunc
 
 	result.Matched = matches
 	result.Extracted = len(result.OutputExtracts) > 0
-	if len(result.DynamicValues) > 0 {
-		return result, true
-	}
 
 	// Don't print if we have matchers, and they have not matched, regardless of extractor
 	if len(operators.Matchers) > 0 && !matches {
@@ -227,6 +224,11 @@ func (operators *Operators) Execute(data map[string]interface{}, match MatchFunc
 	if len(result.Extracts) > 0 || len(result.OutputExtracts) > 0 || matches {
 		return result, true
 	}
+
+	if len(result.DynamicValues) > 0 {
+		return result, true
+	}
+
 	return nil, false
 }
 

--- a/v2/pkg/protocols/protocols.go
+++ b/v2/pkg/protocols/protocols.go
@@ -108,9 +108,9 @@ type Request interface {
 type OutputEventCallback func(result *output.InternalWrappedEvent)
 
 func MakeDefaultResultEvent(request Request, wrapped *output.InternalWrappedEvent) []*output.ResultEvent {
-	if len(wrapped.OperatorsResult.DynamicValues) > 0 && !wrapped.OperatorsResult.Matched {
-		return nil
-	}
+	// if len(wrapped.OperatorsResult.DynamicValues) > 0 && !wrapped.OperatorsResult.Matched {
+	// 	return nil
+	// }
 
 	results := make([]*output.ResultEvent, 0, len(wrapped.OperatorsResult.Matches)+1)
 


### PR DESCRIPTION
## Proposed changes
This PR turns extractors into internal reusable variables and skip output if internal flag is set true. Check linked issue for more details.

## Checklist
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)