### PR TITLE
update: increased limit for file protocol

### DIFF
--- a/v2/pkg/protocols/file/file.go
+++ b/v2/pkg/protocols/file/file.go
@@ -83,9 +83,9 @@ func (request *Request) Compile(options *protocols.ExecuterOptions) error {
 		}
 		request.CompiledOperators = compiled
 	}
-	// By default, use 5 MB as max size to read.
+	// By default, use 1GB (1024 MB) as max size to read.
 	if request.MaxSize == 0 {
-		request.MaxSize = 5 * 1024 * 1024
+		request.MaxSize = 1024 * 1024 * 1024
 	}
 	request.options = options
 


### PR DESCRIPTION


## Proposed changes

Increased default file size to read for file templates from 5 MB to 1GB to avoid false negative results.

fixes - https://github.com/projectdiscovery/nuclei-templates/issues/3477

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)