### PR TITLE
 The debug flags do not work correctly with headless templates

### DIFF
--- a/v2/pkg/protocols/headless/request.go
+++ b/v2/pkg/protocols/headless/request.go
@@ -102,10 +102,15 @@ func (request *Request) executeRequestWithPayloads(inputURL string, payloads map
 		gologger.Info().Msgf("[%s] Dumped Headless request for %s", request.options.TemplateID, inputURL)
 
 		for _, act := range request.Steps {
-			reqBuilder.WriteString(act.String())
+			actStepStr := act.String()
+			if strings.Contains(actStepStr, "{{BaseURL}}") {
+				actStepStr = strings.ReplaceAll(actStepStr, "{{BaseURL}}", inputURL)
+			}
+			reqBuilder.WriteString("\t" + actStepStr)
 			reqBuilder.WriteString("\n")
 		}
-		gologger.Print().Msgf(reqBuilder.String())
+		gologger.Info().Msgf(reqBuilder.String())
+
 	}
 
 	var responseBody string

--- a/v2/pkg/protocols/headless/request.go
+++ b/v2/pkg/protocols/headless/request.go
@@ -103,11 +103,8 @@ func (request *Request) executeRequestWithPayloads(inputURL string, payloads map
 
 		for _, act := range request.Steps {
 			actStepStr := act.String()
-			if strings.Contains(actStepStr, "{{BaseURL}}") {
-				actStepStr = strings.ReplaceAll(actStepStr, "{{BaseURL}}", inputURL)
-			}
-			reqBuilder.WriteString("\t" + actStepStr)
-			reqBuilder.WriteString("\n")
+			actStepStr = strings.ReplaceAll(actStepStr, "{{BaseURL}}", inputURL)
+			reqBuilder.WriteString("\t" + actStepStr + "\n")
 		}
 		gologger.Debug().Msgf(reqBuilder.String())
 

--- a/v2/pkg/protocols/headless/request.go
+++ b/v2/pkg/protocols/headless/request.go
@@ -98,7 +98,7 @@ func (request *Request) executeRequestWithPayloads(inputURL string, payloads map
 	gologger.Verbose().Msgf("Sent Headless request to %s", inputURL)
 
 	reqBuilder := &strings.Builder{}
-	if request.options.Options.Debug || request.options.Options.DebugRequests {
+	if request.options.Options.Debug || request.options.Options.DebugRequests || request.options.Options.DebugResponse {
 		gologger.Info().Msgf("[%s] Dumped Headless request for %s", request.options.TemplateID, inputURL)
 
 		for _, act := range request.Steps {

--- a/v2/pkg/protocols/headless/request.go
+++ b/v2/pkg/protocols/headless/request.go
@@ -109,7 +109,7 @@ func (request *Request) executeRequestWithPayloads(inputURL string, payloads map
 			reqBuilder.WriteString("\t" + actStepStr)
 			reqBuilder.WriteString("\n")
 		}
-		gologger.Info().Msgf(reqBuilder.String())
+		gologger.Debug().Msgf(reqBuilder.String())
 
 	}
 


### PR DESCRIPTION
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->

- `nuclei -t ./headless.yaml -u {URL} -headless -debug / -debug-req / -debug-resp`

```

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v2.8.4-dev

		projectdiscovery.io

[INF] Using Nuclei Engine 2.8.4-dev (development)
[INF] Using Nuclei Templates 9.3.1 (latest)
[INF] Templates added in last update: 2
[INF] Templates loaded for scan: 1
[INF] Targets loaded for scan: 1
[INF] [headless] Dumped Headless request for https://twitter.com
[DBG] 	navigate url:https://twitter.com
	waitload
[INF] No results found. Better luck next time!
```

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)