### PR TITLE
Random IP Helper Function

### DIFF
--- a/integration_tests/http/dsl-functions.yaml
+++ b/integration_tests/http/dsl-functions.yaml
@@ -39,33 +39,34 @@ requests:
         27: {{rand_int()}}
         28: {{rand_ip("192.168.0.0/24")}}
         29: {{rand_ip("2002:c0a8::/24")}}
-        30: {{rand_text_alpha(10, "abc")}}
-        31: {{rand_text_alpha(10, "")}}
-        32: {{rand_text_alpha(10)}}
-        33: {{rand_text_alphanumeric(10, "ab12")}}
-        34: {{rand_text_alphanumeric(10)}}
-        35: {{rand_text_numeric(10, 123)}}
-        36: {{rand_text_numeric(10)}}
-        37: {{regex("H([a-z]+)o", "Hello")}}
-        38: {{remove_bad_chars("abcd", "bc")}}
-        39: {{repeat("a", 5)}}
-        40: {{replace("Hello", "He", "Ha")}}
-        41: {{replace_regex("He123llo", "(\\d+)", "")}}
-        42: {{reverse("abc")}}
-        43: {{sha1("Hello")}}
-        44: {{sha256("Hello")}}
-        45: {{to_lower("HELLO")}}
-        46: {{to_upper("hello")}}
-        47: {{trim("aaaHelloddd", "ad")}}
-        48: {{trim_left("aaaHelloddd", "ad")}}
-        49: {{trim_prefix("aaHelloaa", "aa")}}
-        50: {{trim_right("aaaHelloddd", "ad")}}
-        51: {{trim_space("  Hello  ")}}
-        52: {{trim_suffix("aaHelloaa", "aa")}}
-        53: {{unix_time(10)}}
-        54: {{url_decode("https:%2F%2Fprojectdiscovery.io%3Ftest=1")}}
-        55: {{url_encode("https://projectdiscovery.io/test?a=1")}}
-        56: {{wait_for(1)}}
+        30: {{rand_ip("192.168.0.0/24","10.0.100.0/24")}}
+        31: {{rand_text_alpha(10, "abc")}}
+        32: {{rand_text_alpha(10, "")}}
+        33: {{rand_text_alpha(10)}}
+        34: {{rand_text_alphanumeric(10, "ab12")}}
+        35: {{rand_text_alphanumeric(10)}}
+        36: {{rand_text_numeric(10, 123)}}
+        37: {{rand_text_numeric(10)}}
+        38: {{regex("H([a-z]+)o", "Hello")}}
+        39: {{remove_bad_chars("abcd", "bc")}}
+        40: {{repeat("a", 5)}}
+        41: {{replace("Hello", "He", "Ha")}}
+        42: {{replace_regex("He123llo", "(\\d+)", "")}}
+        43: {{reverse("abc")}}
+        44: {{sha1("Hello")}}
+        45: {{sha256("Hello")}}
+        46: {{to_lower("HELLO")}}
+        47: {{to_upper("hello")}}
+        48: {{trim("aaaHelloddd", "ad")}}
+        49: {{trim_left("aaaHelloddd", "ad")}}
+        50: {{trim_prefix("aaHelloaa", "aa")}}
+        51: {{trim_right("aaaHelloddd", "ad")}}
+        52: {{trim_space("  Hello  ")}}
+        53: {{trim_suffix("aaHelloaa", "aa")}}
+        54: {{unix_time(10)}}
+        55: {{url_decode("https:%2F%2Fprojectdiscovery.io%3Ftest=1")}}
+        56: {{url_encode("https://projectdiscovery.io/test?a=1")}}
+        57: {{wait_for(1)}}
 
     extractors:
       - type: regex

--- a/integration_tests/http/dsl-functions.yaml
+++ b/integration_tests/http/dsl-functions.yaml
@@ -37,33 +37,35 @@ requests:
         25: {{rand_int(1, 10)}}
         26: {{rand_int(10)}}
         27: {{rand_int()}}
-        28: {{rand_text_alpha(10, "abc")}}
-        29: {{rand_text_alpha(10, "")}}
-        30: {{rand_text_alpha(10)}}
-        31: {{rand_text_alphanumeric(10, "ab12")}}
-        32: {{rand_text_alphanumeric(10)}}
-        33: {{rand_text_numeric(10, 123)}}
-        34: {{rand_text_numeric(10)}}
-        35: {{regex("H([a-z]+)o", "Hello")}}
-        36: {{remove_bad_chars("abcd", "bc")}}
-        37: {{repeat("a", 5)}}
-        38: {{replace("Hello", "He", "Ha")}}
-        39: {{replace_regex("He123llo", "(\\d+)", "")}}
-        40: {{reverse("abc")}}
-        41: {{sha1("Hello")}}
-        42: {{sha256("Hello")}}
-        43: {{to_lower("HELLO")}}
-        44: {{to_upper("hello")}}
-        45: {{trim("aaaHelloddd", "ad")}}
-        46: {{trim_left("aaaHelloddd", "ad")}}
-        47: {{trim_prefix("aaHelloaa", "aa")}}
-        48: {{trim_right("aaaHelloddd", "ad")}}
-        49: {{trim_space("  Hello  ")}}
-        50: {{trim_suffix("aaHelloaa", "aa")}}
-        51: {{unix_time(10)}}
-        52: {{url_decode("https:%2F%2Fprojectdiscovery.io%3Ftest=1")}}
-        53: {{url_encode("https://projectdiscovery.io/test?a=1")}}
-        54: {{wait_for(1)}}
+        28: {{rand_ip("192.168.0.0/24")}}
+        29: {{rand_ip("2002:c0a8::/24")}}
+        30: {{rand_text_alpha(10, "abc")}}
+        31: {{rand_text_alpha(10, "")}}
+        32: {{rand_text_alpha(10)}}
+        33: {{rand_text_alphanumeric(10, "ab12")}}
+        34: {{rand_text_alphanumeric(10)}}
+        35: {{rand_text_numeric(10, 123)}}
+        36: {{rand_text_numeric(10)}}
+        37: {{regex("H([a-z]+)o", "Hello")}}
+        38: {{remove_bad_chars("abcd", "bc")}}
+        39: {{repeat("a", 5)}}
+        40: {{replace("Hello", "He", "Ha")}}
+        41: {{replace_regex("He123llo", "(\\d+)", "")}}
+        42: {{reverse("abc")}}
+        43: {{sha1("Hello")}}
+        44: {{sha256("Hello")}}
+        45: {{to_lower("HELLO")}}
+        46: {{to_upper("hello")}}
+        47: {{trim("aaaHelloddd", "ad")}}
+        48: {{trim_left("aaaHelloddd", "ad")}}
+        49: {{trim_prefix("aaHelloaa", "aa")}}
+        50: {{trim_right("aaaHelloddd", "ad")}}
+        51: {{trim_space("  Hello  ")}}
+        52: {{trim_suffix("aaHelloaa", "aa")}}
+        53: {{unix_time(10)}}
+        54: {{url_decode("https:%2F%2Fprojectdiscovery.io%3Ftest=1")}}
+        55: {{url_encode("https://projectdiscovery.io/test?a=1")}}
+        56: {{wait_for(1)}}
 
     extractors:
       - type: regex

--- a/v2/pkg/operators/common/dsl/dsl.go
+++ b/v2/pkg/operators/common/dsl/dsl.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/helpers/deserialization"
+	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/randomip"
 	"github.com/projectdiscovery/nuclei/v2/pkg/types"
 )
 
@@ -400,6 +401,11 @@ func init() {
 				return rand.Intn(max-min) + min, nil
 			},
 		),
+		"rand_ip": makeDslFunction(1, func(args ...interface{}) (interface{}, error) {
+			cidr := args[0].(string)
+			ip := randomip.IPFromRange(cidr)
+			return ip, nil
+		}),
 		"generate_java_gadget": makeDslFunction(3, func(args ...interface{}) (interface{}, error) {
 			gadget := args[0].(string)
 			cmd := args[1].(string)

--- a/v2/pkg/operators/common/dsl/dsl.go
+++ b/v2/pkg/operators/common/dsl/dsl.go
@@ -403,8 +403,7 @@ func init() {
 		),
 		"rand_ip": makeDslFunction(1, func(args ...interface{}) (interface{}, error) {
 			cidr := args[0].(string)
-			ip := randomip.IPFromRange(cidr)
-			return ip, nil
+			return randomip.GetRandomIPWithCidr(cidr)
 		}),
 		"generate_java_gadget": makeDslFunction(3, func(args ...interface{}) (interface{}, error) {
 			gadget := args[0].(string)

--- a/v2/pkg/operators/common/dsl/dsl.go
+++ b/v2/pkg/operators/common/dsl/dsl.go
@@ -401,10 +401,18 @@ func init() {
 				return rand.Intn(max-min) + min, nil
 			},
 		),
-		"rand_ip": makeDslFunction(1, func(args ...interface{}) (interface{}, error) {
-			cidr := args[0].(string)
-			return randomip.GetRandomIPWithCidr(cidr)
-		}),
+		"rand_ip": makeDslWithOptionalArgsFunction(
+			"(cidr ...string) string",
+			func(args ...interface{}) (interface{}, error) {
+				if len(args) == 0 {
+					return nil, invalidDslFunctionError
+				}
+				var cidrs []string
+				for _, arg := range args {
+					cidrs = append(cidrs, arg.(string))
+				}
+				return randomip.GetRandomIPWithCidr(cidrs...)
+			}),
 		"generate_java_gadget": makeDslFunction(3, func(args ...interface{}) (interface{}, error) {
 			gadget := args[0].(string)
 			cmd := args[1].(string)

--- a/v2/pkg/operators/common/dsl/dsl_test.go
+++ b/v2/pkg/operators/common/dsl/dsl_test.go
@@ -125,6 +125,7 @@ func TestGetPrintableDslFunctionSignatures(t *testing.T) {
 	[93mrand_base[0m(length [38;5;208muint[0m, optionalCharSet [38;5;208mstring[0m)[38;5;208m string[0m
 	[93mrand_char[0m(optionalCharSet [38;5;208mstring[0m)[38;5;208m string[0m
 	[93mrand_int[0m(optionalMin, optionalMax [38;5;208muint[0m)[38;5;208m int[0m
+	[93mrand_ip[0m(arg1 [38;5;208minterface{}[0m)[38;5;208m interface{}[0m
 	[93mrand_text_alpha[0m(length [38;5;208muint[0m, optionalBadChars [38;5;208mstring[0m)[38;5;208m string[0m
 	[93mrand_text_alphanumeric[0m(length [38;5;208muint[0m, optionalBadChars [38;5;208mstring[0m)[38;5;208m string[0m
 	[93mrand_text_numeric[0m(length [38;5;208muint[0m, optionalBadNumbers [38;5;208mstring[0m)[38;5;208m string[0m
@@ -235,12 +236,14 @@ func TestDslExpressions(t *testing.T) {
 
 func TestRandDslExpressions(t *testing.T) {
 	randDslExpressions := map[string]string{
-		`rand_base(10, "")`:   `[a-zA-Z0-9]{10}`,
-		`rand_base(5, "abc")`: `[abc]{5}`,
-		`rand_base(5)`:        `[a-zA-Z0-9]{5}`,
-		`rand_char("abc")`:    `[abc]{1}`,
-		`rand_char("")`:       `[a-zA-Z0-9]{1}`,
-		`rand_char()`:         `[a-zA-Z0-9]{1}`,
+		`rand_base(10, "")`:         `[a-zA-Z0-9]{10}`,
+		`rand_base(5, "abc")`:       `[abc]{5}`,
+		`rand_base(5)`:              `[a-zA-Z0-9]{5}`,
+		`rand_char("abc")`:          `[abc]{1}`,
+		`rand_char("")`:             `[a-zA-Z0-9]{1}`,
+		`rand_char()`:               `[a-zA-Z0-9]{1}`,
+		`rand_ip("192.168.0.0/24")`: `(?:[0-9]{1,3}\.){3}[0-9]{1,3}$`,
+		`rand_ip("2001:db8::/64")`:  `(?:[A-Fa-f0-9]{0,4}:){0,7}[A-Fa-f0-9]{0,4}$`,
 
 		`rand_text_alpha(10, "abc")`:         `[^abc]{10}`,
 		`rand_text_alpha(10, "")`:            `[a-zA-Z]{10}`,

--- a/v2/pkg/protocols/common/randomip/randomip.go
+++ b/v2/pkg/protocols/common/randomip/randomip.go
@@ -12,7 +12,12 @@ const (
 	maxIterations = 255
 )
 
-func GetRandomIPWithCidr(cidr string) (net.IP, error) {
+func GetRandomIPWithCidr(cidrs ...string) (net.IP, error) {
+	if len(cidrs) == 0 {
+		return nil, errors.Errorf("must specify at least one cidr")
+	}
+	cidr := cidrs[rand.Intn(len(cidrs))]
+
 	if !iputil.IsCIDR(cidr) {
 		return nil, errors.Errorf("%s is not a valid cidr", cidr)
 	}

--- a/v2/pkg/protocols/common/randomip/randomip.go
+++ b/v2/pkg/protocols/common/randomip/randomip.go
@@ -1,0 +1,66 @@
+package randomip
+
+import (
+	"math/rand"
+	"net"
+	"strings"
+)
+
+func IPFromRange(cidr string) (ip string) {
+
+	_, ipnet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return ""
+	}
+
+	var ipAddr net.IP
+
+	if ipnet.IP.To4() != nil {
+		ipAddr = getRandomIP(ipnet, true, false)
+	}
+	if strings.Contains(ipnet.IP.String(), ":") {
+		ipAddr = getRandomIP(ipnet, false, true)
+	}
+
+	return ipAddr.String()
+}
+
+func getRandomIP(ipnet *net.IPNet, ipv4, ipv6 bool) (ip net.IP) {
+
+GENERATE:
+	ones, _ := ipnet.Mask.Size()
+	quotient := ones / 8
+	remainder := ones % 8
+	var r []byte
+	if ipv4 {
+		r = make([]byte, 4)
+	} else if ipv6 {
+		r = make([]byte, 16)
+	} else {
+		return ip
+	}
+
+	rand.Read(r)
+
+	for i := 0; i <= quotient; i++ {
+		if i == quotient {
+			shifted := byte(r[i]) >> remainder
+			r[i] = ^ipnet.IP[i] & shifted
+		} else {
+			r[i] = ipnet.IP[i]
+		}
+	}
+
+	if ipv4 {
+		ip = net.IP{r[0], r[1], r[2], r[3]}
+	} else {
+		ip = net.IP{r[0], r[1], r[2], r[3], r[4], r[5], r[6], r[7],
+			r[8], r[9], r[10], r[11], r[12], r[13], r[14], r[15]}
+	}
+
+	if ip.Equal(ipnet.IP) {
+		goto GENERATE
+	}
+
+	return ip
+}

--- a/v2/pkg/protocols/common/randomip/randomip.go
+++ b/v2/pkg/protocols/common/randomip/randomip.go
@@ -3,63 +3,68 @@ package randomip
 import (
 	"math/rand"
 	"net"
-	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/projectdiscovery/iputil"
 )
 
-func IPFromRange(cidr string) (ip string) {
+const (
+	maxIterations = 255
+)
 
-	_, ipnet, err := net.ParseCIDR(cidr)
+func GetRandomIPWithCidr(cidr string) (net.IP, error) {
+	if !iputil.IsCIDR(cidr) {
+		return nil, errors.Errorf("%s is not a valid cidr", cidr)
+	}
+
+	baseIp, ipnet, err := net.ParseCIDR(cidr)
 	if err != nil {
-		return ""
+		return nil, err
 	}
 
-	var ipAddr net.IP
-
-	if ipnet.IP.To4() != nil {
-		ipAddr = getRandomIP(ipnet, true, false)
+	switch {
+	case iputil.IsIPv4(baseIp.String()):
+		return getRandomIP(ipnet, 4), nil
+	case iputil.IsIPv6(baseIp.String()):
+		return getRandomIP(ipnet, 16), nil
+	default:
+		return nil, errors.New("invalid base ip")
 	}
-	if strings.Contains(ipnet.IP.String(), ":") {
-		ipAddr = getRandomIP(ipnet, false, true)
-	}
-
-	return ipAddr.String()
 }
 
-func getRandomIP(ipnet *net.IPNet, ipv4, ipv6 bool) (ip net.IP) {
+func getRandomIP(ipnet *net.IPNet, size int) net.IP {
+	ip := ipnet.IP
+	var iteration int
 
-GENERATE:
-	ones, _ := ipnet.Mask.Size()
-	quotient := ones / 8
-	remainder := ones % 8
-	var r []byte
-	if ipv4 {
-		r = make([]byte, 4)
-	} else if ipv6 {
-		r = make([]byte, 16)
-	} else {
-		return ip
-	}
-
-	rand.Read(r)
-
-	for i := 0; i <= quotient; i++ {
-		if i == quotient {
-			shifted := byte(r[i]) >> remainder
-			r[i] = ^ipnet.IP[i] & shifted
-		} else {
-			r[i] = ipnet.IP[i]
+	for iteration < maxIterations {
+		iteration++
+		ones, _ := ipnet.Mask.Size()
+		quotient := ones / 8
+		remainder := ones % 8
+		var r []byte
+		switch size {
+		case 4, 16:
+			r = make([]byte, size)
+		default:
+			return ip
 		}
-	}
 
-	if ipv4 {
-		ip = net.IP{r[0], r[1], r[2], r[3]}
-	} else {
-		ip = net.IP{r[0], r[1], r[2], r[3], r[4], r[5], r[6], r[7],
-			r[8], r[9], r[10], r[11], r[12], r[13], r[14], r[15]}
-	}
+		rand.Read(r)
 
-	if ip.Equal(ipnet.IP) {
-		goto GENERATE
+		for i := 0; i <= quotient; i++ {
+			if i == quotient {
+				shifted := byte(r[i]) >> remainder
+				r[i] = ^ipnet.IP[i] & shifted
+			} else {
+				r[i] = ipnet.IP[i]
+			}
+		}
+
+		ip = r
+
+		if !ip.Equal(ipnet.IP) {
+			break
+		}
 	}
 
 	return ip


### PR DESCRIPTION
## Proposed changes

This PR introduces a helper function called `rand_ip` that allows you to generate a random IPV4 or IPV6 address in each request from a user supplied CIDR range. The generated IP can be used in HTTP headers to bypass/defeat protection mechanisms. Examples of HTTP headers that could use the `rand_ip` function:

- Client-IP
- X-Forwared-For
- TRUE-CLIENT-IP
- HTTP_CLIENT_IP
- HTTP_X_FORWARDED_FOR
- HTTP_X_FORWARDED
- HTTP_X_CLUSTER_CLIENT_IP
- HTTP_FORWARDED_FOR
- HTTP_FORWARDED

 The following is an example request using the `rand_ip` function.

```yaml
id: brute-force

info:
  name: ATO Brute Force
  author: skhalsa-sigsci
  severity: info
  description: ato brute force
  tags: ato,bruteforce

requests:

- payloads:
    username: nuclei/payloads/usernames.txt
    password: nuclei/payloads/passwords.txt
  
  attack: clusterbomb

  headers:
    X-Forwarded-For: '{{rand_ip("192.168.0.0/24")}}'

  raw:
  - |-
    POST /login HTTP/2
    Host: {{Hostname}}
    User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.51 Safari/537.36
    Content-Type: application/x-www-form-urlencoded
    Accept: */*

    name={{username}}&password={{password}}

  stop-at-first-match: true
  matchers:
  - type: status
    status:
    - 406

```




## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)