### PR TITLE
Fixing wrong function/variable name in whois integration test

### DIFF
--- a/v2/cmd/integration-test/whois.go
+++ b/v2/cmd/integration-test/whois.go
@@ -17,7 +17,7 @@ func (h *whoisBasic) Execute(filePath string) error {
 		return err
 	}
 	if len(results) != 1 {
-		return errIncorrectResultsCount(results)
+		return expectResultsCount(results, 1)
 	}
 	return nil
 }

--- a/v2/cmd/integration-test/whois.go
+++ b/v2/cmd/integration-test/whois.go
@@ -16,8 +16,5 @@ func (h *whoisBasic) Execute(filePath string) error {
 	if err != nil {
 		return err
 	}
-	if len(results) != 1 {
-		return expectResultsCount(results, 1)
-	}
-	return nil
+	return expectResultsCount(results, 1)
 }


### PR DESCRIPTION
## Proposed changes
This PR fixes whois integration test by replacing the undeclared function `errIncorrectResultsCount` with `expectResultsCount`

## Checklist
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes (known issue on those failing)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)