### PR TITLE
Disable internal standard library logger

### DIFF
--- a/v2/internal/runner/options.go
+++ b/v2/internal/runner/options.go
@@ -2,6 +2,8 @@ package runner
 
 import (
 	"bufio"
+	"io"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -161,6 +163,10 @@ func configureOutput(options *types.Options) {
 	if options.Silent {
 		gologger.DefaultLogger.SetMaxLevel(levels.LevelSilent)
 	}
+
+	// disable standard logger (ref: https://github.com/golang/go/issues/19895)
+	log.SetFlags(0)
+	log.SetOutput(io.Discard)
 }
 
 // loadResolvers loads resolvers from both user provided flag and file


### PR DESCRIPTION
## Proposed changes
This PR discards the standard `log` library output 

## Checklist
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)