### PR TITLE
Differentiate between interact matchers and markers

### DIFF
--- a/v2/pkg/protocols/common/interactsh/interactsh.go
+++ b/v2/pkg/protocols/common/interactsh/interactsh.go
@@ -345,6 +345,11 @@ func HasMatchers(op *operators.Operators) bool {
 	return false
 }
 
+// HasMarkers checks if the text contains interactsh markers
+func HasMarkers(data string) bool {
+	return strings.Contains(data, interactshURLMarker)
+}
+
 func (c *Client) debugPrintInteraction(interaction *server.Interaction) {
 	builder := &bytes.Buffer{}
 

--- a/v2/pkg/protocols/http/request.go
+++ b/v2/pkg/protocols/http/request.go
@@ -239,9 +239,7 @@ func (request *Request) ExecuteWithResults(reqURL string, dynamicValues, previou
 	for {
 		// returns two values, error and skip, which skips the execution for the request instance.
 		executeFunc := func(data string, payloads, dynamicValue map[string]interface{}) (bool, error) {
-			hasInteractMarkers := interactsh.HasMarkers(data)
 			hasInteractMatchers := interactsh.HasMatchers(request.CompiledOperators)
-
 			generatedHttpRequest, err := generator.Make(reqURL, data, payloads, dynamicValue)
 			if err != nil {
 				if err == io.EOF {
@@ -250,6 +248,7 @@ func (request *Request) ExecuteWithResults(reqURL string, dynamicValues, previou
 				request.options.Progress.IncrementFailedRequestsBy(int64(generator.Total()))
 				return true, err
 			}
+			hasInteractMarkers := interactsh.HasMarkers(data) || len(generatedHttpRequest.interactshURLs) > 0
 			if reqURL == "" {
 				reqURL = generatedHttpRequest.URL()
 			}


### PR DESCRIPTION
## Proposed changes
This PR improves interact matcher/markers identification logic. Previously a request without markers but with an interact matcher was considered with interact markers.

## Checklist
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)