### PR TITLE
Adding truncation info on debug

### DIFF
--- a/v2/pkg/protocols/http/request.go
+++ b/v2/pkg/protocols/http/request.go
@@ -564,7 +564,8 @@ func (request *Request) executeRequest(reqURL string, generatedRequest *generate
 		}
 
 		responseContentType := resp.Header.Get("Content-Type")
-		dumpResponse(event, request.options, response.fullResponse, formedURL, responseContentType)
+		isResponseTruncated := len(gotData) >= request.MaxSize
+		dumpResponse(event, request.options, response.fullResponse, formedURL, responseContentType, isResponseTruncated)
 
 		callback(event)
 	}
@@ -622,7 +623,7 @@ func (request *Request) setCustomHeaders(req *generatedRequest) {
 
 const CRLF = "\r\n"
 
-func dumpResponse(event *output.InternalWrappedEvent, requestOptions *protocols.ExecuterOptions, redirectedResponse []byte, formedURL string, responseContentType string) {
+func dumpResponse(event *output.InternalWrappedEvent, requestOptions *protocols.ExecuterOptions, redirectedResponse []byte, formedURL string, responseContentType string, isResponseTruncated bool) {
 	cliOptions := requestOptions.Options
 	if cliOptions.Debug || cliOptions.DebugResponse {
 		response := string(redirectedResponse)
@@ -634,7 +635,12 @@ func dumpResponse(event *output.InternalWrappedEvent, requestOptions *protocols.
 			highlightedResult = responsehighlighter.Highlight(event.OperatorsResult, response, cliOptions.NoColor, false)
 		}
 
-		gologger.Debug().Msgf("[%s] Dumped HTTP response for %s\n\n%s", requestOptions.TemplateID, formedURL, highlightedResult)
+		msg := "[%s] Dumped HTTP response %s\n\n%s"
+		if isResponseTruncated {
+			msg = "[%s] Dumped HTTP response (Truncated) %s\n\n%s"
+		}
+
+		gologger.Debug().Msgf(msg, requestOptions.TemplateID, formedURL, highlightedResult)
 	}
 }
 


### PR DESCRIPTION
## Proposed changes
This PR adds response truncation info within debug messages

## Checklist
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Notes:
- File truncation: actually, no file is truncated. Those above 5Mb are discarded. This behavior changes in https://github.com/projectdiscovery/nuclei/pull/1634 where also the user is notified of truncated data
- HTTP: truncation message was added for the final response body
- Network: due to the socket nature, each data chunk from server to the client is always of size `read-size` (truncated by design) or read as a whole until `EOF/Timeout`.

## To Discuss:
- Default values are defined per template not globally, how to represent this information in a meaningful and usable way
- `read-size` for network templates seems named appropriately as it's the exact amount of bytes that will be read from the socket