### PR TITLE
Improving unsafe uri path

### DIFF
--- a/v2/pkg/protocols/http/raw/raw.go
+++ b/v2/pkg/protocols/http/raw/raw.go
@@ -59,7 +59,7 @@ read_line:
 	}
 	// Check if we have also a path from the passed base URL and if yes,
 	// append that to the unsafe request as well.
-	if parsedURL.Path != "" && strings.HasPrefix(parts[1], "/") && parts[1] != parsedURL.Path {
+	if parsedURL.Path != "" && parts[1] != "" && parts[1] != parsedURL.Path {
 		rawRequest.UnsafeRawBytes = fixUnsafeRequestPath(parsedURL, parts[1], rawRequest.UnsafeRawBytes)
 	}
 	// Set the request Method
@@ -157,9 +157,14 @@ read_line:
 }
 
 func fixUnsafeRequestPath(baseURL *url.URL, requestPath string, request []byte) []byte {
-	fixedPath := path.Join(baseURL.Path, requestPath)
-	fixed := bytes.Replace(request, []byte(requestPath), []byte(fixedPath), 1)
-	return fixed
+	var fixedPath string
+	if stringsutil.HasPrefixAny(requestPath, "/") {
+		fixedPath = path.Join(baseURL.Path, requestPath)
+	} else {
+		fixedPath = fmt.Sprintf("%s%s", baseURL.Path, requestPath)
+	}
+
+	return bytes.Replace(request, []byte(requestPath), []byte(fixedPath), 1)
 }
 
 // TryFillCustomHeaders after the Host header

--- a/v2/pkg/protocols/http/raw/raw_test.go
+++ b/v2/pkg/protocols/http/raw/raw_test.go
@@ -74,6 +74,12 @@ Accept-Language: en-US,en;q=0.9
 Connection: close`, "https://test.com/test/", true)
 	require.Nil(t, err, "could not parse unsafe request")
 	require.Contains(t, string(request.UnsafeRawBytes), "GET /test/manager/html", "Could not parse unsafe method request path correctly")
+
+	request, err = Parse(`GET ?a=b HTTP/1.1
+	Host: {{Hostname}}
+	Origin: {{BaseURL}}`, "https://test.com/test.js", true)
+	require.Nil(t, err, "could not parse unsafe request")
+	require.Contains(t, string(request.UnsafeRawBytes), "GET /test.js?a=b", "Could not parse unsafe method request path correctly")
 }
 
 func TestTryFillCustomHeaders(t *testing.T) {

--- a/v2/pkg/protocols/http/request.go
+++ b/v2/pkg/protocols/http/request.go
@@ -418,6 +418,9 @@ func (request *Request) executeRequest(input *contextargs.Context, generatedRequ
 		// use request url as matched url if empty
 		if formedURL == "" {
 			formedURL = input.Input
+			if generatedRequest.rawRequest.Path != "" {
+				formedURL = fmt.Sprintf("%s%s", formedURL, generatedRequest.rawRequest.Path)
+			}
 		}
 		if parsed, parseErr := url.Parse(formedURL); parseErr == nil {
 			hostname = parsed.Host


### PR DESCRIPTION
## Proposed changes
This PR improves URI path building in unsafe templates.

## Checklist
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Example
```console
$ cat t.yaml
id: basic-raw-example

info:
  name: Test RAW Template
  author: pdteam
  severity: info

requests:
  - raw:
      - |+
        GET ?a=b HTTP/1.1
        Host: {{Hostname}}
        Origin: {{BaseURL}}

    unsafe: true
$ go run . -t t.yaml -v -u https://192.168.1.1/test.js -debug -duc -no-interactsh
...
[INF] [basic-raw-example] Dumped HTTP request for https://192.168.1.1/test.js

GET /test.js?a=b HTTP/1.1
Host: 192.168.1.1
Origin: https://192.168.1.1/test.js
```