### PR TITLE
Removing unwanted print debug

### DIFF
--- a/v2/pkg/operators/common/dsl/dsl.go
+++ b/v2/pkg/operators/common/dsl/dsl.go
@@ -658,9 +658,7 @@ func init() {
 							return parsedTime.Unix(), nil
 						}
 					}
-					errorMessage := "could not parse the current input with the default layouts"
-					gologger.Debug().Msg(errorMessage + ":\n" + strings.Join(defaultDateTimeLayouts, "\t\n"))
-					return nil, fmt.Errorf(errorMessage)
+					return nil, fmt.Errorf("could not parse the current input with the default layouts")
 				} else if len(args) == 2 {
 					layout := types.ToString(args[1])
 					parsedTime, err := time.Parse(layout, input)


### PR DESCRIPTION
## Proposed changes
Removing unwanted debug instruction as the error is already displayed via `gologger.Error()`

## Checklist
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)