### PR TITLE
Added variable debug support with debug mode

### DIFF
--- a/v2/pkg/protocols/common/helpers/eventcreator/eventcreator.go
+++ b/v2/pkg/protocols/common/helpers/eventcreator/eventcreator.go
@@ -21,9 +21,7 @@ func CreateEventWithAdditionalOptions(request protocols.Request, outputEvent out
 
 	// Dump response variables if ran in debug mode
 	if isResponseDebug {
-		gologger.Debug().Msgf("Protocol response variables")
-		vardump.Variables(outputEvent)
-		gologger.Print().Msgf("\n")
+		gologger.Debug().Msgf("Protocol response variables: \n%s\n", vardump.DumpVariables(outputEvent))
 	}
 	for _, compiledOperator := range request.GetCompiledOperators() {
 		if compiledOperator != nil {

--- a/v2/pkg/protocols/common/helpers/eventcreator/eventcreator.go
+++ b/v2/pkg/protocols/common/helpers/eventcreator/eventcreator.go
@@ -1,9 +1,11 @@
 package eventcreator
 
 import (
+	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/nuclei/v2/pkg/operators"
 	"github.com/projectdiscovery/nuclei/v2/pkg/output"
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols"
+	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/utils/vardump"
 )
 
 // CreateEvent wraps the outputEvent with the result of the operators defined on the request
@@ -16,6 +18,13 @@ func CreateEvent(request protocols.Request, outputEvent output.InternalEvent, is
 func CreateEventWithAdditionalOptions(request protocols.Request, outputEvent output.InternalEvent, isResponseDebug bool,
 	addAdditionalOptions func(internalWrappedEvent *output.InternalWrappedEvent)) *output.InternalWrappedEvent {
 	event := &output.InternalWrappedEvent{InternalEvent: outputEvent}
+
+	// Dump response variables if ran in debug mode
+	if isResponseDebug {
+		gologger.Debug().Msgf("Protocol response variables")
+		vardump.Variables(outputEvent)
+		gologger.Print().Msgf("\n")
+	}
 	for _, compiledOperator := range request.GetCompiledOperators() {
 		if compiledOperator != nil {
 			result, ok := compiledOperator.Execute(outputEvent, request.Match, request.Extract, isResponseDebug)

--- a/v2/pkg/protocols/common/utils/vardump/dump.go
+++ b/v2/pkg/protocols/common/utils/vardump/dump.go
@@ -1,0 +1,34 @@
+package vardump
+
+import (
+	"strings"
+
+	"github.com/projectdiscovery/gologger"
+	"github.com/projectdiscovery/nuclei/v2/pkg/types"
+)
+
+// Variables writes the truncated dump of variables on the stderr
+// in a formatted key-value manner using gologger.
+//
+// The values are truncated to return 50 characters from start and end.
+func Variables(data map[string]interface{}) {
+	var counter int
+
+	builder := &strings.Builder{}
+	for k, v := range data {
+		valueString := types.ToString(v)
+
+		counter++
+		if len(valueString) > 50 {
+			builder.Grow(56) // grow the buffer
+			builder.WriteString(valueString[0:25])
+			builder.WriteString(" .... ")
+			builder.WriteString(valueString[len(valueString)-25:])
+			valueString = builder.String()
+			builder.Reset()
+		}
+		valueString = strings.ReplaceAll(valueString, "\n", " ")
+		valueString = strings.ReplaceAll(valueString, "\r", " ")
+		gologger.Print().Msgf("\t%d. %s => %s", counter, k, valueString)
+	}
+}

--- a/v2/pkg/protocols/common/utils/vardump/dump.go
+++ b/v2/pkg/protocols/common/utils/vardump/dump.go
@@ -1,18 +1,21 @@
 package vardump
 
 import (
+	"strconv"
 	"strings"
 
-	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/nuclei/v2/pkg/types"
 )
 
-// Variables writes the truncated dump of variables on the stderr
-// in a formatted key-value manner using gologger.
+// DumpVariables writes the truncated dump of variables to a string
+// in a formatted key-value manner.
 //
 // The values are truncated to return 50 characters from start and end.
-func Variables(data map[string]interface{}) {
+func DumpVariables(data map[string]interface{}) string {
 	var counter int
+
+	buffer := &strings.Builder{}
+	buffer.Grow(len(data) * 78) // grow buffer to an approximate size
 
 	builder := &strings.Builder{}
 	for k, v := range data {
@@ -20,15 +23,23 @@ func Variables(data map[string]interface{}) {
 
 		counter++
 		if len(valueString) > 50 {
-			builder.Grow(56) // grow the buffer
+			builder.Grow(56)
 			builder.WriteString(valueString[0:25])
 			builder.WriteString(" .... ")
 			builder.WriteString(valueString[len(valueString)-25:])
 			valueString = builder.String()
 			builder.Reset()
 		}
-		valueString = strings.ReplaceAll(valueString, "\n", " ")
-		valueString = strings.ReplaceAll(valueString, "\r", " ")
-		gologger.Print().Msgf("\t%d. %s => %s", counter, k, valueString)
+		valueString = strings.ReplaceAll(strings.ReplaceAll(valueString, "\r", " "), "\n", " ")
+
+		buffer.WriteString("\t")
+		buffer.WriteString(strconv.Itoa(counter))
+		buffer.WriteString(". ")
+		buffer.WriteString(k)
+		buffer.WriteString(" => ")
+		buffer.WriteString(valueString)
+		buffer.WriteString("\n")
 	}
+	final := buffer.String()
+	return final
 }

--- a/v2/pkg/protocols/dns/request.go
+++ b/v2/pkg/protocols/dns/request.go
@@ -48,7 +48,7 @@ func (request *Request) ExecuteWithResults(input string, metadata /*TODO review 
 	variablesMap := request.options.Variables.Evaluate(vars)
 	vars = generators.MergeMaps(variablesMap, vars)
 
-	if request.options.Options.Debug || request.options.Options.DebugResponse {
+	if request.options.Options.Debug || request.options.Options.DebugRequests {
 		gologger.Debug().Msgf("Protocol request variables: \n%s\n", vardump.DumpVariables(vars))
 	}
 

--- a/v2/pkg/protocols/dns/request.go
+++ b/v2/pkg/protocols/dns/request.go
@@ -16,6 +16,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/generators"
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/helpers/eventcreator"
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/helpers/responsehighlighter"
+	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/utils/vardump"
 	templateTypes "github.com/projectdiscovery/nuclei/v2/pkg/templates/types"
 	"github.com/projectdiscovery/nuclei/v2/pkg/utils"
 	"github.com/projectdiscovery/retryabledns"
@@ -46,6 +47,12 @@ func (request *Request) ExecuteWithResults(input string, metadata /*TODO review 
 	vars := GenerateVariables(domain)
 	variablesMap := request.options.Variables.Evaluate(vars)
 	vars = generators.MergeMaps(variablesMap, vars)
+
+	if request.options.Options.Debug || request.options.Options.DebugResponse {
+		gologger.Debug().Msgf("Protocol request variables")
+		vardump.Variables(vars)
+		gologger.Print().Msgf("\n")
+	}
 
 	// Compile each request for the template based on the URL
 	compiledRequest, err := request.Make(domain, vars)

--- a/v2/pkg/protocols/dns/request.go
+++ b/v2/pkg/protocols/dns/request.go
@@ -49,9 +49,7 @@ func (request *Request) ExecuteWithResults(input string, metadata /*TODO review 
 	vars = generators.MergeMaps(variablesMap, vars)
 
 	if request.options.Options.Debug || request.options.Options.DebugResponse {
-		gologger.Debug().Msgf("Protocol request variables")
-		vardump.Variables(vars)
-		gologger.Print().Msgf("\n")
+		gologger.Debug().Msgf("Protocol request variables: \n%s\n", vardump.DumpVariables(vars))
 	}
 
 	// Compile each request for the template based on the URL

--- a/v2/pkg/protocols/headless/request.go
+++ b/v2/pkg/protocols/headless/request.go
@@ -70,7 +70,7 @@ func (request *Request) executeRequestWithPayloads(inputURL string, payloads map
 	}
 	defer instance.Close()
 
-	if request.options.Options.Debug || request.options.Options.DebugResponse {
+	if request.options.Options.Debug || request.options.Options.DebugRequests {
 		gologger.Debug().Msgf("Protocol request variables: \n%s\n", vardump.DumpVariables(payloads))
 	}
 

--- a/v2/pkg/protocols/headless/request.go
+++ b/v2/pkg/protocols/headless/request.go
@@ -14,6 +14,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/helpers/eventcreator"
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/helpers/responsehighlighter"
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/interactsh"
+	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/utils/vardump"
 	httpProtocol "github.com/projectdiscovery/nuclei/v2/pkg/protocols/http"
 	templateTypes "github.com/projectdiscovery/nuclei/v2/pkg/templates/types"
 )
@@ -68,6 +69,12 @@ func (request *Request) executeRequestWithPayloads(inputURL string, payloads map
 		return errors.Wrap(err, couldGetHtmlElementErrorMessage)
 	}
 	defer instance.Close()
+
+	if request.options.Options.Debug || request.options.Options.DebugResponse {
+		gologger.Debug().Msgf("Protocol request variables")
+		vardump.Variables(payloads)
+		gologger.Print().Msgf("\n")
+	}
 
 	instance.SetInteractsh(request.options.Interactsh)
 

--- a/v2/pkg/protocols/headless/request.go
+++ b/v2/pkg/protocols/headless/request.go
@@ -71,9 +71,7 @@ func (request *Request) executeRequestWithPayloads(inputURL string, payloads map
 	defer instance.Close()
 
 	if request.options.Options.Debug || request.options.Options.DebugResponse {
-		gologger.Debug().Msgf("Protocol request variables")
-		vardump.Variables(payloads)
-		gologger.Print().Msgf("\n")
+		gologger.Debug().Msgf("Protocol request variables: \n%s\n", vardump.DumpVariables(payloads))
 	}
 
 	instance.SetInteractsh(request.options.Interactsh)

--- a/v2/pkg/protocols/http/build_request.go
+++ b/v2/pkg/protocols/http/build_request.go
@@ -97,7 +97,7 @@ func (r *requestGenerator) Make(ctx context.Context, baseURL, data string, paylo
 		generators.MergeMaps(dynamicValues, GenerateVariables(parsed, trailingSlash)),
 		generators.BuildPayloadFromOptions(r.request.options.Options),
 	)
-	if r.options.Options.Debug || r.options.Options.DebugResponse {
+	if r.options.Options.Debug || r.options.Options.DebugRequests {
 		gologger.Debug().Msgf("Protocol request variables: \n%s\n", vardump.DumpVariables(values))
 	}
 

--- a/v2/pkg/protocols/http/build_request.go
+++ b/v2/pkg/protocols/http/build_request.go
@@ -17,9 +17,11 @@ import (
 	"github.com/corpix/uarand"
 	"github.com/pkg/errors"
 
+	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/expressions"
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/generators"
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/replacer"
+	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/utils/vardump"
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/dns"
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/http/race"
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/http/raw"
@@ -95,6 +97,11 @@ func (r *requestGenerator) Make(ctx context.Context, baseURL, data string, paylo
 		generators.MergeMaps(dynamicValues, GenerateVariables(parsed, trailingSlash)),
 		generators.BuildPayloadFromOptions(r.request.options.Options),
 	)
+	if r.options.Options.Debug || r.options.Options.DebugResponse {
+		gologger.Debug().Msgf("Protocol request variables")
+		vardump.Variables(values)
+		gologger.Print().Msgf("\n")
+	}
 
 	// If data contains \n it's a raw request, process it like raw. Else
 	// continue with the template based request flow.

--- a/v2/pkg/protocols/http/build_request.go
+++ b/v2/pkg/protocols/http/build_request.go
@@ -98,9 +98,7 @@ func (r *requestGenerator) Make(ctx context.Context, baseURL, data string, paylo
 		generators.BuildPayloadFromOptions(r.request.options.Options),
 	)
 	if r.options.Options.Debug || r.options.Options.DebugResponse {
-		gologger.Debug().Msgf("Protocol request variables")
-		vardump.Variables(values)
-		gologger.Print().Msgf("\n")
+		gologger.Debug().Msgf("Protocol request variables: \n%s\n", vardump.DumpVariables(values))
 	}
 
 	// If data contains \n it's a raw request, process it like raw. Else

--- a/v2/pkg/protocols/network/request.go
+++ b/v2/pkg/protocols/network/request.go
@@ -130,9 +130,7 @@ func (request *Request) executeRequestWithPayloads(variables map[string]interfac
 	interimValues := generators.MergeMaps(variables, payloads)
 
 	if request.options.Options.Debug || request.options.Options.DebugResponse {
-		gologger.Debug().Msgf("Protocol request variables")
-		vardump.Variables(interimValues)
-		gologger.Print().Msgf("\n")
+		gologger.Debug().Msgf("Protocol request variables: \n%s\n", vardump.DumpVariables(interimValues))
 	}
 
 	inputEvents := make(map[string]interface{})

--- a/v2/pkg/protocols/network/request.go
+++ b/v2/pkg/protocols/network/request.go
@@ -23,6 +23,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/helpers/responsehighlighter"
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/interactsh"
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/replacer"
+	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/utils/vardump"
 	templateTypes "github.com/projectdiscovery/nuclei/v2/pkg/templates/types"
 )
 
@@ -128,6 +129,12 @@ func (request *Request) executeRequestWithPayloads(variables map[string]interfac
 
 	interimValues := generators.MergeMaps(variables, payloads)
 
+	if request.options.Options.Debug || request.options.Options.DebugResponse {
+		gologger.Debug().Msgf("Protocol request variables")
+		vardump.Variables(interimValues)
+		gologger.Print().Msgf("\n")
+	}
+
 	inputEvents := make(map[string]interface{})
 	for _, input := range request.Inputs {
 		var data []byte
@@ -190,14 +197,14 @@ func (request *Request) executeRequestWithPayloads(variables map[string]interfac
 	}
 	request.options.Progress.IncrementRequests()
 
-	if request.options.Options.Debug || request.options.Options.DebugRequests || request.options.Options.StoreResponse{
+	if request.options.Options.Debug || request.options.Options.DebugRequests || request.options.Options.StoreResponse {
 		requestBytes := []byte(reqBuilder.String())
 		msg := fmt.Sprintf("[%s] Dumped Network request for %s\n%s", request.options.TemplateID, actualAddress, hex.Dump(requestBytes))
 		if request.options.Options.Debug || request.options.Options.DebugRequests {
-		gologger.Info().Str("address", actualAddress).Msg(msg)
+			gologger.Info().Str("address", actualAddress).Msg(msg)
 		}
-		if request.options.Options.StoreResponse{
-		request.options.Output.WriteStoreDebugData(address, request.options.TemplateID, request.Type().String(), msg)
+		if request.options.Options.StoreResponse {
+			request.options.Output.WriteStoreDebugData(address, request.options.TemplateID, request.Type().String(), msg)
 		}
 		if request.options.Options.VerboseVerbose {
 			gologger.Print().Msgf("\nCompact HEX view:\n%s", hex.EncodeToString(requestBytes))
@@ -300,15 +307,15 @@ func (request *Request) executeRequestWithPayloads(variables map[string]interfac
 
 func dumpResponse(event *output.InternalWrappedEvent, request *Request, response string, actualAddress, address string) {
 	cliOptions := request.options.Options
-	if cliOptions.Debug || cliOptions.DebugResponse || cliOptions.StoreResponse{
+	if cliOptions.Debug || cliOptions.DebugResponse || cliOptions.StoreResponse {
 		requestBytes := []byte(response)
 		highlightedResponse := responsehighlighter.Highlight(event.OperatorsResult, hex.Dump(requestBytes), cliOptions.NoColor, true)
 		msg := fmt.Sprintf("[%s] Dumped Network response for %s\n\n", request.options.TemplateID, actualAddress)
 		if cliOptions.Debug || cliOptions.DebugResponse {
-		gologger.Debug().Msg(fmt.Sprintf("%s%s", msg, highlightedResponse))
+			gologger.Debug().Msg(fmt.Sprintf("%s%s", msg, highlightedResponse))
 		}
-		if cliOptions.StoreResponse{
-		request.options.Output.WriteStoreDebugData(address, request.options.TemplateID, request.Type().String(), fmt.Sprintf("%s%s", msg, hex.Dump(requestBytes)))
+		if cliOptions.StoreResponse {
+			request.options.Output.WriteStoreDebugData(address, request.options.TemplateID, request.Type().String(), fmt.Sprintf("%s%s", msg, hex.Dump(requestBytes)))
 		}
 		if cliOptions.VerboseVerbose {
 			displayCompactHexView(event, response, cliOptions.NoColor)

--- a/v2/pkg/protocols/network/request.go
+++ b/v2/pkg/protocols/network/request.go
@@ -129,7 +129,7 @@ func (request *Request) executeRequestWithPayloads(variables map[string]interfac
 
 	interimValues := generators.MergeMaps(variables, payloads)
 
-	if request.options.Options.Debug || request.options.Options.DebugResponse {
+	if request.options.Options.Debug || request.options.Options.DebugRequests {
 		gologger.Debug().Msgf("Protocol request variables: \n%s\n", vardump.DumpVariables(interimValues))
 	}
 

--- a/v2/pkg/protocols/ssl/ssl.go
+++ b/v2/pkg/protocols/ssl/ssl.go
@@ -131,7 +131,7 @@ func (request *Request) ExecuteWithResults(input string, dynamicValues, previous
 	variablesMap := request.options.Variables.Evaluate(values)
 	payloadValues = generators.MergeMaps(variablesMap, payloadValues)
 
-	if request.options.Options.Debug || request.options.Options.DebugResponse {
+	if request.options.Options.Debug || request.options.Options.DebugRequests {
 		gologger.Debug().Msgf("Protocol request variables: \n%s\n", vardump.DumpVariables(payloadValues))
 	}
 

--- a/v2/pkg/protocols/ssl/ssl.go
+++ b/v2/pkg/protocols/ssl/ssl.go
@@ -24,6 +24,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/generators"
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/helpers/eventcreator"
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/helpers/responsehighlighter"
+	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/utils/vardump"
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/dns"
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/network/networkclientpool"
 	templateTypes "github.com/projectdiscovery/nuclei/v2/pkg/templates/types"
@@ -129,6 +130,12 @@ func (request *Request) ExecuteWithResults(input string, dynamicValues, previous
 	values := generators.MergeMaps(payloadValues, hostnameVariables)
 	variablesMap := request.options.Variables.Evaluate(values)
 	payloadValues = generators.MergeMaps(variablesMap, payloadValues)
+
+	if request.options.Options.Debug || request.options.Options.DebugResponse {
+		gologger.Debug().Msgf("Protocol request variables")
+		vardump.Variables(payloadValues)
+		gologger.Print().Msgf("\n")
+	}
 
 	finalAddress, dataErr := expressions.EvaluateByte([]byte(request.Address), payloadValues)
 	if dataErr != nil {

--- a/v2/pkg/protocols/ssl/ssl.go
+++ b/v2/pkg/protocols/ssl/ssl.go
@@ -132,9 +132,7 @@ func (request *Request) ExecuteWithResults(input string, dynamicValues, previous
 	payloadValues = generators.MergeMaps(variablesMap, payloadValues)
 
 	if request.options.Options.Debug || request.options.Options.DebugResponse {
-		gologger.Debug().Msgf("Protocol request variables")
-		vardump.Variables(payloadValues)
-		gologger.Print().Msgf("\n")
+		gologger.Debug().Msgf("Protocol request variables: \n%s\n", vardump.DumpVariables(payloadValues))
 	}
 
 	finalAddress, dataErr := expressions.EvaluateByte([]byte(request.Address), payloadValues)

--- a/v2/pkg/protocols/websocket/websocket.go
+++ b/v2/pkg/protocols/websocket/websocket.go
@@ -209,9 +209,7 @@ func (request *Request) executeRequestWithPayloads(input, hostname string, dynam
 	}
 
 	if request.options.Options.Debug || request.options.Options.DebugResponse {
-		gologger.Debug().Msgf("Protocol request variables")
-		vardump.Variables(payloadValues)
-		gologger.Print().Msgf("\n")
+		gologger.Debug().Msgf("Protocol request variables: \n%s\n", vardump.DumpVariables(payloadValues))
 	}
 
 	finalAddress, dataErr := expressions.EvaluateByte([]byte(request.Address), payloadValues)

--- a/v2/pkg/protocols/websocket/websocket.go
+++ b/v2/pkg/protocols/websocket/websocket.go
@@ -27,6 +27,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/generators"
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/helpers/eventcreator"
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/helpers/responsehighlighter"
+	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/utils/vardump"
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/network/networkclientpool"
 	templateTypes "github.com/projectdiscovery/nuclei/v2/pkg/templates/types"
 	"github.com/projectdiscovery/nuclei/v2/pkg/types"
@@ -205,6 +206,12 @@ func (request *Request) executeRequestWithPayloads(input, hostname string, dynam
 		Timeout:   time.Duration(requestOptions.Options.Timeout) * time.Second,
 		NetDial:   request.dialer.Dial,
 		TLSConfig: tlsConfig,
+	}
+
+	if request.options.Options.Debug || request.options.Options.DebugResponse {
+		gologger.Debug().Msgf("Protocol request variables")
+		vardump.Variables(payloadValues)
+		gologger.Print().Msgf("\n")
 	}
 
 	finalAddress, dataErr := expressions.EvaluateByte([]byte(request.Address), payloadValues)

--- a/v2/pkg/protocols/websocket/websocket.go
+++ b/v2/pkg/protocols/websocket/websocket.go
@@ -208,7 +208,7 @@ func (request *Request) executeRequestWithPayloads(input, hostname string, dynam
 		TLSConfig: tlsConfig,
 	}
 
-	if request.options.Options.Debug || request.options.Options.DebugResponse {
+	if request.options.Options.Debug || request.options.Options.DebugRequests {
 		gologger.Debug().Msgf("Protocol request variables: \n%s\n", vardump.DumpVariables(payloadValues))
 	}
 

--- a/v2/pkg/protocols/whois/whois.go
+++ b/v2/pkg/protocols/whois/whois.go
@@ -91,9 +91,7 @@ func (request *Request) ExecuteWithResults(input string, dynamicValues, previous
 	variables := generateVariables(input)
 
 	if request.options.Options.Debug || request.options.Options.DebugResponse {
-		gologger.Debug().Msgf("Protocol request variables")
-		vardump.Variables(variables)
-		gologger.Print().Msgf("\n")
+		gologger.Debug().Msgf("Protocol request variables: \n%s\n", vardump.DumpVariables(variables))
 	}
 
 	// and replace placeholders

--- a/v2/pkg/protocols/whois/whois.go
+++ b/v2/pkg/protocols/whois/whois.go
@@ -18,6 +18,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/helpers/eventcreator"
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/helpers/responsehighlighter"
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/replacer"
+	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/utils/vardump"
 	templateTypes "github.com/projectdiscovery/nuclei/v2/pkg/templates/types"
 	"github.com/projectdiscovery/nuclei/v2/pkg/types"
 )
@@ -88,6 +89,13 @@ func (request *Request) GetID() string {
 func (request *Request) ExecuteWithResults(input string, dynamicValues, previous output.InternalEvent, callback protocols.OutputEventCallback) error {
 	// generate variables
 	variables := generateVariables(input)
+
+	if request.options.Options.Debug || request.options.Options.DebugResponse {
+		gologger.Debug().Msgf("Protocol request variables")
+		vardump.Variables(variables)
+		gologger.Print().Msgf("\n")
+	}
+
 	// and replace placeholders
 	query := replacer.Replace(request.Query, variables)
 	// build an rdap request

--- a/v2/pkg/protocols/whois/whois.go
+++ b/v2/pkg/protocols/whois/whois.go
@@ -90,7 +90,7 @@ func (request *Request) ExecuteWithResults(input string, dynamicValues, previous
 	// generate variables
 	variables := generateVariables(input)
 
-	if request.options.Options.Debug || request.options.Options.DebugResponse {
+	if request.options.Options.Debug || request.options.Options.DebugRequests {
 		gologger.Debug().Msgf("Protocol request variables: \n%s\n", vardump.DumpVariables(variables))
 	}
 


### PR DESCRIPTION
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->
Closes #2369

```console
./nuclei -t template.yaml -u https://example.com -debug

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   2.7.6

                projectdiscovery.io

[WRN] Use with caution. You are responsible for your actions.
[WRN] Developers assume no liability and are not responsible for any misuse or damage.
[INF] Using Nuclei Engine 2.7.6 (outdated)
[INF] Using Nuclei Templates 9.1.5 (latest)
[INF] Templates added in last update: 58
[INF] Templates loaded for scan: 1
[DBG] Protocol request variables
        1. FQDN => example.com
        2. TLD => com
        3. Scheme => https
        4. DN => example
        5. Path => 
        6. File => 
        7. Hostname => example.com
        8. RDN => example.com
        9. Host => example.com
        10. Port => 443
        11. BaseURL => https://example.com
        12. SD => 
        13. RootURL => https://example.com

[INF] [test] Dumped HTTP request for https://example.com/

GET / HTTP/1.1
Host: example.com
User-Agent: Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36
Connection: close
Accept-Encoding: gzip

[DBG] Protocol response variables
        1. File => 
        2. SD => 
        3. matched => https://example.com/
        4. expires => Tue, 23 Aug 2022 10:54:23 GMT
        5. content_length => -1
        6. response => HTTP/1.1 200 OK  Connecti .... > </div> </body> </html> 
        7. Path => 
        8. age => 460409
        9. vary => Accept-Encoding
        10. x_cache => HIT
        11. RootURL => https://example.com
        12. Host => example.com
        13. TLD => com
        14. Port => 443
        15. curl-command => curl -X 'GET' -d '' -H 'H .... 6' 'https://example.com/'
        16. cache_control => max-age=604800
        17. Scheme => https
        18. content_type => text/html; charset=UTF-8
        19. template-info => {test pdteam    {info} map[] <nil> }
        20. interactsh-server => 
        21. RDN => example.com
        22. BaseURL => https://example.com
        23. header => HTTP/1.1 200 OK  Connecti .... ncoding  X-Cache: HIT    
        24. template-path => /Users/ice3man/projectdis .... /cmd/nuclei/template.yaml
        25. etag => "3147526947+gzip"
        26. ip => 93.184.216.34
        27. DN => example
        28. duration => 3.158988667
        29. status_code => 200
        30. last_modified => Thu, 17 Oct 2019 07:18:26 GMT
        31. date => Tue, 16 Aug 2022 10:54:23 GMT
        32. all_headers => HTTP/1.1 200 OK  Connecti .... ncoding  X-Cache: HIT    
        33. template-id => test
        34. host => https://example.com
        35. type => http
        36. server => ECS (bsa/EB14)
        37. FQDN => example.com
        38. request => GET / HTTP/1.1  Host: exa .... Accept-Encoding: gzip    
        39. body => <!doctype html> <html> <h .... > </div> </body> </html> 
        40. Hostname => example.com

[DBG] [test] Dumped HTTP response https://example.com/

HTTP/1.1 200 OK
Connection: close
Age: 460409
Cache-Control: max-age=604800
Content-Type: text/html; charset=UTF-8
Date: Tue, 16 Aug 2022 10:54:23 GMT
Etag: "3147526947+gzip"
Expires: Tue, 23 Aug 2022 10:54:23 GMT
Last-Modified: Thu, 17 Oct 2019 07:18:26 GMT
Server: ECS (bsa/EB14)
Vary: Accept-Encoding
X-Cache: HIT
```

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)