### PR TITLE
improving default template path logic

### DIFF
--- a/v2/cmd/integration-test/template-path.go
+++ b/v2/cmd/integration-test/template-path.go
@@ -2,15 +2,14 @@ package main
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 
 	"github.com/projectdiscovery/nuclei/v2/pkg/testutils"
+	"github.com/projectdiscovery/nuclei/v2/pkg/utils"
 )
 
 func getTemplatePath() string {
-	home, _ := os.UserHomeDir()
-	return filepath.Join(home, "nuclei-templates")
+	templatePath, _ := utils.GetDefaultTemplatePath()
+	return templatePath
 }
 
 var templatesPathTestCases = map[string]testutils.TestCase{

--- a/v2/pkg/reporting/exporters/sarif/sarif.go
+++ b/v2/pkg/reporting/exporters/sarif/sarif.go
@@ -4,7 +4,6 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"os"
-	"path/filepath"
 	"strings"
 	"sync"
 
@@ -40,11 +39,10 @@ func New(options *Options) (*Exporter, error) {
 		return nil, errors.Wrap(err, "could not create sarif exporter")
 	}
 
-	home, err := os.UserHomeDir()
+	templatePath, err := utils.GetDefaultTemplatePath()
 	if err != nil {
-		return nil, errors.Wrap(err, "could not get home dir")
+		return nil, errors.Wrap(err, "could not template path")
 	}
-	templatePath := filepath.Join(home, "nuclei-templates")
 
 	run := sarif.NewRun("nuclei", "https://github.com/projectdiscovery/nuclei")
 	return &Exporter{options: options, home: templatePath, sarif: report, run: run, mutex: &sync.Mutex{}}, nil

--- a/v2/pkg/utils/template_path.go
+++ b/v2/pkg/utils/template_path.go
@@ -1,6 +1,8 @@
 package utils
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/projectdiscovery/nuclei/v2/pkg/catalog/config"
@@ -29,4 +31,13 @@ func TemplatePathURL(fullPath string) (string, string) {
 	finalPath := strings.TrimPrefix(strings.TrimPrefix(fullPath, templateDirectory), "/")
 	templateURL := TemplatesRepoURL + finalPath
 	return finalPath, templateURL
+}
+
+// GetDefaultTemplatePath on default settings
+func GetDefaultTemplatePath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, "nuclei-templates"), nil
 }


### PR DESCRIPTION
## Proposed changes
This PR improves the default template path handling in case of missing values both in the CLI option and config settings.

## Checklist
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)