### PR TITLE
Fixing full URL output with unsafe requests

### DIFF
--- a/v2/pkg/protocols/http/raw/raw.go
+++ b/v2/pkg/protocols/http/raw/raw.go
@@ -30,7 +30,7 @@ func Parse(request, baseURL string, unsafe bool) (*Request, error) {
 	rawRequest := &Request{
 		Headers: make(map[string]string),
 	}
-	
+
 	parsedURL, err := url.Parse(baseURL)
 	if err != nil {
 		return nil, fmt.Errorf("could not parse request URL: %w", err)
@@ -116,18 +116,21 @@ func Parse(request, baseURL string, unsafe bool) (*Request, error) {
 	if strings.HasSuffix(parsedURL.Path, "/") && strings.HasPrefix(rawRequest.Path, "/") {
 		parsedURL.Path = strings.TrimSuffix(parsedURL.Path, "/")
 	}
-	if parsedURL.Path != rawRequest.Path {
-		rawRequest.Path = fmt.Sprintf("%s%s", parsedURL.Path, rawRequest.Path)
-	}
-	if strings.HasSuffix(rawRequest.Path, "//") {
-		rawRequest.Path = strings.TrimSuffix(rawRequest.Path, "/")
-	}
-	rawRequest.FullURL = fmt.Sprintf("%s://%s%s", parsedURL.Scheme, strings.TrimSpace(hostURL), rawRequest.Path)
 
-	// If raw request doesn't have a Host header and isn't marked unsafe,
-	// this will generate the Host header from the parsed baseURL
-	if !unsafe && rawRequest.Headers["Host"] == "" {
-		rawRequest.Headers["Host"] = hostURL
+	if !unsafe {
+		if parsedURL.Path != rawRequest.Path {
+			rawRequest.Path = fmt.Sprintf("%s%s", parsedURL.Path, rawRequest.Path)
+		}
+		if strings.HasSuffix(rawRequest.Path, "//") {
+			rawRequest.Path = strings.TrimSuffix(rawRequest.Path, "/")
+		}
+		rawRequest.FullURL = fmt.Sprintf("%s://%s%s", parsedURL.Scheme, strings.TrimSpace(hostURL), rawRequest.Path)
+
+		// If raw request doesn't have a Host header and isn't marked unsafe,
+		// this will generate the Host header from the parsed baseURL
+		if rawRequest.Headers["Host"] == "" {
+			rawRequest.Headers["Host"] = hostURL
+		}
 	}
 
 	// Set the request body

--- a/v2/pkg/protocols/http/request.go
+++ b/v2/pkg/protocols/http/request.go
@@ -418,6 +418,11 @@ func (request *Request) executeRequest(reqURL string, generatedRequest *generate
 		}
 	}
 
+	// use request url as matched url if empty
+	if formedURL == "" {
+		formedURL = reqURL
+	}
+
 	if err != nil {
 		// rawhttp doesn't support draining response bodies.
 		if resp != nil && resp.Body != nil && generatedRequest.rawRequest == nil {


### PR DESCRIPTION
## Proposed changes
This PR fixes garbled full URL output with `unsafe` requests containing an absolute URL as request URI path:

## Checklist
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Notes
Full URL in standard requests is currently [not supported](https://github.com/projectdiscovery/nuclei/blob/e0e48837c6ff649cbe954600e6c643f5b82db96f/v2/pkg/protocols/http/raw/raw.go#L99): 

```go
// Handle case with the full http URL in path. In that case,
// ignore any host header that we encounter and use the path as request URL
```