### PR TITLE
Making matcher name case insensitive

### DIFF
--- a/v2/pkg/model/types/stringslice/stringslice.go
+++ b/v2/pkg/model/types/stringslice/stringslice.go
@@ -52,10 +52,14 @@ func (stringSlice *StringSlice) UnmarshalYAML(unmarshal func(interface{}) error)
 
 	result := make([]string, 0, len(marshalledSlice))
 	for _, value := range marshalledSlice {
-		result = append(result, strings.ToLower(strings.TrimSpace(value))) // TODO do we need to introduce RawStringSlice and/or NormalizedStringSlices?
+		result = append(result, stringSlice.normalize(value))
 	}
 	stringSlice.Value = result
 	return nil
+}
+
+func (stringSlice StringSlice) normalize(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
 }
 
 func (stringSlice StringSlice) MarshalYAML() (interface{}, error) {
@@ -82,7 +86,7 @@ func (stringSlice *StringSlice) UnmarshalJSON(data []byte) error {
 	switch {
 	case len(marshalledValuesAsSlice) > 0:
 		result = marshalledValuesAsSlice
-	case utils.IsNotBlank(marshalledValueAsString):
+	case !utils.IsBlank(marshalledValueAsString):
 		result = strings.Split(marshalledValueAsString, ",")
 	default:
 		result = []string{}
@@ -90,7 +94,7 @@ func (stringSlice *StringSlice) UnmarshalJSON(data []byte) error {
 
 	values := make([]string, 0, len(result))
 	for _, value := range result {
-		values = append(values, strings.ToLower(strings.TrimSpace(value))) // TODO do we need to introduce RawStringSlice and/or NormalizedStringSlices?
+		values = append(values, stringSlice.normalize(value))
 	}
 	stringSlice.Value = values
 	return nil
@@ -112,7 +116,7 @@ func marshalStringToSlice(unmarshal func(interface{}) error) ([]string, error) {
 	switch {
 	case len(marshalledValuesAsSlice) > 0:
 		result = marshalledValuesAsSlice
-	case utils.IsNotBlank(marshalledValueAsString):
+	case !utils.IsBlank(marshalledValueAsString):
 		result = strings.Split(marshalledValueAsString, ",")
 	default:
 		result = []string{}

--- a/v2/pkg/operators/operators.go
+++ b/v2/pkg/operators/operators.go
@@ -3,6 +3,7 @@ package operators
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/pkg/errors"
 
@@ -89,6 +90,23 @@ type Result struct {
 
 	// Optional lineCounts for file protocol
 	LineCount string
+}
+
+func (result *Result) HasMatch(name string) bool {
+	return result.hasItem(name, result.Matches)
+}
+
+func (result *Result) HasExtract(name string) bool {
+	return result.hasItem(name, result.Extracts)
+}
+
+func (result *Result) hasItem(name string, m map[string][]string) bool {
+	for matchName := range m {
+		if strings.EqualFold(name, matchName) {
+			return true
+		}
+	}
+	return false
 }
 
 // MakeDynamicValuesCallback takes an input dynamic values map and calls

--- a/v2/pkg/reporting/exporters/sarif/sarif.go
+++ b/v2/pkg/reporting/exporters/sarif/sarif.go
@@ -57,7 +57,7 @@ func (exporter *Exporter) Export(event *output.ResultEvent) error {
 	templateID := event.TemplateID + "-" + hex.EncodeToString(h.Sum(nil))
 
 	var ruleName string
-	if utils.IsNotBlank(event.Info.Name) {
+	if !utils.IsBlank(event.Info.Name) {
 		ruleName = event.Info.Name
 	}
 
@@ -69,7 +69,7 @@ func (exporter *Exporter) Export(event *output.ResultEvent) error {
 	}
 
 	var ruleDescription string
-	if utils.IsNotBlank(event.Info.Description) {
+	if !utils.IsBlank(event.Info.Description) {
 		ruleDescription = event.Info.Description
 	}
 

--- a/v2/pkg/reporting/format/format.go
+++ b/v2/pkg/reporting/format/format.go
@@ -14,7 +14,6 @@ import (
 	"github.com/projectdiscovery/nuclei/v2/pkg/types"
 )
 
-
 // Summary returns a formatted built one line summary of the event
 func Summary(event *output.ResultEvent) string {
 	template := GetMatchedTemplate(event)
@@ -179,7 +178,7 @@ func ToMarkdownTableString(templateInfo *model.Info) string {
 		insertionOrderedStringMap.ForEach(func(key string, value interface{}) {
 			switch value := value.(type) {
 			case string:
-				if utils.IsNotBlank(value) {
+				if !utils.IsBlank(value) {
 					builder.WriteString(fmt.Sprintf("| %s | %s |\n", key, value))
 				}
 			}

--- a/v2/pkg/utils/utils.go
+++ b/v2/pkg/utils/utils.go
@@ -14,10 +14,6 @@ func IsBlank(value string) bool {
 	return strings.TrimSpace(value) == ""
 }
 
-func IsNotBlank(value string) bool {
-	return !IsBlank(value)
-}
-
 func UnwrapError(err error) error {
 	for { // get the last wrapped error
 		unwrapped := errors.Unwrap(err)

--- a/v2/pkg/workflows/workflows.go
+++ b/v2/pkg/workflows/workflows.go
@@ -105,8 +105,8 @@ func (matcher *Matcher) Match(result *operators.Result) bool {
 	}
 
 	for i, name := range names {
-		_, matchOK := result.Matches[name]
-		_, extractOK := result.Extracts[name]
+		matchOK := result.HasMatch(name)
+		extractOK := result.HasExtract(name)
 
 		if !matchOK && !extractOK {
 			if matcher.condition == ANDCondition {


### PR DESCRIPTION
## Proposed changes
Workflows matchers name are normalized as they are forcefully of type StringSlice, instead template's matcher's name doesn't get any normalization. This PR makes workflow's subtemplates matcher's name case insensitive.


## Checklist
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Example
```console
$ cat basic-template.yaml
id: basic-template

info:
  name: basic-template
  author: capiton
  severity: info

requests:
  - method: GET
    path:
      - "{{RootURL}}"

    matchers:
      - type: word
        name: PHP
        condition: and
        words:
          - php
$ cat basic-workflow.yaml
id: basic-workflow

info:
  name: Test HTTP Template
  author: capiton

workflows:
  - template: basic-template.yaml
    matchers:
      - name: 
          - PHP
        condition: and

        subtemplates:
          - tags: cve
$ go run . -w basic-workflow.yaml -u http://192.168.1.1
```