### PR TITLE
Adding custom ip to protocol generated variables

### DIFF
--- a/v2/internal/runner/templates.go
+++ b/v2/internal/runner/templates.go
@@ -2,7 +2,7 @@ package runner
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -46,7 +46,7 @@ func (r *Runner) listAvailableStoreTemplates(store *loader.Store) {
 				colorize := !r.options.NoColor
 
 				path := tpl.Path
-				tplBody, err := ioutil.ReadFile(path)
+				tplBody, err := os.ReadFile(path)
 				if err != nil {
 					gologger.Error().Msgf("Could not read the template %s: %s", path, err)
 					continue

--- a/v2/pkg/protocols/common/contextargs/variables.go
+++ b/v2/pkg/protocols/common/contextargs/variables.go
@@ -1,0 +1,9 @@
+package contextargs
+
+// GenerateVariables from context args
+func GenerateVariables(ctx *Context) map[string]interface{} {
+	vars := map[string]interface{}{
+		"Ip": ctx.MetaInput.CustomIP,
+	}
+	return vars
+}

--- a/v2/pkg/protocols/common/contextargs/variables.go
+++ b/v2/pkg/protocols/common/contextargs/variables.go
@@ -3,7 +3,7 @@ package contextargs
 // GenerateVariables from context args
 func GenerateVariables(ctx *Context) map[string]interface{} {
 	vars := map[string]interface{}{
-		"Ip": ctx.MetaInput.CustomIP,
+		"ip": ctx.MetaInput.CustomIP,
 	}
 	return vars
 }

--- a/v2/pkg/protocols/common/updatecheck/client.go
+++ b/v2/pkg/protocols/common/updatecheck/client.go
@@ -3,7 +3,6 @@ package updatecheck
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"time"
@@ -54,7 +53,7 @@ func GetLatestIgnoreFile() ([]byte, error) {
 	}
 	defer body.Close()
 
-	data, err := ioutil.ReadAll(body)
+	data, err := io.ReadAll(body)
 	if err != nil {
 		return nil, err
 	}

--- a/v2/pkg/protocols/headless/request.go
+++ b/v2/pkg/protocols/headless/request.go
@@ -30,13 +30,13 @@ func (request *Request) Type() templateTypes.ProtocolType {
 }
 
 // ExecuteWithResults executes the protocol requests and returns results instead of writing them.
-func (request *Request) ExecuteWithResults(input *contextargs.Context, metadata, previous output.InternalEvent /*TODO review unused parameter*/, callback protocols.OutputEventCallback) error {
+func (request *Request) ExecuteWithResults(input *contextargs.Context, metadata, previous output.InternalEvent, callback protocols.OutputEventCallback) error {
 	inputURL := input.MetaInput.Input
 	if request.options.Browser.UserAgent() == "" {
 		request.options.Browser.SetUserAgent(request.compiledUserAgent)
 	}
 
-	vars := GenerateVariables(inputURL)
+	vars := utils.GenerateVariablesWithContextArgs(input, false)
 	payloads := generators.BuildPayloadFromOptions(request.options.Options)
 	values := generators.MergeMaps(vars, metadata, payloads)
 	variablesMap := request.options.Variables.Evaluate(values)
@@ -150,14 +150,4 @@ func dumpResponse(event *output.InternalWrappedEvent, requestOptions *protocols.
 		highlightedResponse := responsehighlighter.Highlight(event.OperatorsResult, responseBody, cliOptions.NoColor, false)
 		gologger.Debug().Msgf("[%s] Dumped Headless response for %s\n\n%s", requestOptions.TemplateID, input, highlightedResponse)
 	}
-}
-
-// GenerateVariables will create default variables
-func GenerateVariables(URL string) map[string]interface{} {
-	parsed, err := url.Parse(URL)
-	if err != nil {
-		return nil
-	}
-
-	return utils.GenerateVariables(parsed, false)
 }

--- a/v2/pkg/protocols/http/build_request_test.go
+++ b/v2/pkg/protocols/http/build_request_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/projectdiscovery/nuclei/v2/pkg/model"
 	"github.com/projectdiscovery/nuclei/v2/pkg/model/types/severity"
+	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/contextargs"
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/generators"
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/interactsh"
 	"github.com/projectdiscovery/nuclei/v2/pkg/testutils"
@@ -50,7 +51,7 @@ func TestMakeRequestFromModal(t *testing.T) {
 
 	generator := request.newGenerator(false)
 	inputData, payloads, _ := generator.nextValue()
-	req, err := generator.Make(context.Background(), "https://example.com", inputData, payloads, map[string]interface{}{})
+	req, err := generator.Make(context.Background(), contextargs.NewWithInput("https://example.com"), inputData, payloads, map[string]interface{}{})
 	require.Nil(t, err, "could not make http request")
 
 	bodyBytes, _ := req.request.BodyBytes()
@@ -78,13 +79,13 @@ func TestMakeRequestFromModalTrimSuffixSlash(t *testing.T) {
 
 	generator := request.newGenerator(false)
 	inputData, payloads, _ := generator.nextValue()
-	req, err := generator.Make(context.Background(), "https://example.com/test.php", inputData, payloads, map[string]interface{}{})
+	req, err := generator.Make(context.Background(), contextargs.NewWithInput("https://example.com/test.php"), inputData, payloads, map[string]interface{}{})
 	require.Nil(t, err, "could not make http request")
 	require.Equal(t, "https://example.com/test.php?query=example", req.request.URL.String(), "could not get correct request path")
 
 	generator = request.newGenerator(false)
 	inputData, payloads, _ = generator.nextValue()
-	req, err = generator.Make(context.Background(), "https://example.com/test/", inputData, payloads, map[string]interface{}{})
+	req, err = generator.Make(context.Background(), contextargs.NewWithInput("https://example.com/test/"), inputData, payloads, map[string]interface{}{})
 	require.Nil(t, err, "could not make http request")
 	require.Equal(t, "https://example.com/test/?query=example", req.request.URL.String(), "could not get correct request path")
 }
@@ -118,13 +119,13 @@ Accept-Encoding: gzip`},
 
 	generator := request.newGenerator(false)
 	inputData, payloads, _ := generator.nextValue()
-	req, err := generator.Make(context.Background(), "https://example.com", inputData, payloads, map[string]interface{}{})
+	req, err := generator.Make(context.Background(), contextargs.NewWithInput("https://example.com"), inputData, payloads, map[string]interface{}{})
 	require.Nil(t, err, "could not make http request")
 	authorization := req.request.Header.Get("Authorization")
 	require.Equal(t, "Basic admin:admin", authorization, "could not get correct authorization headers from raw")
 
 	inputData, payloads, _ = generator.nextValue()
-	req, err = generator.Make(context.Background(), "https://example.com", inputData, payloads, map[string]interface{}{})
+	req, err = generator.Make(context.Background(), contextargs.NewWithInput("https://example.com"), inputData, payloads, map[string]interface{}{})
 	require.Nil(t, err, "could not make http request")
 	authorization = req.request.Header.Get("Authorization")
 	require.Equal(t, "Basic admin:guest", authorization, "could not get correct authorization headers from raw")
@@ -159,13 +160,13 @@ Accept-Encoding: gzip`},
 
 	generator := request.newGenerator(false)
 	inputData, payloads, _ := generator.nextValue()
-	req, err := generator.Make(context.Background(), "https://example.com", inputData, payloads, map[string]interface{}{})
+	req, err := generator.Make(context.Background(), contextargs.NewWithInput("https://example.com"), inputData, payloads, map[string]interface{}{})
 	require.Nil(t, err, "could not make http request")
 	authorization := req.request.Header.Get("Authorization")
 	require.Equal(t, "Basic YWRtaW46YWRtaW4=", authorization, "could not get correct authorization headers from raw")
 
 	inputData, payloads, _ = generator.nextValue()
-	req, err = generator.Make(context.Background(), "https://example.com", inputData, payloads, map[string]interface{}{})
+	req, err = generator.Make(context.Background(), contextargs.NewWithInput("https://example.com"), inputData, payloads, map[string]interface{}{})
 	require.Nil(t, err, "could not make http request")
 	authorization = req.request.Header.Get("Authorization")
 	require.Equal(t, "Basic YWRtaW46Z3Vlc3Q=", authorization, "could not get correct authorization headers from raw")
@@ -203,7 +204,7 @@ func TestMakeRequestFromModelUniqueInteractsh(t *testing.T) {
 	require.Nil(t, err, "could not create interactsh client")
 
 	inputData, payloads, _ := generator.nextValue()
-	got, err := generator.Make(context.Background(), "https://example.com", inputData, payloads, map[string]interface{}{})
+	got, err := generator.Make(context.Background(), contextargs.NewWithInput("https://example.com"), inputData, payloads, map[string]interface{}{})
 	require.Nil(t, err, "could not make http request")
 
 	// check if all the interactsh markers are replaced with unique urls

--- a/v2/pkg/protocols/http/utils/variables.go
+++ b/v2/pkg/protocols/http/utils/variables.go
@@ -6,12 +6,22 @@ import (
 	"path"
 	"strings"
 
+	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/contextargs"
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/generators"
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/dns"
 )
 
-// GenerateVariables will create default variables after parsing a url
-func GenerateVariables(parsed *url.URL, trailingSlash bool) map[string]interface{} {
+// GenerateVariables will create default variables with context args
+func GenerateVariablesWithContextArgs(input *contextargs.Context, trailingSlash bool) map[string]interface{} {
+	parsed, err := url.Parse(input.MetaInput.Input)
+	if err != nil {
+		return nil
+	}
+	return GenerateVariablesWithURL(parsed, trailingSlash, contextargs.GenerateVariables(input))
+}
+
+// GenerateVariables will create default variables after parsing a url with additional variables
+func GenerateVariablesWithURL(parsed *url.URL, trailingSlash bool, additionalVars map[string]interface{}) map[string]interface{} {
 	domain := parsed.Host
 	if strings.Contains(parsed.Host, ":") {
 		domain = strings.Split(parsed.Host, ":")[0]
@@ -49,5 +59,5 @@ func GenerateVariables(parsed *url.URL, trailingSlash bool) map[string]interface
 		"File":     base,
 		"Scheme":   parsed.Scheme,
 	}
-	return generators.MergeMaps(httpVariables, dns.GenerateVariables(domain))
+	return generators.MergeMaps(httpVariables, dns.GenerateVariables(domain), additionalVars)
 }

--- a/v2/pkg/protocols/http/utils/variables_test.go
+++ b/v2/pkg/protocols/http/utils/variables_test.go
@@ -4,13 +4,14 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/contextargs"
 	"github.com/stretchr/testify/require"
 )
 
 func TestVariables(t *testing.T) {
 	baseURL := "http://localhost:9001/test/123"
 	parsed, _ := url.Parse(baseURL)
-	values := GenerateVariables(parsed, true)
+	values := GenerateVariablesWithURL(parsed, true, nil)
 
 	require.Equal(t, values["BaseURL"], parsed.String(), "incorrect baseurl")
 	require.Equal(t, values["RootURL"], "http://localhost:9001", "incorrect rootURL")
@@ -23,7 +24,7 @@ func TestVariables(t *testing.T) {
 
 	baseURL = "https://example.com"
 	parsed, _ = url.Parse(baseURL)
-	values = GenerateVariables(parsed, false)
+	values = GenerateVariablesWithURL(parsed, false, nil)
 
 	require.Equal(t, values["BaseURL"], parsed.String(), "incorrect baseurl")
 	require.Equal(t, values["Host"], "example.com", "incorrect domain name")
@@ -35,7 +36,7 @@ func TestVariables(t *testing.T) {
 
 	baseURL = "ftp://foobar.com/"
 	parsed, _ = url.Parse(baseURL)
-	values = GenerateVariables(parsed, true)
+	values = GenerateVariablesWithURL(parsed, true, nil)
 
 	require.Equal(t, values["BaseURL"], parsed.String(), "incorrect baseurl")
 	require.Equal(t, values["Host"], "foobar.com", "incorrect domain name")
@@ -44,4 +45,18 @@ func TestVariables(t *testing.T) {
 	require.Equal(t, values["Port"], "", "incorrect port number") // Unsupported protocol results in a blank port
 	require.Equal(t, values["Scheme"], "ftp", "incorrect scheme")
 	require.Equal(t, values["Hostname"], "foobar.com", "incorrect hostname")
+
+	baseURL = "http://scanme.sh"
+	ctxArgs := contextargs.NewWithInput(baseURL)
+	ctxArgs.MetaInput.CustomIP = "1.2.3.4"
+	values = GenerateVariablesWithContextArgs(ctxArgs, true)
+
+	require.Equal(t, values["BaseURL"], baseURL, "incorrect baseurl")
+	require.Equal(t, values["Host"], "scanme.sh", "incorrect domain name")
+	require.Equal(t, values["RootURL"], "http://scanme.sh", "incorrect rootURL")
+	require.Equal(t, values["Path"], "", "incorrect path")
+	require.Equal(t, values["Port"], "80", "incorrect port number")
+	require.Equal(t, values["Scheme"], "http", "incorrect scheme")
+	require.Equal(t, values["Hostname"], "scanme.sh", "incorrect hostname")
+	require.Equal(t, values["Ip"], "1.2.3.4", "incorrect ip")
 }

--- a/v2/pkg/protocols/http/utils/variables_test.go
+++ b/v2/pkg/protocols/http/utils/variables_test.go
@@ -58,5 +58,5 @@ func TestVariables(t *testing.T) {
 	require.Equal(t, values["Port"], "80", "incorrect port number")
 	require.Equal(t, values["Scheme"], "http", "incorrect scheme")
 	require.Equal(t, values["Hostname"], "scanme.sh", "incorrect hostname")
-	require.Equal(t, values["Ip"], "1.2.3.4", "incorrect ip")
+	require.Equal(t, values["ip"], "1.2.3.4", "incorrect ip")
 }


### PR DESCRIPTION
## Proposed changes
Adding `Ip` if a custom ip is provided for protocol generated variables. This PR also fixes lint errors and extends the use of contextargs in nuclei.

## Checklist
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Example
```yaml
$ cat test.yaml
id: test

info:
  name: debug
  author: test
  severity: info
  description: Ip 
  tags: http

requests:
  - raw:
      - |
        GET /{{Ip}} HTTP/1.1
        Host: scanme.sh
$ echo https://scanme.sh | go run . -v -scan-all-ips -t test.yaml
...
[VER] [test] Sent HTTP request to https://scanme.sh/128.199.158.128
...
```