### PR TITLE
Added debug match/non-match listing with debug

### DIFF
--- a/v2/pkg/protocols/dns/request.go
+++ b/v2/pkg/protocols/dns/request.go
@@ -109,7 +109,7 @@ func (request *Request) ExecuteWithResults(input string, metadata /*TODO review 
 	for k, v := range vars {
 		outputEvent[k] = v
 	}
-	event := eventcreator.CreateEvent(request, outputEvent, request.options.Options.Debug || request.options.Options.DebugResponse)
+	event := eventcreator.CreateEvent(request, outputEvent, request.options.Options.Debug || request.options.Options.DebugRequests || request.options.Options.DebugResponse)
 	// TODO: dynamic values are not supported yet
 
 	dumpResponse(event, request, request.options, response.String(), domain)

--- a/v2/pkg/protocols/file/request.go
+++ b/v2/pkg/protocols/file/request.go
@@ -195,7 +195,7 @@ func (request *Request) processReader(reader io.Reader, filePath, input string, 
 
 func (request *Request) findMatchesWithReader(reader io.Reader, input, filePath string, totalBytes int64, previous output.InternalEvent) ([]FileMatch, *operators.Result) {
 	var bytesCount, linesCount, wordsCount int
-	isResponseDebug := request.options.Options.Debug || request.options.Options.DebugResponse
+	isResponseDebug := request.options.Options.Debug || request.options.Options.DebugRequests || request.options.Options.DebugResponse
 	totalBytesString := units.BytesSize(float64(totalBytes))
 
 	scanner := bufio.NewScanner(reader)

--- a/v2/pkg/protocols/headless/request.go
+++ b/v2/pkg/protocols/headless/request.go
@@ -112,7 +112,7 @@ func (request *Request) executeRequestWithPayloads(inputURL string, payloads map
 
 	var event *output.InternalWrappedEvent
 	if len(page.InteractshURLs) == 0 {
-		event = eventcreator.CreateEvent(request, outputEvent, request.options.Options.Debug || request.options.Options.DebugResponse)
+		event = eventcreator.CreateEvent(request, outputEvent, request.options.Options.Debug || request.options.Options.DebugRequests || request.options.Options.DebugResponse)
 		callback(event)
 	} else if request.options.Interactsh != nil {
 		event = &output.InternalWrappedEvent{InternalEvent: outputEvent}

--- a/v2/pkg/protocols/http/request.go
+++ b/v2/pkg/protocols/http/request.go
@@ -585,7 +585,7 @@ func (request *Request) executeRequest(reqURL string, generatedRequest *generate
 		// prune signature internal values if any
 		request.pruneSignatureInternalValues(generatedRequest.meta)
 
-		event := eventcreator.CreateEventWithAdditionalOptions(request, generators.MergeMaps(generatedRequest.dynamicValues, finalEvent), request.options.Options.Debug || request.options.Options.DebugResponse, func(internalWrappedEvent *output.InternalWrappedEvent) {
+		event := eventcreator.CreateEventWithAdditionalOptions(request, generators.MergeMaps(generatedRequest.dynamicValues, finalEvent), request.options.Options.Debug || request.options.Options.DebugRequests || request.options.Options.DebugResponse, func(internalWrappedEvent *output.InternalWrappedEvent) {
 			internalWrappedEvent.OperatorsResult.PayloadValues = generatedRequest.meta
 		})
 		if hasInteractMatchers {

--- a/v2/pkg/protocols/network/request.go
+++ b/v2/pkg/protocols/network/request.go
@@ -190,14 +190,14 @@ func (request *Request) executeRequestWithPayloads(variables map[string]interfac
 	}
 	request.options.Progress.IncrementRequests()
 
-	if request.options.Options.Debug || request.options.Options.DebugRequests || request.options.Options.StoreResponse{
+	if request.options.Options.Debug || request.options.Options.DebugRequests || request.options.Options.StoreResponse {
 		requestBytes := []byte(reqBuilder.String())
 		msg := fmt.Sprintf("[%s] Dumped Network request for %s\n%s", request.options.TemplateID, actualAddress, hex.Dump(requestBytes))
 		if request.options.Options.Debug || request.options.Options.DebugRequests {
-		gologger.Info().Str("address", actualAddress).Msg(msg)
+			gologger.Info().Str("address", actualAddress).Msg(msg)
 		}
-		if request.options.Options.StoreResponse{
-		request.options.Output.WriteStoreDebugData(address, request.options.TemplateID, request.Type().String(), msg)
+		if request.options.Options.StoreResponse {
+			request.options.Output.WriteStoreDebugData(address, request.options.TemplateID, request.Type().String(), msg)
 		}
 		if request.options.Options.VerboseVerbose {
 			gologger.Print().Msgf("\nCompact HEX view:\n%s", hex.EncodeToString(requestBytes))
@@ -275,7 +275,7 @@ func (request *Request) executeRequestWithPayloads(variables map[string]interfac
 
 	var event *output.InternalWrappedEvent
 	if len(interactshURLs) == 0 {
-		event = eventcreator.CreateEventWithAdditionalOptions(request, generators.MergeMaps(payloads, outputEvent), request.options.Options.Debug || request.options.Options.DebugResponse, func(wrappedEvent *output.InternalWrappedEvent) {
+		event = eventcreator.CreateEventWithAdditionalOptions(request, generators.MergeMaps(payloads, outputEvent), request.options.Options.Debug || request.options.Options.DebugRequests || request.options.Options.DebugResponse, func(wrappedEvent *output.InternalWrappedEvent) {
 			wrappedEvent.OperatorsResult.PayloadValues = payloads
 		})
 		callback(event)
@@ -300,15 +300,15 @@ func (request *Request) executeRequestWithPayloads(variables map[string]interfac
 
 func dumpResponse(event *output.InternalWrappedEvent, request *Request, response string, actualAddress, address string) {
 	cliOptions := request.options.Options
-	if cliOptions.Debug || cliOptions.DebugResponse || cliOptions.StoreResponse{
+	if cliOptions.Debug || cliOptions.DebugResponse || cliOptions.StoreResponse {
 		requestBytes := []byte(response)
 		highlightedResponse := responsehighlighter.Highlight(event.OperatorsResult, hex.Dump(requestBytes), cliOptions.NoColor, true)
 		msg := fmt.Sprintf("[%s] Dumped Network response for %s\n\n", request.options.TemplateID, actualAddress)
 		if cliOptions.Debug || cliOptions.DebugResponse {
-		gologger.Debug().Msg(fmt.Sprintf("%s%s", msg, highlightedResponse))
+			gologger.Debug().Msg(fmt.Sprintf("%s%s", msg, highlightedResponse))
 		}
-		if cliOptions.StoreResponse{
-		request.options.Output.WriteStoreDebugData(address, request.options.TemplateID, request.Type().String(), fmt.Sprintf("%s%s", msg, hex.Dump(requestBytes)))
+		if cliOptions.StoreResponse {
+			request.options.Output.WriteStoreDebugData(address, request.options.TemplateID, request.Type().String(), fmt.Sprintf("%s%s", msg, hex.Dump(requestBytes)))
 		}
 		if cliOptions.VerboseVerbose {
 			displayCompactHexView(event, response, cliOptions.NoColor)

--- a/v2/pkg/protocols/offlinehttp/request.go
+++ b/v2/pkg/protocols/offlinehttp/request.go
@@ -91,7 +91,7 @@ func (request *Request) ExecuteWithResults(input string, metadata /*TODO review 
 				outputEvent[k] = v
 			}
 
-			event := eventcreator.CreateEvent(request, outputEvent, request.options.Options.Debug || request.options.Options.DebugResponse)
+			event := eventcreator.CreateEvent(request, outputEvent, request.options.Options.Debug || request.options.Options.DebugRequests || request.options.Options.DebugResponse)
 			callback(event)
 		}(data)
 	})

--- a/v2/pkg/protocols/ssl/ssl.go
+++ b/v2/pkg/protocols/ssl/ssl.go
@@ -227,6 +227,7 @@ func (request *Request) ExecuteWithResults(input string, dynamicValues, previous
 
 	data := make(map[string]interface{})
 
+	data["template-id"] = request.options.TemplateID
 	data["type"] = request.Type().String()
 	data["response"] = jsonDataString
 	data["host"] = input

--- a/v2/pkg/protocols/ssl/ssl.go
+++ b/v2/pkg/protocols/ssl/ssl.go
@@ -234,15 +234,15 @@ func (request *Request) ExecuteWithResults(input string, dynamicValues, previous
 	data["not_after"] = float64(certNotAfter)
 	data["ip"] = request.dialer.GetDialedIP(hostname)
 
-	event := eventcreator.CreateEvent(request, data, requestOptions.Options.Debug || requestOptions.Options.DebugResponse)
+	event := eventcreator.CreateEvent(request, data, requestOptions.Options.Debug || request.options.Options.DebugRequests || requestOptions.Options.DebugResponse)
 	if requestOptions.Options.Debug || requestOptions.Options.DebugResponse || requestOptions.Options.StoreResponse {
 		msg := fmt.Sprintf("[%s] Dumped SSL response for %s", requestOptions.TemplateID, input)
 		if requestOptions.Options.Debug || requestOptions.Options.DebugResponse {
-		gologger.Debug().Msg(msg)
-		gologger.Print().Msgf("%s", responsehighlighter.Highlight(event.OperatorsResult, jsonDataString, requestOptions.Options.NoColor, false))
+			gologger.Debug().Msg(msg)
+			gologger.Print().Msgf("%s", responsehighlighter.Highlight(event.OperatorsResult, jsonDataString, requestOptions.Options.NoColor, false))
 		}
 		if requestOptions.Options.StoreResponse {
-		request.options.Output.WriteStoreDebugData(input, request.options.TemplateID, request.Type().String(), fmt.Sprintf("%s\n%s", msg, jsonDataString))
+			request.options.Output.WriteStoreDebugData(input, request.options.TemplateID, request.Type().String(), fmt.Sprintf("%s\n%s", msg, jsonDataString))
 		}
 	}
 	callback(event)

--- a/v2/pkg/protocols/websocket/websocket.go
+++ b/v2/pkg/protocols/websocket/websocket.go
@@ -246,6 +246,7 @@ func (request *Request) executeRequestWithPayloads(input, hostname string, dynam
 		data[k] = v
 	}
 
+	data["template-id"] = request.options.TemplateID
 	data["type"] = request.Type().String()
 	data["success"] = "true"
 	data["request"] = requestOutput

--- a/v2/pkg/protocols/websocket/websocket.go
+++ b/v2/pkg/protocols/websocket/websocket.go
@@ -254,7 +254,7 @@ func (request *Request) executeRequestWithPayloads(input, hostname string, dynam
 	data["matched"] = addressToDial
 	data["ip"] = request.dialer.GetDialedIP(hostname)
 
-	event := eventcreator.CreateEventWithAdditionalOptions(request, data, requestOptions.Options.Debug || requestOptions.Options.DebugResponse, func(internalWrappedEvent *output.InternalWrappedEvent) {
+	event := eventcreator.CreateEventWithAdditionalOptions(request, data, requestOptions.Options.Debug || request.options.Options.DebugRequests || requestOptions.Options.DebugResponse, func(internalWrappedEvent *output.InternalWrappedEvent) {
 		internalWrappedEvent.OperatorsResult.PayloadValues = payloadValues
 	})
 	if requestOptions.Options.Debug || requestOptions.Options.DebugResponse {

--- a/v2/pkg/protocols/whois/whois.go
+++ b/v2/pkg/protocols/whois/whois.go
@@ -116,6 +116,7 @@ func (request *Request) ExecuteWithResults(input string, dynamicValues, previous
 	jsonData, _ := jsoniter.Marshal(response)
 	jsonDataString := string(jsonData)
 
+	data["template-id"] = request.options.TemplateID
 	data["type"] = request.Type().String()
 	data["host"] = query
 	data["response"] = jsonDataString

--- a/v2/pkg/protocols/whois/whois.go
+++ b/v2/pkg/protocols/whois/whois.go
@@ -120,7 +120,7 @@ func (request *Request) ExecuteWithResults(input string, dynamicValues, previous
 	data["host"] = query
 	data["response"] = jsonDataString
 
-	event := eventcreator.CreateEvent(request, data, request.options.Options.Debug || request.options.Options.DebugResponse)
+	event := eventcreator.CreateEvent(request, data, request.options.Options.Debug || request.options.Options.DebugRequests || request.options.Options.DebugResponse)
 	if request.options.Options.Debug || request.options.Options.DebugResponse {
 		gologger.Debug().Msgf("[%s] Dumped WHOIS response for %s", request.options.TemplateID, query)
 		gologger.Print().Msgf("%s", responsehighlighter.Highlight(event.OperatorsResult, jsonDataString, request.options.Options.NoColor, false))


### PR DESCRIPTION
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->
Added debug mode match/non-match display.

```
> ./nuclei -t template.yaml -u https://www.dropbox.com -debug-req

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   2.6.9

                projectdiscovery.io

[WRN] Use with caution. You are responsible for your actions.
[WRN] Developers assume no liability and are not responsible for any misuse or damage.
[INF] Using Nuclei Engine 2.6.9 (latest)
[INF] Using Nuclei Templates 8.9.8 (latest)
[INF] Templates added in last update: 27
[INF] Templates loaded for scan: 1
[INF] [test-template] Dumped HTTP request for https://www.dropbox.com

GET /login HTTP/1.1
Host: www.dropbox.com
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2227.1 Safari/537.36
Connection: close
Accept: */*
Accept-Language: en
Accept-Encoding: gzip

[DBG] [test-template:status-1] [HTTP/1.1 200] Matched ✔
[DBG] [test-template:word-2] Not Matched ❌
[INF] No results found. Better luck next time!
```

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)