### PR TITLE
Helper functions

### DIFF
--- a/v2/pkg/operators/common/dsl/dsl.go
+++ b/v2/pkg/operators/common/dsl/dsl.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"compress/zlib"
+	"crypto/hmac"
 	"crypto/md5"
 	"crypto/sha1"
 	"crypto/sha256"
@@ -227,6 +228,11 @@ func init() {
 			decodeString, err := hex.DecodeString(types.ToString(args[0]))
 			return string(decodeString), err
 		}),
+		"hmac_sha1": makeDslFunction(2, func(args ...interface{}) (interface{}, error) {
+			h := hmac.New(sha1.New, []byte(args[1].(string)))
+			h.Write([]byte(args[0].(string)))
+			return hex.EncodeToString(h.Sum(nil)), nil
+		}),
 		"html_escape": makeDslFunction(1, func(args ...interface{}) (interface{}, error) {
 			return html.EscapeString(types.ToString(args[0])), nil
 		}),
@@ -265,6 +271,23 @@ func init() {
 				builder := &strings.Builder{}
 				for _, argument := range arguments {
 					builder.WriteString(types.ToString(argument))
+				}
+				return builder.String(), nil
+			},
+		),
+		"concat_ws": makeDslWithOptionalArgsFunction(
+			"(args ...interface{}) string",
+			func(arguments ...interface{}) (interface{}, error) {
+				builder := &strings.Builder{}
+				separator := arguments[len(arguments)-1]
+				arguments = arguments[:len(arguments)-1]
+
+				for i, argument := range arguments {
+					builder.WriteString(types.ToString(argument))
+
+					if i != len(arguments)-1 {
+						builder.WriteString(types.ToString(separator))
+					}
 				}
 				return builder.String(), nil
 			},

--- a/v2/pkg/operators/common/dsl/dsl_test.go
+++ b/v2/pkg/operators/common/dsl/dsl_test.go
@@ -110,6 +110,7 @@ func TestGetPrintableDslFunctionSignatures(t *testing.T) {
 	[93mbase64_py[0m(arg1 [38;5;208minterface{}[0m)[38;5;208m interface{}[0m
 	[93mcompare_versions[0m(firstVersion, constraints [38;5;208m...string[0m)[38;5;208m bool[0m
 	[93mconcat[0m(args [38;5;208m...interface{}[0m)[38;5;208m string[0m
+	[93mconcat_ws[0m(args [38;5;208m...interface{}[0m)[38;5;208m string[0m
 	[93mcontains[0m(arg1, arg2 [38;5;208minterface{}[0m)[38;5;208m interface{}[0m
 	[93mdate[0m(arg1 [38;5;208minterface{}[0m)[38;5;208m interface{}[0m
 	[93mdec_to_hex[0m(arg1 [38;5;208minterface{}[0m)[38;5;208m interface{}[0m
@@ -118,6 +119,7 @@ func TestGetPrintableDslFunctionSignatures(t *testing.T) {
 	[93mgzip_decode[0m(arg1 [38;5;208minterface{}[0m)[38;5;208m interface{}[0m
 	[93mhex_decode[0m(arg1 [38;5;208minterface{}[0m)[38;5;208m interface{}[0m
 	[93mhex_encode[0m(arg1 [38;5;208minterface{}[0m)[38;5;208m interface{}[0m
+	[93mhmac_sha1[0m(arg1, arg2 [38;5;208minterface{}[0m)[38;5;208m interface{}[0m
 	[93mhtml_escape[0m(arg1 [38;5;208minterface{}[0m)[38;5;208m interface{}[0m
 	[93mhtml_unescape[0m(arg1 [38;5;208minterface{}[0m)[38;5;208m interface{}[0m
 	[93mlen[0m(arg1 [38;5;208minterface{}[0m)[38;5;208m interface{}[0m
@@ -188,6 +190,7 @@ func TestDslExpressions(t *testing.T) {
 		`remove_bad_chars("abcd", "bc")`:                 "ad",
 		`replace("Hello", "He", "Ha")`:                   "Hallo",
 		`concat("Hello", 123, "world")`:                  "Hello123world",
+		`concat_ws("Hello", 123, "world", "_")`:          "Hello_123_world",
 		`repeat("a", 5)`:                                 "aaaaa",
 		`repeat("a", "5")`:                               "aaaaa",
 		`repeat("../", "5")`:                             "../../../../../",
@@ -226,6 +229,7 @@ func TestDslExpressions(t *testing.T) {
 		`compare_versions('v1.1.1', '>v1.1.0')`:            true,
 		`compare_versions('v1.0.0', '>v0.0.1,<v1.0.1')`:    true,
 		`compare_versions('v1.0.0', '>v0.0.1', '<v1.0.1')`: true,
+		`hmac_sha1('test','scrt')`:                         "8856b111056d946d5c6c92a21b43c233596623c6",
 	}
 
 	for dslExpression, expectedResult := range dslExpressions {


### PR DESCRIPTION
hmac_sha1 and concat_ws (with seperator) these are helpful in
signing API requests.

Examples:

|`concat_ws("Hello", 123, "world", "_")`  |        `Hello_123_world`
--|--
|`hmac_sha1('test','scrt')`          |               `8856b111056d946d5c6c92a21b43c233596623c6`

## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->

Creates two new DSL helper functions. One for hmac_sha1 and another for concat_ws (which is concat with a separator.

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)