### PR TITLE
use go-homedir instead of standard os.userhomedir

### DIFF
--- a/v2/internal/runner/healthcheck.go
+++ b/v2/internal/runner/healthcheck.go
@@ -3,11 +3,11 @@ package runner
 import (
 	"fmt"
 	"net"
-	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 
+	"github.com/mitchellh/go-homedir"
 	"github.com/projectdiscovery/fileutil"
 	"github.com/projectdiscovery/goflags"
 	"github.com/projectdiscovery/nuclei/v2/pkg/catalog/config"
@@ -29,7 +29,7 @@ func DoHealthCheck(options *types.Options) string {
 	var testResult string
 
 	nucleiIgnorePath := filepath.Join(cfgFileFolder, ".nuclei-ignore")
-	homedir, _ := os.UserHomeDir()
+	homedir, _ := homedir.Dir()
 	nucleiTemplatePath := filepath.Join(homedir, "nuclei-templates/.checksum")
 	for _, filename := range []string{cfgFilePath, nucleiIgnorePath, nucleiTemplatePath} {
 		ok, err := fileutil.IsReadable(filename)

--- a/v2/internal/runner/update.go
+++ b/v2/internal/runner/update.go
@@ -73,10 +73,10 @@ func (r *Runner) updateTemplates() error { // TODO this method does more than ju
 			TemplatesDirectory: defaultTemplatesDirectory,
 			NucleiVersion:      config.Version,
 		}
+		r.templatesConfig = currentConfig
 		if writeErr := config.WriteConfiguration(currentConfig); writeErr != nil {
 			return errors.Wrap(writeErr, "could not write template configuration")
 		}
-		r.templatesConfig = currentConfig
 	}
 	if r.options.TemplatesDirectory == "" {
 		if r.templatesConfig.TemplatesDirectory != "" {

--- a/v2/pkg/catalog/config/config.go
+++ b/v2/pkg/catalog/config/config.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 
 	jsoniter "github.com/json-iterator/go"
+	"github.com/mitchellh/go-homedir"
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 
@@ -41,7 +42,7 @@ func getConfigDetails() (string, error) {
 
 // GetConfigDir returns the nuclei configuration directory
 func GetConfigDir() (string, error) {
-	home, err := os.UserHomeDir()
+	home, err := homedir.Dir()
 	if err != nil {
 		return "", err
 	}

--- a/v2/pkg/utils/template_path.go
+++ b/v2/pkg/utils/template_path.go
@@ -1,10 +1,10 @@
 package utils
 
 import (
-	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/mitchellh/go-homedir"
 	"github.com/projectdiscovery/nuclei/v2/pkg/catalog/config"
 )
 
@@ -35,7 +35,7 @@ func TemplatePathURL(fullPath string) (string, string) {
 
 // GetDefaultTemplatePath on default settings
 func GetDefaultTemplatePath() (string, error) {
-	home, err := os.UserHomeDir()
+	home, err := homedir.Dir()
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## Proposed changes
`go-homedir` handles multiple edge cases of user home directory resolution.
If there is any edge case still left we can handle the error and/or introduce a flag to set a base directory for nuclei to run.
<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->


## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)