### PR TITLE
Fixing race-requests block on curl generation command

### DIFF
--- a/integration_tests/http/race-multiple.yaml
+++ b/integration_tests/http/race-multiple.yaml
@@ -1,0 +1,46 @@
+id: race-condition-testing
+
+info:
+  name: Race condition testing with multiple requests
+  author: pdteam
+  severity: info
+
+requests:
+  - raw:  
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+
+        id=1
+
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+
+        id=2
+
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+
+        id=3
+
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+
+        id=4
+
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+
+        id=5
+
+    threads: 5
+    race: true
+
+    matchers:
+      - type: status
+        status:
+          - 200

--- a/integration_tests/http/race-simple.yaml
+++ b/integration_tests/http/race-simple.yaml
@@ -1,0 +1,23 @@
+id: race-condition-testing
+
+info:
+  name: Race Condition testing
+  author: pdteam
+  severity: info
+
+requests:
+  - raw:
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+
+        test      
+
+    race: true
+    race_count: 10
+
+    matchers:
+      - type: status
+        part: header
+        status:
+          - 200

--- a/v2/cmd/integration-test/http.go
+++ b/v2/cmd/integration-test/http.go
@@ -42,6 +42,8 @@ var httpTestcases = map[string]testutils.TestCase{
 	"http/get-redirects-chain-headers.yaml":        &httpGetRedirectsChainHeaders{},
 	"http/dsl-matcher-variable.yaml":               &httpDSLVariable{},
 	"http/dsl-functions.yaml":                      &httpDSLFunctions{},
+	"http/race-simple.yaml":                        &httpRaceSimple{},
+	"http/race-multiple.yaml":                      &httpRaceMultiple{},
 }
 
 type httpInteractshRequest struct{}
@@ -688,4 +690,40 @@ func (h *httpGetRedirectsChainHeaders) Execute(filePath string) error {
 	}
 
 	return expectResultsCount(results, 1)
+}
+
+type httpRaceSimple struct{}
+
+// Execute executes a test case and returns an error if occurred
+func (h *httpRaceSimple) Execute(filePath string) error {
+	router := httprouter.New()
+	router.GET("/", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+		w.WriteHeader(http.StatusOK)
+	})
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+
+	results, err := testutils.RunNucleiTemplateAndGetResults(filePath, ts.URL, debug)
+	if err != nil {
+		return err
+	}
+	return expectResultsCount(results, 10)
+}
+
+type httpRaceMultiple struct{}
+
+// Execute executes a test case and returns an error if occurred
+func (h *httpRaceMultiple) Execute(filePath string) error {
+	router := httprouter.New()
+	router.GET("/", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+		w.WriteHeader(http.StatusOK)
+	})
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+
+	results, err := testutils.RunNucleiTemplateAndGetResults(filePath, ts.URL, debug)
+	if err != nil {
+		return err
+	}
+	return expectResultsCount(results, 5)
 }

--- a/v2/pkg/protocols/http/request.go
+++ b/v2/pkg/protocols/http/request.go
@@ -457,7 +457,7 @@ func (request *Request) executeRequest(reqURL string, generatedRequest *generate
 	}()
 
 	var curlCommand string
-	if !request.Unsafe && resp != nil && generatedRequest.request != nil && resp.Request != nil {
+	if !request.Unsafe && resp != nil && generatedRequest.request != nil && resp.Request != nil && !request.Race {
 		bodyBytes, _ := generatedRequest.request.BodyBytes()
 		resp.Request.Body = ioutil.NopCloser(bytes.NewReader(bodyBytes))
 		command, _ := http2curl.GetCurlCommand(resp.Request)


### PR DESCRIPTION
## Proposed changes
This PR fixes the issue reported in #1471 caused by the curl command generation logic attempting to read from the request body, which in case of race requests uses an open-gate mechanism to act synchronously

## Checklist
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)