### PR TITLE
Added support for blank Request-URI which specifies no slash suffix

### DIFF
--- a/v2/pkg/protocols/http/raw/raw.go
+++ b/v2/pkg/protocols/http/raw/raw.go
@@ -51,6 +51,9 @@ read_line:
 	}
 
 	parts := strings.Split(s, " ")
+	if len(parts) == 2 {
+		parts = []string{parts[0], "", parts[1]}
+	}
 	if len(parts) < 3 && !unsafe {
 		return nil, fmt.Errorf("malformed request supplied")
 	}


### PR DESCRIPTION
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->

Closes https://github.com/projectdiscovery/nuclei/issues/2377

```yaml
id: test

info:
  name: test
  author: pdteam
  severity: info

requests:
  - raw:
      - |
        GET HTTP/1.1
        Host: {{Hostname}}
```

```console
echo https://example.com/test.html  | ./nuclei -t template.yaml -debug-req 

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   2.7.5-dev

                projectdiscovery.io

[WRN] Use with caution. You are responsible for your actions.
[WRN] Developers assume no liability and are not responsible for any misuse or damage.
[INF] Using Nuclei Engine 2.7.5-dev (development)
[INF] Using Nuclei Templates 9.1.4 (latest)
[INF] Templates added in last update: 52
[INF] Templates loaded for scan: 1
[INF] [test] Dumped HTTP request for https://example.com/test.html

GET /test.html HTTP/1.1
Host: example.com
User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.114 Safari/537.36
Connection: close
Accept-Encoding: gzip

[INF] No results found. Better luck next time!
```

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)