### PR TITLE
Fixing CVE annotate crash

### DIFF
--- a/v2/cmd/cve-annotate/main.go
+++ b/v2/cmd/cve-annotate/main.go
@@ -71,7 +71,7 @@ func getCVEData(client *nvd.Client, filePath, data string) {
 	cveName := matches[0][1]
 
 	severityMatches := severityRegex.FindAllStringSubmatch(data, 1)
-	if len(matches) == 0 {
+	if len(severityMatches) == 0 {
 		return
 	}
 	severityValue := severityMatches[0][1]


### PR DESCRIPTION
## Proposed changes
This PR fixes the `cve-annotate` commands crash because of wrong variable name

## Checklist
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)