### PR TITLE
Replacing expression regex with lexical analyzer

### DIFF
--- a/v2/pkg/protocols/common/expressions/expressions.go
+++ b/v2/pkg/protocols/common/expressions/expressions.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/projectdiscovery/nuclei/v2/pkg/operators/common/dsl"
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/generators"
+	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/marker"
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/replacer"
-	"github.com/projectdiscovery/stringsutil"
 )
 
 // Evaluate checks if the match contains a dynamic variable, for each
@@ -55,18 +55,11 @@ func evaluate(data string, base map[string]interface{}) (string, error) {
 
 func findMatches(data string) []string {
 	var matches []string
-	tokens := strings.Split(data, "{{")
-	for _, token := range tokens {
-		closingToken := strings.LastIndex(token, "}}")
-		var match string
+	for _, token := range strings.Split(data, marker.ParenthesisOpen) {
+		closingToken := strings.LastIndex(token, marker.ParenthesisClose)
 		if closingToken > 0 {
-			match = token[:closingToken]
-		} else {
-			match = stringsutil.Before(token, "}}")
+			matches = append(matches, token[:closingToken])
 		}
-
-		matches = append(matches, match)
 	}
-
 	return matches
 }

--- a/v2/pkg/protocols/common/expressions/expressions_test.go
+++ b/v2/pkg/protocols/common/expressions/expressions_test.go
@@ -12,6 +12,7 @@ func TestEvaluate(t *testing.T) {
 		expected string
 		extra    map[string]interface{}
 	}{
+		{input: "{{url_encode('test}aaa')}}", expected: "test%7Daaa", extra: map[string]interface{}{}},
 		{input: "{{hex_encode('PING')}}", expected: "50494e47", extra: map[string]interface{}{}},
 		{input: "test", expected: "test", extra: map[string]interface{}{}},
 		{input: "{{hex_encode(Item)}}", expected: "50494e47", extra: map[string]interface{}{"Item": "PING"}},

--- a/v2/pkg/protocols/common/expressions/expressions_test.go
+++ b/v2/pkg/protocols/common/expressions/expressions_test.go
@@ -19,6 +19,8 @@ func TestEvaluate(t *testing.T) {
 		{input: "{{hex_encode(Item)}}\r\n", expected: "50494e47\r\n", extra: map[string]interface{}{"Item": "PING"}},
 		{input: "{{someTestData}}{{hex_encode('PING')}}", expected: "{{someTestData}}50494e47", extra: map[string]interface{}{}},
 		{input: `_IWP_JSON_PREFIX_{{base64("{\"iwp_action\":\"add_site\",\"params\":{\"username\":\"\"}}")}}`, expected: "_IWP_JSON_PREFIX_eyJpd3BfYWN0aW9uIjoiYWRkX3NpdGUiLCJwYXJhbXMiOnsidXNlcm5hbWUiOiIifX0=", extra: map[string]interface{}{}},
+		{input: "{{}}", expected: "{{}}", extra: map[string]interface{}{}},
+		{input: `"{{hex_encode('PING')}}"`, expected: `"50494e47"`, extra: map[string]interface{}{}},
 	}
 	for _, item := range items {
 		value, err := Evaluate(item.input, item.extra)

--- a/v2/pkg/protocols/common/generators/maps.go
+++ b/v2/pkg/protocols/common/generators/maps.go
@@ -3,6 +3,8 @@ package generators
 import (
 	"reflect"
 	"strings"
+
+	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/marker"
 )
 
 // MergeMapsMany merges many maps into a new map
@@ -85,5 +87,5 @@ func CopyMapWithDefaultValue(originalMap map[string][]string, defaultValue inter
 
 // TrimDelimiters removes trailing brackets
 func TrimDelimiters(s string) string {
-	return strings.TrimSuffix(strings.TrimPrefix(s, "{{"), "}}")
+	return strings.TrimSuffix(strings.TrimPrefix(s, marker.ParenthesisOpen), marker.ParenthesisClose)
 }

--- a/v2/pkg/protocols/common/marker/marker.go
+++ b/v2/pkg/protocols/common/marker/marker.go
@@ -1,0 +1,10 @@
+package marker
+
+const (
+	// General marker (open/close)
+	General = "§"
+	// ParenthesisOpen marker - begin of a placeholder
+	ParenthesisOpen = "{{"
+	// ParenthesisClose marker - end of a placeholder
+	ParenthesisClose = "}}"
+)

--- a/v2/pkg/protocols/common/replacer/replacer.go
+++ b/v2/pkg/protocols/common/replacer/replacer.go
@@ -3,14 +3,8 @@ package replacer
 import (
 	"strings"
 
+	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/marker"
 	"github.com/projectdiscovery/nuclei/v2/pkg/types"
-)
-
-// Payload marker constants
-const (
-	MarkerGeneral          = "§"
-	MarkerParenthesisOpen  = "{{"
-	MarkerParenthesisClose = "}}"
 )
 
 // Replace replaces placeholders in template with values on the fly.
@@ -19,16 +13,16 @@ func Replace(template string, values map[string]interface{}) string {
 
 	builder := &strings.Builder{}
 	for key, val := range values {
-		builder.WriteString(MarkerParenthesisOpen)
+		builder.WriteString(marker.ParenthesisOpen)
 		builder.WriteString(key)
-		builder.WriteString(MarkerParenthesisClose)
+		builder.WriteString(marker.ParenthesisClose)
 		replacerItems = append(replacerItems, builder.String())
 		builder.Reset()
 		replacerItems = append(replacerItems, types.ToString(val))
 
-		builder.WriteString(MarkerGeneral)
+		builder.WriteString(marker.General)
 		builder.WriteString(key)
-		builder.WriteString(MarkerGeneral)
+		builder.WriteString(marker.General)
 		replacerItems = append(replacerItems, builder.String())
 		builder.Reset()
 		replacerItems = append(replacerItems, types.ToString(val))

--- a/v2/pkg/protocols/headless/engine/page_actions.go
+++ b/v2/pkg/protocols/headless/engine/page_actions.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-rod/rod/lib/proto"
 	"github.com/go-rod/rod/lib/utils"
 	"github.com/pkg/errors"
+	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/marker"
 	"github.com/segmentio/ksuid"
 	"github.com/valyala/fasttemplate"
 )
@@ -254,7 +255,7 @@ func (p *Page) NavigateURL(action *Action, out map[string]string, parsed *url.UR
 	parsedString := parsed.String()
 	values["BaseURL"] = parsedString
 
-	final := fasttemplate.ExecuteStringStd(URL, "{{", "}}", values)
+	final := fasttemplate.ExecuteStringStd(URL, marker.ParenthesisOpen, marker.ParenthesisClose, values)
 	if err := p.page.Navigate(final); err != nil {
 		return errors.Wrap(err, "could not navigate")
 	}


### PR DESCRIPTION
## Proposed changes
This PR replaces the expression delimiters regex with a lexical analyzer already implemented in https://github.com/projectdiscovery/nuclei/blob/610beb8534e0701592bb5dd44355a0db3337cace/v2/pkg/protocols/common/expressions/expressions.go#L66

## Checklist
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)