### PR TITLE
Replacing murmur3 with internal safe-pointer version

### DIFF
--- a/v2/pkg/operators/common/dsl/dsl.go
+++ b/v2/pkg/operators/common/dsl/dsl.go
@@ -153,7 +153,9 @@ func init() {
 			return hex.EncodeToString(hash.Sum(nil)), nil
 		}),
 		"mmh3": makeDslFunction(1, func(args ...interface{}) (interface{}, error) {
-			return fmt.Sprintf("%d", int32(murmur3.Sum32WithSeed([]byte(types.ToString(args[0])), 0))), nil
+			hasher := murmur3.New32WithSeed(0)
+			hasher.Write([]byte(fmt.Sprint(args[0])))
+			return fmt.Sprint(hasher.Sum32()), nil
 		}),
 		"contains": makeDslFunction(2, func(args ...interface{}) (interface{}, error) {
 			return strings.Contains(types.ToString(args[0]), types.ToString(args[1])), nil

--- a/v2/pkg/operators/common/dsl/dsl.go
+++ b/v2/pkg/operators/common/dsl/dsl.go
@@ -155,7 +155,7 @@ func init() {
 		"mmh3": makeDslFunction(1, func(args ...interface{}) (interface{}, error) {
 			hasher := murmur3.New32WithSeed(0)
 			hasher.Write([]byte(fmt.Sprint(args[0])))
-			return fmt.Sprint(hasher.Sum32()), nil
+			return fmt.Sprintf("%d", int32(hasher.Sum32())), nil
 		}),
 		"contains": makeDslFunction(2, func(args ...interface{}) (interface{}, error) {
 			return strings.Contains(types.ToString(args[0]), types.ToString(args[1])), nil


### PR DESCRIPTION
## Proposed changes
This PR replaces the `murmur3` hasher with a memory-safe version.

## Checklist
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Notes
Other parts of the core use unsafe pointers. This may cause unexpected behaviors in the future.