### PR TITLE
Optionally disable templates syntax strict check

### DIFF
--- a/v2/cmd/nuclei/main.go
+++ b/v2/cmd/nuclei/main.go
@@ -104,7 +104,7 @@ on extensive configurability, massive extensibility and ease of use.`)
 		flagSet.FileNormalizedOriginalStringSliceVarP(&options.Workflows, "workflows", "w", []string{}, "list of workflow or workflow directory to run (comma-separated, file)"),
 		flagSet.FileNormalizedOriginalStringSliceVarP(&options.WorkflowURLs, "workflow-url", "wu", []string{}, "list of workflow urls to run (comma-separated, file)"),
 		flagSet.BoolVar(&options.Validate, "validate", false, "validate the passed templates to nuclei"),
-		flagSet.BoolVar(&options.StrictSyntax, "strict-syntax", true, "Force strict syntax check on passed templates to nuclei"),
+		flagSet.BoolVar(&options.NoStrictSyntax, "no-strict-syntax", false, "Disable strict syntax check on templates"),
 		flagSet.BoolVar(&options.TemplateList, "tl", false, "list all available templates"),
 		flagSet.StringSliceVarConfigOnly(&options.RemoteTemplateDomainList, "remote-template-domain", []string{"api.nuclei.sh"}, "allowed domain list to load remote templates from"),
 	)

--- a/v2/cmd/nuclei/main.go
+++ b/v2/cmd/nuclei/main.go
@@ -104,7 +104,7 @@ on extensive configurability, massive extensibility and ease of use.`)
 		flagSet.FileNormalizedOriginalStringSliceVarP(&options.Workflows, "workflows", "w", []string{}, "list of workflow or workflow directory to run (comma-separated, file)"),
 		flagSet.FileNormalizedOriginalStringSliceVarP(&options.WorkflowURLs, "workflow-url", "wu", []string{}, "list of workflow urls to run (comma-separated, file)"),
 		flagSet.BoolVar(&options.Validate, "validate", false, "validate the passed templates to nuclei"),
-		flagSet.BoolVar(&options.NoStrictSyntax, "no-strict-syntax", false, "Disable strict syntax check on templates"),
+		flagSet.BoolVarP(&options.NoStrictSyntax, "no-strict-syntax", "nss", false, "Disable strict syntax check on templates"),
 		flagSet.BoolVar(&options.TemplateList, "tl", false, "list all available templates"),
 		flagSet.StringSliceVarConfigOnly(&options.RemoteTemplateDomainList, "remote-template-domain", []string{"api.nuclei.sh"}, "allowed domain list to load remote templates from"),
 	)

--- a/v2/cmd/nuclei/main.go
+++ b/v2/cmd/nuclei/main.go
@@ -104,6 +104,7 @@ on extensive configurability, massive extensibility and ease of use.`)
 		flagSet.FileNormalizedOriginalStringSliceVarP(&options.Workflows, "workflows", "w", []string{}, "list of workflow or workflow directory to run (comma-separated, file)"),
 		flagSet.FileNormalizedOriginalStringSliceVarP(&options.WorkflowURLs, "workflow-url", "wu", []string{}, "list of workflow urls to run (comma-separated, file)"),
 		flagSet.BoolVar(&options.Validate, "validate", false, "validate the passed templates to nuclei"),
+		flagSet.BoolVar(&options.StrictSyntax, "strict-syntax", true, "Force strict syntax check on passed templates to nuclei"),
 		flagSet.BoolVar(&options.TemplateList, "tl", false, "list all available templates"),
 		flagSet.StringSliceVarConfigOnly(&options.RemoteTemplateDomainList, "remote-template-domain", []string{"api.nuclei.sh"}, "allowed domain list to load remote templates from"),
 	)

--- a/v2/internal/runner/runner.go
+++ b/v2/internal/runner/runner.go
@@ -90,6 +90,9 @@ func New(options *types.Options) (*Runner, error) {
 		// Does not update the templates when validate flag is used
 		options.NoUpdateTemplates = true
 	}
+	// Set strictSyntax
+	parsers.StrictSyntax = options.StrictSyntax
+
 	if err := runner.updateTemplates(); err != nil {
 		gologger.Error().Msgf("Could not update templates: %s\n", err)
 	}

--- a/v2/internal/runner/runner.go
+++ b/v2/internal/runner/runner.go
@@ -90,8 +90,7 @@ func New(options *types.Options) (*Runner, error) {
 		// Does not update the templates when validate flag is used
 		options.NoUpdateTemplates = true
 	}
-	// Set strictSyntax
-	parsers.StrictSyntax = options.StrictSyntax
+	parsers.NoStrictSyntax = options.NoStrictSyntax
 
 	if err := runner.updateTemplates(); err != nil {
 		gologger.Error().Msgf("Could not update templates: %s\n", err)

--- a/v2/pkg/parsers/parser.go
+++ b/v2/pkg/parsers/parser.go
@@ -103,6 +103,7 @@ func validateTemplateFields(template *templates.Template) error {
 var (
 	parsedTemplatesCache *cache.Templates
 	ShouldValidate       bool
+	StrictSyntax         bool
 	fieldErrorRegexp     = regexp.MustCompile(`not found in`)
 	templateIDRegexp     = regexp.MustCompile(`^([a-zA-Z0-9]+[-_])*[a-zA-Z0-9]+$`)
 )
@@ -133,7 +134,12 @@ func ParseTemplate(templatePath string) (*templates.Template, error) {
 	}
 
 	template := &templates.Template{}
-	if err := yaml.UnmarshalStrict(data, template); err != nil {
+	if StrictSyntax {
+		err = yaml.UnmarshalStrict(data, template)
+	}else{
+		err = yaml.Unmarshal(data, template)
+	}
+	if err != nil {
 		errString := err.Error()
 		if !fieldErrorRegexp.MatchString(errString) {
 			stats.Increment(SyntaxErrorStats)

--- a/v2/pkg/parsers/parser.go
+++ b/v2/pkg/parsers/parser.go
@@ -103,7 +103,7 @@ func validateTemplateFields(template *templates.Template) error {
 var (
 	parsedTemplatesCache *cache.Templates
 	ShouldValidate       bool
-	StrictSyntax         bool
+	NoStrictSyntax       bool
 	fieldErrorRegexp     = regexp.MustCompile(`not found in`)
 	templateIDRegexp     = regexp.MustCompile(`^([a-zA-Z0-9]+[-_])*[a-zA-Z0-9]+$`)
 )
@@ -134,10 +134,10 @@ func ParseTemplate(templatePath string) (*templates.Template, error) {
 	}
 
 	template := &templates.Template{}
-	if StrictSyntax {
-		err = yaml.UnmarshalStrict(data, template)
-	}else{
+	if NoStrictSyntax {
 		err = yaml.Unmarshal(data, template)
+	} else {
+		err = yaml.UnmarshalStrict(data, template)
 	}
 	if err != nil {
 		errString := err.Error()

--- a/v2/pkg/types/types.go
+++ b/v2/pkg/types/types.go
@@ -161,6 +161,8 @@ type Options struct {
 	Version bool
 	// Validate validates the templates passed to nuclei.
 	Validate bool
+	// StrictSyntax forces the templates passed to nuclei to be exact.
+	StrictSyntax bool
 	// Verbose flag indicates whether to show verbose output or not
 	Verbose        bool
 	VerboseVerbose bool

--- a/v2/pkg/types/types.go
+++ b/v2/pkg/types/types.go
@@ -161,8 +161,8 @@ type Options struct {
 	Version bool
 	// Validate validates the templates passed to nuclei.
 	Validate bool
-	// StrictSyntax forces the templates passed to nuclei to be exact.
-	StrictSyntax bool
+	// NoStrictSyntax disables strict syntax check on nuclei templates (allows custom key-value pairs).
+	NoStrictSyntax bool
 	// Verbose flag indicates whether to show verbose output or not
 	Verbose        bool
 	VerboseVerbose bool


### PR DESCRIPTION
## Proposed changes

This PR creates a new option for templates `strict-syntax`.  This allows modified or enriched templates to be processed by nuclei. Fixes https://github.com/projectdiscovery/nuclei/issues/2265

Currently it is not possible to use Nuclei with templates, which have other (custom) fields even outside of the template models. 

Enriched Data would be able to be processed via `--strict-syntax=false` 



## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)