### PR TITLE
Adding automatic request condition detection

### DIFF
--- a/integration_tests/http/request-condition.yaml
+++ b/integration_tests/http/request-condition.yaml
@@ -10,8 +10,7 @@ requests:
     path:
       - "{{BaseURL}}/200"
       - "{{BaseURL}}/400"
- 
-    req-condition: true
+
     matchers:
       - type: dsl
         dsl:

--- a/v2/pkg/protocols/http/cluster.go
+++ b/v2/pkg/protocols/http/cluster.go
@@ -10,7 +10,7 @@ import (
 // are similar enough to be considered one and can be checked by
 // just adding the matcher/extractors for the request and the correct IDs.
 func (request *Request) CanCluster(other *Request) bool {
-	if len(request.Payloads) > 0 || len(request.Raw) > 0 || len(request.Body) > 0 || request.Unsafe || request.ReqCondition || request.Name != "" {
+	if len(request.Payloads) > 0 || len(request.Raw) > 0 || len(request.Body) > 0 || request.Unsafe || request.NeedsRequestCondition() || request.Name != "" {
 		return false
 	}
 	if request.Method != other.Method ||

--- a/v2/pkg/protocols/http/http.go
+++ b/v2/pkg/protocols/http/http.go
@@ -176,6 +176,7 @@ type Request struct {
 	//   ReqCondition automatically assigns numbers to requests and preserves their history.
 	//
 	//   This allows matching on them later for multi-request conditions.
+	// Deprecated: request condition will be detected automatically (https://github.com/projectdiscovery/nuclei/issues/2393)
 	ReqCondition bool `yaml:"req-condition,omitempty" jsonschema:"title=preserve request history,description=Automatically assigns numbers to requests and preserves their history"`
 	// description: |
 	//   StopAtFirstMatch stops the execution of the requests and template as soon as a match is found.

--- a/v2/pkg/protocols/http/request.go
+++ b/v2/pkg/protocols/http/request.go
@@ -611,7 +611,7 @@ func (request *Request) executeRequest(input *contextargs.Context, generatedRequ
 		}
 
 		// Add to history the current request number metadata if asked by the user.
-		if request.ReqCondition {
+		if request.NeedsRequestCondition() {
 			for k, v := range outputEvent {
 				key := fmt.Sprintf("%s_%d", k, requestCount)
 				previousEvent[key] = v

--- a/v2/pkg/protocols/http/request_condition.go
+++ b/v2/pkg/protocols/http/request_condition.go
@@ -12,19 +12,30 @@ var (
 // NeedsRequestCondition determines if request condition should be enabled
 func (request *Request) NeedsRequestCondition() bool {
 	for _, matcher := range request.Matchers {
-		for _, dslExpression := range matcher.DSL {
-			if reRequestCondition.MatchString(dslExpression) {
-				return true
-			}
+		if checkRequestConditionExpressions(matcher.DSL...) {
+			return true
+		}
+		if checkRequestConditionExpressions(matcher.Part) {
+			return true
 		}
 	}
 	for _, extractor := range request.Extractors {
-		for _, dslExpression := range extractor.DSL {
-			if reRequestCondition.MatchString(dslExpression) {
-				return true
-			}
+		if checkRequestConditionExpressions(extractor.DSL...) {
+			return true
+		}
+		if checkRequestConditionExpressions(extractor.Part) {
+			return true
 		}
 	}
 
+	return false
+}
+
+func checkRequestConditionExpressions(expressions ...string) bool {
+	for _, expression := range expressions {
+		if reRequestCondition.MatchString(expression) {
+			return true
+		}
+	}
 	return false
 }

--- a/v2/pkg/protocols/http/request_condition.go
+++ b/v2/pkg/protocols/http/request_condition.go
@@ -1,0 +1,30 @@
+package http
+
+import (
+	"regexp"
+)
+
+var (
+	// Determines if request condition are needed by detecting the pattern _xxx
+	reRequestCondition = regexp.MustCompile(`(?m)_\d+`)
+)
+
+// NeedsRequestCondition determines if request condition should be enabled
+func (request *Request) NeedsRequestCondition() bool {
+	for _, matcher := range request.Matchers {
+		for _, dslExpression := range matcher.DSL {
+			if reRequestCondition.MatchString(dslExpression) {
+				return true
+			}
+		}
+	}
+	for _, extractor := range request.Extractors {
+		for _, dslExpression := range extractor.DSL {
+			if reRequestCondition.MatchString(dslExpression) {
+				return true
+			}
+		}
+	}
+
+	return false
+}

--- a/v2/pkg/protocols/http/validate.go
+++ b/v2/pkg/protocols/http/validate.go
@@ -3,7 +3,7 @@ package http
 import "github.com/pkg/errors"
 
 func (request *Request) validate() error {
-	if request.Race && request.ReqCondition {
+	if request.Race && request.NeedsRequestCondition() {
 		return errors.New("'race' and 'req-condition' can't be used together")
 	}
 


### PR DESCRIPTION
## Proposed changes
This PR implements automatic detection of `req-condition` by detecting the `_xxx` pattern (with `xxx` being any digit).

## Checklist
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

Notes: it seems like that the integration test `nuclei/integration_tests/http/request-condition-new.yaml` is not about request condition, and it should be renamed (it's about request id prefix).