### PR TITLE
http: prevent HTTP 'connection' header from being added twice

### DIFF
--- a/v2/cmd/integration-test/http.go
+++ b/v2/cmd/integration-test/http.go
@@ -586,7 +586,7 @@ func (h *httpRawUnsafeRequest) Execute(filePath string) error {
 
 	ts := testutils.NewTCPServer(nil, defaultStaticPort, func(conn net.Conn) {
 		defer conn.Close()
-		_, _ = conn.Write([]byte("HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 36\r\nContent-Type: text/plain; charset=utf-8\r\n\r\nThis is test raw-unsafe-matcher test"))
+		_, _ = conn.Write([]byte("HTTP/1.1 200 OK\r\nContent-Length: 36\r\nContent-Type: text/plain; charset=utf-8\r\n\r\nThis is test raw-unsafe-matcher test"))
 	})
 	defer ts.Close()
 

--- a/v2/pkg/protocols/http/http.go
+++ b/v2/pkg/protocols/http/http.go
@@ -237,6 +237,7 @@ func (request *Request) Compile(options *protocols.ExecuterOptions) error {
 		NoTimeout:       false,
 		FollowRedirects: request.Redirects,
 		CookieReuse:     request.CookieReuse,
+		Connection:      &httpclientpool.ConnectionConfiguration{},
 	}
 	// If we have request level timeout, ignore http client timeouts
 	for _, req := range request.Raw {
@@ -248,7 +249,7 @@ func (request *Request) Compile(options *protocols.ExecuterOptions) error {
 
 	// if the headers contain "Connection" we need to disable the automatic keep alive of the standard library
 	if _, hasConnectionHeader := request.Headers["Connection"]; hasConnectionHeader {
-		connectionConfiguration.Connection = &httpclientpool.ConnectionConfiguration{DisableKeepAlive: false}
+		connectionConfiguration.Connection.DisableKeepAlive = true
 	}
 
 	client, err := httpclientpool.Get(options.Options, connectionConfiguration)


### PR DESCRIPTION
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->


## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
---

This is the template I used while testing. I simply switched the 'Connection' value between 'keep-alive' and 'close'.

```yml
id: debug-template

info:
  name: Debug template
  author: miguel 
  severity: critical

requests:
  - raw:
      - |
        POST  HTTP/1.1
        Host: {{Hostname}}
        Connection: keep-alive
        Content-Length: 35

        foobarbazzofrefrfjhjfjhrjhfrjhfhjfr

    matchers:
      - type: word
        part: body
        words:
          - "OK"
```

---

What nuclei was sending over the wire before this patch:

<img width="690" alt="behavior-before-patch" src="https://user-images.githubusercontent.com/6826244/186113311-f99f6a6f-d9fc-405d-94a1-339e76a6df7e.png">

What nuclei sends now given the above template:

<img width="690" alt="behavior-after-patch" src="https://user-images.githubusercontent.com/6826244/186113364-cf9fec4a-9909-4866-9b18-fcac6c7f883d.png">

When no connection header is supplied, it defaults to 'close'. That's an easy thing to change in case you prefer to default to keep-alive.

Notice how in the original code, the comment said keep-alives were being disabled but the DisableKeepAlives attribute was being set to `false` therefore keeping them.

