### PR TITLE
Adding SNI override via request annotations

### DIFF
--- a/integration_tests/http/get-override-sni.yaml
+++ b/integration_tests/http/get-override-sni.yaml
@@ -1,0 +1,18 @@
+id: basic-raw-http-example
+
+info:
+  name: Test RAW GET Template
+  author: pdteam
+  severity: info
+
+requests:
+  - raw:
+      - |
+        @tls-sni:request.host
+        GET / HTTP/1.1
+        Host: test
+
+    matchers:
+      - type: word
+        words:
+          - "test-ok"

--- a/v2/cmd/integration-test/http.go
+++ b/v2/cmd/integration-test/http.go
@@ -48,6 +48,7 @@ var httpTestcases = map[string]testutils.TestCase{
 	"http/stop-at-first-match.yaml":                 &httpStopAtFirstMatch{},
 	"http/stop-at-first-match-with-extractors.yaml": &httpStopAtFirstMatchWithExtractors{},
 	"http/variables.yaml":                           &httpVariables{},
+	"http/get-override-sni.yaml":                    &httpSniAnnotation{},
 }
 
 type httpInteractshRequest struct{}
@@ -808,5 +809,27 @@ func (h *httpVariables) Execute(filePath string) error {
 		return err
 	}
 
+	return expectResultsCount(results, 1)
+}
+
+type httpSniAnnotation struct{}
+
+// Execute executes a test case and returns an error if occurred
+func (h *httpSniAnnotation) Execute(filePath string) error {
+	router := httprouter.New()
+	router.GET("/", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+		if r.TLS.ServerName == "test" {
+			_, _ = w.Write([]byte("test-ok"))
+		} else {
+			_, _ = w.Write([]byte("test-ko"))
+		}
+	})
+	ts := httptest.NewTLSServer(router)
+	defer ts.Close()
+
+	results, err := testutils.RunNucleiTemplateAndGetResults(filePath, ts.URL, debug)
+	if err != nil {
+		return err
+	}
 	return expectResultsCount(results, 1)
 }

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/projectdiscovery/clistats v0.0.8
 	github.com/projectdiscovery/cryptoutil v1.0.0
-	github.com/projectdiscovery/fastdialer v0.0.15-0.20220127193345-f06b0fd54d47
+	github.com/projectdiscovery/fastdialer v0.0.16-0.20220509174423-0e57a7c8cf83
 	github.com/projectdiscovery/filekv v0.0.0-20210915124239-3467ef45dd08
 	github.com/projectdiscovery/fileutil v0.0.0-20220427234316-40b2541a84b8
 	github.com/projectdiscovery/goflags v0.0.8-0.20220412061559-5119d6086323

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -436,6 +436,8 @@ github.com/projectdiscovery/cryptoutil v1.0.0/go.mod h1:VJvSNE8f8A1MgpjgAL2GPJSQ
 github.com/projectdiscovery/fastdialer v0.0.12/go.mod h1:RkRbxqDCcCFhfNUbkzBIz/ieD4uda2JuUA4WJ+RLee0=
 github.com/projectdiscovery/fastdialer v0.0.15-0.20220127193345-f06b0fd54d47 h1:TUsZiwez9uFmph1hlTsiH7rdB+wi4524+lMuV2z6FaM=
 github.com/projectdiscovery/fastdialer v0.0.15-0.20220127193345-f06b0fd54d47/go.mod h1:GbQvP1ezGlQn0af3lVcl08b5eRQu960T7A9pwazybSo=
+github.com/projectdiscovery/fastdialer v0.0.16-0.20220509174423-0e57a7c8cf83 h1:1hzvl0lsWpvQ8nn1s9YMyBjO13/Z+f/T4W2jroOohfo=
+github.com/projectdiscovery/fastdialer v0.0.16-0.20220509174423-0e57a7c8cf83/go.mod h1:wn6jSJ1fIO6kLplFEbFIkRB6Kj/Q6VngnzKuBHLVPiI=
 github.com/projectdiscovery/filekv v0.0.0-20210915124239-3467ef45dd08 h1:NwD1R/du1dqrRKN3SJl9kT6tN3K9puuWFXEvYF2ihew=
 github.com/projectdiscovery/filekv v0.0.0-20210915124239-3467ef45dd08/go.mod h1:paLCnwV8sL7ppqIwVQodQrk3F6mnWafwTDwRd7ywZwQ=
 github.com/projectdiscovery/fileutil v0.0.0-20210914153648-31f843feaad4/go.mod h1:U+QCpQnX8o2N2w0VUGyAzjM3yBAe4BKedVElxiImsx0=

--- a/v2/pkg/protocols/common/protocolstate/state.go
+++ b/v2/pkg/protocols/common/protocolstate/state.go
@@ -21,6 +21,7 @@ func Init(options *types.Options) error {
 	}
 	opts.WithDialerHistory = true
 	opts.WithZTLS = options.ZTLS
+	opts.SNIName = options.SNI
 	dialer, err := fastdialer.NewDialer(opts)
 	if err != nil {
 		return errors.Wrap(err, "could not create dialer")

--- a/v2/pkg/protocols/headless/engine/http_client.go
+++ b/v2/pkg/protocols/headless/engine/http_client.go
@@ -37,6 +37,7 @@ func newHttpClient(options *types.Options) (*http.Client, error) {
 
 	transport := &http.Transport{
 		DialContext:         dialer.Dial,
+		DialTLSContext:      dialer.DialTLS,
 		MaxIdleConns:        500,
 		MaxIdleConnsPerHost: 500,
 		MaxConnsPerHost:     500,

--- a/v2/pkg/protocols/http/build_request.go
+++ b/v2/pkg/protocols/http/build_request.go
@@ -288,7 +288,10 @@ func (r *requestGenerator) handleRawWithPayloads(ctx context.Context, rawRequest
 		return nil, err
 	}
 
-	parseAnnotations(rawRequest, req)
+	if reqWithAnnotations, hasAnnotations := parseAnnotations(rawRequest, req); hasAnnotations {
+		req = reqWithAnnotations
+		request = request.WithContext(req.Context())
+	}
 
 	return &generatedRequest{request: request, meta: generatorValues, original: r.request, dynamicValues: finalValues, interactshURLs: r.interactshURLs}, nil
 }

--- a/v2/pkg/protocols/http/httpclientpool/clientpool.go
+++ b/v2/pkg/protocols/http/httpclientpool/clientpool.go
@@ -187,6 +187,7 @@ func wrappedGet(options *types.Options, configuration *Configuration) (*retryabl
 
 	transport := &http.Transport{
 		DialContext:         Dialer.Dial,
+		DialTLSContext:      Dialer.DialTLS,
 		MaxIdleConns:        maxIdleConns,
 		MaxIdleConnsPerHost: maxIdleConnsPerHost,
 		MaxConnsPerHost:     maxConnsPerHost,

--- a/v2/pkg/reporting/exporters/es/elasticsearch.go
+++ b/v2/pkg/reporting/exporters/es/elasticsearch.go
@@ -63,6 +63,7 @@ func New(option *Options) (*Exporter, error) {
 				MaxIdleConns:        10,
 				MaxIdleConnsPerHost: 10,
 				DialContext:         protocolstate.Dialer.Dial,
+				DialTLSContext:      protocolstate.Dialer.DialTLS,
 				TLSClientConfig:     &tls.Config{InsecureSkipVerify: option.SSLVerification},
 			},
 		}


### PR DESCRIPTION
## Proposed changes
This PR implements SNI override via request annotations. The annotations has a syntax like `@tls-sni:value`. if `value` is equal to `request.host` then the value of the `Host` header is used as SNI name.

## Checklist
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Correlated PRs
- https://github.com/projectdiscovery/fastdialer/pull/35
- https://github.com/projectdiscovery/nuclei-docs/pull/37

## Example
```console
$ cat t.yaml
id: example

info:
  name: example
  author: pdteam
  severity: info

requests:
  - raw:
      # request.host => copy the value of Host header
      # any other value is copied literally
      - |
        @tls-sni:request.host
        GET / HTTP/1.1
        Host: test
        Origin: {{BaseURL}}

    matchers:
      - type: word
        words:
          - "test ok"
$ echo https://192.168.1.1 | go run . -t t.yaml
```

## Improvements
- SNI for SSL Templates
- SNI for Network templates