### PR TITLE
reordering unsafe test in the map

### DIFF
--- a/v2/cmd/integration-test/http.go
+++ b/v2/cmd/integration-test/http.go
@@ -19,6 +19,7 @@ import (
 )
 
 var httpTestcases = map[string]testutils.TestCase{
+	"http/raw-unsafe-request.yaml":                  &httpRawUnsafeRequest{},
 	"http/get-headers.yaml":                         &httpGetHeaders{},
 	"http/get-query-string.yaml":                    &httpGetQueryString{},
 	"http/get-redirects.yaml":                       &httpGetRedirects{},
@@ -34,7 +35,6 @@ var httpTestcases = map[string]testutils.TestCase{
 	"http/raw-get.yaml":                             &httpRawGet{},
 	"http/raw-payload.yaml":                         &httpRawPayload{},
 	"http/raw-post-body.yaml":                       &httpRawPostBody{},
-	"http/raw-unsafe-request.yaml":                  &httpRawUnsafeRequest{},
 	"http/request-condition.yaml":                   &httpRequestCondition{},
 	"http/request-condition-new.yaml":               &httpRequestCondition{},
 	"http/interactsh.yaml":                          &httpInteractshRequest{},


### PR DESCRIPTION
## Proposed changes
This PR attempts to fix #2677 

## Checklist
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

Notes: It's still unclear the reason of the parsing error, but after multiple runs moving the faulty test at the very beginning seems to indirectly fix the issue on windows (even if maps iteration happens in random order)