### PR TITLE
Adding support for navigation history to matchers

### DIFF
--- a/v2/pkg/protocols/headless/engine/page.go
+++ b/v2/pkg/protocols/headless/engine/page.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/go-rod/rod"
@@ -14,6 +15,12 @@ type Page struct {
 	rules    []requestRule
 	instance *Instance
 	router   *rod.HijackRouter
+	History  []HistoryData
+}
+
+type HistoryData struct {
+	RawRequest  string
+	RawResponse string
 }
 
 // Run runs a list of actions by creating a new page in the browser.
@@ -80,4 +87,13 @@ func (p *Page) URL() string {
 		return ""
 	}
 	return info.URL
+}
+
+func (p *Page) DumpHistory() string {
+	var historyDump strings.Builder
+	for _, historyData := range p.History {
+		historyDump.WriteString(historyData.RawRequest)
+		historyDump.WriteString(historyData.RawResponse)
+	}
+	return historyDump.String()
 }

--- a/v2/pkg/protocols/headless/engine/page.go
+++ b/v2/pkg/protocols/headless/engine/page.go
@@ -16,7 +16,7 @@ type Page struct {
 	rules        []requestRule
 	instance     *Instance
 	router       *rod.HijackRouter
-	historyMutex sync.RWMutex
+	historyMutex *sync.RWMutex
 	History      []HistoryData
 }
 
@@ -40,7 +40,7 @@ func (i *Instance) Run(baseURL *url.URL, actions []*Action, timeout time.Duratio
 		}
 	}
 
-	createdPage := &Page{page: page, instance: i}
+	createdPage := &Page{page: page, instance: i, historyMutex: &sync.RWMutex{}}
 	router := page.HijackRequests()
 	if routerErr := router.Add("*", "", createdPage.routingRuleHandler); routerErr != nil {
 		return nil, nil, routerErr

--- a/v2/pkg/protocols/headless/engine/page.go
+++ b/v2/pkg/protocols/headless/engine/page.go
@@ -18,6 +18,7 @@ type Page struct {
 	History  []HistoryData
 }
 
+// HistoryData contains the page request/response pairs
 type HistoryData struct {
 	RawRequest  string
 	RawResponse string
@@ -89,6 +90,7 @@ func (p *Page) URL() string {
 	return info.URL
 }
 
+// DumpHistory returns the full page navigation history
 func (p *Page) DumpHistory() string {
 	var historyDump strings.Builder
 	for _, historyData := range p.History {

--- a/v2/pkg/protocols/headless/engine/rules.go
+++ b/v2/pkg/protocols/headless/engine/rules.go
@@ -64,9 +64,11 @@ func (p *Page) routingRuleHandler(ctx *rod.Hijack) {
 	var rawResp strings.Builder
 	respPayloads := ctx.Response.Payload()
 	if respPayloads != nil {
-		rawResp.WriteString(fmt.Sprintf("HTTP/1.1 %d %s\n", respPayloads.ResponseCode, respPayloads.ResponsePhrase))
+		rawResp.WriteString("HTTP/1.1 ")
+		rawResp.WriteString(fmt.Sprint(respPayloads.ResponseCode))
+		rawResp.WriteString(" " + respPayloads.ResponsePhrase + "+\n")
 		for _, header := range respPayloads.ResponseHeaders {
-			rawResp.WriteString(fmt.Sprintf("%s: %s\n", header.Name, header.Value))
+			rawResp.WriteString(header.Name + ": " + header.Value + "\n")
 		}
 		rawResp.WriteString("\n")
 		rawResp.WriteString(ctx.Response.Body())
@@ -77,5 +79,5 @@ func (p *Page) routingRuleHandler(ctx *rod.Hijack) {
 		RawRequest:  rawReq,
 		RawResponse: rawResp.String(),
 	}
-	p.History = append(p.History, historyData)
+	p.addToHistory(historyData)
 }

--- a/v2/pkg/protocols/headless/operators.go
+++ b/v2/pkg/protocols/headless/operators.go
@@ -54,6 +54,8 @@ func (request *Request) getMatchPart(part string, data output.InternalEvent) (st
 	switch part {
 	case "body", "resp", "":
 		part = "data"
+	case "history":
+		part = "history"
 	}
 
 	item, ok := data[part]
@@ -66,12 +68,13 @@ func (request *Request) getMatchPart(part string, data output.InternalEvent) (st
 }
 
 // responseToDSLMap converts a headless response to a map for use in DSL matching
-func (request *Request) responseToDSLMap(resp, req, host, matched string) output.InternalEvent {
+func (request *Request) responseToDSLMap(resp, req, host, matched string, history string) output.InternalEvent {
 	return output.InternalEvent{
 		"host":          host,
 		"matched":       matched,
 		"req":           req,
 		"data":          resp,
+		"history":       history,
 		"type":          request.Type().String(),
 		"template-id":   request.options.TemplateID,
 		"template-info": request.options.TemplateInfo,

--- a/v2/pkg/protocols/headless/request.go
+++ b/v2/pkg/protocols/headless/request.go
@@ -66,7 +66,7 @@ func (request *Request) ExecuteWithResults(inputURL string, metadata, previous o
 	if err == nil {
 		responseBody, _ = html.HTML()
 	}
-	outputEvent := request.responseToDSLMap(responseBody, reqBuilder.String(), inputURL, inputURL)
+	outputEvent := request.responseToDSLMap(responseBody, reqBuilder.String(), inputURL, inputURL, page.DumpHistory())
 	for k, v := range out {
 		outputEvent[k] = v
 	}


### PR DESCRIPTION
## Proposed changes
This PR adds support for navigation history (HTTP raw request/responses) to matchers


## Checklist
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes - failing on known ones (interactsh)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## How to reproduce
1) Use the following template:
```yaml
id: test

info:
  name: test
  author: pdteam
  severity: info
  reference: test
  tags: headless

headless:
  - steps:
      - args:
          url: "{{BaseURL}}/test"
        action: navigate
      - action: waitload
    matchers:
      - type: word
        part: history
        words:
          - "test"
```
2) Run nuclei with a headless matcher on `history`:
```console
$ echo http://localhost:8000 | go run . -duc -no-interactsh -t headless.yaml -headless

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   2.5.8-dev

                projectdiscovery.io

[WRN] Use with caution. You are responsible for your actions.
[WRN] Developers assume no liability and are not responsible for any misuse or damage.
[INF] Using Nuclei Engine 2.5.8-dev (development)
[INF] Using Nuclei Templates 8.7.9 (latest)
[INF] Using Interactsh Server https://interact.sh
[INF] Templates added in last update: 19
[INF] Templates loaded for scan: 1
[2021-12-29 09:55:33] [test] [headless] [info] http://localhost:8000
```