### PR TITLE
Disable static compilation for osx

### DIFF
--- a/v2/Makefile
+++ b/v2/Makefile
@@ -3,11 +3,17 @@ GOCMD=go
 GOBUILD=$(GOCMD) build
 GOMOD=$(GOCMD) mod
 GOTEST=$(GOCMD) test
-GOGET=$(GOCMD) get
+GOFLAGS := -v
+# This should be disabled if the binary uses pprof
+LDFLAGS := -s -w
+
+ifneq ($(shell go env GOOS),darwin)
+LDFLAGS := -extldflags "-static"
+endif
     
 all: build
 build:
-	$(GOBUILD) -v -ldflags="-extldflags=-static" -o "nuclei" cmd/nuclei/main.go
+	$(GOBUILD) $(GOFLAGS) -ldflags '$(LDFLAGS)' -o "nuclei" cmd/nuclei/main.go
 docs:
 	if ! which dstdocgen > /dev/null; then
 		echo -e "Command not found! Install? (y/n) \c"
@@ -17,7 +23,7 @@ docs:
 	$(GOBUILD) -o "cmd/docgen/docgen" cmd/docgen/docgen.go
 	./cmd/docgen/docgen docs.md nuclei-jsonschema.json
 test:
-	$(GOTEST) -v ./...
+	$(GOTEST) $(GOFLAGS) ./...
 integration:
 	bash ../integration_tests/run.sh
 functional:


### PR DESCRIPTION
## Proposed changes
This PR disables static compilation for OSX and enables few compiler flags to reduce binary size and strip debugging symbols.

## Checklist
- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)