### PR TITLE
Use nuclei-templates instead of custom autoscan directory list

### DIFF
--- a/v2/pkg/protocols/common/automaticscan/automaticscan.go
+++ b/v2/pkg/protocols/common/automaticscan/automaticscan.go
@@ -67,6 +67,8 @@ func New(opts Options) (*Service, error) {
 	if opts.ExecuterOpts.Options.Verbose {
 		gologger.Verbose().Msgf("Normalized mapping (%d): %v\n", len(mappingData), mappingData)
 	}
+	defaultTemplatesDirectories := []string{"nuclei-templates/"}
+
 	// adding custom template path if available
 	if len(opts.ExecuterOpts.Options.Templates) > 0 {
 		defaultTemplatesDirectories = append(defaultTemplatesDirectories, opts.ExecuterOpts.Options.Templates...)
@@ -117,10 +119,6 @@ func (s *Service) Execute() {
 		gologger.Error().Msgf("Could not execute wappalyzer based detection: %s", err)
 	}
 }
-
-var (
-	defaultTemplatesDirectories = []string{"cves/", "default-logins/", "dns/", "exposures/", "miscellaneous/", "misconfiguration/", "network/", "takeovers/", "vulnerabilities/"}
-)
 
 const maxDefaultBody = 2 * 1024 * 1024
 

--- a/v2/pkg/protocols/common/automaticscan/automaticscan.go
+++ b/v2/pkg/protocols/common/automaticscan/automaticscan.go
@@ -67,7 +67,7 @@ func New(opts Options) (*Service, error) {
 	if opts.ExecuterOpts.Options.Verbose {
 		gologger.Verbose().Msgf("Normalized mapping (%d): %v\n", len(mappingData), mappingData)
 	}
-	defaultTemplatesDirectories := []string{"nuclei-templates/"}
+	defaultTemplatesDirectories := []string{config.TemplatesDirectory}
 
 	// adding custom template path if available
 	if len(opts.ExecuterOpts.Options.Templates) > 0 {


### PR DESCRIPTION
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->
Replaced custom automatic scan directory list with default nuclei-templates directory to allow loading of all templates based on identified tags. Closes #1950

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)