### PR TITLE
Disable include directive preprocessing by default

### DIFF
--- a/v2/internal/runner/runner.go
+++ b/v2/internal/runner/runner.go
@@ -53,6 +53,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v2/pkg/types"
 	"github.com/projectdiscovery/nuclei/v2/pkg/utils"
 	"github.com/projectdiscovery/nuclei/v2/pkg/utils/stats"
+	"github.com/projectdiscovery/nuclei/v2/pkg/utils/yaml"
 	yamlwrapper "github.com/projectdiscovery/nuclei/v2/pkg/utils/yaml"
 	"github.com/projectdiscovery/retryablehttp-go"
 	stringsutil "github.com/projectdiscovery/utils/strings"
@@ -107,7 +108,10 @@ func New(options *types.Options) (*Runner, error) {
 		// Does not update the templates when validate flag is used
 		options.NoUpdateTemplates = true
 	}
+
+	// TODO: refactor to pass options reference globally without cycles
 	parsers.NoStrictSyntax = options.NoStrictSyntax
+	yaml.StrictSyntax = !options.NoStrictSyntax
 
 	// parse the runner.options.GithubTemplateRepo and store the valid repos in runner.customTemplateRepos
 	runner.customTemplates = customtemplates.ParseCustomTemplates(runner.options)

--- a/v2/pkg/utils/yaml/preprocess.go
+++ b/v2/pkg/utils/yaml/preprocess.go
@@ -12,8 +12,14 @@ import (
 
 var reImportsPattern = regexp.MustCompile(`(?m)# !include:(.+.yaml)`)
 
+// StrictSyntax determines if pre-processing directives should be observed
+var StrictSyntax bool
+
 // PreProcess all include directives
 func PreProcess(data []byte) ([]byte, error) {
+	if StrictSyntax {
+		return data, nil
+	}
 	// find all matches like !include:path\n
 	importMatches := reImportsPattern.FindAllSubmatch(data, -1)
 


### PR DESCRIPTION
## Proposed changes
This PR disables by default the `include` directive pre-processing unless `-no-strict-syntax` is used


## Checklist
- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)