### PR TITLE
Adding prototype for unexpected fields validation in matchers

### DIFF
--- a/v2/pkg/operators/matchers/compile.go
+++ b/v2/pkg/operators/matchers/compile.go
@@ -31,6 +31,12 @@ func (matcher *Matcher) CompileMatchers() error {
 	}
 
 	matcher.matcherType = computedType
+
+	// Validate the matcher structure
+	if err := matcher.Validate(); err != nil {
+		return err
+	}
+
 	// By default, match on body if user hasn't provided any specific items
 	if matcher.Part == "" {
 		matcher.Part = "body"

--- a/v2/pkg/operators/matchers/validate.go
+++ b/v2/pkg/operators/matchers/validate.go
@@ -1,0 +1,51 @@
+package matchers
+
+import (
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Validate perform initial validation on the matcher structure
+func (matcher *Matcher) Validate() error {
+	// uses yaml marshaling to convert the struct to map[string]interface to have same field names
+	matcherMap := make(map[string]interface{})
+	marshaledMatcher, err := yaml.Marshal(matcher)
+	if err != nil {
+		return err
+	}
+	if err := yaml.Unmarshal(marshaledMatcher, &matcherMap); err != nil {
+		return err
+	}
+
+	var unexpectedFields []string
+	switch matcher.matcherType {
+	case DSLMatcher:
+		unexpectedFields = []string{"status", "regex", "words", "size", "binary", "part"}
+	case StatusMatcher:
+		unexpectedFields = []string{"dsl", "regex", "words", "size", "binary"}
+	case SizeMatcher:
+		unexpectedFields = []string{"dsl", "regex", "words", "status", "binary"}
+	case WordsMatcher:
+		unexpectedFields = []string{"dsl", "regex", "size", "status", "binary"}
+	case BinaryMatcher:
+		unexpectedFields = []string{"dsl", "regex", "size", "status", "words"}
+	case RegexMatcher:
+		unexpectedFields = []string{"dsl", "binary", "size", "status", "words"}
+	}
+	return checkUnexpectedFields(matcher, matcherMap, unexpectedFields...)
+}
+
+func checkUnexpectedFields(m *Matcher, matcherMap map[string]interface{}, unexpectedFields ...string) error {
+	var foundUnexpectedFields []string
+	for _, name := range unexpectedFields {
+		if _, ok := matcherMap[name]; ok {
+			foundUnexpectedFields = append(foundUnexpectedFields, name)
+		}
+	}
+	if len(foundUnexpectedFields) > 0 {
+		return fmt.Errorf("matcher %s has unexpected fields: %s", m.matcherType, strings.Join(foundUnexpectedFields, ","))
+	}
+	return nil
+}

--- a/v2/pkg/operators/matchers/validate.go
+++ b/v2/pkg/operators/matchers/validate.go
@@ -27,7 +27,7 @@ func (matcher *Matcher) Validate() error {
 	case DSLMatcher:
 		expectedFields = append(commonExpectedFields, "dsl")
 	case StatusMatcher:
-		expectedFields = append(commonExpectedFields, "status")
+		expectedFields = append(commonExpectedFields, "status", "part")
 	case SizeMatcher:
 		expectedFields = append(commonExpectedFields, "size", "part")
 	case WordsMatcher:

--- a/v2/pkg/operators/matchers/validate_test.go
+++ b/v2/pkg/operators/matchers/validate_test.go
@@ -1,0 +1,18 @@
+package matchers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidate(t *testing.T) {
+	m := &Matcher{matcherType: DSLMatcher, DSL: []string{"anything"}}
+
+	err := m.Validate()
+	require.Nil(t, err, "Could not validate correct template")
+
+	m = &Matcher{matcherType: DSLMatcher, Part: "test"}
+	err = m.Validate()
+	require.NotNil(t, err, "Invalid template was correctly validated")
+}


### PR DESCRIPTION
## Proposed changes
This PR implements matchers validation for unexpected fields via yaml marshaling

## Checklist
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)