### PR TITLE
use request  numbering as per template definition in req-condition

### DIFF
--- a/v2/pkg/protocols/http/request.go
+++ b/v2/pkg/protocols/http/request.go
@@ -582,6 +582,7 @@ func (request *Request) executeRequest(reqURL string, generatedRequest *generate
 		if request.ReqCondition {
 			for k, v := range outputEvent {
 				key := fmt.Sprintf("%s_%d", k, requestCount)
+				previousEvent[key] = v
 				finalEvent[key] = v
 			}
 		}

--- a/v2/pkg/protocols/http/request.go
+++ b/v2/pkg/protocols/http/request.go
@@ -240,7 +240,6 @@ func (request *Request) ExecuteWithResults(reqURL string, dynamicValues, previou
 	generator := request.newGenerator()
 
 	var gotDynamicValues map[string][]string
-	requestCount := 1
 	var requestErr error
 	for {
 		// returns two values, error and skip, which skips the execution for the request instance.
@@ -285,7 +284,7 @@ func (request *Request) ExecuteWithResults(reqURL string, dynamicValues, previou
 				} else {
 					callback(event)
 				}
-			}, requestCount)
+			}, generator.currentIndex)
 
 			// If a variable is unresolved, skip all further requests
 			if err == errStopExecution {
@@ -297,7 +296,6 @@ func (request *Request) ExecuteWithResults(reqURL string, dynamicValues, previou
 				}
 				requestErr = err
 			}
-			requestCount++
 			request.options.Progress.IncrementRequests()
 
 			// If this was a match, and we want to stop at first match, skip all further requests.
@@ -584,7 +582,6 @@ func (request *Request) executeRequest(reqURL string, generatedRequest *generate
 		if request.ReqCondition {
 			for k, v := range outputEvent {
 				key := fmt.Sprintf("%s_%d", k, requestCount)
-				previousEvent[key] = v
 				finalEvent[key] = v
 			}
 		}


### PR DESCRIPTION
Below template should match only on changing `status_code_8` to `status_code_2` in the matcher:
```yaml
id: login-dome

info:
  name: Login-dome
  author: dome
  severity: high

requests:
  - raw:
      - |
        GET /login.php HTTP/1.1
        Host: {{Hostname}}

      - |
        POST /login.php HTTP/1.1
        Host: {{Hostname}}
        Content-Type: application/x-www-form-urlencoded

        username={{usernames}}&password={{passwords}}

    attack: clusterbomb
    payloads:
      usernames:
        - "user"
        - "root"

      passwords:
        - "123456"
        - "111111"

    req-condition: true
    matchers:
      - type: dsl
        dsl:
          - status_code_8 == 404
```
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->


## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)