### PR TITLE
Improving RFC request/response passive parsing

### DIFF
--- a/integration_tests/offlinehttp/data/req-resp-with-http-keywords.txt
+++ b/integration_tests/offlinehttp/data/req-resp-with-http-keywords.txt
@@ -1,0 +1,26 @@
+GET / HTTP/1.1
+Host: pastebin.com
+User-Agent: curl/7.79.1
+Accept: */*
+Connection: close
+
+HTTP/1.1 200 OK
+Date: Tue, 21 Jun 2022 09:32:01 GMT
+Content-Type: text/plain; charset=utf-8
+Connection: close
+x-frame-options: DENY
+x-content-type-options: nosniff
+x-xss-protection: 1;mode=block
+cache-control: public, max-age=1801
+CF-Cache-Status: HIT
+Age: 1585
+Last-Modified: Tue, 21 Jun 2022 09:05:36 GMT
+Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+Server: cloudflare
+CF-RAY: 71ebbc0a7ea83b8b-CDG
+
+54
+line1
+this is a line containing HTTP/1.1 FOO BAR
+line3
+0

--- a/integration_tests/offlinehttp/rfc-req-resp.yaml
+++ b/integration_tests/offlinehttp/rfc-req-resp.yaml
@@ -1,0 +1,15 @@
+id: rfc-req-resp
+
+info:
+  name: Basic GET Request
+  author: pdteam
+  severity: info
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    matchers:
+      - type: word
+        words:
+          - "this is a line containing HTTP/1.1 FOO BAR"

--- a/v2/cmd/integration-test/integration-test.go
+++ b/v2/cmd/integration-test/integration-test.go
@@ -32,6 +32,7 @@ var (
 		"templatesPath": templatesPathTestCases,
 		"templatesDir":  templatesDirTestCases,
 		"file":          fileTestcases,
+		"offlineHttp":   offlineHttpTestcases,
 	}
 )
 

--- a/v2/cmd/integration-test/offline-http.go
+++ b/v2/cmd/integration-test/offline-http.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"github.com/projectdiscovery/nuclei/v2/pkg/testutils"
+)
+
+var offlineHttpTestcases = map[string]testutils.TestCase{
+	"offlinehttp/rfc-req-resp.yaml": &RfcRequestResponse{},
+}
+
+type RfcRequestResponse struct{}
+
+// Execute executes a test case and returns an error if occurred
+func (h *RfcRequestResponse) Execute(filePath string) error {
+	results, err := testutils.RunNucleiTemplateAndGetResults(filePath, "offlinehttp/data/", debug, "-passive")
+	if err != nil {
+		return err
+	}
+
+	return expectResultsCount(results, 1)
+}

--- a/v2/pkg/protocols/offlinehttp/read_response.go
+++ b/v2/pkg/protocols/offlinehttp/read_response.go
@@ -12,8 +12,16 @@ var noMinor = regexp.MustCompile(`HTTP/([0-9]) `)
 
 // readResponseFromString reads a raw http response from a string.
 func readResponseFromString(data string) (*http.Response, error) {
-	var final string
+	// Check if "data" contains RFC compatible Request followed by a response
+	br := bufio.NewReader(strings.NewReader(data))
+	if req, err := http.ReadRequest(br); err == nil {
+		if resp, err := http.ReadResponse(br, req); err == nil {
+			return resp, nil
+		}
+	}
 
+	// otherwise tries to patch known cases such as http minor version
+	var final string
 	if strings.HasPrefix(data, "HTTP/") {
 		final = addMinorVersionToHTTP(data)
 	} else {


### PR DESCRIPTION
## Proposed changes
This PR adds a check in the passive parsing helper function that tries to parse passive request/response with the standard library, before switching to placeholder matching.

## Checklist
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Notes
In this particular case the parsing still fails due to a bug in `proxify` related to request body length miscalculation (ref https://github.com/projectdiscovery/proxify/issues/135)