### PR TITLE
#3046 persistent failed item status and #2065 failed items reporting error once

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -12,7 +12,7 @@ jobs:
     name: Test Builds
     strategy:
       matrix:
-        go-version: [1.18.x, 1.19.x]
+        go-version: [1.19.x]
         os: [ubuntu-latest, windows-latest, macOS-12]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/changelog-indexer.yaml
+++ b/.github/workflows/changelog-indexer.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
 
       - name: Intalling Indexer
         run: |

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
 
       - name: Check out code
         uses: actions/checkout@v3

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Run golangci-lint

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: "Set up Go"
         uses: actions/setup-go@v3
         with: 
-          go-version: 1.18
+          go-version: 1.19
 
       - name: Generate YAML Syntax Documentation
         id: generate-docs

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with: 
-          go-version: 1.18
+          go-version: 1.19
 
       - uses: goreleaser/goreleaser-action@v3
         with: 

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -18,7 +18,7 @@ jobs:
       - name: "Set up Go"
         uses: actions/setup-go@v3
         with: 
-          go-version: 1.18
+          go-version: 1.19
       
       - name: Run unit Tests
         working-directory: v2/

--- a/.github/workflows/template-validate.yml
+++ b/.github/workflows/template-validate.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with: 
-          go-version: 1.18
+          go-version: 1.19
 
       - name: Template Validation
         run: |

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ We have a [dedicated repository](https://github.com/projectdiscovery/nuclei-temp
 
 # Install Nuclei
 
-Nuclei requires **go1.18** to install successfully. Run the following command to install the latest version -
+Nuclei requires **go1.19** to install successfully. Run the following command to install the latest version -
 
 ```sh
 go install -v github.com/projectdiscovery/nuclei/v2/cmd/nuclei@latest

--- a/README_CN.md
+++ b/README_CN.md
@@ -52,7 +52,7 @@ Nuclei使用零误报的定制模板向目标发送请求，同时可以对主�
 
 # 安装Nuclei
 
-Nuclei需要**go1.18**才能安装成功。执行下列命令安装最新版本的Nuclei
+Nuclei需要**go1.19**才能安装成功。执行下列命令安装最新版本的Nuclei
 
 ```sh
 go install -v github.com/projectdiscovery/nuclei/v2/cmd/nuclei@latest

--- a/README_ID.md
+++ b/README_ID.md
@@ -52,7 +52,7 @@ Kami memiliki [repositori khusus](https://github.com/projectdiscovery/nuclei-tem
 
 # Instalasi Nuclei
 
-Nuclei membutuhkan **go1.18** agar dapat diinstall. Jalankan perintah berikut untuk menginstal versi terbaru -
+Nuclei membutuhkan **go1.19** agar dapat diinstall. Jalankan perintah berikut untuk menginstal versi terbaru -
 
 ```sh
 go install -v github.com/projectdiscovery/nuclei/v2/cmd/nuclei@latest

--- a/README_KR.md
+++ b/README_KR.md
@@ -50,7 +50,7 @@ Nuclei는 템플릿을 기반으로 대상 간에 요청을 보내기 위해 사
 
 # 설치
 
-Nuclei를 성공적으로 설치하기 위해서 **go1.18**가 필요합니다. 다음 명령을 실행하여 최신 버전을 설치합니다.
+Nuclei를 성공적으로 설치하기 위해서 **go1.19**가 필요합니다. 다음 명령을 실행하여 최신 버전을 설치합니다.
 
 ```sh
 go install -v github.com/projectdiscovery/nuclei/v2/cmd/nuclei@latest

--- a/helm/templates/interactsh-ingress.yaml
+++ b/helm/templates/interactsh-ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.interactsh.ingress.enabled -}}
 {{- $fullName := include "nuclei.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if and .Values.interactsh.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+{{- if and .Values.interactsh.ingress.className (not (semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.interactsh.ingress.annotations "kubernetes.io/ingress.class") }}
   {{- $_ := set .Values.interactsh.ingress.annotations "kubernetes.io/ingress.class" .Values.interactsh.ingress.className}}
   {{- end }}
@@ -23,7 +23,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.interactsh.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  {{- if and .Values.interactsh.ingress.className (semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion) }}
   ingressClassName: {{ .Values.interactsh.ingress.className }}
   {{- end }}
   {{- if .Values.interactsh.ingress.tls }}
@@ -43,7 +43,7 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ .path }}
-            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            {{- if and .pathType (semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion) }}
             pathType: {{ .pathType }}
             {{- end }}
             backend:

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -1,6 +1,6 @@
 module github.com/projectdiscovery/nuclei/v2
 
-go 1.18
+go 1.19
 
 require (
 	github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible

--- a/v2/pkg/protocols/common/hosterrorscache/hosterrorscache.go
+++ b/v2/pkg/protocols/common/hosterrorscache/hosterrorscache.go
@@ -94,18 +94,16 @@ func (c *Cache) Check(value string) bool {
 	}
 	numberOfErrorsValue := numberOfErrors.(int)
 
-	if numberOfErrors == -1 {
+	if numberOfErrorsValue >= c.MaxHostError+1 {
 		return true
 	}
-	fmt.Println("A", finalValue, numberOfErrorsValue, numberOfErrors, c.MaxHostError)
 	if numberOfErrorsValue >= c.MaxHostError {
-		_ = c.failedTargets.Set(finalValue, -1)
 		if c.verbose {
 			gologger.Verbose().Msgf("Skipping %s as previously unresponsive %d times", finalValue, numberOfErrorsValue)
 		}
 		return true
 	}
-	fmt.Println("B", finalValue, numberOfErrorsValue, numberOfErrors, c.MaxHostError)
+	fmt.Println(finalValue, numberOfErrorsValue, numberOfErrors, c.MaxHostError)
 	return false
 }
 

--- a/v2/pkg/protocols/common/hosterrorscache/hosterrorscache.go
+++ b/v2/pkg/protocols/common/hosterrorscache/hosterrorscache.go
@@ -1,6 +1,7 @@
 package hosterrorscache
 
 import (
+	"fmt"
 	"net"
 	"net/url"
 	"regexp"
@@ -96,6 +97,7 @@ func (c *Cache) Check(value string) bool {
 	if numberOfErrors == -1 {
 		return true
 	}
+	fmt.Println("A", finalValue, numberOfErrorsValue, numberOfErrors, c.MaxHostError)
 	if numberOfErrorsValue >= c.MaxHostError {
 		_ = c.failedTargets.Set(finalValue, -1)
 		if c.verbose {
@@ -103,6 +105,7 @@ func (c *Cache) Check(value string) bool {
 		}
 		return true
 	}
+	fmt.Println("B", finalValue, numberOfErrorsValue, numberOfErrors, c.MaxHostError)
 	return false
 }
 

--- a/v2/pkg/protocols/common/hosterrorscache/hosterrorscache.go
+++ b/v2/pkg/protocols/common/hosterrorscache/hosterrorscache.go
@@ -1,7 +1,6 @@
 package hosterrorscache
 
 import (
-	"fmt"
 	"net"
 	"net/url"
 	"regexp"
@@ -103,7 +102,6 @@ func (c *Cache) Check(value string) bool {
 		}
 		return true
 	}
-	fmt.Println(finalValue, numberOfErrorsValue, numberOfErrors, c.MaxHostError)
 	return false
 }
 

--- a/v2/pkg/protocols/common/hosterrorscache/hosterrorscache.go
+++ b/v2/pkg/protocols/common/hosterrorscache/hosterrorscache.go
@@ -116,13 +116,6 @@ func (c *Cache) MarkFailed(value string, err error) {
 		return
 	}
 	finalValue := c.normalizeCacheValue(value)
-	if !c.failedTargets.Has(finalValue) {
-		newItem := &cacheItem{errors: atomic.Int32{}}
-		newItem.errors.Store(1)
-		_ = c.failedTargets.Set(finalValue, newItem)
-		return
-	}
-
 	existingCacheItem, err := c.failedTargets.GetIFPresent(finalValue)
 	if err != nil || existingCacheItem == nil {
 		newItem := &cacheItem{errors: atomic.Int32{}}
@@ -135,11 +128,11 @@ func (c *Cache) MarkFailed(value string, err error) {
 	_ = c.failedTargets.Set(finalValue, existingCacheItemValue)
 }
 
-var checkErrorRegexp = regexp.MustCompile(`(no address found for host|Client\.Timeout exceeded while awaiting headers|could not resolve host|connection refused)`)
+var reCheckError = regexp.MustCompile(`(no address found for host|Client\.Timeout exceeded while awaiting headers|could not resolve host|connection refused)`)
 
 // checkError checks if an error represents a type that should be
 // added to the host skipping table.
 func (c *Cache) checkError(err error) bool {
 	errString := err.Error()
-	return checkErrorRegexp.MatchString(errString)
+	return reCheckError.MatchString(errString)
 }

--- a/v2/pkg/protocols/common/hosterrorscache/hosterrorscache_test.go
+++ b/v2/pkg/protocols/common/hosterrorscache/hosterrorscache_test.go
@@ -2,6 +2,7 @@ package hosterrorscache
 
 import (
 	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -25,6 +26,37 @@ func TestCacheCheckMarkFailed(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		cache.MarkFailed("test", fmt.Errorf("could not resolve host"))
 	}
+
+	value := cache.Check("test")
+	require.Equal(t, true, value, "could not get checked value")
+}
+
+func TestCacheItemCheckMarkFailedMultipleCalls(t *testing.T) {
+	cache := New(3, DefaultMaxHostsCount)
+
+	var wg sync.WaitGroup
+	wg.Add(30)
+
+	for i := 0; i < 30; i++ {
+		go func(i int) {
+			cache.MarkFailed("http://asdasjkdashkjdahsjkdhas:80", fmt.Errorf("no address found for host"))
+			if value, err := cache.failedTargets.Get("http://example.com:80"); err == nil && value != nil {
+				require.Equal(t, 1, value, "could not get correct number of marked failed hosts")
+			}
+			cache.MarkFailed("http://asdasjkdashkjdahsjkdhas:80", fmt.Errorf("Client.Timeout exceeded while awaiting headers"))
+			if value, err := cache.failedTargets.Get("example.com:80"); err == nil && value != nil {
+				require.Equal(t, 2, value, "could not get correct number of marked failed hosts")
+			}
+			cache.MarkFailed("http://asdasjkdashkjdahsjkdhas", fmt.Errorf("could not resolve host"))
+			if value, err := cache.failedTargets.Get("example.com"); err == nil && value != nil {
+				require.Equal(t, 1, value, "could not get correct number of marked failed hosts")
+			}
+			for i := 0; i < 3; i++ {
+				cache.MarkFailed("test", fmt.Errorf("could not resolve host"))
+			}
+		}(i)
+	}
+	wg.Wait()
 
 	value := cache.Check("test")
 	require.Equal(t, true, value, "could not get checked value")

--- a/v2/pkg/protocols/common/hosterrorscache/hosterrorscache_test.go
+++ b/v2/pkg/protocols/common/hosterrorscache/hosterrorscache_test.go
@@ -34,7 +34,7 @@ func TestCacheItemDo(t *testing.T) {
 	)
 
 	wg := sync.WaitGroup{}
-	for i := 0; i < 5; i++ {
+	for i := 0; i < 100; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/v2/pkg/protocols/common/hosterrorscache/hosterrorscache_test.go
+++ b/v2/pkg/protocols/common/hosterrorscache/hosterrorscache_test.go
@@ -40,8 +40,6 @@ func TestCacheCheck(t *testing.T) {
 }
 
 func TestCacheItemDo(t *testing.T) {
-	t.Parallel()
-
 	var (
 		count int
 		item  cacheItem
@@ -88,41 +86,7 @@ func TestCacheMarkFailed(t *testing.T) {
 	}
 }
 
-func TestCacheMarkFailedMultipleCalls(t *testing.T) {
-	cache := New(3, DefaultMaxHostsCount)
-
-	tests := []struct {
-		host     string
-		expected int
-	}{
-		{"http://example.com:80", 1},
-		{"example.com:80", 2},
-		{"example.com", 1},
-	}
-
-	for _, test := range tests {
-		normalizedCacheValue := cache.normalizeCacheValue(test.host)
-		cache.MarkFailed(test.host, fmt.Errorf("no address found for host"))
-		failedTarget, err := cache.failedTargets.Get(normalizedCacheValue)
-		require.Nil(t, err)
-		require.NotNil(t, failedTarget)
-
-		value, ok := failedTarget.(*cacheItem)
-		require.True(t, ok)
-		require.EqualValues(t, test.expected, value.errors.Load())
-
-		existingCacheItem, err := cache.failedTargets.GetIFPresent(normalizedCacheValue)
-		require.Nil(t, err)
-		require.NotNil(t, existingCacheItem)
-		existingCacheItemValue := existingCacheItem.(*cacheItem)
-		skippingValue := existingCacheItemValue.errors.Load() >= int32(test.expected)
-		require.Equal(t, true, skippingValue, "Didn't skipped host")
-	}
-}
-
 func TestCacheMarkFailedConcurrent(t *testing.T) {
-	t.Parallel()
-
 	cache := New(3, DefaultMaxHostsCount)
 
 	tests := []struct {

--- a/v2/pkg/protocols/common/hosterrorscache/hosterrorscache_test.go
+++ b/v2/pkg/protocols/common/hosterrorscache/hosterrorscache_test.go
@@ -20,6 +20,7 @@ func TestCacheCheckMarkFailed(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		cache.MarkFailed(test.host, fmt.Errorf("no address found for host"))
 		failedTarget, err := cache.failedTargets.Get(test.host)
 		require.Nil(t, err)
 		require.NotNil(t, failedTarget)

--- a/v2/pkg/protocols/common/hosterrorscache/hosterrorscache_test.go
+++ b/v2/pkg/protocols/common/hosterrorscache/hosterrorscache_test.go
@@ -2,7 +2,6 @@ package hosterrorscache
 
 import (
 	"fmt"
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -11,18 +10,24 @@ import (
 func TestCacheCheckMarkFailed(t *testing.T) {
 	cache := New(3, DefaultMaxHostsCount)
 
-	cache.MarkFailed("http://example.com:80", fmt.Errorf("no address found for host"))
-	if value, err := cache.failedTargets.Get("http://example.com:80"); err == nil && value != nil {
-		require.Equal(t, 1, value, "could not get correct number of marked failed hosts")
+	if failedTarget, err := cache.failedTargets.Get("http://example.com:80"); err == nil && failedTarget != nil {
+		if value, ok := failedTarget.(*cacheItem); ok {
+			require.EqualValues(t, 1, value.errors.Load(), "could not get correct number of marked failed hosts")
+		}
 	}
-	cache.MarkFailed("example.com:80", fmt.Errorf("Client.Timeout exceeded while awaiting headers"))
-	if value, err := cache.failedTargets.Get("example.com:80"); err == nil && value != nil {
-		require.Equal(t, 2, value, "could not get correct number of marked failed hosts")
+
+	if failedTarget, err := cache.failedTargets.Get("example.com:80"); err == nil && failedTarget != nil {
+		if value, ok := failedTarget.(*cacheItem); ok {
+			require.EqualValues(t, 1, value.errors.Load(), "could not get correct number of marked failed hosts")
+		}
 	}
-	cache.MarkFailed("example.com", fmt.Errorf("could not resolve host"))
-	if value, err := cache.failedTargets.Get("example.com"); err == nil && value != nil {
-		require.Equal(t, 1, value, "could not get correct number of marked failed hosts")
+
+	if failedTarget, err := cache.failedTargets.Get("example.com"); err == nil && failedTarget != nil {
+		if value, ok := failedTarget.(*cacheItem); ok {
+			require.EqualValues(t, 1, value.errors.Load(), "could not get correct number of marked failed hosts")
+		}
 	}
+
 	for i := 0; i < 3; i++ {
 		cache.MarkFailed("test", fmt.Errorf("could not resolve host"))
 	}
@@ -32,31 +37,31 @@ func TestCacheCheckMarkFailed(t *testing.T) {
 }
 
 func TestCacheItemCheckMarkFailedMultipleCalls(t *testing.T) {
+	t.Parallel()
+
 	cache := New(3, DefaultMaxHostsCount)
 
-	var wg sync.WaitGroup
-	wg.Add(30)
-
-	for i := 0; i < 30; i++ {
-		go func(i int) {
-			cache.MarkFailed("http://asdasjkdashkjdahsjkdhas:80", fmt.Errorf("no address found for host"))
-			if value, err := cache.failedTargets.Get("http://example.com:80"); err == nil && value != nil {
-				require.Equal(t, 1, value, "could not get correct number of marked failed hosts")
-			}
-			cache.MarkFailed("http://asdasjkdashkjdahsjkdhas:80", fmt.Errorf("Client.Timeout exceeded while awaiting headers"))
-			if value, err := cache.failedTargets.Get("example.com:80"); err == nil && value != nil {
-				require.Equal(t, 2, value, "could not get correct number of marked failed hosts")
-			}
-			cache.MarkFailed("http://asdasjkdashkjdahsjkdhas", fmt.Errorf("could not resolve host"))
-			if value, err := cache.failedTargets.Get("example.com"); err == nil && value != nil {
-				require.Equal(t, 1, value, "could not get correct number of marked failed hosts")
-			}
-			for i := 0; i < 3; i++ {
-				cache.MarkFailed("test", fmt.Errorf("could not resolve host"))
-			}
-		}(i)
+	if failedTarget, err := cache.failedTargets.Get("http://asdasjkdashkjdahsjkdhas:80"); err == nil && failedTarget != nil {
+		if value, ok := failedTarget.(*cacheItem); ok {
+			require.EqualValues(t, 1, value.errors.Load(), "could not get correct number of marked failed hosts")
+		}
 	}
-	wg.Wait()
+
+	if failedTarget, err := cache.failedTargets.Get("asdasjkdashkjdahsjkdhas:80"); err == nil && failedTarget != nil {
+		if value, ok := failedTarget.(*cacheItem); ok {
+			require.EqualValues(t, 1, value.errors.Load(), "could not get correct number of marked failed hosts")
+		}
+	}
+
+	if failedTarget, err := cache.failedTargets.Get("asdasjkdashkjdahsjkdhas"); err == nil && failedTarget != nil {
+		if value, ok := failedTarget.(*cacheItem); ok {
+			require.EqualValues(t, 1, value.errors.Load(), "could not get correct number of marked failed hosts")
+		}
+	}
+
+	for i := 0; i < 3; i++ {
+		cache.MarkFailed("test", fmt.Errorf("could not resolve host"))
+	}
 
 	value := cache.Check("test")
 	require.Equal(t, true, value, "could not get checked value")

--- a/v2/pkg/protocols/common/hosterrorscache/hosterrorscache_test.go
+++ b/v2/pkg/protocols/common/hosterrorscache/hosterrorscache_test.go
@@ -41,22 +41,58 @@ func TestCacheItemCheckMarkFailedMultipleCalls(t *testing.T) {
 
 	cache := New(3, DefaultMaxHostsCount)
 
-	if failedTarget, err := cache.failedTargets.Get("http://asdasjkdashkjdahsjkdhas:80"); err == nil && failedTarget != nil {
+	hostValue := "http://asdasjkdashkjdahsjkdhas:80"
+
+	if failedTarget, err := cache.failedTargets.Get(hostValue); err == nil && failedTarget != nil {
 		if value, ok := failedTarget.(*cacheItem); ok {
 			require.EqualValues(t, 1, value.errors.Load(), "could not get correct number of marked failed hosts")
 		}
 	}
 
-	if failedTarget, err := cache.failedTargets.Get("asdasjkdashkjdahsjkdhas:80"); err == nil && failedTarget != nil {
+	existingCacheItem, err := cache.failedTargets.GetIFPresent(hostValue)
+	if err == nil {
+		skippingValue := false
+		existingCacheItemValue := existingCacheItem.(*cacheItem)
+		if existingCacheItemValue.errors.Load() >= int32(cache.MaxHostError) {
+			skippingValue = true
+		}
+		require.Equal(t, true, skippingValue, "Didn't skipped host")
+	}
+
+	hostValue = "asdasjkdashkjdahsjkdhas:80"
+
+	if failedTarget, err := cache.failedTargets.Get(hostValue); err == nil && failedTarget != nil {
 		if value, ok := failedTarget.(*cacheItem); ok {
 			require.EqualValues(t, 1, value.errors.Load(), "could not get correct number of marked failed hosts")
 		}
 	}
 
-	if failedTarget, err := cache.failedTargets.Get("asdasjkdashkjdahsjkdhas"); err == nil && failedTarget != nil {
+	existingCacheItem, err = cache.failedTargets.GetIFPresent(hostValue)
+	if err == nil {
+		skippingValue := false
+		existingCacheItemValue := existingCacheItem.(*cacheItem)
+		if existingCacheItemValue.errors.Load() >= int32(cache.MaxHostError) {
+			skippingValue = true
+		}
+		require.Equal(t, true, skippingValue, "Didn't skipped host")
+	}
+
+	hostValue = "asdasjkdashkjdahsjkdhas"
+
+	if failedTarget, err := cache.failedTargets.Get(hostValue); err == nil && failedTarget != nil {
 		if value, ok := failedTarget.(*cacheItem); ok {
 			require.EqualValues(t, 1, value.errors.Load(), "could not get correct number of marked failed hosts")
 		}
+	}
+
+	existingCacheItem, err = cache.failedTargets.GetIFPresent(hostValue)
+	if err == nil {
+		skippingValue := false
+		existingCacheItemValue := existingCacheItem.(*cacheItem)
+		if existingCacheItemValue.errors.Load() >= int32(cache.MaxHostError) {
+			skippingValue = true
+		}
+		require.Equal(t, true, skippingValue, "Didn't skipped host")
 	}
 
 	for i := 0; i < 3; i++ {


### PR DESCRIPTION
## Proposed changes
This PR:
- Fixes #3046 by removing the set to -1 behaviour
- Fixes #2065 by implementing sync.Once behavior on self-evicting cache items 

## Checklist
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)