### PR TITLE
Improving body dump logic for HTTP requests

### DIFF
--- a/v2/pkg/protocols/http/utils.go
+++ b/v2/pkg/protocols/http/utils.go
@@ -117,15 +117,17 @@ func dump(req *generatedRequest, reqURL string) ([]byte, error) {
 	if req.request != nil {
 		// Create a copy on the fly of the request body - ignore errors
 		bodyBytes, _ := req.request.BodyBytes()
+		var dumpBody bool
 		if len(bodyBytes) > 0 {
 			req.request.Request.ContentLength = int64(len(bodyBytes))
 			req.request.Request.Body = ioutil.NopCloser(bytes.NewReader(bodyBytes))
 		} else {
 			req.request.Request.ContentLength = 0
 			req.request.Request.Body = nil
+			delete(req.request.Request.Header, "Content-length")
 		}
 
-		dumpBytes, err := httputil.DumpRequestOut(req.request.Request, true)
+		dumpBytes, err := httputil.DumpRequestOut(req.request.Request, dumpBody)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Proposed changes
This PR improves the body dump logic by removing the content-length header before passing the HTTP request to the standard dump function

## Checklist
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)