### PR TITLE
add options to specify User-Agent in headless template

### DIFF
--- a/v2/pkg/model/types/userAgent/user_agent.go
+++ b/v2/pkg/model/types/userAgent/user_agent.go
@@ -1,0 +1,95 @@
+package userAgent
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/alecthomas/jsonschema"
+	"github.com/pkg/errors"
+)
+
+type UserAgent int
+
+// name:UserAgent
+const (
+	// name:random
+	Random UserAgent = iota
+	// name:off
+	Off
+	// name:default
+	Default
+	// name:custom
+	Custom
+	limit
+)
+
+var userAgentMappings = map[UserAgent]string{
+	Random:  "random",
+	Off:     "off",
+	Default: "default",
+	Custom:  "custom",
+}
+
+func GetSupportedUserAgentOptions() []UserAgent {
+	var result []UserAgent
+	for index := UserAgent(1); index < limit; index++ {
+		result = append(result, index)
+	}
+	return result
+}
+
+func toUserAgent(valueToMap string) (UserAgent, error) {
+	normalizedValue := normalizeValue(valueToMap)
+	for key, currentValue := range userAgentMappings {
+		if normalizedValue == currentValue {
+			return key, nil
+		}
+	}
+	return -1, errors.New("Invalid userAgent: " + valueToMap)
+}
+
+func normalizeValue(value string) string {
+	return strings.TrimSpace(strings.ToLower(value))
+}
+
+func (userAgent UserAgent) String() string {
+	return userAgentMappings[userAgent]
+}
+
+// UserAgentHolder holds a UserAgent type. Required for un/marshalling purposes
+type UserAgentHolder struct {
+	Value UserAgent `mapping:"true"`
+}
+
+func (userAgentHolder UserAgentHolder) JSONSchemaType() *jsonschema.Type {
+	gotType := &jsonschema.Type{
+		Type:        "string",
+		Title:       "userAgent for the headless",
+		Description: "userAgent for the headless http request",
+	}
+	for _, userAgent := range GetSupportedUserAgentOptions() {
+		gotType.Enum = append(gotType.Enum, userAgent.String())
+	}
+	return gotType
+}
+
+func (userAgentHolder *UserAgentHolder) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var marshalledUserAgent string
+	if err := unmarshal(&marshalledUserAgent); err != nil {
+		return err
+	}
+	computedUserAgent, err := toUserAgent(marshalledUserAgent)
+	if err != nil {
+		return err
+	}
+	userAgentHolder.Value = computedUserAgent
+	return nil
+}
+
+func (userAgentHolder *UserAgentHolder) MarshalJSON() ([]byte, error) {
+	return json.Marshal(userAgentHolder.Value.String())
+}
+
+func (userAgentHolder UserAgentHolder) MarshalYAML() (interface{}, error) {
+	return userAgentHolder.Value.String(), nil
+}

--- a/v2/pkg/protocols/headless/engine/engine.go
+++ b/v2/pkg/protocols/headless/engine/engine.go
@@ -8,7 +8,6 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/corpix/uarand"
 	"github.com/go-rod/rod"
 	"github.com/go-rod/rod/lib/launcher"
 	"github.com/pkg/errors"
@@ -89,9 +88,6 @@ func New(options *types.Options) (*Browser, error) {
 			customAgent = parts[1]
 		}
 	}
-	if customAgent == "" {
-		customAgent = uarand.GetRandom()
-	}
 
 	httpclient, err := newHttpClient(options)
 	if err != nil {
@@ -114,6 +110,16 @@ func MustDisableSandbox() bool {
 	// linux with root user needs "--no-sandbox" option
 	// https://github.com/chromium/chromium/blob/c4d3c31083a2e1481253ff2d24298a1dfe19c754/chrome/test/chromedriver/client/chromedriver.py#L209
 	return runtime.GOOS == "linux" && os.Geteuid() == 0
+}
+
+// SetUserAgent sets custom user agent to the browser
+func (b *Browser) SetUserAgent(customUserAgent string) {
+	b.customAgent = customUserAgent
+}
+
+// UserAgent fetch the currently set custom user agent
+func (b *Browser) UserAgent() string {
+	return b.customAgent
 }
 
 // Close closes the browser engine

--- a/v2/pkg/protocols/headless/request.go
+++ b/v2/pkg/protocols/headless/request.go
@@ -26,6 +26,9 @@ func (request *Request) Type() templateTypes.ProtocolType {
 
 // ExecuteWithResults executes the protocol requests and returns results instead of writing them.
 func (request *Request) ExecuteWithResults(inputURL string, metadata, previous output.InternalEvent /*TODO review unused parameter*/, callback protocols.OutputEventCallback) error {
+	if request.options.Browser.UserAgent() == "" {
+		request.options.Browser.SetUserAgent(request.compiledUserAgent)
+	}
 	payloads := generators.BuildPayloadFromOptions(request.options.Options)
 	if request.generator != nil {
 		iterator := request.generator.NewIterator()


### PR DESCRIPTION
## Proposed changes

`user_agent`: `random` | `off` | `default` | `custom`

example template: 
```yaml
id: extract-urls

info:
  name: Extract URLs from HTML attributes
  author: dwisiswant0
  severity: info
  tags: headless,extractor

headless:
  - steps:
      - args:
          url: "{{BaseURL}}"
        action: navigate
      - action: waitload
      - action: script
        name: extract
        args:
          code: |
            '\n' + [...new Set(Array.from(document.querySelectorAll('[src], [href], [url], [action]')).map(i => i.src || i.href || i.url || i.action))].join('\r\n') + '\n'

    user_agent: custom
    custom_user_agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36

    extractors:
      - type: kval
        part: extract
        kval:
          - extract
```


## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)