### PR TITLE
Fixing race conditions

### DIFF
--- a/v2/internal/runner/runner.go
+++ b/v2/internal/runner/runner.go
@@ -633,11 +633,9 @@ func isTemplate(filename string) bool {
 
 // SaveResumeConfig to file
 func (r *Runner) SaveResumeConfig(path string) error {
-	resumeCfg := types.NewResumeCfg()
-	r.resumeCfg.Lock()
-	resumeCfg.ResumeFrom = r.resumeCfg.Current
-	data, _ := json.MarshalIndent(resumeCfg, "", "\t")
-	r.resumeCfg.Unlock()
+	resumeCfgClone := r.resumeCfg.Clone()
+	resumeCfgClone.ResumeFrom = resumeCfgClone.Current
+	data, _ := json.MarshalIndent(resumeCfgClone, "", "\t")
 
 	return os.WriteFile(path, data, os.ModePerm)
 }


### PR DESCRIPTION
## Proposed changes
This PR fixes a map race condition on the ResumeConfig structure and another race condition in interact client hostname field.

## Checklist
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Check
```console
$ echo http://192.168.1.1 | go run -race .
$ echo http://192.168.1.1 | go run -race . # before the end hit ctrl+c
```