### PR TITLE
Skip unresolved expressions using a regex

### DIFF
--- a/v2/pkg/protocols/common/expressions/variables.go
+++ b/v2/pkg/protocols/common/expressions/variables.go
@@ -6,7 +6,10 @@ import (
 	"strings"
 )
 
-var unresolvedVariablesRegex = regexp.MustCompile(`(?:%7[B|b]|\{){2}([^}]+)(?:%7[D|d]|\}){2}["'\)\}]*`)
+var (
+	numericalExpressionRegex = regexp.MustCompile(`[0-9+\-*/]+`)
+	unresolvedVariablesRegex = regexp.MustCompile(`(?:%7[B|b]|\{){2}([^}]+)(?:%7[D|d]|\}){2}["'\)\}]*`)
+)
 
 // ContainsUnresolvedVariables returns an error with variable names if the passed
 // input contains unresolved {{<pattern-here>}} variables.
@@ -19,6 +22,10 @@ func ContainsUnresolvedVariables(items ...string) error {
 		var unresolvedVariables []string
 		for _, match := range matches {
 			if len(match) < 2 {
+				continue
+			}
+			// Skip if the match is an expression
+			if numericalExpressionRegex.MatchString(match[1]) {
 				continue
 			}
 			unresolvedVariables = append(unresolvedVariables, match[1])
@@ -45,6 +52,10 @@ func ContainsVariablesWithNames(names map[string]interface{}, items ...string) e
 				continue
 			}
 			matchName := match[1]
+			// Skip if the match is an expression
+			if numericalExpressionRegex.MatchString(matchName) {
+				continue
+			}
 			if _, ok := names[matchName]; !ok {
 				unresolvedVariables = append(unresolvedVariables, matchName)
 			}
@@ -71,6 +82,10 @@ func ContainsVariablesWithIgnoreList(skipNames map[string]interface{}, items ...
 				continue
 			}
 			matchName := match[1]
+			// Skip if the match is an expression
+			if numericalExpressionRegex.MatchString(matchName) {
+				continue
+			}
 			if _, ok := skipNames[matchName]; ok {
 				continue
 			}

--- a/v2/pkg/protocols/common/expressions/variables_test.go
+++ b/v2/pkg/protocols/common/expressions/variables_test.go
@@ -16,6 +16,7 @@ func TestUnresolvedVariablesCheck(t *testing.T) {
 		{"{{test}}/{{another}}", errors.New("unresolved variables found: test,another")},
 		{"test", nil},
 		{"%7b%7btest%7d%7d", errors.New("unresolved variables found: test")},
+		{"{{7*7}}", nil},
 	}
 	for _, test := range tests {
 		err := ContainsUnresolvedVariables(test.data)


### PR DESCRIPTION
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->
Closes #1539. An additional step is implemented using a regex during unresolved variable checking to identify if the found match is a numeric expression and if that is the case, it is skipped from the match as an unresolved variable.

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)