### PR TITLE
Fixing exit at first match with extractors

### DIFF
--- a/integration_tests/http/stop-at-first-match-with-extractors.yaml
+++ b/integration_tests/http/stop-at-first-match-with-extractors.yaml
@@ -1,0 +1,18 @@
+id: stop-at-first-match-with-extractors
+
+info:
+  name: Stop at first match Request with extractors
+  author: pdteam
+  severity: info
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}?a=1"
+      - "{{BaseURL}}?a=2"
+    stop-at-first-match: true
+    extractors:
+      - type: kval
+        part: header
+        kval:
+          - "date"

--- a/integration_tests/http/stop-at-first-match.yaml
+++ b/integration_tests/http/stop-at-first-match.yaml
@@ -1,0 +1,17 @@
+id: stop-at-first-match
+
+info:
+  name: Stop at first match Request
+  author: pdteam
+  severity: info
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}?a=1"
+      - "{{BaseURL}}?a=2"
+    matchers:
+      - type: word
+        words:
+          - "This is test"
+    stop-at-first-match: true

--- a/v2/cmd/integration-test/http.go
+++ b/v2/cmd/integration-test/http.go
@@ -18,32 +18,34 @@ import (
 )
 
 var httpTestcases = map[string]testutils.TestCase{
-	"http/get-headers.yaml":                        &httpGetHeaders{},
-	"http/get-query-string.yaml":                   &httpGetQueryString{},
-	"http/get-redirects.yaml":                      &httpGetRedirects{},
-	"http/get.yaml":                                &httpGet{},
-	"http/post-body.yaml":                          &httpPostBody{},
-	"http/post-json-body.yaml":                     &httpPostJSONBody{},
-	"http/post-multipart-body.yaml":                &httpPostMultipartBody{},
-	"http/raw-cookie-reuse.yaml":                   &httpRawCookieReuse{},
-	"http/raw-dynamic-extractor.yaml":              &httpRawDynamicExtractor{},
-	"http/raw-get-query.yaml":                      &httpRawGetQuery{},
-	"http/raw-get.yaml":                            &httpRawGet{},
-	"http/raw-payload.yaml":                        &httpRawPayload{},
-	"http/raw-post-body.yaml":                      &httpRawPostBody{},
-	"http/raw-unsafe-request.yaml":                 &httpRawUnsafeRequest{},
-	"http/request-condition.yaml":                  &httpRequestCondition{},
-	"http/request-condition-new.yaml":              &httpRequestCondition{},
-	"http/interactsh.yaml":                         &httpInteractshRequest{},
-	"http/interactsh-stop-at-first-match.yaml":     &httpInteractshStopAtFirstMatchRequest{},
-	"http/self-contained.yaml":                     &httpRequestSelContained{},
-	"http/get-case-insensitive.yaml":               &httpGetCaseInsensitive{},
-	"http/get.yaml,http/get-case-insensitive.yaml": &httpGetCaseInsensitiveCluster{},
-	"http/get-redirects-chain-headers.yaml":        &httpGetRedirectsChainHeaders{},
-	"http/dsl-matcher-variable.yaml":               &httpDSLVariable{},
-	"http/dsl-functions.yaml":                      &httpDSLFunctions{},
-	"http/race-simple.yaml":                        &httpRaceSimple{},
-	"http/race-multiple.yaml":                      &httpRaceMultiple{},
+	"http/get-headers.yaml":                         &httpGetHeaders{},
+	"http/get-query-string.yaml":                    &httpGetQueryString{},
+	"http/get-redirects.yaml":                       &httpGetRedirects{},
+	"http/get.yaml":                                 &httpGet{},
+	"http/post-body.yaml":                           &httpPostBody{},
+	"http/post-json-body.yaml":                      &httpPostJSONBody{},
+	"http/post-multipart-body.yaml":                 &httpPostMultipartBody{},
+	"http/raw-cookie-reuse.yaml":                    &httpRawCookieReuse{},
+	"http/raw-dynamic-extractor.yaml":               &httpRawDynamicExtractor{},
+	"http/raw-get-query.yaml":                       &httpRawGetQuery{},
+	"http/raw-get.yaml":                             &httpRawGet{},
+	"http/raw-payload.yaml":                         &httpRawPayload{},
+	"http/raw-post-body.yaml":                       &httpRawPostBody{},
+	"http/raw-unsafe-request.yaml":                  &httpRawUnsafeRequest{},
+	"http/request-condition.yaml":                   &httpRequestCondition{},
+	"http/request-condition-new.yaml":               &httpRequestCondition{},
+	"http/interactsh.yaml":                          &httpInteractshRequest{},
+	"http/interactsh-stop-at-first-match.yaml":      &httpInteractshStopAtFirstMatchRequest{},
+	"http/self-contained.yaml":                      &httpRequestSelContained{},
+	"http/get-case-insensitive.yaml":                &httpGetCaseInsensitive{},
+	"http/get.yaml,http/get-case-insensitive.yaml":  &httpGetCaseInsensitiveCluster{},
+	"http/get-redirects-chain-headers.yaml":         &httpGetRedirectsChainHeaders{},
+	"http/dsl-matcher-variable.yaml":                &httpDSLVariable{},
+	"http/dsl-functions.yaml":                       &httpDSLFunctions{},
+	"http/race-simple.yaml":                         &httpRaceSimple{},
+	"http/race-multiple.yaml":                       &httpRaceMultiple{},
+	"http/stop-at-first-match.yaml":                 &httpStopAtFirstMatch{},
+	"http/stop-at-first-match-with-extractors.yaml": &httpStopAtFirstMatchWithExtractors{},
 }
 
 type httpInteractshRequest struct{}
@@ -726,4 +728,42 @@ func (h *httpRaceMultiple) Execute(filePath string) error {
 		return err
 	}
 	return expectResultsCount(results, 5)
+}
+
+type httpStopAtFirstMatch struct{}
+
+// Execute executes a test case and returns an error if occurred
+func (h *httpStopAtFirstMatch) Execute(filePath string) error {
+	router := httprouter.New()
+	router.GET("/", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+		fmt.Fprintf(w, "This is test")
+	})
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+
+	results, err := testutils.RunNucleiTemplateAndGetResults(filePath, ts.URL, debug)
+	if err != nil {
+		return err
+	}
+
+	return expectResultsCount(results, 1)
+}
+
+type httpStopAtFirstMatchWithExtractors struct{}
+
+// Execute executes a test case and returns an error if occurred
+func (h *httpStopAtFirstMatchWithExtractors) Execute(filePath string) error {
+	router := httprouter.New()
+	router.GET("/", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+		fmt.Fprintf(w, "This is test")
+	})
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+
+	results, err := testutils.RunNucleiTemplateAndGetResults(filePath, ts.URL, debug)
+	if err != nil {
+		return err
+	}
+
+	return expectResultsCount(results, 2)
 }

--- a/v2/pkg/protocols/http/request.go
+++ b/v2/pkg/protocols/http/request.go
@@ -256,13 +256,13 @@ func (request *Request) ExecuteWithResults(reqURL string, dynamicValues, previou
 			if request.options.HostErrorsCache != nil && request.options.HostErrorsCache.Check(reqURL) {
 				return true, nil
 			}
-			var gotOutput bool
+			var gotMatches bool
 			request.options.RateLimiter.Take()
 
 			err = request.executeRequest(reqURL, generatedHttpRequest, previous, hasInteractMarkers, func(event *output.InternalWrappedEvent) {
 				// Add the extracts to the dynamic values if any.
 				if event.OperatorsResult != nil {
-					gotOutput = true
+					gotMatches = event.OperatorsResult.Matched
 					gotDynamicValues = generators.MergeMapsMany(event.OperatorsResult.DynamicValues, dynamicValues, gotDynamicValues)
 				}
 				if hasInteractMarkers && request.options.Interactsh != nil {
@@ -292,7 +292,7 @@ func (request *Request) ExecuteWithResults(reqURL string, dynamicValues, previou
 			request.options.Progress.IncrementRequests()
 
 			// If this was a match, and we want to stop at first match, skip all further requests.
-			if (generatedHttpRequest.original.options.Options.StopAtFirstMatch || generatedHttpRequest.original.options.StopAtFirstMatch || request.StopAtFirstMatch) && gotOutput {
+			if (generatedHttpRequest.original.options.Options.StopAtFirstMatch || generatedHttpRequest.original.options.StopAtFirstMatch || request.StopAtFirstMatch) && gotMatches {
 				return true, nil
 			}
 			return false, nil


### PR DESCRIPTION
## Proposed changes
This PR fixes a wrong behavior causing the iterations to terminate early in case of extracted data

## Checklist
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)