### PR TITLE
fix: socks5 proxy not working on https target

### DIFF
--- a/v2/pkg/protocols/http/httpclientpool/clientpool.go
+++ b/v2/pkg/protocols/http/httpclientpool/clientpool.go
@@ -218,12 +218,12 @@ func wrappedGet(options *types.Options, configuration *Configuration) (*retryabl
 		if proxyErr == nil {
 			transport.DialContext = dc.DialContext
 			transport.DialTLSContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
-				// upgrade proxy conn to tls connection
-				rawConn, err2 := dc.DialContext(ctx, network, addr)
-				if err2 != nil {
-					return nil, err2
+				// upgrade proxy connection to tls
+				conn, err := dc.DialContext(ctx, network, addr)
+				if err != nil {
+					return nil, err
 				}
-				return tls.Client(rawConn, tlsConfig), nil
+				return tls.Client(conn, tlsConfig), nil
 			}
 		}
 	}

--- a/v2/pkg/protocols/http/httpclientpool/clientpool.go
+++ b/v2/pkg/protocols/http/httpclientpool/clientpool.go
@@ -217,6 +217,14 @@ func wrappedGet(options *types.Options, configuration *Configuration) (*retryabl
 		})
 		if proxyErr == nil {
 			transport.DialContext = dc.DialContext
+			transport.DialTLSContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+				// upgrade proxy conn to tls connection
+				rawConn, err2 := dc.DialContext(ctx, network, addr)
+				if err2 != nil {
+					return nil, err2
+				}
+				return tls.Client(rawConn, tlsConfig), nil
+			}
 		}
 	}
 


### PR DESCRIPTION
## Proposed changes

nuclei socks5 proxy setting does not work for https target, maybe we need a UT?

## Checklist


- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)