### PR TITLE
Adding global SNI support for HTTP protocol via CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ nuclei -h
 This will display help for the tool. Here are all the switches it supports.
 
 
-```yaml
+```console
 Nuclei is a fast, template based vulnerability scanner focusing
 on extensive configurability, massive extensibility and ease of use.
 
@@ -150,6 +150,7 @@ CONFIGURATIONS:
    -ck, -client-key string     client key file (PEM-encoded) used for authenticating against scanned hosts
    -ca, -client-ca string      client certificate authority file (PEM-encoded) used for authenticating against scanned hosts
    -ztls                       Use ztls library with autofallback to standard one for tls13
+   -sni string                 Global SNI hostname (default: input domain name)
 
 INTERACTSH:
    -iserver, -interactsh-server string  interactsh server url for self-hosted instance (default: oast.pro,oast.live,oast.site,oast.online,oast.fun,oast.me)

--- a/integration_tests/http/get-sni.yaml
+++ b/integration_tests/http/get-sni.yaml
@@ -1,0 +1,15 @@
+id: basic-get
+
+info:
+  name: Basic GET Request with CLI SNI
+  author: pdteam
+  severity: info
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    matchers:
+      - type: word
+        words:
+          - "test-ok"

--- a/v2/cmd/integration-test/http.go
+++ b/v2/cmd/integration-test/http.go
@@ -47,6 +47,7 @@ var httpTestcases = map[string]testutils.TestCase{
 	"http/race-multiple.yaml":                       &httpRaceMultiple{},
 	"http/stop-at-first-match.yaml":                 &httpStopAtFirstMatch{},
 	"http/stop-at-first-match-with-extractors.yaml": &httpStopAtFirstMatchWithExtractors{},
+	"http/variables.yaml":                           &httpVariables{},
 	"http/get-sni.yaml":                             &customCLISNI{},
 }
 
@@ -818,9 +819,9 @@ func (h *customCLISNI) Execute(filePath string) error {
 	router := httprouter.New()
 	router.GET("/", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 		if r.TLS.ServerName == "test" {
-			w.Write([]byte("test-ok"))
+			_, _ = w.Write([]byte("test-ok"))
 		} else {
-			w.Write([]byte("test-ko"))
+			_, _ = w.Write([]byte("test-ko"))
 		}
 	})
 	ts := httptest.NewTLSServer(router)

--- a/v2/cmd/nuclei/main.go
+++ b/v2/cmd/nuclei/main.go
@@ -147,6 +147,7 @@ on extensive configurability, massive extensibility and ease of use.`)
 		flagSet.StringVarP(&options.ClientKeyFile, "client-key", "ck", "", "client key file (PEM-encoded) used for authenticating against scanned hosts"),
 		flagSet.StringVarP(&options.ClientCAFile, "client-ca", "ca", "", "client certificate authority file (PEM-encoded) used for authenticating against scanned hosts"),
 		flagSet.BoolVar(&options.ZTLS, "ztls", false, "Use ztls library with autofallback to standard one for tls13"),
+		flagSet.StringVar(&options.SNI, "sni", "", "Global SNI hostname (default: input domain name)"),
 	)
 
 	createGroup(flagSet, "interactsh", "interactsh",

--- a/v2/pkg/protocols/headless/engine/http_client.go
+++ b/v2/pkg/protocols/headless/engine/http_client.go
@@ -28,6 +28,10 @@ func newHttpClient(options *types.Options) (*http.Client, error) {
 		InsecureSkipVerify: true,
 	}
 
+	if options.SNI != "" {
+		tlsConfig.ServerName = options.SNI
+	}
+
 	// Add the client certificate authentication to the request if it's configured
 	var err error
 	tlsConfig, err = utils.AddConfiguredClientCertToRequest(tlsConfig, options)

--- a/v2/pkg/protocols/http/httpclientpool/clientpool.go
+++ b/v2/pkg/protocols/http/httpclientpool/clientpool.go
@@ -179,6 +179,10 @@ func wrappedGet(options *types.Options, configuration *Configuration) (*retryabl
 		InsecureSkipVerify: true,
 	}
 
+	if options.SNI != "" {
+		tlsConfig.ServerName = options.SNI
+	}
+
 	// Add the client certificate authentication to the request if it's configured
 	tlsConfig, err = utils.AddConfiguredClientCertToRequest(tlsConfig, options)
 	if err != nil {

--- a/v2/pkg/protocols/websocket/websocket.go
+++ b/v2/pkg/protocols/websocket/websocket.go
@@ -185,11 +185,15 @@ func (request *Request) executeRequestWithPayloads(input, hostname string, dynam
 		}
 		header.Set(key, string(finalData))
 	}
+	tlsConfig := &tls.Config{InsecureSkipVerify: true, ServerName: hostname}
+	if requestOptions.Options.SNI != "" {
+		tlsConfig.ServerName = requestOptions.Options.SNI
+	}
 	websocketDialer := ws.Dialer{
 		Header:    ws.HandshakeHeaderHTTP(header),
 		Timeout:   time.Duration(requestOptions.Options.Timeout) * time.Second,
 		NetDial:   request.dialer.Dial,
-		TLSConfig: &tls.Config{InsecureSkipVerify: true, ServerName: hostname},
+		TLSConfig: tlsConfig,
 	}
 
 	finalAddress, dataErr := expressions.EvaluateByte([]byte(request.Address), payloadValues)

--- a/v2/pkg/types/types.go
+++ b/v2/pkg/types/types.go
@@ -214,6 +214,8 @@ type Options struct {
 	StoreResponseDir string
 	// DisableRedirects disables following redirects for http request module
 	DisableRedirects bool
+	// SNI custom hostname
+	SNI string
 }
 
 func (options *Options) AddVarPayload(key string, value interface{}) {


### PR DESCRIPTION
## Proposed changes
This PR adds support for custom SNI hostname via the new CLI paramter `-sni`

## Checklist
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Example
`test.yaml`
```yaml
id: test

info:
  name: test
  author: test
  severity: info
  tags: test

requests:
  - raw:
      - |
        GET / HTTP/1.1
        Host: test
```

Command:
```console
$ echo https://192.168.1.1 | go run . -t test.yaml -sni test123
```

Wireshark:
<img width="735" alt="Screenshot 2022-05-11 at 08 38 44" src="https://user-images.githubusercontent.com/13421144/167784539-94ad462f-fde9-4520-86dd-8f2f9a34db82.png">

