### PR TITLE
Added attack-type option to override template attack-type

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ CONFIGURATIONS:
    -ztls                          use ztls library with autofallback to standard one for tls13
    -sni string                    tls sni hostname to use (default: input domain name)
    -i, -interface string          network interface to use for network scan
+   -at, -attack-type string       type of payload combinations to perform (batteringram,pitchfork,clusterbomb)
    -sip, -source-ip string        source ip address to use for network scan
    -config-directory string       Override the default config path ($home/.config)
    -rsr, -response-size-read int  max response size to read in bytes (default 10485760)

--- a/integration_tests/http/custom-attack-type.yaml
+++ b/integration_tests/http/custom-attack-type.yaml
@@ -1,0 +1,23 @@
+id: custom-attack-type
+
+info:
+  name: Custom Attack Type
+  author: pdteam
+  severity: info
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/?a={{test}}&b={{values}}"
+    payloads:
+      test:
+        - hello
+        - another
+      values:
+        - data
+        - hacking
+    attack: pitchfork
+    matchers:
+      - type: word
+        words:
+          - "This is test custom payload"

--- a/v2/cmd/nuclei/main.go
+++ b/v2/cmd/nuclei/main.go
@@ -194,6 +194,7 @@ on extensive configurability, massive extensibility and ease of use.`)
 		flagSet.BoolVar(&options.ZTLS, "ztls", false, "use ztls library with autofallback to standard one for tls13"),
 		flagSet.StringVar(&options.SNI, "sni", "", "tls sni hostname to use (default: input domain name)"),
 		flagSet.StringVarP(&options.Interface, "interface", "i", "", "network interface to use for network scan"),
+		flagSet.StringVarP(&options.AttackType, "attack-type", "at", "", "type of payload combinations to perform (batteringram,pitchfork,clusterbomb)"),
 		flagSet.StringVarP(&options.SourceIP, "source-ip", "sip", "", "source ip address to use for network scan"),
 		flagSet.StringVar(&options.CustomConfigDir, "config-directory", "", "Override the default config path ($home/.config)"),
 		flagSet.IntVarP(&options.ResponseReadSize, "response-size-read", "rsr", 10*1024*1024, "max response size to read in bytes"),

--- a/v2/pkg/protocols/common/generators/generators.go
+++ b/v2/pkg/protocols/common/generators/generators.go
@@ -16,7 +16,7 @@ type PayloadGenerator struct {
 }
 
 // New creates a new generator structure for payload generation
-func New(payloads map[string]interface{}, attackType AttackType, templatePath string, catalog catalog.Catalog) (*PayloadGenerator, error) {
+func New(payloads map[string]interface{}, attackType AttackType, templatePath string, catalog catalog.Catalog, customAttackType string) (*PayloadGenerator, error) {
 	if attackType.String() == "" {
 		attackType = BatteringRamAttack
 	}
@@ -49,6 +49,13 @@ func New(payloads map[string]interface{}, attackType AttackType, templatePath st
 	generator.Type = attackType
 	generator.payloads = compiled
 
+	if customAttackType != "" {
+		attackTypeNew, err := toAttackType(customAttackType)
+		if err != nil {
+			return nil, errors.Wrap(err, "could not parse custom attack-type")
+		}
+		generator.Type = attackTypeNew
+	}
 	// Validate the batteringram payload set
 	if attackType == BatteringRamAttack {
 		if len(payloads) != 1 {

--- a/v2/pkg/protocols/common/generators/generators_test.go
+++ b/v2/pkg/protocols/common/generators/generators_test.go
@@ -12,7 +12,7 @@ func TestBatteringRamGenerator(t *testing.T) {
 	usernames := []string{"admin", "password"}
 
 	catalogInstance := disk.NewCatalog("")
-	generator, err := New(map[string]interface{}{"username": usernames}, BatteringRamAttack, "", catalogInstance)
+	generator, err := New(map[string]interface{}{"username": usernames}, BatteringRamAttack, "", catalogInstance, "")
 	require.Nil(t, err, "could not create generator")
 
 	iterator := generator.NewIterator()
@@ -32,7 +32,7 @@ func TestPitchforkGenerator(t *testing.T) {
 	passwords := []string{"password1", "password2", "password3"}
 
 	catalogInstance := disk.NewCatalog("")
-	generator, err := New(map[string]interface{}{"username": usernames, "password": passwords}, PitchForkAttack, "", catalogInstance)
+	generator, err := New(map[string]interface{}{"username": usernames, "password": passwords}, PitchForkAttack, "", catalogInstance, "")
 	require.Nil(t, err, "could not create generator")
 
 	iterator := generator.NewIterator()
@@ -54,7 +54,7 @@ func TestClusterbombGenerator(t *testing.T) {
 	passwords := []string{"admin", "password", "token"}
 
 	catalogInstance := disk.NewCatalog("")
-	generator, err := New(map[string]interface{}{"username": usernames, "password": passwords}, ClusterBombAttack, "", catalogInstance)
+	generator, err := New(map[string]interface{}{"username": usernames, "password": passwords}, ClusterBombAttack, "", catalogInstance, "")
 	require.Nil(t, err, "could not create generator")
 
 	iterator := generator.NewIterator()

--- a/v2/pkg/protocols/headless/headless.go
+++ b/v2/pkg/protocols/headless/headless.go
@@ -95,7 +95,7 @@ func (request *Request) Compile(options *protocols.ExecuterOptions) error {
 
 	if len(request.Payloads) > 0 {
 		var err error
-		request.generator, err = generators.New(request.Payloads, request.AttackType.Value, options.TemplatePath, options.Catalog)
+		request.generator, err = generators.New(request.Payloads, request.AttackType.Value, options.TemplatePath, options.Catalog, options.Options.AttackType)
 		if err != nil {
 			return errors.Wrap(err, "could not parse payloads")
 		}

--- a/v2/pkg/protocols/http/http.go
+++ b/v2/pkg/protocols/http/http.go
@@ -347,7 +347,7 @@ func (request *Request) Compile(options *protocols.ExecuterOptions) error {
 	}
 
 	if len(request.Payloads) > 0 {
-		request.generator, err = generators.New(request.Payloads, request.AttackType.Value, request.options.TemplatePath, request.options.Catalog)
+		request.generator, err = generators.New(request.Payloads, request.AttackType.Value, request.options.TemplatePath, request.options.Catalog, request.options.Options.AttackType)
 		if err != nil {
 			return errors.Wrap(err, "could not parse payloads")
 		}

--- a/v2/pkg/protocols/http/request_generator_test.go
+++ b/v2/pkg/protocols/http/request_generator_test.go
@@ -34,7 +34,7 @@ func TestRequestGeneratorClusterBombSingle(t *testing.T) {
 		Raw:        []string{`GET /{{username}}:{{password}} HTTP/1.1`},
 	}
 	catalogInstance := disk.NewCatalog("")
-	req.generator, err = generators.New(req.Payloads, req.AttackType.Value, "", catalogInstance)
+	req.generator, err = generators.New(req.Payloads, req.AttackType.Value, "", catalogInstance, "")
 	require.Nil(t, err, "could not create generator")
 
 	generator := req.newGenerator()
@@ -58,7 +58,7 @@ func TestRequestGeneratorClusterBombMultipleRaw(t *testing.T) {
 		Raw:        []string{`GET /{{username}}:{{password}} HTTP/1.1`, `GET /{{username}}@{{password}} HTTP/1.1`},
 	}
 	catalogInstance := disk.NewCatalog("")
-	req.generator, err = generators.New(req.Payloads, req.AttackType.Value, "", catalogInstance)
+	req.generator, err = generators.New(req.Payloads, req.AttackType.Value, "", catalogInstance, "")
 	require.Nil(t, err, "could not create generator")
 
 	generator := req.newGenerator()

--- a/v2/pkg/protocols/network/network.go
+++ b/v2/pkg/protocols/network/network.go
@@ -184,7 +184,7 @@ func (request *Request) Compile(options *protocols.ExecuterOptions) error {
 	}
 
 	if len(request.Payloads) > 0 {
-		request.generator, err = generators.New(request.Payloads, request.AttackType.Value, request.options.TemplatePath, request.options.Catalog)
+		request.generator, err = generators.New(request.Payloads, request.AttackType.Value, request.options.TemplatePath, request.options.Catalog, request.options.Options.AttackType)
 		if err != nil {
 			return errors.Wrap(err, "could not parse payloads")
 		}

--- a/v2/pkg/protocols/websocket/websocket.go
+++ b/v2/pkg/protocols/websocket/websocket.go
@@ -104,7 +104,7 @@ func (request *Request) Compile(options *protocols.ExecuterOptions) error {
 	request.dialer = client
 
 	if len(request.Payloads) > 0 {
-		request.generator, err = generators.New(request.Payloads, request.AttackType.Value, request.options.TemplatePath, options.Catalog)
+		request.generator, err = generators.New(request.Payloads, request.AttackType.Value, request.options.TemplatePath, options.Catalog, options.Options.AttackType)
 		if err != nil {
 			return errors.Wrap(err, "could not parse payloads")
 		}

--- a/v2/pkg/types/types.go
+++ b/v2/pkg/types/types.go
@@ -244,6 +244,8 @@ type Options struct {
 	Interface string
 	// SourceIP sets custom source IP address for network requests
 	SourceIP string
+	// AttackType overrides template level attack-type configuration
+	AttackType string
 	// ResponseReadSize is the maximum size of response to read
 	ResponseReadSize int
 	// ResponseSaveSize is the maximum size of response to save


### PR DESCRIPTION
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->
Closes https://github.com/projectdiscovery/nuclei/issues/2666

```console
echo http://0.0.0.0:59761 | ./nuclei -t test.yaml -v -at clusterbomb

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   2.7.8

		projectdiscovery.io

[WRN] Use with caution. You are responsible for your actions.
[WRN] Developers assume no liability and are not responsible for any misuse or damage.
[INF] Using Nuclei Engine 2.7.8 (latest)
[INF] Using Nuclei Templates 9.2.4 (latest)
[INF] Templates added in last update: 40
[INF] Templates loaded for scan: 1
[VER] [custom-attack-type] Sent HTTP request to http://0.0.0.0:59761/?a=hello&b=data
[VER] [custom-attack-type] Sent HTTP request to http://0.0.0.0:59761/?a=another&b=data
[VER] [custom-attack-type] Sent HTTP request to http://0.0.0.0:59761/?a=hello&b=hacking
[VER] [custom-attack-type] Sent HTTP request to http://0.0.0.0:59761/?a=another&b=hacking
[INF] No results found. Better luck next time!
```

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)