### PR TITLE
Fixed a issue with random invalid matches in DSL

### DIFF
--- a/v2/pkg/operators/matchers/match.go
+++ b/v2/pkg/operators/matchers/match.go
@@ -59,7 +59,9 @@ func (matcher *Matcher) MatchWords(corpus string, data map[string]interface{}) (
 		word, err = expressions.Evaluate(word, data)
 		if err != nil {
 			gologger.Warning().Msgf("Error while evaluating word matcher: %q", word)
-			continue
+			if matcher.condition == ANDCondition {
+				return false, []string{}
+			}
 		}
 		// Continue if the word doesn't match
 		if !strings.Contains(corpus, word) {
@@ -180,6 +182,9 @@ func (matcher *Matcher) MatchDSL(data map[string]interface{}) bool {
 
 		result, err := expression.Evaluate(data)
 		if err != nil {
+			if matcher.condition == ANDCondition {
+				return false
+			}
 			if strings.Contains(err.Error(), "No parameter") {
 				gologger.Warning().Msgf("[%s] %s", data["template-id"], err.Error())
 			} else {


### PR DESCRIPTION
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->

Closes #2194. This PR fixes an issue where if the DSL failed with AND condition, the evaluation moved on the next items which would lead to false-positive matches sometimes with invalid results being shown.

The behaviour is fixed by exiting the match function as soon as a DSL evaluate error is encountered.

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)