### PR TITLE
automerge url parameters from input and templates

### DIFF
--- a/v2/pkg/protocols/http/build_request.go
+++ b/v2/pkg/protocols/http/build_request.go
@@ -79,9 +79,8 @@ func (r *requestGenerator) Make(ctx context.Context, baseURL, data string, paylo
 		return nil, err
 	}
 
-	data, parsed = baseURLWithTemplatePrefs(data, parsed)
-
 	isRawRequest := len(r.request.Raw) > 0
+	data, parsed = baseURLWithTemplatePrefs(data, parsed, isRawRequest)
 
 	// If the request is not a raw request, and the URL input path is suffixed with
 	// a trailing slash, and our Input URL is also suffixed with a trailing slash,
@@ -185,19 +184,66 @@ func (r *requestGenerator) Total() int {
 }
 
 // baseURLWithTemplatePrefs returns the url for BaseURL keeping
-// the template port and path preference over the user provided one.
-func baseURLWithTemplatePrefs(data string, parsed *url.URL) (string, *url.URL) {
+// the template port along with any query parameters over the user provided one.
+func baseURLWithTemplatePrefs(data string, parsed *url.URL, isRaw bool) (string, *url.URL) {
 	// template port preference over input URL port if template has a port
 	matches := urlWithPortRegex.FindAllStringSubmatch(data, -1)
-	if len(matches) == 0 {
+	if len(matches) > 0 {
+		port := matches[0][1]
+		parsed.Host = net.JoinHostPort(parsed.Hostname(), port)
+		data = strings.ReplaceAll(data, ":"+port, "")
+		if parsed.Path == "" {
+			parsed.Path = "/"
+		}
+	}
+
+	if isRaw {
+		// do not swap parameters from parsedURL to base
 		return data, parsed
 	}
-	port := matches[0][1]
-	parsed.Host = net.JoinHostPort(parsed.Hostname(), port)
-	data = strings.ReplaceAll(data, ":"+port, "")
-	if parsed.Path == "" {
-		parsed.Path = "/"
+
+	// transfer any parmas from URL to data( i.e {{BaseURL}} )
+	params := parsed.Query()
+	if len(params) == 0 {
+		return data, parsed
 	}
+	// remove any existing params from parsedInput (tracked using params)
+	// parsed.RawQuery = ""
+
+	// ex: {{BaseURL}}/metrics?user=xxx
+	dataURLrelpath := strings.TrimLeft(data, "{{BaseURL}}") //nolint:all
+
+	if dataURLrelpath == "" || dataURLrelpath == "/" {
+		// just attach raw query to data
+		dataURLrelpath = "/?" + params.Encode()
+	} else {
+		// parse existing data
+		if strings.HasPrefix(dataURLrelpath, "?") {
+			// if it is {{BaseURL}}?s=xx add path in between
+			dataURLrelpath = "/" + dataURLrelpath
+		}
+		// /?action=x or /metrics/ parse it
+		payloadpath, err := url.Parse(dataURLrelpath)
+		if err != nil {
+			// payload not possible to parse (edgecase)
+			dataURLrelpath = dataURLrelpath + "?" + params.Encode()
+		} else {
+			payloadparams := payloadpath.Query()
+			if len(payloadparams) != 0 {
+				// ex: /?action=x
+				for k := range payloadparams {
+					params.Add(k, payloadparams.Get(k))
+				}
+			}
+			//ex: /?admin=user&action=x
+			payloadpath.RawQuery = params.Encode()
+			dataURLrelpath = payloadpath.String()
+		}
+
+	}
+
+	data = "{{BaseURL}}" + dataURLrelpath
+	parsed.RawQuery = ""
 	return data, parsed
 }
 

--- a/v2/pkg/protocols/http/build_request.go
+++ b/v2/pkg/protocols/http/build_request.go
@@ -215,18 +215,13 @@ func baseURLWithTemplatePrefs(data string, parsed *url.URL, isRaw bool) (string,
 
 	if dataURLrelpath == "" || dataURLrelpath == "/" {
 		// just attach raw query to data
-		dataURLrelpath = "/?" + params.Encode()
+		dataURLrelpath += "?" + params.Encode()
 	} else {
-		// parse existing data
-		if strings.HasPrefix(dataURLrelpath, "?") {
-			// if it is {{BaseURL}}?s=xx add path in between
-			dataURLrelpath = "/" + dataURLrelpath
-		}
 		// /?action=x or /metrics/ parse it
 		payloadpath, err := url.Parse(dataURLrelpath)
 		if err != nil {
 			// payload not possible to parse (edgecase)
-			dataURLrelpath = dataURLrelpath + "?" + params.Encode()
+			dataURLrelpath += "?" + params.Encode()
 		} else {
 			payloadparams := payloadpath.Query()
 			if len(payloadparams) != 0 {

--- a/v2/pkg/protocols/http/build_request_test.go
+++ b/v2/pkg/protocols/http/build_request_test.go
@@ -20,7 +20,7 @@ func TestBaseURLWithTemplatePrefs(t *testing.T) {
 	parsed, _ := url.Parse(baseURL)
 
 	data := "{{BaseURL}}:8000/newpath"
-	data, parsed = baseURLWithTemplatePrefs(data, parsed)
+	data, parsed = baseURLWithTemplatePrefs(data, parsed, false)
 	require.Equal(t, "http://localhost:8000/test", parsed.String(), "could not get correct value")
 	require.Equal(t, "{{BaseURL}}/newpath", data, "could not get correct data")
 }

--- a/v2/pkg/protocols/http/raw/raw.go
+++ b/v2/pkg/protocols/http/raw/raw.go
@@ -7,9 +7,9 @@ import (
 	"fmt"
 	"io"
 	"net/url"
-	"path"
 	"strings"
 
+	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/http/utils"
 	"github.com/projectdiscovery/rawhttp/client"
 	stringsutil "github.com/projectdiscovery/utils/strings"
 )
@@ -40,9 +40,10 @@ func Parse(request, baseURL string, unsafe bool) (*Request, error) {
 		// Join path with input along with parameters
 		relUrl, relerr := url.Parse(relpath)
 		if relUrl == nil {
-			newpath = path.Join(inputURL.Path, relpath)
+			// special case when url.Parse fails
+			newpath = utils.JoinURLPath(inputURL.Path, relpath)
 		} else {
-			newpath = path.Join(inputURL.Path, relUrl.Path)
+			newpath = utils.JoinURLPath(inputURL.Path, relUrl.Path)
 			if len(relUrl.Query()) > 0 {
 				relParam := relUrl.Query()
 				for k := range relParam {

--- a/v2/pkg/protocols/http/raw/raw_test.go
+++ b/v2/pkg/protocols/http/raw/raw_test.go
@@ -29,17 +29,18 @@ Host: {{Hostname}}`, "https://example.com:8080/test", false)
 		request, err := Parse(`GET ?username=test&password=test HTTP/1.1
 Host: {{Hostname}}:123`, "https://example.com:8080/test", false)
 		require.Nil(t, err, "could not parse GET request")
-		require.Equal(t, "https://example.com:8080/test?username=test&password=test", request.FullURL, "Could not parse request url correctly")
+		// url.values are sorted to avoid randomness of using maps
+		require.Equal(t, "https://example.com:8080/test?password=test&username=test", request.FullURL, "Could not parse request url correctly")
 
 		request, err = Parse(`GET ?username=test&password=test HTTP/1.1
 Host: {{Hostname}}:123`, "https://example.com:8080/test/", false)
 		require.Nil(t, err, "could not parse GET request")
-		require.Equal(t, "https://example.com:8080/test/?username=test&password=test", request.FullURL, "Could not parse request url correctly")
+		require.Equal(t, "https://example.com:8080/test/?password=test&username=test", request.FullURL, "Could not parse request url correctly")
 
 		request, err = Parse(`GET /?username=test&password=test HTTP/1.1
 		Host: {{Hostname}}:123`, "https://example.com:8080/test/", false)
 		require.Nil(t, err, "could not parse GET request")
-		require.Equal(t, "https://example.com:8080/test/?username=test&password=test", request.FullURL, "Could not parse request url correctly")
+		require.Equal(t, "https://example.com:8080/test/?password=test&username=test", request.FullURL, "Could not parse request url correctly")
 	})
 }
 

--- a/v2/pkg/protocols/http/utils/url.go
+++ b/v2/pkg/protocols/http/utils/url.go
@@ -13,17 +13,16 @@ func JoinURLPath(elem1 string, elem2 string) string {
 		Path.Join converts /test/ to /test
 		this should be handled manually
 	*/
-	if elem2 == "" || elem2 == "/" || elem2 == "/?" {
-		if elem2 == "" {
-			return elem1
-		} else {
-			// check for extra slash
-			if strings.HasSuffix(elem1, "/") && strings.HasPrefix(elem2, "/") {
-				elem1 = strings.TrimRight(elem1, "/")
-			}
-			// merge and return
-			return fmt.Sprintf("%v%v", elem1, elem2)
+	if elem2 == "" {
+		return elem1
+	}
+	if elem2 == "/" || elem2 == "/?" {
+		// check for extra slash
+		if strings.HasSuffix(elem1, "/") && strings.HasPrefix(elem2, "/") {
+			elem1 = strings.TrimRight(elem1, "/")
 		}
+		// merge and return
+		return fmt.Sprintf("%v%v", elem1, elem2)
 	} else {
 		if strings.HasPrefix(elem2, "?") {
 			// path2 is parameter and not a url append and return
@@ -34,5 +33,4 @@ func JoinURLPath(elem1 string, elem2 string) string {
 		// if not encoded properly
 		return path.Join(elem1, elem2)
 	}
-
 }

--- a/v2/pkg/protocols/http/utils/url.go
+++ b/v2/pkg/protocols/http/utils/url.go
@@ -1,0 +1,38 @@
+package utils
+
+import (
+	"fmt"
+	"path"
+	"strings"
+)
+
+// Joins two relative paths and handles trailing slash edgecase
+func JoinURLPath(elem1 string, elem2 string) string {
+	/*
+		Trailing Slash EdgeCase
+		Path.Join converts /test/ to /test
+		this should be handled manually
+	*/
+	if elem2 == "" || elem2 == "/" || elem2 == "/?" {
+		if elem2 == "" {
+			return elem1
+		} else {
+			// check for extra slash
+			if strings.HasSuffix(elem1, "/") && strings.HasPrefix(elem2, "/") {
+				elem1 = strings.TrimRight(elem1, "/")
+			}
+			// merge and return
+			return fmt.Sprintf("%v%v", elem1, elem2)
+		}
+	} else {
+		if strings.HasPrefix(elem2, "?") {
+			// path2 is parameter and not a url append and return
+			return fmt.Sprintf("%v%v", elem1, elem2)
+		}
+		// Note:
+		// path.Join implicitly calls path.Clean so any relative paths are filtered
+		// if not encoded properly
+		return path.Join(elem1, elem2)
+	}
+
+}

--- a/v2/pkg/protocols/http/utils/url_test.go
+++ b/v2/pkg/protocols/http/utils/url_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestURLJoin(t *testing.T) {
-
 	fmt.Println(path.Join("/wp-content", "/wp-content/admin.php"))
 	testcases := []struct {
 		URL1         string

--- a/v2/pkg/protocols/http/utils/url_test.go
+++ b/v2/pkg/protocols/http/utils/url_test.go
@@ -1,0 +1,30 @@
+package utils_test
+
+import (
+	"fmt"
+	"path"
+	"testing"
+
+	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/http/utils"
+)
+
+func TestURLJoin(t *testing.T) {
+
+	fmt.Println(path.Join("/wp-content", "/wp-content/admin.php"))
+	testcases := []struct {
+		URL1         string
+		URL2         string
+		ExpectedJoin string
+	}{
+		{"/test/", "", "/test/"},
+		{"/test", "/", "/test/"},
+		{"/test", "?param=true", "/test?param=true"},
+		{"/test/", "/", "/test/"},
+	}
+	for _, v := range testcases {
+		res := utils.JoinURLPath(v.URL1, v.URL2)
+		if res != v.ExpectedJoin {
+			t.Errorf("failed to join urls expected %v but got %v", v.ExpectedJoin, res)
+		}
+	}
+}


### PR DESCRIPTION
## Proposed changes

- Currently when input has parameters they don't merge with template path and url parameters as discussed in  
https://github.com/projectdiscovery/nuclei/discussions/1392
- Now parameters are added instead of replacing any existing parameters.
`Ex:  https://scanme.sh/?user=pd  |  nuclei -t some-template.yaml  `
final url if `some-template.yaml` adds `user=admin` would be 
`https://scanme.sh/?user=pd&user=admin`
- This also applies for Raw requests . 

## Can be Validated Using

```sh
echo "https://scanme.sh/admin/?user=pd" | go run . -t automerge-params.yaml -silent
```

## Checklist

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)