### PR TITLE
allow use of docker image in build pipelines

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,4 @@ RUN go install -v github.com/projectdiscovery/nuclei/v2/cmd/nuclei@latest
 FROM alpine:3.15.0
 RUN apk add --no-cache bind-tools ca-certificates chromium
 COPY --from=build-env /go/bin/nuclei /usr/local/bin/nuclei
-ENTRYPOINT ["nuclei"]
+CMD ["nuclei"]


### PR DESCRIPTION
## Proposed changes

Allow the docker container to be used in a build pipeline, such as in GitLab.

### Explanation

An ENTRYPOINT forces the container to run the specified command, where as CMD can be overridden. Build pipelines don't work with ENTRYPOINT since it prevents them from executing commands in the container.

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Testing

I published this to docker hub under my name: https://hub.docker.com/repository/docker/carlin/nuclei and I am using it in my GitLab build pipeline already.