### PR TITLE
Adding support for Debug http verb

### DIFF
--- a/v2/pkg/protocols/http/http_method_types.go
+++ b/v2/pkg/protocols/http/http_method_types.go
@@ -33,6 +33,8 @@ const (
 	HTTPPatch
 	// name:PURGE
 	HTTPPurge
+	// name:Debug
+	HTTPDebug
 	limit
 )
 
@@ -48,6 +50,7 @@ var HTTPMethodMapping = map[HTTPMethodType]string{
 	HTTPTrace:   "TRACE",
 	HTTPPatch:   "PATCH",
 	HTTPPurge:   "PURGE",
+	HTTPDebug:   "DEBUG",
 }
 
 // GetSupportedHTTPMethodTypes returns list of supported types
@@ -90,7 +93,7 @@ func (holder HTTPMethodTypeHolder) JSONSchemaType() *jsonschema.Type {
 	gotType := &jsonschema.Type{
 		Type:        "string",
 		Title:       "method is the HTTP request method",
-		Description: "Method is the HTTP Request Method,enum=GET,enum=HEAD,enum=POST,enum=PUT,enum=DELETE,enum=CONNECT,enum=OPTIONS,enum=TRACE,enum=PATCH,enum=PURGE",
+		Description: "Method is the HTTP Request Method,enum=GET,enum=HEAD,enum=POST,enum=PUT,enum=DELETE,enum=CONNECT,enum=OPTIONS,enum=TRACE,enum=PATCH,enum=PURGE,enum=DEBUG",
 	}
 	for _, types := range GetSupportedHTTPMethodTypes() {
 		gotType.Enum = append(gotType.Enum, types.String())


### PR DESCRIPTION
## Proposed changes
This PR supports the `DEBUG` HTTP verb for non-raw http requests.

## Checklist
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Notes
I think validation for HTTP verbs should be removed since it's not consistent with the raw format that allows arbitrary values and prevents testing more extended HTTP-based protocols such as WebDAV (examples of used verbs COPY, LOCK, MKCOL, ...)