### PR TITLE
enable debugging/output of generated oob URLs for tracking

### DIFF
--- a/v2/cmd/nuclei/main.go
+++ b/v2/cmd/nuclei/main.go
@@ -144,6 +144,7 @@ on extensive configurability, massive extensibility and ease of use.`)
 		flagSet.BoolVar(&options.Debug, "debug", false, "show all requests and responses"),
 		flagSet.BoolVar(&options.DebugRequests, "debug-req", false, "show all sent requests"),
 		flagSet.BoolVar(&options.DebugResponse, "debug-resp", false, "show all received responses"),
+		flagSet.BoolVar(&options.DebugCorrelations, "debug-correlations", false, "show all generated interactsh-urls"),
 		flagSet.NormalizedStringSliceVarP(&options.Proxy, "proxy", "p", []string{}, "List of HTTP(s)/SOCKS5 proxy to use (comma separated or file input)"),
 		flagSet.StringVarP(&options.TraceLogFile, "trace-log", "tlog", "", "file to write sent requests trace log"),
 		flagSet.StringVarP(&options.ErrorLogFile, "error-log", "elog", "", "file to write sent requests error log"),

--- a/v2/pkg/output/output.go
+++ b/v2/pkg/output/output.go
@@ -108,6 +108,15 @@ type ResultEvent struct {
 	FileToIndexPosition map[string]int `json:"-"`
 }
 
+type CorrelationEvent struct {
+	// InteractshURLs contains all generated URLs
+	InteractshURLs []string
+	// ReqURL is the target URL
+	ReqURL string
+	// TemplateID is the ID of the template for the result.
+	TemplateID string
+}
+
 // NewStandardWriter creates a new output writer based on user configurations
 func NewStandardWriter(colors, noMetadata, noTimestamp, json, jsonReqResp, MatcherStatus bool, file, traceFile string, errorFile string) (*StandardWriter, error) {
 	auroraColorizer := aurora.NewAurora(colors)

--- a/v2/pkg/protocols/http/request.go
+++ b/v2/pkg/protocols/http/request.go
@@ -3,6 +3,7 @@ package http
 import (
 	"bytes"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -355,6 +356,18 @@ func (request *Request) executeRequest(reqURL string, generatedRequest *generate
 			gologger.Info().Msgf("[%s] Dumped HTTP request for %s\n\n", request.options.TemplateID, reqURL)
 			gologger.Print().Msgf("%s", dumpedRequestString)
 		}
+		if request.options.Options.Debug || request.options.Options.DebugCorrelations {
+			corrEvent := output.CorrelationEvent{
+				InteractshURLs: generatedRequest.interactshURLs,
+				ReqURL:         reqURL,
+				TemplateID:     request.options.TemplateID,
+			}
+			if bts, err := json.Marshal(corrEvent); err == nil {
+				gologger.Info().Msgf("[%s] Correlation for %s\n", request.options.TemplateID, reqURL)
+				gologger.Print().Msg(string(bts))
+			}
+		}
+
 	}
 	var formedURL string
 	var hostname string

--- a/v2/pkg/types/types.go
+++ b/v2/pkg/types/types.go
@@ -132,6 +132,8 @@ type Options struct {
 	DebugRequests bool
 	// DebugResponse mode allows debugging response for the engine
 	DebugResponse bool
+	// DebugCorrelations mode allows outputting of generated URLs in stderr logs
+	DebugCorrelations bool
 	// Silent suppresses any extra text and only writes found URLs on screen.
 	Silent bool
 	// Version specifies if we should just show version and exit


### PR DESCRIPTION
## Proposed changes

This PR adds a new flag and helps to correlate oob requests from Nuclei. 

If the nuclei client did not pull the oob responses from the interactsh server, then no event is created and it's impossible to identify the origin nor request.
Especially the correlation with the system is problematic if internal DNS log have identified vulnerable systems, but cannot correlate the request nor actor. 

With the output of the generated URLs one can easily identify not only the system but can answer if the request were sent from you or not.
```bash
[INF] [CVE-2021-44228] Correlation for http://127.0.0.1:8009/log4jcanary
{"InteractshURLs":["<uuid>.interact.sh","<uuid>.interact.sh"],"ReqURL":"http://127.0.0.1:8009/log4jcanary","TemplateID":"CVE-2021-44228"}
```

## Checklist

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)