### PR TITLE
Fixed http filepaths ending with slash + query strings

### DIFF
--- a/v2/pkg/protocols/http/build_request_test.go
+++ b/v2/pkg/protocols/http/build_request_test.go
@@ -210,6 +210,22 @@ Accept-Encoding: gzip`},
 	require.Equal(t, "Basic YWRtaW46Z3Vlc3Q=", authorization, "could not get correct authorization headers from raw")
 }
 
+func TestFixTrailingSlashFilename(t *testing.T) {
+	tests := []struct {
+		value    string
+		expected string
+	}{
+		{"https://example.com", "https://example.com"},
+		{"https://example.com/test/", "https://example.com/test/"},
+		{"https://example.com/example.html/", "https://example.com/example.html"},
+		{"https://example.com/example.php?test=1/", "https://example.com/example.php?test=1"},
+	}
+	for _, item := range tests {
+		returned := fixTrailingSlashFilename(item.value)
+		require.Equal(t, item.expected, returned, "could not get fixed filename")
+	}
+}
+
 func TestMakeRequestFromModelUniqueInteractsh(t *testing.T) {
 
 	options := testutils.DefaultOptions


### PR DESCRIPTION
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->
Closes #2377

```console
 echo https://example.com/test.html  | ./nuclei -t template.yaml -debug-req

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   2.7.5-dev

                projectdiscovery.io

[WRN] Use with caution. You are responsible for your actions.
[WRN] Developers assume no liability and are not responsible for any misuse or damage.
[INF] Using Nuclei Engine 2.7.5-dev (development)
[INF] Using Nuclei Templates 9.1.4 (latest)
[INF] Templates added in last update: 52
[INF] Templates loaded for scan: 1
[INF] [test] Dumped HTTP request for https://example.com/test.html

GET /test.html HTTP/1.1
Host: example.com
User-Agent: Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/37.0.2049.0 Safari/537.36
Connection: close
Accept-Encoding: gzip

[INF] No results found. Better luck next time!
```

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)