### PR TITLE
Removing invalid negative paths for windows

### DIFF
--- a/integration_tests/http/self-contained.yaml
+++ b/integration_tests/http/self-contained.yaml
@@ -9,7 +9,7 @@ self-contained: true
 requests:
   - raw:
       - |
-        GET http://localhost:5431/ HTTP/1.1
+        GET http://127.0.0.1:5431/ HTTP/1.1
         Host: {{Hostname}}
 
     matchers:

--- a/integration_tests/network/self-contained.yaml
+++ b/integration_tests/network/self-contained.yaml
@@ -8,7 +8,7 @@ info:
 self-contained: true
 network:
   - host:
-      - "localhost:5431"
+      - "127.0.0.1:5431"
 
     matchers:
       - type: word

--- a/v2/internal/runner/update_test.go
+++ b/v2/internal/runner/update_test.go
@@ -119,7 +119,7 @@ func TestDownloadReleaseAndUnzipDeletion(t *testing.T) {
 	require.Equal(t, "base.yaml", results.deletions[0], "could not get correct new deletions")
 }
 
-func TestCalculateTemplateAbsolutePath(t *testing.T) {
+func TestCalculateTemplateAbsolutePathPositiveScenario(t *testing.T) {
 	configuredTemplateDirectory := filepath.Join(os.TempDir(), "templates")
 	defer os.RemoveAll(configuredTemplateDirectory)
 
@@ -134,24 +134,6 @@ func TestCalculateTemplateAbsolutePath(t *testing.T) {
 			require.Nil(t, err)
 			require.Equal(t, expectedTemplateAbsPath, calculatedTemplateAbsPath)
 			require.False(t, skipFile)
-		}
-	})
-
-	t.Run("negative scenarios", func(t *testing.T) {
-		filePathsFromZip := []string{
-			"./../nuclei-templates/../cve/test.yaml",
-			"nuclei-templates/../cve/test.yaml",
-			"nuclei-templates/cve/../test.yaml",
-			"nuclei-templates/././../cve/test.yaml",
-			"nuclei-templates/.././../cve/test.yaml",
-			"nuclei-templates/.././../cve/../test.yaml",
-		}
-
-		for _, filePathFromZip := range filePathsFromZip {
-			calculatedTemplateAbsPath, skipFile, err := calculateTemplateAbsolutePath(filePathFromZip, configuredTemplateDirectory)
-			require.Nil(t, err)
-			require.True(t, skipFile)
-			require.Equal(t, "", calculatedTemplateAbsPath)
 		}
 	})
 }

--- a/v2/internal/runner/update_unix_test.go
+++ b/v2/internal/runner/update_unix_test.go
@@ -1,0 +1,34 @@
+//go:build !windows
+
+package runner
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCalculateTemplateAbsolutePathNegativeScenario(t *testing.T) {
+	configuredTemplateDirectory := filepath.Join(os.TempDir(), "templates")
+	defer os.RemoveAll(configuredTemplateDirectory)
+
+	t.Run("negative scenarios", func(t *testing.T) {
+		filePathsFromZip := []string{
+			"./../nuclei-templates/../cve/test.yaml",
+			"nuclei-templates/../cve/test.yaml",
+			"nuclei-templates/cve/../test.yaml",
+			"nuclei-templates/././../cve/test.yaml",
+			"nuclei-templates/.././../cve/test.yaml",
+			"nuclei-templates/.././../cve/../test.yaml",
+		}
+
+		for _, filePathFromZip := range filePathsFromZip {
+			calculatedTemplateAbsPath, skipFile, err := calculateTemplateAbsolutePath(filePathFromZip, configuredTemplateDirectory)
+			require.Nil(t, err)
+			require.True(t, skipFile)
+			require.Equal(t, "", calculatedTemplateAbsPath)
+		}
+	})
+}


### PR DESCRIPTION
## Proposed changes
Removing invalid negative scenarios specific for linux. Full/Partial paths on windows with `filepath.Join` will never start with a `.` as they are cleaned and will always end up within the configured path template.

## Checklist
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes (go 17.5 automatically fixes #1309 )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)