### PR TITLE
Adding GH token detection

### DIFF
--- a/v2/internal/runner/update.go
+++ b/v2/internal/runner/update.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/go-github/github"
 	"github.com/olekukonko/tablewriter"
 	"github.com/pkg/errors"
+	"golang.org/x/oauth2"
 
 	"github.com/projectdiscovery/folderutil"
 	"github.com/projectdiscovery/gologger"
@@ -223,7 +224,16 @@ func (r *Runner) checkNucleiIgnoreFileUpdates(configDir string) bool {
 
 // getLatestReleaseFromGithub returns the latest release from GitHub
 func (r *Runner) getLatestReleaseFromGithub(latestTag string) (*github.RepositoryRelease, error) {
-	gitHubClient := github.NewClient(nil)
+	var tc *http.Client
+	if token, ok := os.LookupEnv("GITHUB_API_TOKEN"); ok {
+		ctx := context.Background()
+		ts := oauth2.StaticTokenSource(
+			&oauth2.Token{AccessToken: token},
+		)
+		tc = oauth2.NewClient(ctx, ts)
+	}
+
+	gitHubClient := github.NewClient(tc)
 
 	release, _, err := gitHubClient.Repositories.GetReleaseByTag(context.Background(), userName, repoName, "v"+latestTag)
 	if err != nil {


### PR DESCRIPTION
## Proposed changes
This PR allows the internal GH client to use `GITHUB_API_TOKEN` between the environment variables. This allows authenticated requests when updating templates.

## Checklist
- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)