### PR TITLE
Adding support for payloads in headless protocol

### DIFF
--- a/integration_tests/headless/headless-payloads.yaml
+++ b/integration_tests/headless/headless-payloads.yaml
@@ -1,0 +1,26 @@
+id: headless-payloads
+
+info:
+  name: headless payloads example
+  author: pdteam
+  severity: info
+  tags: headless
+
+headless:
+  - attack: clusterbomb
+    payloads:
+      aa:
+        - aa
+        - bb
+      bb:
+        - cc
+        - dd
+    steps:
+      - args:
+          url: "{{BaseURL}}?aa={{aa}}&bb={{bb}}"
+        action: navigate
+      - action: waitload
+    matchers:
+      - type: word
+        words:
+          - "test"

--- a/v2/cmd/integration-test/headless.go
+++ b/v2/cmd/integration-test/headless.go
@@ -90,6 +90,5 @@ func (h *headlessPayloads) Execute(filePath string) error {
 		return err
 	}
 
-	// 2 actions per 4 results => 8
-	return expectResultsCount(results, 8)
+	return expectResultsCount(results, 4)
 }

--- a/v2/cmd/integration-test/headless.go
+++ b/v2/cmd/integration-test/headless.go
@@ -13,6 +13,7 @@ var headlessTestcases = map[string]testutils.TestCase{
 	"headless/headless-basic.yaml":          &headlessBasic{},
 	"headless/headless-header-action.yaml":  &headlessHeaderActions{},
 	"headless/headless-extract-values.yaml": &headlessExtractValues{},
+	"headless/headless-payloads.yaml":       &headlessPayloads{},
 }
 
 type headlessBasic struct{}
@@ -72,4 +73,23 @@ func (h *headlessExtractValues) Execute(filePath string) error {
 	}
 
 	return expectResultsCount(results, 3)
+}
+
+type headlessPayloads struct{}
+
+// Execute executes a test case and returns an error if occurred
+func (h *headlessPayloads) Execute(filePath string) error {
+	router := httprouter.New()
+	router.GET("/", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+		_, _ = w.Write([]byte("<html><body>test</body></html>"))
+	})
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+	results, err := testutils.RunNucleiTemplateAndGetResults(filePath, ts.URL, debug, "-headless")
+	if err != nil {
+		return err
+	}
+
+	// 2 actions per 4 results => 8
+	return expectResultsCount(results, 8)
 }

--- a/v2/pkg/protocols/headless/engine/page.go
+++ b/v2/pkg/protocols/headless/engine/page.go
@@ -19,6 +19,7 @@ type Page struct {
 	mutex          *sync.RWMutex
 	History        []HistoryData
 	InteractshURLs []string
+	payloads       map[string]interface{}
 }
 
 // HistoryData contains the page request/response pairs
@@ -28,7 +29,7 @@ type HistoryData struct {
 }
 
 // Run runs a list of actions by creating a new page in the browser.
-func (i *Instance) Run(baseURL *url.URL, actions []*Action, timeout time.Duration) (map[string]string, *Page, error) {
+func (i *Instance) Run(baseURL *url.URL, actions []*Action, payloads map[string]interface{}, timeout time.Duration) (map[string]string, *Page, error) {
 	page, err := i.engine.Page(proto.TargetCreateTarget{})
 	if err != nil {
 		return nil, nil, err
@@ -41,7 +42,7 @@ func (i *Instance) Run(baseURL *url.URL, actions []*Action, timeout time.Duratio
 		}
 	}
 
-	createdPage := &Page{page: page, instance: i, mutex: &sync.RWMutex{}}
+	createdPage := &Page{page: page, instance: i, mutex: &sync.RWMutex{}, payloads: payloads}
 	router := page.HijackRequests()
 	if routerErr := router.Add("*", "", createdPage.routingRuleHandler); routerErr != nil {
 		return nil, nil, routerErr

--- a/v2/pkg/protocols/headless/engine/page_actions.go
+++ b/v2/pkg/protocols/headless/engine/page_actions.go
@@ -621,8 +621,10 @@ func (p *Page) getActionArg(action *Action, arg string) string {
 }
 
 func (p *Page) getActionArgWithDefaultValues(action *Action, arg string) string {
-	values := generators.BuildPayloadFromOptions(p.instance.browser.options)
-	return p.getActionArgWithValues(action, arg, values)
+	return p.getActionArgWithValues(action, arg, generators.MergeMaps(
+		generators.BuildPayloadFromOptions(p.instance.browser.options),
+		p.payloads,
+	))
 }
 
 func (p *Page) getActionArgWithValues(action *Action, arg string, values map[string]interface{}) string {

--- a/v2/pkg/protocols/headless/engine/page_actions_test.go
+++ b/v2/pkg/protocols/headless/engine/page_actions_test.go
@@ -529,7 +529,7 @@ func testHeadless(t *testing.T, actions []*Action, timeout time.Duration, handle
 
 	parsed, err := url.Parse(ts.URL)
 	require.Nil(t, err, "could not parse URL")
-	extractedData, page, err := instance.Run(parsed, actions, timeout)
+	extractedData, page, err := instance.Run(parsed, actions, nil, timeout)
 	assert(page, err, extractedData)
 
 	if page != nil {

--- a/v2/pkg/protocols/headless/headless.go
+++ b/v2/pkg/protocols/headless/headless.go
@@ -3,8 +3,10 @@ package headless
 import (
 	"github.com/pkg/errors"
 
+	"github.com/projectdiscovery/fileutil"
 	"github.com/projectdiscovery/nuclei/v2/pkg/operators"
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols"
+	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/generators"
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/headless/engine"
 )
 
@@ -12,6 +14,20 @@ import (
 type Request struct {
 	// ID is the optional id of the request
 	ID string `yaml:"id,omitempty" jsonschema:"title=id of the request,description=Optional ID of the headless request"`
+
+	// description: |
+	//   Attack is the type of payload combinations to perform.
+	//
+	//   Batteringram is inserts the same payload into all defined payload positions at once, pitchfork combines multiple payload sets and clusterbomb generates
+	//   permutations and combinations for all payloads.
+	AttackType generators.AttackTypeHolder `yaml:"attack,omitempty" jsonschema:"title=attack is the payload combination,description=Attack is the type of payload combinations to perform,enum=batteringram,enum=pitchfork,enum=clusterbomb"`
+	// description: |
+	//   Payloads contains any payloads for the current request.
+	//
+	//   Payloads support both key-values combinations where a list
+	//   of payloads is provided, or optionally a single file can also
+	//   be provided as payload which will be read on run-time.
+	Payloads map[string]interface{} `yaml:"payloads,omitempty" jsonschema:"title=payloads for the network request,description=Payloads contains any payloads for the current request"`
 
 	// description: |
 	//   Steps is the list of actions to run for headless request
@@ -22,7 +38,8 @@ type Request struct {
 	CompiledOperators   *operators.Operators `yaml:"-"`
 
 	// cache any variables that may be needed for operation.
-	options *protocols.ExecuterOptions
+	options   *protocols.ExecuterOptions
+	generator *generators.PayloadGenerator
 }
 
 // RequestPartDefinitions contains a mapping of request part definitions and their
@@ -52,6 +69,28 @@ func (request *Request) GetID() string {
 
 // Compile compiles the protocol request for further execution.
 func (request *Request) Compile(options *protocols.ExecuterOptions) error {
+	// TODO: logic similar to network + http => probably can be refactored
+	// Resolve payload paths from vars if they exists
+	for name, payload := range options.Options.VarsPayload() {
+		payloadStr, ok := payload.(string)
+		// check if inputs contains the payload
+		var hasPayloadName bool
+		if ok && hasPayloadName && fileutil.FileExists(payloadStr) {
+			if request.Payloads == nil {
+				request.Payloads = make(map[string]interface{})
+			}
+			request.Payloads[name] = payloadStr
+		}
+	}
+
+	if len(request.Payloads) > 0 {
+		var err error
+		request.generator, err = generators.New(request.Payloads, request.AttackType.Value, options.TemplatePath, options.Catalog)
+		if err != nil {
+			return errors.Wrap(err, "could not parse payloads")
+		}
+	}
+
 	if len(request.Matchers) > 0 || len(request.Extractors) > 0 {
 		compiled := &request.Operators
 		if err := compiled.Compile(); err != nil {

--- a/v2/pkg/protocols/headless/headless.go
+++ b/v2/pkg/protocols/headless/headless.go
@@ -27,7 +27,7 @@ type Request struct {
 	//   Payloads support both key-values combinations where a list
 	//   of payloads is provided, or optionally a single file can also
 	//   be provided as payload which will be read on run-time.
-	Payloads map[string]interface{} `yaml:"payloads,omitempty" jsonschema:"title=payloads for the network request,description=Payloads contains any payloads for the current request"`
+	Payloads map[string]interface{} `yaml:"payloads,omitempty" jsonschema:"title=payloads for the headless request,description=Payloads contains any payloads for the current request"`
 
 	// description: |
 	//   Steps is the list of actions to run for headless request

--- a/v2/pkg/protocols/headless/headless.go
+++ b/v2/pkg/protocols/headless/headless.go
@@ -74,8 +74,7 @@ func (request *Request) Compile(options *protocols.ExecuterOptions) error {
 	for name, payload := range options.Options.VarsPayload() {
 		payloadStr, ok := payload.(string)
 		// check if inputs contains the payload
-		var hasPayloadName bool
-		if ok && hasPayloadName && fileutil.FileExists(payloadStr) {
+		if ok && fileutil.FileExists(payloadStr) {
 			if request.Payloads == nil {
 				request.Payloads = make(map[string]interface{})
 			}


### PR DESCRIPTION
## Proposed changes
This PR adds support for payloads in headless protocol

```yaml
id: headless-payloads

info:
  name: headless payloads example
  author: pdteam
  severity: info
  tags: headless

headless:
  - attack: clusterbomb
    payloads:
      aa:
        - aa
        - bb
      bb:
        - cc
        - dd
    steps:
      - args:
          url: "{{BaseURL}}?aa={{aa}}&bb={{bb}}"
        action: navigate
      - action: waitload
    matchers:
      - type: word
        words:
          - "test"
```

## Checklist
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)