### PR TITLE
Reverting retryablehttp-go to fix custom http client

### DIFF
--- a/v2/go.mod
+++ b/v2/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/projectdiscovery/nuclei-updatecheck-api v0.0.0-20211006155443-c0a8d610a4df
 	github.com/projectdiscovery/rawhttp v0.1.3
 	github.com/projectdiscovery/retryabledns v1.0.17
-	github.com/projectdiscovery/retryablehttp-go v1.0.3
+	github.com/projectdiscovery/retryablehttp-go v1.0.4-0.20221124110224-30d8f5ff0c0b
 	github.com/projectdiscovery/stringsutil v0.0.2 // indirect
 	github.com/projectdiscovery/yamldoc-go v1.0.3-0.20211126104922-00d2c6bb43b6
 	github.com/remeh/sizedwaitgroup v1.0.0
@@ -164,7 +164,7 @@ require (
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/projectdiscovery/blackrock v0.0.0-20220628111055-35616c71b2dc // indirect
 	github.com/projectdiscovery/mapcidr v1.0.3
-	github.com/projectdiscovery/networkpolicy v0.0.2-0.20220525172507-b844eafc878d // indirect
+	github.com/projectdiscovery/networkpolicy v0.0.2-0.20220525172507-b844eafc878d
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/rogpeppe/go-internal v1.8.0 // indirect
 	github.com/saintfish/chardet v0.0.0-20120816061221-3af4cd4741ca // indirect

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -659,8 +659,8 @@ github.com/projectdiscovery/retryabledns v1.0.17 h1:XKzI26UKYt2g7YLJ/EcyYmM04sfD
 github.com/projectdiscovery/retryabledns v1.0.17/go.mod h1:Dyhq/f0sGmXueso0+Ah3LbJfsX4PXpBrpfiyjZZ8SDk=
 github.com/projectdiscovery/retryablehttp-go v1.0.1/go.mod h1:SrN6iLZilNG1X4neq1D+SBxoqfAF4nyzvmevkTkWsek=
 github.com/projectdiscovery/retryablehttp-go v1.0.2/go.mod h1:dx//aY9V247qHdsRf0vdWHTBZuBQ2vm6Dq5dagxrDYI=
-github.com/projectdiscovery/retryablehttp-go v1.0.3 h1:8kIb3LPnt6tdZvCcTmvq3cowYOed4S/B9q2Mgf/EuwI=
-github.com/projectdiscovery/retryablehttp-go v1.0.3/go.mod h1:t4buiLTB0HtI+62iHfGDqQVTv/i+8OhAKwaX93TGsFE=
+github.com/projectdiscovery/retryablehttp-go v1.0.4-0.20221124110224-30d8f5ff0c0b h1:OhIM6lAOxCfwiTkOZeiymWIPl+P7dJjLvtIRPWmaEis=
+github.com/projectdiscovery/retryablehttp-go v1.0.4-0.20221124110224-30d8f5ff0c0b/go.mod h1:t4buiLTB0HtI+62iHfGDqQVTv/i+8OhAKwaX93TGsFE=
 github.com/projectdiscovery/sliceutil v0.0.1 h1:YoCqCMcdwz+gqNfW5hFY8UvNHoA6SfyBSNkVahatleg=
 github.com/projectdiscovery/sliceutil v0.0.1/go.mod h1:0wBmhU5uTDwMfrEZfvwH9qa5k60Q4shPVOC9E6LGsDI=
 github.com/projectdiscovery/stringsutil v0.0.0-20210804142656-fd3c28dbaafe/go.mod h1:oTRc18WBv9t6BpaN9XBY+QmG28PUpsyDzRht56Qf49I=

--- a/v2/pkg/protocols/common/generators/load_test.go
+++ b/v2/pkg/protocols/common/generators/load_test.go
@@ -3,6 +3,7 @@ package generators
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/projectdiscovery/nuclei/v2/pkg/catalog/disk"
@@ -35,7 +36,10 @@ func TestLoadPayloads(t *testing.T) {
 		require.NoError(t, err, "could not load payloads")
 		require.Equal(t, map[string][]string{"new": {"test", "another"}}, values, "could not get values")
 	})
-	t.Run("no-sandbox", func(t *testing.T) {
+	t.Run("no-sandbox-unix", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			return
+		}
 		_, err := generator.loadPayloads(map[string]interface{}{
 			"new": "/etc/passwd",
 		}, "/random", "/test", false)


### PR DESCRIPTION
## Proposed changes
This PR fixes retryablehttp-go custom http client

## Checklist
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)