### PR TITLE
Adding support for CLI/ENV vars to headless

### DIFF
--- a/v2/go.mod
+++ b/v2/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/projectdiscovery/goflags v0.0.8-0.20220121110825-48035ad3ffe0
 	github.com/projectdiscovery/gologger v1.1.4
 	github.com/projectdiscovery/hmap v0.0.2-0.20210917080408-0fd7bd286bfa
-	github.com/projectdiscovery/interactsh v0.0.8-0.20220112083504-b0b3b2f359a5
+	github.com/projectdiscovery/interactsh v1.0.1-0.20220131074403-ca8bb8f87cd0
 	github.com/projectdiscovery/nuclei-updatecheck-api v0.0.0-20211006155443-c0a8d610a4df
 	github.com/projectdiscovery/rawhttp v0.0.7
 	github.com/projectdiscovery/retryabledns v1.0.13-0.20211109182249-43d38df59660
@@ -112,7 +112,7 @@ require (
 	github.com/iancoleman/orderedmap v0.0.0-20190318233801-ac98e3ecb4b0 // indirect
 	github.com/itchyny/timefmt-go v0.1.3 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
-	github.com/klauspost/compress v1.13.6 // indirect
+	github.com/klauspost/compress v1.14.1 // indirect
 	github.com/klauspost/cpuid/v2 v2.0.9 // indirect
 	github.com/klauspost/pgzip v1.2.5 // indirect
 	github.com/leodido/go-urn v1.2.1 // indirect

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -305,8 +305,8 @@ github.com/karrick/godirwalk v1.16.1 h1:DynhcF+bztK8gooS0+NDJFrdNZjJ3gzVzC545UNA
 github.com/karrick/godirwalk v1.16.1/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.4.1/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
-github.com/klauspost/compress v1.13.6 h1:P76CopJELS0TiO2mebmnzgWaajssP/EszplttgQxcgc=
-github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
+github.com/klauspost/compress v1.14.1 h1:hLQYb23E8/fO+1u53d02A97a8UnsddcvYzq4ERRU4ds=
+github.com/klauspost/compress v1.14.1/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/klauspost/cpuid v1.2.0 h1:NMpwD2G9JSFOE1/TJjGSo5zG7Yb2bTe7eq1jH+irmeE=
 github.com/klauspost/cpuid v1.2.0/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/klauspost/cpuid/v2 v2.0.9 h1:lgaqFMSdTdQYdZ04uHyN2d/eKdOMyi2YLSvlQIBFYa4=
@@ -428,8 +428,8 @@ github.com/projectdiscovery/hmap v0.0.2-0.20210616215655-7b78e7f33d1f/go.mod h1:
 github.com/projectdiscovery/hmap v0.0.2-0.20210917080408-0fd7bd286bfa h1:9sZWFUAshIa/ea0RKjGRuuZiS5PzYXAFjTRUnSbezr0=
 github.com/projectdiscovery/hmap v0.0.2-0.20210917080408-0fd7bd286bfa/go.mod h1:lV5f/PNPmCCjCN/dR317/chN9s7VG5h/xcbFfXOz8Fo=
 github.com/projectdiscovery/interactsh v0.0.4/go.mod h1:PtJrddeBW1/LeOVgTvvnjUl3Hu/17jTkoIi8rXeEODE=
-github.com/projectdiscovery/interactsh v0.0.8-0.20220112083504-b0b3b2f359a5 h1:PXwVuZCnB9xpx075zcZh4lj0ZpJY/dfvuw+Ok5Hqyf4=
-github.com/projectdiscovery/interactsh v0.0.8-0.20220112083504-b0b3b2f359a5/go.mod h1:jXtAbjMnesRxBLY70m9DLXRwVp88gWueOtXfgj49b+Q=
+github.com/projectdiscovery/interactsh v1.0.1-0.20220131074403-ca8bb8f87cd0 h1:Olf2RG9sLqZF157gC664G6A3DU0Fta6VD/OWiNP3LbI=
+github.com/projectdiscovery/interactsh v1.0.1-0.20220131074403-ca8bb8f87cd0/go.mod h1:UW8wdok5mrDOXzcHxRjUCCDIScc/3hCpw8QjVDeXHEE=
 github.com/projectdiscovery/ipranger v0.0.2/go.mod h1:kcAIk/lo5rW+IzUrFkeYyXnFJ+dKwYooEOHGVPP/RWE=
 github.com/projectdiscovery/iputil v0.0.0-20210414194613-4b4d2517acf0/go.mod h1:PQAqn5h5NXsQTF4ZA00ZTYLRzGCjOtcCq8llAqrsd1A=
 github.com/projectdiscovery/iputil v0.0.0-20210429152401-c18a5408ca46/go.mod h1:PQAqn5h5NXsQTF4ZA00ZTYLRzGCjOtcCq8llAqrsd1A=

--- a/v2/pkg/protocols/headless/engine/instance.go
+++ b/v2/pkg/protocols/headless/engine/instance.go
@@ -7,12 +7,16 @@ import (
 
 	"github.com/go-rod/rod"
 	"github.com/go-rod/rod/lib/utils"
+	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/interactsh"
 )
 
 // Instance is an isolated browser instance opened for doing operations with it.
 type Instance struct {
 	browser *Browser
 	engine  *rod.Browser
+
+	// redundant due to dependency cycle
+	interactsh *interactsh.Client
 }
 
 // NewInstance creates a new instance for the current browser.
@@ -37,6 +41,11 @@ func (b *Browser) NewInstance() (*Instance, error) {
 // Close closes all the tabs and pages for a browser instance
 func (i *Instance) Close() error {
 	return i.engine.Close()
+}
+
+// SetInteractsh client
+func (i *Instance) SetInteractsh(interactsh *interactsh.Client) {
+	i.interactsh = interactsh
 }
 
 // maxBackoffSleeper is a backoff sleeper respecting max backoff values

--- a/v2/pkg/protocols/headless/engine/page_actions.go
+++ b/v2/pkg/protocols/headless/engine/page_actions.go
@@ -627,5 +627,11 @@ func (p *Page) getActionArgWithDefaultValues(action *Action, arg string) string 
 
 func (p *Page) getActionArgWithValues(action *Action, arg string, values map[string]interface{}) string {
 	argValue := action.GetArg(arg)
-	return replaceWithValues(argValue, values)
+	argValue = replaceWithValues(argValue, values)
+	if p.instance.interactsh != nil {
+		var interactshURLs []string
+		argValue, interactshURLs = p.instance.interactsh.ReplaceMarkers(argValue, p.InteractshURLs)
+		p.addInteractshURL(interactshURLs...)
+	}
+	return argValue
 }

--- a/v2/pkg/protocols/headless/engine/page_actions.go
+++ b/v2/pkg/protocols/headless/engine/page_actions.go
@@ -14,9 +14,8 @@ import (
 	"github.com/go-rod/rod/lib/proto"
 	"github.com/go-rod/rod/lib/utils"
 	"github.com/pkg/errors"
-	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/marker"
+	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/generators"
 	"github.com/segmentio/ksuid"
-	"github.com/valyala/fasttemplate"
 )
 
 // ExecuteActions executes a list of actions on a page.
@@ -90,12 +89,12 @@ const elementDidNotAppearMessage = "Element did not appear in the given amount o
 
 // WaitVisible waits until an element appears.
 func (p *Page) WaitVisible(act *Action, out map[string]string) error {
-	timeout, err := getTimeout(act)
+	timeout, err := getTimeout(p, act)
 	if err != nil {
 		return errors.Wrap(err, "Wrong timeout given")
 	}
 
-	pollTime, err := getPollTime(act)
+	pollTime, err := getPollTime(p, act)
 	if err != nil {
 		return errors.Wrap(err, "Wrong polling time given")
 	}
@@ -143,16 +142,16 @@ func createBackOffSleeper(pollTimeout, timeout time.Duration) utils.Sleeper {
 	}
 }
 
-func getTimeout(act *Action) (time.Duration, error) {
-	return geTimeParameter(act, "timeout", 3, time.Second)
+func getTimeout(p *Page, act *Action) (time.Duration, error) {
+	return geTimeParameter(p, act, "timeout", 3, time.Second)
 }
 
-func getPollTime(act *Action) (time.Duration, error) {
-	return geTimeParameter(act, "pollTime", 100, time.Millisecond)
+func getPollTime(p *Page, act *Action) (time.Duration, error) {
+	return geTimeParameter(p, act, "pollTime", 100, time.Millisecond)
 }
 
-func geTimeParameter(act *Action, parameterName string, defaultValue time.Duration, duration time.Duration) (time.Duration, error) {
-	pollTimeString := act.GetArg(parameterName)
+func geTimeParameter(p *Page, act *Action, parameterName string, defaultValue time.Duration, duration time.Duration) (time.Duration, error) {
+	pollTimeString := p.getActionArgWithDefaultValues(act, parameterName)
 	if pollTimeString == "" {
 		return defaultValue * duration, nil
 	}
@@ -165,11 +164,11 @@ func geTimeParameter(act *Action, parameterName string, defaultValue time.Durati
 
 // ActionAddHeader executes a AddHeader action.
 func (p *Page) ActionAddHeader(act *Action, out map[string]string /*TODO review unused parameter*/) error {
-	in := act.GetArg("part")
+	in := p.getActionArgWithDefaultValues(act, "part")
 
 	args := make(map[string]string)
-	args["key"] = act.GetArg("key")
-	args["value"] = act.GetArg("value")
+	args["key"] = p.getActionArgWithDefaultValues(act, "key")
+	args["value"] = p.getActionArgWithDefaultValues(act, "value")
 	rule := requestRule{
 		Action: ActionAddHeader,
 		Part:   in,
@@ -181,11 +180,11 @@ func (p *Page) ActionAddHeader(act *Action, out map[string]string /*TODO review 
 
 // ActionSetHeader executes a SetHeader action.
 func (p *Page) ActionSetHeader(act *Action, out map[string]string /*TODO review unused parameter*/) error {
-	in := act.GetArg("part")
+	in := p.getActionArgWithDefaultValues(act, "part")
 
 	args := make(map[string]string)
-	args["key"] = act.GetArg("key")
-	args["value"] = act.GetArg("value")
+	args["key"] = p.getActionArgWithDefaultValues(act, "key")
+	args["value"] = p.getActionArgWithDefaultValues(act, "value")
 	rule := requestRule{
 		Action: ActionSetHeader,
 		Part:   in,
@@ -197,10 +196,10 @@ func (p *Page) ActionSetHeader(act *Action, out map[string]string /*TODO review 
 
 // ActionDeleteHeader executes a DeleteHeader action.
 func (p *Page) ActionDeleteHeader(act *Action, out map[string]string /*TODO review unused parameter*/) error {
-	in := act.GetArg("part")
+	in := p.getActionArgWithDefaultValues(act, "part")
 
 	args := make(map[string]string)
-	args["key"] = act.GetArg("key")
+	args["key"] = p.getActionArgWithDefaultValues(act, "key")
 	rule := requestRule{
 		Action: ActionDeleteHeader,
 		Part:   in,
@@ -212,10 +211,10 @@ func (p *Page) ActionDeleteHeader(act *Action, out map[string]string /*TODO revi
 
 // ActionSetBody executes a SetBody action.
 func (p *Page) ActionSetBody(act *Action, out map[string]string /*TODO review unused parameter*/) error {
-	in := act.GetArg("part")
+	in := p.getActionArgWithDefaultValues(act, "part")
 
 	args := make(map[string]string)
-	args["body"] = act.GetArg("body")
+	args["body"] = p.getActionArgWithDefaultValues(act, "body")
 	rule := requestRule{
 		Action: ActionSetBody,
 		Part:   in,
@@ -227,10 +226,10 @@ func (p *Page) ActionSetBody(act *Action, out map[string]string /*TODO review un
 
 // ActionSetMethod executes an SetMethod action.
 func (p *Page) ActionSetMethod(act *Action, out map[string]string /*TODO review unused parameter*/) error {
-	in := act.GetArg("part")
+	in := p.getActionArgWithDefaultValues(act, "part")
 
 	args := make(map[string]string)
-	args["method"] = act.GetArg("method")
+	args["method"] = p.getActionArgWithDefaultValues(act, "method")
 	rule := requestRule{
 		Action: ActionSetMethod,
 		Part:   in,
@@ -242,20 +241,22 @@ func (p *Page) ActionSetMethod(act *Action, out map[string]string /*TODO review 
 
 // NavigateURL executes an ActionLoadURL actions loading a URL for the page.
 func (p *Page) NavigateURL(action *Action, out map[string]string, parsed *url.URL /*TODO review unused parameter*/) error {
-	URL := action.GetArg("url")
+	URL := p.getActionArgWithDefaultValues(action, "url")
 	if URL == "" {
 		return errors.New("invalid arguments provided")
 	}
+
 	// Handle the dynamic value substitution here.
 	URL, parsed = baseURLWithTemplatePrefs(URL, parsed)
-	values := map[string]interface{}{"Hostname": parsed.Hostname()}
 	if strings.HasSuffix(parsed.Path, "/") && strings.Contains(URL, "{{BaseURL}}/") {
 		parsed.Path = strings.TrimSuffix(parsed.Path, "/")
 	}
 	parsedString := parsed.String()
-	values["BaseURL"] = parsedString
+	final := replaceWithValues(URL, map[string]interface{}{
+		"Hostname": parsed.Hostname(),
+		"BaseURL":  parsedString,
+	})
 
-	final := fasttemplate.ExecuteStringStd(URL, marker.ParenthesisOpen, marker.ParenthesisClose, values)
 	if err := p.page.Navigate(final); err != nil {
 		return errors.Wrap(err, "could not navigate")
 	}
@@ -264,11 +265,11 @@ func (p *Page) NavigateURL(action *Action, out map[string]string, parsed *url.UR
 
 // RunScript runs a script on the loaded page
 func (p *Page) RunScript(action *Action, out map[string]string) error {
-	code := action.GetArg("code")
+	code := p.getActionArgWithDefaultValues(action, "code")
 	if code == "" {
 		return errors.New("invalid arguments provided")
 	}
-	if action.GetArg("hook") == "true" {
+	if p.getActionArgWithDefaultValues(action, "hook") == "true" {
 		if _, err := p.page.EvalOnNewDocument(code); err != nil {
 			return err
 		}
@@ -300,7 +301,7 @@ func (p *Page) ClickElement(act *Action, out map[string]string /*TODO review unu
 
 // KeyboardAction executes a keyboard action on the page.
 func (p *Page) KeyboardAction(act *Action, out map[string]string /*TODO review unused parameter*/) error {
-	return p.page.Keyboard.Press([]rune(act.GetArg("keys"))...)
+	return p.page.Keyboard.Press([]rune(p.getActionArgWithDefaultValues(act, "keys"))...)
 }
 
 // RightClickElement executes right click actions for an element.
@@ -320,7 +321,7 @@ func (p *Page) RightClickElement(act *Action, out map[string]string /*TODO revie
 
 // Screenshot executes screenshot action on a page
 func (p *Page) Screenshot(act *Action, out map[string]string) error {
-	to := act.GetArg("to")
+	to := p.getActionArgWithDefaultValues(act, "to")
 	if to == "" {
 		to = ksuid.New().String()
 		if act.Name != "" {
@@ -329,7 +330,7 @@ func (p *Page) Screenshot(act *Action, out map[string]string) error {
 	}
 	var data []byte
 	var err error
-	if act.GetArg("fullpage") == "true" {
+	if p.getActionArgWithDefaultValues(act, "fullpage") == "true" {
 		data, err = p.page.Screenshot(true, &proto.PageCaptureScreenshot{})
 	} else {
 		data, err = p.page.Screenshot(false, &proto.PageCaptureScreenshot{})
@@ -346,7 +347,7 @@ func (p *Page) Screenshot(act *Action, out map[string]string) error {
 
 // InputElement executes input element actions for an element.
 func (p *Page) InputElement(act *Action, out map[string]string /*TODO review unused parameter*/) error {
-	value := act.GetArg("value")
+	value := p.getActionArgWithDefaultValues(act, "value")
 	if value == "" {
 		return errors.New("invalid arguments provided")
 	}
@@ -365,7 +366,7 @@ func (p *Page) InputElement(act *Action, out map[string]string /*TODO review unu
 
 // TimeInputElement executes time input on an element
 func (p *Page) TimeInputElement(act *Action, out map[string]string /*TODO review unused parameter*/) error {
-	value := act.GetArg("value")
+	value := p.getActionArgWithDefaultValues(act, "value")
 	if value == "" {
 		return errors.New("invalid arguments provided")
 	}
@@ -388,7 +389,7 @@ func (p *Page) TimeInputElement(act *Action, out map[string]string /*TODO review
 
 // SelectInputElement executes select input statement action on a element
 func (p *Page) SelectInputElement(act *Action, out map[string]string /*TODO review unused parameter*/) error {
-	value := act.GetArg("value")
+	value := p.getActionArgWithDefaultValues(act, "value")
 	if value == "" {
 		return errors.New("invalid arguments provided")
 	}
@@ -401,10 +402,10 @@ func (p *Page) SelectInputElement(act *Action, out map[string]string /*TODO revi
 	}
 
 	selectedBool := false
-	if act.GetArg("selected") == "true" {
+	if p.getActionArgWithDefaultValues(act, "selected") == "true" {
 		selectedBool = true
 	}
-	by := act.GetArg("selector")
+	by := p.getActionArgWithDefaultValues(act, "selector")
 	if err := element.Select([]string{value}, selectedBool, selectorBy(by)); err != nil {
 		return errors.Wrap(err, "could not select input")
 	}
@@ -450,7 +451,7 @@ func (p *Page) FilesInput(act *Action, out map[string]string /*TODO review unuse
 	if err = element.ScrollIntoView(); err != nil {
 		return errors.Wrap(err, "could not scroll into view")
 	}
-	value := act.GetArg("value")
+	value := p.getActionArgWithDefaultValues(act, "value")
 	filesPaths := strings.Split(value, ",")
 	if err := element.SetFiles(filesPaths); err != nil {
 		return errors.Wrap(err, "could not set files")
@@ -467,9 +468,9 @@ func (p *Page) ExtractElement(act *Action, out map[string]string) error {
 	if err = element.ScrollIntoView(); err != nil {
 		return errors.Wrap(err, "could not scroll into view")
 	}
-	switch act.GetArg("target") {
+	switch p.getActionArgWithDefaultValues(act, "target") {
 	case "attribute":
-		attrName := act.GetArg("attribute")
+		attrName := p.getActionArgWithDefaultValues(act, "attribute")
 		if attrName == "" {
 			return errors.New("attribute can't be empty")
 		}
@@ -503,7 +504,7 @@ func (p *protoEvent) ProtoEvent() string {
 
 // WaitEvent waits for an event to happen on the page.
 func (p *Page) WaitEvent(act *Action, out map[string]string /*TODO review unused parameter*/) error {
-	event := act.GetArg("event")
+	event := p.getActionArgWithDefaultValues(act, "event")
 	if event == "" {
 		return errors.New("event not recognized")
 	}
@@ -511,7 +512,7 @@ func (p *Page) WaitEvent(act *Action, out map[string]string /*TODO review unused
 
 	// Uses another instance in order to be able to chain the timeout only to the wait operation
 	pageCopy := p.page
-	timeout := act.GetArg("timeout")
+	timeout := p.getActionArg(act, "timeout")
 	if timeout != "" {
 		ts, err := strconv.Atoi(timeout)
 		if err != nil {
@@ -613,4 +614,18 @@ func baseURLWithTemplatePrefs(data string, parsed *url.URL) (string, *url.URL) {
 		parsed.Path = "/"
 	}
 	return data, parsed
+}
+
+func (p *Page) getActionArg(action *Action, arg string) string {
+	return p.getActionArgWithValues(action, arg, nil)
+}
+
+func (p *Page) getActionArgWithDefaultValues(action *Action, arg string) string {
+	values := generators.BuildPayloadFromOptions(p.instance.browser.options)
+	return p.getActionArgWithValues(action, arg, values)
+}
+
+func (p *Page) getActionArgWithValues(action *Action, arg string, values map[string]interface{}) string {
+	argValue := action.GetArg(arg)
+	return replaceWithValues(argValue, values)
 }

--- a/v2/pkg/protocols/headless/engine/util.go
+++ b/v2/pkg/protocols/headless/engine/util.go
@@ -1,0 +1,10 @@
+package engine
+
+import (
+	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/marker"
+	"github.com/valyala/fasttemplate"
+)
+
+func replaceWithValues(data string, values map[string]interface{}) string {
+	return fasttemplate.ExecuteStringStd(data, marker.ParenthesisOpen, marker.ParenthesisClose, values)
+}


### PR DESCRIPTION
## Proposed changes
This PR adds support for CLI/Env/Interactsh vars to headless protocol

## Checklist
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## How to reproduce
`template.yaml`
```yaml
id: test
info:
  name: Test
  author: pdteam
  severity: info
  tags: headless

headless:
  - steps:
      - args:
          url: "{{BaseURL}}/login{{A}}.php?a=bb&c={{interactsh-url}}"
        action: navigate
      - action: waitload
    matchers:
      - part: interactsh_protocol
        type: word
        words:
          - "http"
```
command:
```console
echo http://localhost:8000 | nuclei -iserver http://interact.sh -headless -t template.yaml -duc -debug -v -vv -var A=1
```