### PR TITLE
Adding support for DNS CAA query

### DIFF
--- a/integration_tests/dns/caa.yaml
+++ b/integration_tests/dns/caa.yaml
@@ -1,0 +1,22 @@
+id: caa-fingerprinting
+
+info:
+  name: CAA Fingerprint
+  author: pdteam
+  severity: info
+  tags: dns,caa
+
+dns:
+  - name: "{{FQDN}}"
+    type: CAA
+
+    matchers:
+      - type: word
+        words:
+          - "IN\tCAA"
+
+    extractors:
+      - type: regex
+        group: 1
+        regex:
+          - "IN\tCAA\t(.+)"

--- a/v2/cmd/integration-test/dns.go
+++ b/v2/cmd/integration-test/dns.go
@@ -7,6 +7,7 @@ import (
 var dnsTestCases = map[string]testutils.TestCase{
 	"dns/basic.yaml": &dnsBasic{},
 	"dns/ptr.yaml":   &dnsPtr{},
+	"dns/caa.yaml":   &dnsCAA{},
 }
 
 type dnsBasic struct{}
@@ -32,6 +33,22 @@ func (h *dnsPtr) Execute(filePath string) error {
 	var routerErr error
 
 	results, err := testutils.RunNucleiTemplateAndGetResults(filePath, "1.1.1.1", debug)
+	if err != nil {
+		return err
+	}
+	if routerErr != nil {
+		return routerErr
+	}
+	return expectResultsCount(results, 1)
+}
+
+type dnsCAA struct{}
+
+// Execute executes a test case and returns an error if occurred
+func (h *dnsCAA) Execute(filePath string) error {
+	var routerErr error
+
+	results, err := testutils.RunNucleiTemplateAndGetResults(filePath, "google.com", debug)
 	if err != nil {
 		return err
 	}

--- a/v2/pkg/protocols/dns/dns.go
+++ b/v2/pkg/protocols/dns/dns.go
@@ -234,6 +234,8 @@ func questionTypeToInt(questionType string) uint16 {
 		question = dns.TypeDS
 	case "AAAA":
 		question = dns.TypeAAAA
+	case "CAA":
+		question = dns.TypeCAA
 	}
 	return question
 }

--- a/v2/pkg/protocols/dns/dns_types.go
+++ b/v2/pkg/protocols/dns/dns_types.go
@@ -31,6 +31,8 @@ const (
 	TXT
 	// name:AAAA
 	AAAA
+	// name:CAA
+	CAA
 	limit
 )
 
@@ -45,6 +47,7 @@ var DNSRequestTypeMapping = map[DNSRequestType]string{
 	MX:    "MX",
 	TXT:   "TXT",
 	AAAA:  "AAAA",
+	CAA:   "CAA",
 }
 
 // GetSupportedDNSRequestTypes returns list of supported types


### PR DESCRIPTION
## Proposed changes
This PR adds support for CAA query type in DNS protocol


## Checklist
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## How to reproduce
`template.yaml`
```yaml
id: caa-example

info:
  name: CAA Example
  author: pdteam
  severity: info
  tags: dns,caa

dns:
  - name: "{{FQDN}}"
    type: CAA

    matchers:
      - type: word
        words:
          - "IN\tCAA"

    extractors:
      - type: regex
        group: 1
        regex:
          - "IN\tCAA\t(.+)"
```
run with:
```console
$ echo google.com | go run . -t template.yaml 

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   2.6.0-dev

                projectdiscovery.io

[WRN] Use with caution. You are responsible for your actions.
[WRN] Developers assume no liability and are not responsible for any misuse or damage.
[INF] Using Nuclei Engine 2.6.0-dev (development)
[INF] Using Nuclei Templates 8.8.4 (latest)
[INF] Templates added in last update: 56
[INF] Templates loaded for scan: 1
[2022-02-02 07:56:33] [caa-example] [dns] [info] google.com [0 issue "pki.goog"]
```