### PR TITLE
Adding support for ignore file path override if custom config file is used

### DIFF
--- a/v2/cmd/nuclei/main.go
+++ b/v2/cmd/nuclei/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/projectdiscovery/goflags"
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/nuclei/v2/internal/runner"
+	"github.com/projectdiscovery/nuclei/v2/pkg/catalog/config"
 	"github.com/projectdiscovery/nuclei/v2/pkg/model/types/severity"
 	templateTypes "github.com/projectdiscovery/nuclei/v2/pkg/templates/types"
 	"github.com/projectdiscovery/nuclei/v2/pkg/types"
@@ -173,6 +174,10 @@ on extensive configurability, massive extensibility and ease of use.`)
 	if cfgFile != "" {
 		if err := flagSet.MergeConfigFile(cfgFile); err != nil {
 			gologger.Fatal().Msgf("Could not read config: %s\n", err)
+		}
+		cfgFileFolder := filepath.Dir(cfgFile)
+		if err := config.OverrideIgnoreFilePath(cfgFileFolder); err != nil {
+			gologger.Warning().Msgf("Could not read ignore file from custom path: %s\n", err)
 		}
 	}
 }

--- a/v2/pkg/catalog/config/config.go
+++ b/v2/pkg/catalog/config/config.go
@@ -106,13 +106,24 @@ func ReadIgnoreFile() IgnoreFile {
 	return ignore
 }
 
-// customIgnoreFilePath contains a custom path for the ignore file
-var customIgnoreFilePath string
+var (
+	// customIgnoreFilePath contains a custom path for the ignore file
+	customIgnoreFilePath string
+	// ErrCustomIgnoreFilePathNotExist is raised when the ignore file doesn't exist in the custom path
+	ErrCustomIgnoreFilePathNotExist = errors.New("Ignore file doesn't exist in custom path")
+	// ErrCustomFolderNotExist is raised when the custom ignore folder doesn't exist
+	ErrCustomFolderNotExist = errors.New("The custom ignore path doesn't exist")
+)
 
 // OverrideIgnoreFilePath with a custom existing folder
 func OverrideIgnoreFilePath(customPath string) error {
+	// custom path does not exist
 	if !fileutil.FolderExists(customPath) {
-		return errors.Errorf("the path doesn't exist: %s", customPath)
+		return ErrCustomFolderNotExist
+	}
+	// ignore file within the custom path does not exist
+	if !fileutil.FileExists(filepath.Join(customPath, nucleiIgnoreFile)) {
+		return ErrCustomIgnoreFilePathNotExist
 	}
 	customIgnoreFilePath = customPath
 	return nil

--- a/v2/pkg/catalog/config/config.go
+++ b/v2/pkg/catalog/config/config.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 
+	"github.com/projectdiscovery/fileutil"
 	"github.com/projectdiscovery/gologger"
 )
 
@@ -105,9 +106,26 @@ func ReadIgnoreFile() IgnoreFile {
 	return ignore
 }
 
+// customIgnoreFilePath contains a custom path for the ignore file
+var customIgnoreFilePath string
+
+// OverrideIgnoreFilePath with a custom existing folder
+func OverrideIgnoreFilePath(customPath string) error {
+	if !fileutil.FolderExists(customPath) {
+		return errors.Errorf("the path doesn't exist: %s", customPath)
+	}
+	customIgnoreFilePath = customPath
+	return nil
+}
+
 // getIgnoreFilePath returns the ignore file path for the runner
 func getIgnoreFilePath() string {
 	var defIgnoreFilePath string
+
+	if customIgnoreFilePath != "" {
+		defIgnoreFilePath = filepath.Join(customIgnoreFilePath, nucleiIgnoreFile)
+		return defIgnoreFilePath
+	}
 
 	home, err := os.UserHomeDir()
 	if err == nil {


### PR DESCRIPTION
## Proposed changes
If a custom config file is specified, this PR attempts to load `.nuclei-ignore` from the same folder.

## Checklist
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)