### PR TITLE
Fix the required parameters for GitLab issues

### DIFF
--- a/v2/cmd/nuclei/issue-tracker-config.yaml
+++ b/v2/cmd/nuclei/issue-tracker-config.yaml
@@ -30,8 +30,8 @@
 #  username: ""
 #  # token is the token for GitLab account.
 #  token: ""
-#  # project-id is the ID of the repository.
-#  project-id: ""
+#  # project-name is the name of the repository.
+#  project-name: ""
 #  # issue-label (optional) is the label of the created issue type
 #  issue-label: ""
 #  # severity-as-label (optional) sets the severity as the label of the created issue type


### PR DESCRIPTION
For GitLab, project-name is required - not project-id.

## Proposed changes

Using the template as provided results in the following runtime error when opening issues with GitLab:

```
Could not create runner: could not parse reporting config file: validation failed for these fields: Options.GitLab.ProjectName: required
```

Changing the template to use `name` instead of `id` fixes the error.


## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)