### PR TITLE
Fixing 307/308 follow redirects with empty body

### DIFF
--- a/v2/pkg/protocols/http/utils.go
+++ b/v2/pkg/protocols/http/utils.go
@@ -133,7 +133,7 @@ func dump(req *generatedRequest, reqURL string) ([]byte, error) {
 		// The original req.Body gets modified indirectly by httputil.DumpRequestOut so we set it again to nil if it was empty
 		// Otherwise redirects like 307/308 would fail (as they require the body to be sent along)
 		if len(bodyBytes) == 0 {
-			req.request.Request.ContentLength = int64(len(bodyBytes))
+			req.request.Request.ContentLength = 0
 			req.request.Request.Body = nil
 		}
 


### PR DESCRIPTION
## Proposed changes
This PR allows the http engine to follow temporary redirects with status code 307/308 with empty body

## Checklist
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)