### PR TITLE
Adding http request validation at compile time

### DIFF
--- a/v2/pkg/protocols/http/http.go
+++ b/v2/pkg/protocols/http/http.go
@@ -226,6 +226,10 @@ func (request *Request) isRaw() bool {
 
 // Compile compiles the protocol request for further execution.
 func (request *Request) Compile(options *protocols.ExecuterOptions) error {
+	if err := request.validate(); err != nil {
+		return errors.Wrap(err, "validation error")
+	}
+
 	connectionConfiguration := &httpclientpool.Configuration{
 		Threads:         request.Threads,
 		MaxRedirects:    request.MaxRedirects,

--- a/v2/pkg/protocols/http/validate.go
+++ b/v2/pkg/protocols/http/validate.go
@@ -1,0 +1,11 @@
+package http
+
+import "github.com/pkg/errors"
+
+func (request *Request) validate() error {
+	if request.Race && request.ReqCondition {
+		return errors.New("race and req-condition can't be used together")
+	}
+
+	return nil
+}

--- a/v2/pkg/protocols/http/validate.go
+++ b/v2/pkg/protocols/http/validate.go
@@ -4,7 +4,7 @@ import "github.com/pkg/errors"
 
 func (request *Request) validate() error {
 	if request.Race && request.ReqCondition {
-		return errors.New("race and req-condition can't be used together")
+		return errors.New("'race' and 'req-condition' can't be used together")
 	}
 
 	return nil


### PR DESCRIPTION
## Proposed changes
This PR adds validation for HTTP template requests and fixes #2140 

## Checklist
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Example
```console
$ cat test.yaml 
id: basic-example

info:
  name: Test HTTP Template
  author: pdteam
  severity: info

requests:
  - method: GET
    path:
      - "{{BaseURL}}"

    race: true
    race_count: 100
    req-condition: true
$ echo http://127.0.0.1:8000 | go run .  -t test.yaml -v
...
[WRN] Could not parse template /Users/user/go/src/github.com/projectdiscovery/nuclei/v2/cmd/nuclei/test.yaml: could not compile request: validation error: race and req-condition can't be used together
[WRN] Found 1 templates with runtime error (use -validate flag for further examination)
...
[FTL] Could not run nuclei: no valid templates were found
exit status 1
```