### PR TITLE
Add stop at first match for interactsh matchers

### DIFF
--- a/integration_tests/http/interactsh-stop-at-first-match.yaml
+++ b/integration_tests/http/interactsh-stop-at-first-match.yaml
@@ -1,0 +1,23 @@
+id: interactsh-stop-at-first-match-integration-test
+
+info:
+  name: Interactsh StopAtFirstMatch Integration Test
+  author: pdteam
+  severity: info
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+      - "{{BaseURL}}"
+      - "{{BaseURL}}"
+    headers:
+      url: 'http://{{interactsh-url}}'
+
+    stop-at-first-match: true
+
+    matchers:
+      - type: word
+        part: interactsh_protocol # Confirms the HTTP Interaction
+        words:
+          - "http"

--- a/v2/internal/runner/runner.go
+++ b/v2/internal/runner/runner.go
@@ -159,7 +159,7 @@ func New(options *types.Options) (*Runner, error) {
 	opts.ColldownPeriod = time.Duration(options.InteractionsCoolDownPeriod) * time.Second
 	opts.PollDuration = time.Duration(options.InteractionsPollDuration) * time.Second
 	opts.NoInteractsh = runner.options.NoInteractsh
-
+	opts.StopAtFirstMatch = runner.options.StopAtFirstMatch
 	interactshClient, err := interactsh.New(opts)
 	if err != nil {
 		gologger.Error().Msgf("Could not create interactsh client: %s", err)

--- a/v2/pkg/protocols/common/interactsh/interactsh.go
+++ b/v2/pkg/protocols/common/interactsh/interactsh.go
@@ -180,12 +180,6 @@ func (c *Client) firstTimeInitializeClient() error {
 	return nil
 }
 
-func hash(s string) string {
-	h := sha1.New()
-	h.Write([]byte(s))
-	return hex.EncodeToString(h.Sum(nil))
-}
-
 // processInteractionForRequest processes an interaction for a request
 func (c *Client) processInteractionForRequest(interaction *server.Interaction, data *RequestData) bool {
 	data.Event.InternalEvent["interactsh_protocol"] = interaction.Protocol
@@ -348,12 +342,8 @@ func debugPrintInteraction(interaction *server.Interaction) {
 	fmt.Fprint(os.Stderr, builder.String())
 }
 
-// contains returns true if the given string is in the given array
-func contains(array []string, str string) bool {
-	for _, s := range array {
-		if s == str {
-			return true
-		}
-	}
-	return false
+func hash(s string) string {
+	h := sha1.New()
+	h.Write([]byte(s))
+	return hex.EncodeToString(h.Sum(nil))
 }

--- a/v2/pkg/protocols/common/interactsh/interactsh.go
+++ b/v2/pkg/protocols/common/interactsh/interactsh.go
@@ -169,7 +169,7 @@ func (c *Client) firstTimeInitializeClient() error {
 		}
 
 		if _, ok := request.Event.InternalEvent["stop-at-first-match"]; ok {
-			gotItem := c.matchedTemplates.Get(hash(request.Event.InternalEvent["template-id"].(string) + request.Event.InternalEvent["host"].(string)))
+			gotItem := c.matchedTemplates.Get(hash(request.Event.InternalEvent["template-id"].(string), request.Event.InternalEvent["host"].(string)))
 			if gotItem != nil {
 				return
 			}
@@ -205,7 +205,7 @@ func (c *Client) processInteractionForRequest(interaction *server.Interaction, d
 	if writer.WriteResult(data.Event, c.options.Output, c.options.Progress, c.options.IssuesClient) {
 		c.matched = true
 		if _, ok := data.Event.InternalEvent["stop-at-first-match"]; ok {
-			c.matchedTemplates.Set(hash(data.Event.InternalEvent["template-id"].(string)+data.Event.InternalEvent["host"].(string)), true, defaultInteractionDuration)
+			c.matchedTemplates.Set(hash(data.Event.InternalEvent["template-id"].(string), data.Event.InternalEvent["host"].(string)), true, defaultInteractionDuration)
 		}
 	}
 	return true
@@ -342,8 +342,9 @@ func debugPrintInteraction(interaction *server.Interaction) {
 	fmt.Fprint(os.Stderr, builder.String())
 }
 
-func hash(s string) string {
+func hash(templateID, host string) string {
 	h := sha1.New()
-	h.Write([]byte(s))
+	h.Write([]byte(templateID))
+	h.Write([]byte(host))
 	return hex.EncodeToString(h.Sum(nil))
 }

--- a/v2/pkg/protocols/common/interactsh/interactsh.go
+++ b/v2/pkg/protocols/common/interactsh/interactsh.go
@@ -233,9 +233,9 @@ func (c *Client) ReplaceMarkers(data string, interactshURLs []string) (string, [
 	return data, interactshURLs
 }
 
-// SetStopAtFirstMatch sets StopAtFirstMatch for interactsh client options
-func (c *Client) SetStopAtFirstMatch(stopAtFirstMatch bool) {
-	c.options.StopAtFirstMatch = stopAtFirstMatch
+// SetStopAtFirstMatch sets StopAtFirstMatch true for interactsh client options
+func (c *Client) SetStopAtFirstMatch() {
+	c.options.StopAtFirstMatch = true
 }
 
 // MakeResultEventFunc is a result making function for nuclei

--- a/v2/pkg/protocols/http/build_request.go
+++ b/v2/pkg/protocols/http/build_request.go
@@ -62,7 +62,7 @@ func (r *requestGenerator) Make(baseURL, data string, payloads, dynamicValues ma
 
 	if r.options.Interactsh != nil {
 		if r.options.StopAtFirstMatch || r.request.StopAtFirstMatch {
-			r.options.Interactsh.SetStopAtFirstMatch(true)
+			r.options.Interactsh.SetStopAtFirstMatch()
 		}
 
 		data, r.interactshURLs = r.options.Interactsh.ReplaceMarkers(data, r.interactshURLs)

--- a/v2/pkg/protocols/http/build_request.go
+++ b/v2/pkg/protocols/http/build_request.go
@@ -61,6 +61,10 @@ func (r *requestGenerator) Make(baseURL, data string, payloads, dynamicValues ma
 	ctx := context.Background()
 
 	if r.options.Interactsh != nil {
+		if r.options.StopAtFirstMatch || r.request.StopAtFirstMatch {
+			r.options.Interactsh.SetStopAtFirstMatch(true)
+		}
+
 		data, r.interactshURLs = r.options.Interactsh.ReplaceMarkers(data, r.interactshURLs)
 		for payloadName, payloadValue := range payloads {
 			payloads[payloadName], r.interactshURLs = r.options.Interactsh.ReplaceMarkers(types.ToString(payloadValue), r.interactshURLs)

--- a/v2/pkg/protocols/http/build_request.go
+++ b/v2/pkg/protocols/http/build_request.go
@@ -61,11 +61,8 @@ func (r *requestGenerator) Make(baseURL, data string, payloads, dynamicValues ma
 	ctx := context.Background()
 
 	if r.options.Interactsh != nil {
-		if r.options.StopAtFirstMatch || r.request.StopAtFirstMatch {
-			r.options.Interactsh.SetStopAtFirstMatch()
-		}
 
-		data, r.interactshURLs = r.options.Interactsh.ReplaceMarkers(data, r.interactshURLs)
+		data, r.interactshURLs = r.options.Interactsh.ReplaceMarkers(data, []string{})
 		for payloadName, payloadValue := range payloads {
 			payloads[payloadName], r.interactshURLs = r.options.Interactsh.ReplaceMarkers(types.ToString(payloadValue), r.interactshURLs)
 		}

--- a/v2/pkg/protocols/http/operators.go
+++ b/v2/pkg/protocols/http/operators.go
@@ -125,6 +125,10 @@ func (request *Request) responseToDSLMap(resp *http.Response, host, matched, raw
 	data["template-id"] = request.options.TemplateID
 	data["template-info"] = request.options.TemplateInfo
 	data["template-path"] = request.options.TemplatePath
+
+	if request.StopAtFirstMatch || request.options.StopAtFirstMatch {
+		data["stop-at-first-match"] = true
+	}
 	return data
 }
 

--- a/v2/pkg/protocols/network/request.go
+++ b/v2/pkg/protocols/network/request.go
@@ -142,9 +142,6 @@ func (request *Request) executeRequestWithPayloads(variables map[string]interfac
 		reqBuilder.Grow(len(input.Data))
 
 		if request.options.Interactsh != nil {
-			if request.options.StopAtFirstMatch {
-				request.options.Interactsh.SetStopAtFirstMatch()
-			}
 			var transformedData string
 			transformedData, interactshURLs = request.options.Interactsh.ReplaceMarkers(string(data), []string{})
 			data = []byte(transformedData)
@@ -250,6 +247,9 @@ func (request *Request) executeRequestWithPayloads(variables map[string]interfac
 	response := responseBuilder.String()
 	outputEvent := request.responseToDSLMap(reqBuilder.String(), string(final[:n]), response, input, actualAddress)
 	outputEvent["ip"] = request.dialer.GetDialedIP(hostname)
+	if request.options.StopAtFirstMatch {
+		outputEvent["stop-at-first-match"] = true
+	}
 	for k, v := range previous {
 		outputEvent[k] = v
 	}

--- a/v2/pkg/protocols/network/request.go
+++ b/v2/pkg/protocols/network/request.go
@@ -143,7 +143,7 @@ func (request *Request) executeRequestWithPayloads(variables map[string]interfac
 
 		if request.options.Interactsh != nil {
 			if request.options.StopAtFirstMatch {
-				request.options.Interactsh.SetStopAtFirstMatch(true)
+				request.options.Interactsh.SetStopAtFirstMatch()
 			}
 			var transformedData string
 			transformedData, interactshURLs = request.options.Interactsh.ReplaceMarkers(string(data), []string{})

--- a/v2/pkg/protocols/network/request.go
+++ b/v2/pkg/protocols/network/request.go
@@ -142,6 +142,9 @@ func (request *Request) executeRequestWithPayloads(variables map[string]interfac
 		reqBuilder.Grow(len(input.Data))
 
 		if request.options.Interactsh != nil {
+			if request.options.StopAtFirstMatch {
+				request.options.Interactsh.SetStopAtFirstMatch(true)
+			}
 			var transformedData string
 			transformedData, interactshURLs = request.options.Interactsh.ReplaceMarkers(string(data), []string{})
 			data = []byte(transformedData)


### PR DESCRIPTION
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->
Extend `stop at first match` support to interactsh matchers

Example template (from [issue](https://github.com/projectdiscovery/nuclei/issues/1361))
```yaml 
id: test-interactsh

info:
  name: interactsh test
  author: pdteam
  severity: info

requests:
  - raw:
      - |
        GET /api/geoping/{{interactsh-url}} HTTP/1.1
        Host: {{Hostname}}

      - |
        GET /api/geoping/{{interactsh-url}} HTTP/1.1
        Host: {{Hostname}}

    stop-at-first-match: true
    matchers:
      - type: word
        part: interactsh_protocol  # Confirms the DNS Interaction
        words:
          - "dns"
```
```bash
echo https://geonet.shodan.io | nuclei -t test.yaml 

[test-interactsh] [http] [info] https://geonet.shodan.io/api/geoping/c70q752ciaeivnpbsr1gc8y48cyyyyyyr.interact.sh
```

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)