### PR TITLE
Extending http variables list with dns generated variables

### DIFF
--- a/v2/pkg/protocols/dns/dns.go
+++ b/v2/pkg/protocols/dns/dns.go
@@ -183,7 +183,7 @@ func (request *Request) Make(domain string) (*dns.Msg, error) {
 
 	var q dns.Question
 
-	final := replacer.Replace(request.Name, generateDNSVariables(domain))
+	final := replacer.Replace(request.Name, GenerateDNSVariables(domain))
 
 	q.Name = dns.Fqdn(final)
 	q.Qclass = request.class
@@ -250,7 +250,8 @@ func classToInt(class string) uint16 {
 	return uint16(result)
 }
 
-func generateDNSVariables(domain string) map[string]interface{} {
+// GenerateDNSVariables from a dns name
+func GenerateDNSVariables(domain string) map[string]interface{} {
 	parsed, err := publicsuffix.Parse(strings.TrimSuffix(domain, "."))
 	if err != nil {
 		return map[string]interface{}{"FQDN": domain}

--- a/v2/pkg/protocols/dns/dns_test.go
+++ b/v2/pkg/protocols/dns/dns_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestGenerateDNSVariables(t *testing.T) {
-	vars := generateDNSVariables("www.projectdiscovery.io")
+	vars := GenerateDNSVariables("www.projectdiscovery.io")
 	require.Equal(t, map[string]interface{}{
 		"FQDN": "www.projectdiscovery.io",
 		"RDN":  "projectdiscovery.io",

--- a/v2/pkg/protocols/http/build_request.go
+++ b/v2/pkg/protocols/http/build_request.go
@@ -20,6 +20,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/expressions"
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/generators"
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/replacer"
+	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/dns"
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/http/race"
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/http/raw"
 	"github.com/projectdiscovery/nuclei/v2/pkg/types"
@@ -377,7 +378,7 @@ func generateVariables(parsed *url.URL, trailingSlash bool) map[string]interface
 	if base == "." {
 		base = ""
 	}
-	return map[string]interface{}{
+	httpVariables := map[string]interface{}{
 		"BaseURL":  parsed.String(),
 		"RootURL":  fmt.Sprintf("%s://%s", parsed.Scheme, parsed.Host),
 		"Hostname": parsed.Host,
@@ -387,4 +388,5 @@ func generateVariables(parsed *url.URL, trailingSlash bool) map[string]interface
 		"File":     base,
 		"Scheme":   parsed.Scheme,
 	}
+	return generators.MergeMaps(httpVariables, dns.GenerateDNSVariables(domain))
 }


### PR DESCRIPTION
## Proposed changes
This PR extends the list of variables for HTTP protocol with DNS ones generated from the domain name (ref https://github.com/projectdiscovery/nuclei/issues/1174)

## Checklist
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)