### PR TITLE
Fixed typo in the `-stop-at-first-match` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ OPTIMIZATIONS:
    -mhe, -max-host-error int           max errors for a host before skipping from scan (default 30)
    -project                            use a project folder to avoid sending same request multiple times
    -project-path string                set a specific project path
-   -spm, -stop-at-first-path           stop processing HTTP requests after the first match (may break template/workflow logic)
+   -spm, -stop-at-first-match          stop processing HTTP requests after the first match (may break template/workflow logic)
    -stream                             stream mode - start elaborating without sorting the input
    -irt, -input-read-timeout duration  timeout on input read (default 3m0s)
    -no-stdin                           Disable Stdin processing

--- a/README_CN.md
+++ b/README_CN.md
@@ -155,7 +155,7 @@ Nuclei是一款注重于可配置性、可扩展性和易用性的基于模板�
    -mhe, -max-host-error int            某主机扫描失败次数，跳过该主机（默认：30）
    -project                             使用项目文件夹避免多次发送同一请求
    -project-path string                 设置特定的项目文件夹
-   -spm, -stop-at-first-path            得到一个结果后停止（或许会中断模板和工作流的逻辑）
+   -spm, -stop-at-first-match           得到一个结果后停止（或许会中断模板和工作流的逻辑）
    -stream                              流模式 - 在不整理输入的情况下详细描述
 
 无界面浏览器：

--- a/README_KR.md
+++ b/README_KR.md
@@ -179,7 +179,7 @@ OPTIMIZATIONS:
    -mhe, -max-host-error int   스캔을 건너뛰기 전에 호스트에 대한 최대 오류 수 (기본 30)
    -project                    프로젝트 폴더를 사용하여 동일한 요청을 여러 번 보내지 않음
    -project-path string        특정 프로젝트 경로 설정
-   -spm, -stop-at-first-path   첫 번째 일치 후 HTTP 요청 처리 중지 (template/workflow 로직이 중단될 수 있음)
+   -spm, -stop-at-first-match  첫 번째 일치 후 HTTP 요청 처리 중지 (template/workflow 로직이 중단될 수 있음)
    -stream                     stream 모드 - 입력을 정렬하지 않고 elaborating 시작
 
 HEADLESS:

--- a/v2/cmd/nuclei/main.go
+++ b/v2/cmd/nuclei/main.go
@@ -229,7 +229,7 @@ on extensive configurability, massive extensibility and ease of use.`)
 		flagSet.IntVarP(&options.MaxHostError, "max-host-error", "mhe", 30, "max errors for a host before skipping from scan"),
 		flagSet.BoolVar(&options.Project, "project", false, "use a project folder to avoid sending same request multiple times"),
 		flagSet.StringVar(&options.ProjectPath, "project-path", os.TempDir(), "set a specific project path"),
-		flagSet.BoolVarP(&options.StopAtFirstMatch, "stop-at-first-path", "spm", false, "stop processing HTTP requests after the first match (may break template/workflow logic)"),
+		flagSet.BoolVarP(&options.StopAtFirstMatch, "stop-at-first-match", "spm", false, "stop processing HTTP requests after the first match (may break template/workflow logic)"),
 		flagSet.BoolVar(&options.Stream, "stream", false, "stream mode - start elaborating without sorting the input"),
 		flagSet.DurationVarP(&options.InputReadTimeout, "input-read-timeout", "irt", time.Duration(3*time.Minute), "timeout on input read"),
 		flagSet.BoolVarP(&options.DisableHTTPProbe, "no-httpx", "nh", false, "disable httpx probing for non-url input"),


### PR DESCRIPTION
`-stop-at-first-match` instead of `-stop-at-first-path`