### PR TITLE
Adding stricter check on offline templates list

### DIFF
--- a/v2/pkg/templates/compile.go
+++ b/v2/pkg/templates/compile.go
@@ -3,7 +3,6 @@ package templates
 import (
 	"fmt"
 	"reflect"
-	"strings"
 
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
@@ -14,6 +13,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/offlinehttp"
 	"github.com/projectdiscovery/nuclei/v2/pkg/templates/cache"
 	"github.com/projectdiscovery/nuclei/v2/pkg/utils"
+	"github.com/projectdiscovery/stringsutil"
 )
 
 var (
@@ -203,8 +203,13 @@ func (template *Template) compileOfflineHTTPRequest(options protocols.ExecuterOp
 
 mainLoop:
 	for _, req := range template.RequestsHTTP {
+		hasPaths := len(req.Path) > 0
+		if !hasPaths {
+			break mainLoop
+		}
 		for _, path := range req.Path {
-			if !(strings.EqualFold(path, "{{BaseURL}}") || strings.EqualFold(path, "{{BaseURL}}/")) {
+			pathIsBaseURL := stringsutil.EqualFoldAny(path, "{{BaseURL}}", "{{BaseURL}}/", "/")
+			if !pathIsBaseURL {
 				break mainLoop
 			}
 		}


### PR DESCRIPTION
## Proposed changes
This PR implements a stricter check on list of templates used for offline matching, discarding raw ones

## Checklist
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Notes
Once https://github.com/projectdiscovery/nuclei/pull/2192 is merged, the following test templates should be added to offline integration tests:

**offline-allowed-paths** => match
```yaml
id: offline-allowed-paths

info:
  name: offline-allowed-paths
  author: pdteam
  severity: info
  description: offline-allowed-paths

requests:
  - path:
      - "{{BaseURL}}"
      - "{{BaseURL}}/"
      - "/"

    matchers:
      - type: status
        status:
          - 200
```
**offline-raw.yaml** => no match
```yaml
id: offline-raw
info:
  name: Test Offline raw Template
  author: pdteam
  severity: info

requests:
  - raw:
      - |
        GET / HTTP/1.1
        Host: {{Hostname}}
        
    matchers:
      - type: status
        status:
          - 200
```

**test.txt**
```
HTTP/1.1 200 OK
Date: Tue, 21 Jun 2022 09:32:01 GMT
Content-Type: text/plain; charset=utf-8
Connection: close
x-frame-options: DENY
x-content-type-options: nosniff
x-xss-protection: 1;mode=block
cache-control: public, max-age=1801
CF-Cache-Status: HIT
Age: 1585
Last-Modified: Tue, 21 Jun 2022 09:05:36 GMT
Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
Server: cloudflare
CF-RAY: 71ebbc0a7ea83b8b-CDG

45
line1
this is a line containing FOO BAR
line3
0
```