### PR TITLE
Adding HexOrString helper

### DIFF
--- a/v2/pkg/reporting/format/format.go
+++ b/v2/pkg/reporting/format/format.go
@@ -2,7 +2,6 @@ package format
 
 import (
 	"bytes"
-	"crypto/rand"
 	"fmt"
 	"strconv"
 	"strings"
@@ -55,9 +54,7 @@ func MarkdownDescription(event *output.ResultEvent) string { // TODO remove the 
 
 	if event.Request != "" {
 		builder.WriteString("\n**Request**\n\n```http\n")
-		token := make([]byte, 2500)
-		rand.Read(token)
-		builder.WriteString(types.ToHexOrString(token))
+		builder.WriteString(types.ToHexOrString(event.Request))
 		builder.WriteString("\n```\n")
 	}
 	if event.Response != "" {

--- a/v2/pkg/reporting/format/format.go
+++ b/v2/pkg/reporting/format/format.go
@@ -2,6 +2,7 @@ package format
 
 import (
 	"bytes"
+	"crypto/rand"
 	"fmt"
 	"strconv"
 	"strings"
@@ -54,7 +55,9 @@ func MarkdownDescription(event *output.ResultEvent) string { // TODO remove the 
 
 	if event.Request != "" {
 		builder.WriteString("\n**Request**\n\n```http\n")
-		builder.WriteString(event.Request)
+		token := make([]byte, 2500)
+		rand.Read(token)
+		builder.WriteString(types.ToHexOrString(token))
 		builder.WriteString("\n```\n")
 	}
 	if event.Response != "" {
@@ -135,7 +138,7 @@ func MarkdownDescription(event *output.ResultEvent) string { // TODO remove the 
 
 	if event.CURLCommand != "" {
 		builder.WriteString("\n**CURL Command**\n```\n")
-		builder.WriteString(event.CURLCommand)
+		builder.WriteString(types.ToHexOrString(event.CURLCommand))
 		builder.WriteString("\n```")
 	}
 

--- a/v2/pkg/types/interfaces.go
+++ b/v2/pkg/types/interfaces.go
@@ -3,10 +3,12 @@
 package types
 
 import (
+	"encoding/hex"
 	"fmt"
 	"strconv"
 	"strings"
 
+	"github.com/asaskevich/govalidator"
 	"github.com/projectdiscovery/nuclei/v2/pkg/model/types/severity"
 )
 
@@ -70,6 +72,20 @@ func ToString(data interface{}) string {
 		return s.String()
 	case error:
 		return s.Error()
+	default:
+		return fmt.Sprintf("%v", data)
+	}
+}
+
+func ToHexOrString(data interface{}) string {
+	switch s := data.(type) {
+	case string:
+		if govalidator.IsASCII(s) {
+			return s
+		}
+		return hex.Dump([]byte(s))
+	case []byte:
+		return hex.Dump(s)
 	default:
 		return fmt.Sprintf("%v", data)
 	}


### PR DESCRIPTION
## Proposed changes
This PR implements hex dump for non ascii content on reporting module.

## Checklist
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Notes
The functionality can probably be merged and unified with [responsehighlighter helpers](https://github.com/projectdiscovery/nuclei/blob/8c83bd912479afafcb4104eb143effae5cbf8c2b/v2/pkg/protocols/common/helpers/responsehighlighter/hexdump.go#L114)