### PR TITLE
Add targets number in output banner

### DIFF
--- a/v2/internal/runner/runner.go
+++ b/v2/internal/runner/runner.go
@@ -601,7 +601,10 @@ func (r *Runner) displayExecutionInfo(store *loader.Store) {
 	if len(store.Workflows()) > 0 {
 		gologger.Info().Msgf("Workflows loaded for scan: %d", len(store.Workflows()))
 	}
+
+	gologger.Info().Msgf("Hosts to scan: %d", r.hmapInputProvider.Count())
 }
+
 func (r *Runner) readNewTemplatesWithVersionFile(version string) ([]string, error) {
 	resp, err := http.DefaultClient.Get(fmt.Sprintf("https://raw.githubusercontent.com/projectdiscovery/nuclei-templates/%s/.new-additions", version))
 	if err != nil {

--- a/v2/internal/runner/runner.go
+++ b/v2/internal/runner/runner.go
@@ -602,7 +602,7 @@ func (r *Runner) displayExecutionInfo(store *loader.Store) {
 		gologger.Info().Msgf("Workflows loaded for scan: %d", len(store.Workflows()))
 	}
 
-	gologger.Info().Msgf("Hosts to scan: %d", r.hmapInputProvider.Count())
+	gologger.Info().Msgf("Targets loaded for scan: %d", r.hmapInputProvider.Count())
 }
 
 func (r *Runner) readNewTemplatesWithVersionFile(version string) ([]string, error) {


### PR DESCRIPTION
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->
When nuclei is executed, it prints an informational line telling how many hosts it will scan (as it's already done for templates, workflows, templates added in the last update).
Just run nuclei as normal and an additional line will be printed:
`[INF] Targets loaded for scan: 31948`

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

This PR closes #2798.