### PR TITLE
Return wrapped errors for DSL compilation problems

### DIFF
--- a/v2/pkg/operators/common/dsl/dsl.go
+++ b/v2/pkg/operators/common/dsl/dsl.go
@@ -872,3 +872,16 @@ func appendSingleDigitZero(value string) string {
 	}
 	return value
 }
+
+type CompilationError struct {
+	DslSignature string
+	WrappedError error
+}
+
+func (e *CompilationError) Error() string {
+	return fmt.Sprintf("could not compile DSL expression %q: %v", e.DslSignature, e.WrappedError)
+}
+
+func (e *CompilationError) Unwrap() error {
+	return e.WrappedError
+}

--- a/v2/pkg/operators/extractors/compile.go
+++ b/v2/pkg/operators/extractors/compile.go
@@ -45,7 +45,7 @@ func (e *Extractor) CompileExtractors() error {
 	for _, dslExp := range e.DSL {
 		compiled, err := govaluate.NewEvaluableExpressionWithFunctions(dslExp, dsl.HelperFunctions)
 		if err != nil {
-			return fmt.Errorf("could not compile dsl: %s", dslExp)
+			return &dsl.CompilationError{DslSignature: dslExp, WrappedError: err}
 		}
 		e.dslCompiled = append(e.dslCompiled, compiled)
 	}

--- a/v2/pkg/operators/matchers/compile.go
+++ b/v2/pkg/operators/matchers/compile.go
@@ -64,7 +64,7 @@ func (matcher *Matcher) CompileMatchers() error {
 	for _, dslExpression := range matcher.DSL {
 		compiledExpression, err := govaluate.NewEvaluableExpressionWithFunctions(dslExpression, dsl.HelperFunctions)
 		if err != nil {
-			return &DslCompilationError{DslSignature: dslExpression, WrappedError: err}
+			return &dsl.CompilationError{DslSignature: dslExpression, WrappedError: err}
 		}
 		matcher.dslCompiled = append(matcher.dslCompiled, compiledExpression)
 	}
@@ -88,17 +88,4 @@ func (matcher *Matcher) CompileMatchers() error {
 		}
 	}
 	return nil
-}
-
-type DslCompilationError struct {
-	DslSignature string
-	WrappedError error
-}
-
-func (e *DslCompilationError) Error() string {
-	return fmt.Sprintf("could not compile DSL expression: %s. %v", e.DslSignature, e.WrappedError)
-}
-
-func (e *DslCompilationError) Unwrap() error {
-	return e.WrappedError
 }

--- a/v2/pkg/protocols/common/executer/executer.go
+++ b/v2/pkg/protocols/common/executer/executer.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/nuclei/v2/pkg/operators/common/dsl"
-	"github.com/projectdiscovery/nuclei/v2/pkg/operators/matchers"
 	"github.com/projectdiscovery/nuclei/v2/pkg/output"
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols"
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/helpers/writer"
@@ -33,7 +32,7 @@ func (e *Executer) Compile() error {
 
 	for _, request := range e.requests {
 		if err := request.Compile(e.options); err != nil {
-			var dslCompilationError *matchers.DslCompilationError
+			var dslCompilationError *dsl.CompilationError
 			if errors.As(err, &dslCompilationError) {
 				if cliOptions.Verbose {
 					rawErrorMessage := dslCompilationError.Error()


### PR DESCRIPTION
## Proposed changes

This allows the DSL help information to be printed when in debug mode.

Fixes #2481.

## Checklist

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)