### PR TITLE
use formedURL instead reqURL in http request dump message

### DIFF
--- a/v2/pkg/protocols/http/request.go
+++ b/v2/pkg/protocols/http/request.go
@@ -425,6 +425,10 @@ func (request *Request) executeRequest(reqURL string, generatedRequest *generate
 			resp, err = request.httpClient.Do(generatedRequest.request)
 		}
 	}
+	// use request url as matched url if empty
+	if formedURL == "" {
+		formedURL = reqURL
+	}
 
 	// Dump the requests containing all headers
 	if !generatedRequest.original.Race {
@@ -435,7 +439,7 @@ func (request *Request) executeRequest(reqURL string, generatedRequest *generate
 		}
 		dumpedRequestString := string(dumpedRequest)
 		if request.options.Options.Debug || request.options.Options.DebugRequests || request.options.Options.StoreResponse {
-			msg := fmt.Sprintf("[%s] Dumped HTTP request for %s\n\n", request.options.TemplateID, reqURL)
+			msg := fmt.Sprintf("[%s] Dumped HTTP request for %s\n\n", request.options.TemplateID, formedURL)
 
 			if request.options.Options.Debug || request.options.Options.DebugRequests {
 				gologger.Info().Msg(msg)
@@ -445,11 +449,6 @@ func (request *Request) executeRequest(reqURL string, generatedRequest *generate
 				request.options.Output.WriteStoreDebugData(reqURL, request.options.TemplateID, request.Type().String(), fmt.Sprintf("%s\n%s", msg, dumpedRequestString))
 			}
 		}
-	}
-
-	// use request url as matched url if empty
-	if formedURL == "" {
-		formedURL = reqURL
 	}
 
 	if err != nil {


### PR DESCRIPTION
Before:

```console
[INF] [kevinlab-bems-sqli] Dumped HTTP request for https://example.com
```

Now:

```console
[INF] [kevinlab-bems-sqli] Dumped HTTP request for https://example.com/http/index.php
```

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)