### PR TITLE
protect against multiple unnecessary Init calls

### DIFF
--- a/v2/pkg/protocols/common/protocolstate/state.go
+++ b/v2/pkg/protocols/common/protocolstate/state.go
@@ -12,6 +12,9 @@ var Dialer *fastdialer.Dialer
 
 // Init creates the Dialer instance based on user configuration
 func Init(options *types.Options) error {
+	if Dialer != nil {
+		return nil
+	}
 	opts := fastdialer.DefaultOptions
 	if options.SystemResolvers {
 		opts.EnableFallback = true


### PR DESCRIPTION
## Proposed changes

We are using Nuclei as an embedded library, and ran a loop such that we were calling `protocolinit.Init(defaultOpts)` many times.  In this `Init` function, `fastdialer.NewDialer(opts)` is called, which calls `loadResolverFile()` which attempts to open a file.

When running Nuclei embedded in an AWS lambda, where there are [tight limits on the number of open file descriptors](https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-limits.html) you can open, we quickly ran into this error: 

`could not create dialer: open /tmp/hm4055102281/LOG: too many open files` 

It may be the case that running such a loop and re-initing is user error (mine!), but I think this PR may offer a bit of safety for the unaware.

Also notice in the checklist below it calls for PRs against `nuclei/tree/dev` branch.  Should it just say `nuclei/dev` instead?

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)