### PR TITLE
Optional use of local chrome for headless tests via tags

### DIFF
--- a/v2/pkg/protocols/headless/engine/page_actions_test.go
+++ b/v2/pkg/protocols/headless/engine/page_actions_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/protocolstate"
+	"github.com/projectdiscovery/nuclei/v2/pkg/testutils/testheadless"
 	"github.com/projectdiscovery/nuclei/v2/pkg/types"
 )
 
@@ -516,7 +517,7 @@ func testHeadless(t *testing.T, actions []*Action, timeout time.Duration, handle
 	t.Helper()
 	_ = protocolstate.Init(&types.Options{})
 
-	browser, err := New(&types.Options{ShowBrowser: false})
+	browser, err := New(&types.Options{ShowBrowser: false, UseInstalledChrome: testheadless.HeadlessLocal})
 	require.Nil(t, err, "could not create browser")
 	defer browser.Close()
 

--- a/v2/pkg/testutils/testheadless/headless_local.go
+++ b/v2/pkg/testutils/testheadless/headless_local.go
@@ -1,0 +1,6 @@
+//go:build headless_local
+
+package testheadless
+
+// HeadlessLocal determines if local headless chrome should be used in tests
+const HeadlessLocal = true

--- a/v2/pkg/testutils/testheadless/headless_runtime.go
+++ b/v2/pkg/testutils/testheadless/headless_runtime.go
@@ -1,0 +1,6 @@
+//go:build !headless_local
+
+package testheadless
+
+// HeadlessLocal determines if local headless chrome should be used in tests
+const HeadlessLocal = false


### PR DESCRIPTION
## Proposed changes
This PR adds support to use local headless chrome to perform headless tests:
```console
$ go test ./... -tags headless_local
```

Fixes https://github.com/projectdiscovery/team-backlogs/issues/190

## Checklist
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)