### PR TITLE
Adding custom cancel function

### DIFF
--- a/v2/pkg/protocols/http/request.go
+++ b/v2/pkg/protocols/http/request.go
@@ -267,6 +267,11 @@ func (request *Request) ExecuteWithResults(input *contextargs.Context, dynamicVa
 				request.options.Progress.IncrementFailedRequestsBy(int64(generator.Total()))
 				return true, err
 			}
+
+			if generatedHttpRequest.customCancelFunction != nil {
+				defer generatedHttpRequest.customCancelFunction()
+			}
+
 			// If the variables contain interactsh urls, use them
 			if len(interactURLs) > 0 {
 				generatedHttpRequest.interactshURLs = append(generatedHttpRequest.interactshURLs, interactURLs...)

--- a/v2/pkg/protocols/http/request_annotations_test.go
+++ b/v2/pkg/protocols/http/request_annotations_test.go
@@ -21,7 +21,8 @@ func TestRequestParseAnnotationsTimeout(t *testing.T) {
 		httpReq, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
 		require.Nil(t, err, "could not create http request")
 
-		newRequest, modified := request.parseAnnotations(rawRequest, httpReq)
+		newRequest, cancelFunc, modified := request.parseAnnotations(rawRequest, httpReq)
+		require.NotNil(t, cancelFunc, "could not initialize valid cancel function")
 		require.True(t, modified, "could not get correct modified value")
 		_, deadlined := newRequest.Context().Deadline()
 		require.True(t, deadlined, "could not get set request deadline")
@@ -37,7 +38,8 @@ func TestRequestParseAnnotationsTimeout(t *testing.T) {
 		httpReq, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://example.com", nil)
 		require.Nil(t, err, "could not create http request")
 
-		newRequest, modified := request.parseAnnotations(rawRequest, httpReq)
+		newRequest, cancelFunc, modified := request.parseAnnotations(rawRequest, httpReq)
+		require.Nil(t, cancelFunc, "cancel function should be nil")
 		require.False(t, modified, "could not get correct modified value")
 		_, deadlined := newRequest.Context().Deadline()
 		require.False(t, deadlined, "could not get set request deadline")


### PR DESCRIPTION
## Proposed changes
This PR adds a new field `customCancelFunction` to `generatedRequest` to avoid context leaks for timeouts introduced via request annotation.

## Checklist
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)