### PR TITLE
Excluding non yaml file from new additions loading

### DIFF
--- a/v2/internal/runner/runner.go
+++ b/v2/internal/runner/runner.go
@@ -38,6 +38,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v2/pkg/utils"
 	"github.com/projectdiscovery/nuclei/v2/pkg/utils/stats"
 	yamlwrapper "github.com/projectdiscovery/nuclei/v2/pkg/utils/yaml"
+	"github.com/projectdiscovery/stringsutil"
 )
 
 // Runner is a client for running the enumeration process.
@@ -452,7 +453,9 @@ func (r *Runner) readNewTemplatesFile() ([]string, error) {
 		if text == "" {
 			continue
 		}
-		templatesList = append(templatesList, text)
+		if isNewTemplate(text) {
+			templatesList = append(templatesList, text)
+		}
 	}
 	return templatesList, nil
 }
@@ -476,9 +479,17 @@ func (r *Runner) countNewTemplates() int {
 		if text == "" {
 			continue
 		}
-		count++
+
+		if isNewTemplate(text) {
+			count++
+		}
+
 	}
 	return count
+}
+
+func isNewTemplate(filename string) bool {
+	return stringsutil.EqualFoldAny(filepath.Ext(filename), templates.TemplateExtension)
 }
 
 // SaveResumeConfig to file

--- a/v2/pkg/templates/templates.go
+++ b/v2/pkg/templates/templates.go
@@ -21,6 +21,11 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+const (
+	// TemplateExtension defines the template default file extension
+	TemplateExtension = ".yaml"
+)
+
 // Template is a YAML input file which defines all the requests and
 // other metadata for a template.
 type Template struct {


### PR DESCRIPTION
## Proposed changes
This PR excludes non-YAML files from new additions loading, causing a validation error previously.

## Checklist
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)