### PR TITLE
Fixing typo in request/response history

### DIFF
--- a/v2/pkg/protocols/headless/engine/rules.go
+++ b/v2/pkg/protocols/headless/engine/rules.go
@@ -66,7 +66,7 @@ func (p *Page) routingRuleHandler(ctx *rod.Hijack) {
 	if respPayloads != nil {
 		rawResp.WriteString("HTTP/1.1 ")
 		rawResp.WriteString(fmt.Sprint(respPayloads.ResponseCode))
-		rawResp.WriteString(" " + respPayloads.ResponsePhrase + "+\n")
+		rawResp.WriteString(" " + respPayloads.ResponsePhrase + "\n")
 		for _, header := range respPayloads.ResponseHeaders {
 			rawResp.WriteString(header.Name + ": " + header.Value + "\n")
 		}


### PR DESCRIPTION
## Proposed changes
This PR fixes a typo introduced while building the requests/responses history (ref: https://github.com/projectdiscovery/nuclei/pull/1432#discussion_r779461578)

## Checklist
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)