### PR TITLE
Allow cli and enviroment variables to be substituted in the templates…

### DIFF
--- a/v2/pkg/protocols/common/generators/options.go
+++ b/v2/pkg/protocols/common/generators/options.go
@@ -4,6 +4,8 @@ import (
 	"github.com/projectdiscovery/nuclei/v2/pkg/types"
 )
 
+var Options = &types.Options{}
+
 // BuildPayloadFromOptions returns a map with the payloads provided via CLI
 func BuildPayloadFromOptions(options *types.Options) map[string]interface{} {
 	m := make(map[string]interface{})


### PR DESCRIPTION
… variables section

## Proposed changes

I want to be able to have environment variables and cli variables substituted in the variables section of the template before the variables are evaluated. This allows us to pass env variables that contain sensitive information that will then go through the hmac filter in the variables section. This might be a lot of layers of substitution, but this simplifies things for us. See example below. Uppercase variables are those being based in via env vars.

```
$ nuclei -ev -V path=/api/v1/check -t check.yaml

variables:
  my_date: "{{date_time('Mon, 02 Jan 2006 15:04:05 -0700')}}"
  my_join: "{{join('\n', '{{my_date}}', 'GET', '{{HOST}}', '{{path}}', '')}}"
  my_hmac: "{{hmac('sha1', '{{my_join}}', '{{SKEY}}')}}"

requests:
  - method: GET
    path:
      - "https://{{HOST}}{{path}}"
    headers:
      Host: "{{HOST}}"
      Date: "{{my_date}}"
      Authorization: Basic {{base64('{{IKEY}}:{{my_hmac}}')}}
``` 

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [X] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)