### PR TITLE
added custom config flag

### DIFF
--- a/v2/cmd/integration-test/custom-dir.go
+++ b/v2/cmd/integration-test/custom-dir.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"os"
+
+	"github.com/projectdiscovery/nuclei/v2/pkg/testutils"
+)
+
+func getCustomConfigsDir() string {
+	temp := os.TempDir()
+	return temp
+}
+
+type customConfigDirTest struct{}
+
+var customConfigDirTestCases = map[string]testutils.TestCase{
+	"dns/cname-fingerprint.yaml": &customConfigDirTest{},
+}
+
+// Execute executes a test case and returns an error if occurred
+func (h *customConfigDirTest) Execute(filePath string) error {
+	defer os.RemoveAll(getCustomConfigsDir())
+
+	var routerErr error
+
+	results, err := testutils.RunNucleiTemplateAndGetResults(filePath, "8x8exch02.8x8.com", debug, "-config-directory", getCustomConfigsDir())
+	if err != nil {
+		return err
+	}
+	if routerErr != nil {
+		return routerErr
+	}
+	return expectResultsCount(results, 1)
+}

--- a/v2/cmd/integration-test/integration-test.go
+++ b/v2/cmd/integration-test/integration-test.go
@@ -19,20 +19,21 @@ var (
 	failed  = aurora.Red("[✘]").String()
 
 	protocolTests = map[string]map[string]testutils.TestCase{
-		"http":          httpTestcases,
-		"network":       networkTestcases,
-		"dns":           dnsTestCases,
-		"workflow":      workflowTestcases,
-		"loader":        loaderTestcases,
-		"websocket":     websocketTestCases,
-		"headless":      headlessTestcases,
-		"whois":         whoisTestCases,
-		"ssl":           sslTestcases,
-		"code":          codeTestcases,
-		"templatesPath": templatesPathTestCases,
-		"templatesDir":  templatesDirTestCases,
-		"file":          fileTestcases,
-		"offlineHttp":   offlineHttpTestcases,
+		"http":            httpTestcases,
+		"network":         networkTestcases,
+		"dns":             dnsTestCases,
+		"workflow":        workflowTestcases,
+		"loader":          loaderTestcases,
+		"websocket":       websocketTestCases,
+		"headless":        headlessTestcases,
+		"whois":           whoisTestCases,
+		"ssl":             sslTestcases,
+		"code":            codeTestcases,
+		"templatesPath":   templatesPathTestCases,
+		"templatesDir":    templatesDirTestCases,
+		"file":            fileTestcases,
+		"offlineHttp":     offlineHttpTestcases,
+		"customConfigDir": customConfigDirTestCases,
 	}
 )
 

--- a/v2/cmd/nuclei/main.go
+++ b/v2/cmd/nuclei/main.go
@@ -160,6 +160,7 @@ on extensive configurability, massive extensibility and ease of use.`)
 		flagSet.BoolVarP(&options.ShowMatchLine, "show-match-line", "sml", false, "show match lines for file templates, works with extractors only"),
 		flagSet.BoolVar(&options.ZTLS, "ztls", false, "use ztls library with autofallback to standard one for tls13"),
 		flagSet.StringVar(&options.SNI, "sni", "", "tls sni hostname to use (default: input domain name)"),
+		flagSet.StringVar(&options.CustomConfigDir, "config-directory", "", "Override the default config path ($home/.config)"),
 	)
 
 	flagSet.CreateGroup("interactsh", "interactsh",
@@ -238,7 +239,9 @@ on extensive configurability, massive extensibility and ease of use.`)
 	if options.LeaveDefaultPorts {
 		http.LeaveDefaultPorts = true
 	}
-
+	if options.CustomConfigDir != "" {
+		config.SetCustomConfigDirectory(options.CustomConfigDir)
+	}
 	if cfgFile != "" {
 		if err := flagSet.MergeConfigFile(cfgFile); err != nil {
 			gologger.Fatal().Msgf("Could not read config: %s\n", err)

--- a/v2/cmd/nuclei/main.go
+++ b/v2/cmd/nuclei/main.go
@@ -255,7 +255,7 @@ on extensive configurability, massive extensibility and ease of use.`)
 			return nil
 		}
 		if err := readConfigFile(); err != nil {
-			readConfigFile()
+			_=readConfigFile()
 		}
 	}
 	if cfgFile != "" {

--- a/v2/cmd/nuclei/main.go
+++ b/v2/cmd/nuclei/main.go
@@ -248,7 +248,7 @@ on extensive configurability, massive extensibility and ease of use.`)
 		if err := flagSet.MergeConfigFile(configPath); err != nil && err != io.EOF {
 			if home, err := homedir.Dir(); err == nil {
 				path := filepath.Join(home, ".config", "nuclei", "config.yaml")
-				fileutil.CopyFile(path, configPath)
+				_ =fileutil.CopyFile(path, configPath)
 				goto readConfigFile
 			}
 		}

--- a/v2/cmd/nuclei/main.go
+++ b/v2/cmd/nuclei/main.go
@@ -246,7 +246,7 @@ on extensive configurability, massive extensibility and ease of use.`)
 		configPath := filepath.Join(options.CustomConfigDir, "config.yaml")
 		ignoreFile := filepath.Join(options.CustomConfigDir, ".nuclei-ignore")
 		if !fileutil.FileExists(ignoreFile) {
-			fileutil.CopyFile(originalIgnorePath, ignoreFile)
+			_ = fileutil.CopyFile(originalIgnorePath, ignoreFile)
 		}
 		readConfigFile := func() error {
 			if err := flagSet.MergeConfigFile(configPath); err != nil && !errors.Is(err, io.EOF) {

--- a/v2/cmd/nuclei/main.go
+++ b/v2/cmd/nuclei/main.go
@@ -241,8 +241,13 @@ on extensive configurability, massive extensibility and ease of use.`)
 		http.LeaveDefaultPorts = true
 	}
 	if options.CustomConfigDir != "" {
+		originalIgnorePath := config.GetIgnoreFilePath()
 		config.SetCustomConfigDirectory(options.CustomConfigDir)
 		configPath := filepath.Join(options.CustomConfigDir, "config.yaml")
+		ignoreFile := filepath.Join(options.CustomConfigDir, ".nuclei-ignore")
+		if !fileutil.FileExists(ignoreFile) {
+			fileutil.CopyFile(originalIgnorePath, ignoreFile)
+		}
 		readConfigFile := func() error {
 			if err := flagSet.MergeConfigFile(configPath); err != nil && !errors.Is(err, io.EOF) {
 				defaultConfigPath, _ := goflags.GetConfigFilePath()
@@ -255,7 +260,7 @@ on extensive configurability, massive extensibility and ease of use.`)
 			return nil
 		}
 		if err := readConfigFile(); err != nil {
-			_=readConfigFile()
+			_ = readConfigFile()
 		}
 	}
 	if cfgFile != "" {

--- a/v2/internal/runner/healthcheck.go
+++ b/v2/internal/runner/healthcheck.go
@@ -7,7 +7,6 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/mitchellh/go-homedir"
 	"github.com/projectdiscovery/fileutil"
 	"github.com/projectdiscovery/goflags"
 	"github.com/projectdiscovery/nuclei/v2/pkg/catalog/config"
@@ -18,7 +17,6 @@ import (
 func DoHealthCheck(options *types.Options) string {
 	// RW permissions on config file
 	cfgFilePath, _ := goflags.GetConfigFilePath()
-	cfgFileFolder := filepath.Dir(cfgFilePath)
 	var test strings.Builder
 	test.WriteString(fmt.Sprintf("Version: %s\n", config.Version))
 	test.WriteString(fmt.Sprintf("Operative System: %s\n", runtime.GOOS))
@@ -28,9 +26,13 @@ func DoHealthCheck(options *types.Options) string {
 
 	var testResult string
 
-	nucleiIgnorePath := filepath.Join(cfgFileFolder, ".nuclei-ignore")
-	homedir, _ := homedir.Dir()
-	nucleiTemplatePath := filepath.Join(homedir, "nuclei-templates/.checksum")
+	nucleiIgnorePath := config.GetIgnoreFilePath()
+	cf, _ := config.ReadConfiguration()
+	templatePath := ""
+	if cf != nil {
+		templatePath = cf.TemplatesDirectory
+	}
+	nucleiTemplatePath := filepath.Join(templatePath, "/", ".checksum")
 	for _, filename := range []string{cfgFilePath, nucleiIgnorePath, nucleiTemplatePath} {
 		ok, err := fileutil.IsReadable(filename)
 		if ok {

--- a/v2/pkg/catalog/config/config.go
+++ b/v2/pkg/catalog/config/config.go
@@ -34,6 +34,9 @@ var customConfigDirectory string
 
 func SetCustomConfigDirectory(dir string) {
 	customConfigDirectory = dir
+	if !fileutil.FolderExists(dir) {
+		fileutil.CreateFolder(dir)
+	}
 }
 func getConfigDetails() (string, error) {
 	configDir, err := GetConfigDir()

--- a/v2/pkg/catalog/config/config.go
+++ b/v2/pkg/catalog/config/config.go
@@ -35,7 +35,7 @@ var customConfigDirectory string
 func SetCustomConfigDirectory(dir string) {
 	customConfigDirectory = dir
 	if !fileutil.FolderExists(dir) {
-		fileutil.CreateFolder(dir)
+		_ = fileutil.CreateFolder(dir)
 	}
 }
 func getConfigDetails() (string, error) {

--- a/v2/pkg/catalog/config/config.go
+++ b/v2/pkg/catalog/config/config.go
@@ -30,6 +30,11 @@ const nucleiConfigFilename = ".templates-config.json"
 // Version is the current version of nuclei
 const Version = `2.7.5-dev`
 
+var customConfigDirectory string
+
+func SetCustomConfigDirectory(dir string) {
+	customConfigDirectory = dir
+}
 func getConfigDetails() (string, error) {
 	configDir, err := GetConfigDir()
 	if err != nil {
@@ -42,7 +47,15 @@ func getConfigDetails() (string, error) {
 
 // GetConfigDir returns the nuclei configuration directory
 func GetConfigDir() (string, error) {
-	home, err := homedir.Dir()
+	var (
+		home string
+		err  error
+	)
+	if customConfigDirectory != "" {
+		home = customConfigDirectory
+		return home, nil
+	}
+	home, err = homedir.Dir()
 	if err != nil {
 		return "", err
 	}
@@ -55,7 +68,6 @@ func ReadConfiguration() (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	file, err := os.Open(templatesConfigFile)
 	if err != nil {
 		return nil, err
@@ -100,7 +112,7 @@ type IgnoreFile struct {
 
 // ReadIgnoreFile reads the nuclei ignore file returning blocked tags and paths
 func ReadIgnoreFile() IgnoreFile {
-	file, err := os.Open(getIgnoreFilePath())
+	file, err := os.Open(GetIgnoreFilePath())
 	if err != nil {
 		gologger.Error().Msgf("Could not read nuclei-ignore file: %s\n", err)
 		return IgnoreFile{}
@@ -138,8 +150,8 @@ func OverrideIgnoreFilePath(customPath string) error {
 	return nil
 }
 
-// getIgnoreFilePath returns the ignore file path for the runner
-func getIgnoreFilePath() string {
+// GetIgnoreFilePath returns the ignore file path for the runner
+func GetIgnoreFilePath() string {
 	var defIgnoreFilePath string
 
 	if customIgnoreFilePath != "" {

--- a/v2/pkg/types/types.go
+++ b/v2/pkg/types/types.go
@@ -234,6 +234,8 @@ type Options struct {
 	InputReadTimeout time.Duration
 	// Disable stdin for input processing
 	DisableStdin bool
+	// Custom Config Directory
+	CustomConfigDir string
 }
 
 func (options *Options) AddVarPayload(key string, value interface{}) {


### PR DESCRIPTION
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->

closes #1612 

```console
MacBook-Pro:nuclei user$ ./nuclei -config-directory /Users/user/Documents/testing

[WRN] Use with caution. You are responsible for your actions.
[WRN] Developers assume no liability and are not responsible for any misuse or damage.
[INF] Using Nuclei Engine 2.7.5-dev (development)
[INF] Using Nuclei Templates 9.1.4 (latest)
[INF] Templates added in last update: 52
[INF] Templates loaded for scan: 3778
[INF] No results found. Better luck next time!
```

```console
MacBook-Pro:testing user$ ls -la
total 24
drwxr-xr-x   5 user staff   160 Aug  9 10:28 .
drwx------+ 37 user  staff  1184 Aug  9 10:26 ..
-rw-r--r--   1 user  staff   693 Aug  9 10:28 .nuclei-ignore
-rw-r--r--   1 user staff   267 Aug  9 10:34 .templates-config.json
-rw-r--r--   1 user staff  3998 Aug  9 10:28 config.yaml
```

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)