### PR TITLE
Add support to query DNS TLSA record

### DIFF
--- a/integration_tests/dns/tlsa.yaml
+++ b/integration_tests/dns/tlsa.yaml
@@ -1,0 +1,22 @@
+id: tlsa-fingerprinting
+
+info:
+  name: TLSA Fingerprint
+  author: pdteam
+  severity: info
+  tags: dns,tlsa
+
+dns:
+  - name: "{{FQDN}}"
+    type: TLSA
+
+    matchers:
+      - type: word
+        words:
+          - "IN\tTLSA"
+
+    extractors:
+      - type: regex
+        group: 1
+        regex:
+          - "IN\tTLSA\t(.+)"

--- a/v2/cmd/integration-test/dns.go
+++ b/v2/cmd/integration-test/dns.go
@@ -8,6 +8,7 @@ var dnsTestCases = map[string]testutils.TestCase{
 	"dns/basic.yaml":     &dnsBasic{},
 	"dns/ptr.yaml":       &dnsPtr{},
 	"dns/caa.yaml":       &dnsCAA{},
+	"dns/tlsa.yaml":      &dnsCAA{},
 	"dns/variables.yaml": &dnsVariables{},
 }
 
@@ -57,6 +58,22 @@ func (h *dnsCAA) Execute(filePath string) error {
 		return routerErr
 	}
 	return expectResultsCount(results, 1)
+}
+
+type dnsTLSA struct{}
+
+// Execute executes a test case and returns an error if occurred
+func (h *dnsTLSA) Execute(filePath string) error {
+	var routerErr error
+
+	results, err := testutils.RunNucleiTemplateAndGetResults(filePath, "google.com", debug)
+	if err != nil {
+		return err
+	}
+	if routerErr != nil {
+		return routerErr
+	}
+	return expectResultsCount(results, 0)
 }
 
 type dnsVariables struct{}

--- a/v2/cmd/integration-test/dns.go
+++ b/v2/cmd/integration-test/dns.go
@@ -66,7 +66,7 @@ type dnsTLSA struct{}
 func (h *dnsTLSA) Execute(filePath string) error {
 	var routerErr error
 
-	results, err := testutils.RunNucleiTemplateAndGetResults(filePath, "google.com", debug)
+	results, err := testutils.RunNucleiTemplateAndGetResults(filePath, "scanme.sh", debug)
 	if err != nil {
 		return err
 	}

--- a/v2/cmd/integration-test/dns.go
+++ b/v2/cmd/integration-test/dns.go
@@ -8,7 +8,7 @@ var dnsTestCases = map[string]testutils.TestCase{
 	"dns/basic.yaml":     &dnsBasic{},
 	"dns/ptr.yaml":       &dnsPtr{},
 	"dns/caa.yaml":       &dnsCAA{},
-	"dns/tlsa.yaml":      &dnsCAA{},
+	"dns/tlsa.yaml":      &dnsTLSA{},
 	"dns/variables.yaml": &dnsVariables{},
 }
 

--- a/v2/cmd/integration-test/dns.go
+++ b/v2/cmd/integration-test/dns.go
@@ -73,7 +73,7 @@ func (h *dnsTLSA) Execute(filePath string) error {
 	if routerErr != nil {
 		return routerErr
 	}
-	return expectResultsCount(results, 0)
+	return expectResultsCount(results, 1)
 }
 
 type dnsVariables struct{}

--- a/v2/cmd/integration-test/dns.go
+++ b/v2/cmd/integration-test/dns.go
@@ -73,7 +73,7 @@ func (h *dnsTLSA) Execute(filePath string) error {
 	if routerErr != nil {
 		return routerErr
 	}
-	return expectResultsCount(results, 1)
+	return expectResultsCount(results, 0)
 }
 
 type dnsVariables struct{}

--- a/v2/pkg/protocols/dns/dns.go
+++ b/v2/pkg/protocols/dns/dns.go
@@ -221,6 +221,8 @@ func questionTypeToInt(questionType string) uint16 {
 		question = dns.TypeAAAA
 	case "CAA":
 		question = dns.TypeCAA
+	case "TLSA":
+		question = dns.TypeTLSA
 	}
 	return question
 }

--- a/v2/pkg/protocols/dns/dns_types.go
+++ b/v2/pkg/protocols/dns/dns_types.go
@@ -33,6 +33,8 @@ const (
 	AAAA
 	// name:CAA
 	CAA
+	// name:TLSA
+	TLSA
 	limit
 )
 
@@ -48,6 +50,7 @@ var DNSRequestTypeMapping = map[DNSRequestType]string{
 	TXT:   "TXT",
 	AAAA:  "AAAA",
 	CAA:   "CAA",
+	TLSA:  "TLSA",
 }
 
 // GetSupportedDNSRequestTypes returns list of supported types


### PR DESCRIPTION
## Proposed changes

Adding support to query DNS TLSA record.  
Resolved https://github.com/projectdiscovery/nuclei/issues/2942

```
# tps.yaml
id: tlsa-fingerprinting

info:
  name: TLSA Fingerprint
  author: pdteam
  severity: info
  tags: dns,tlsa

dns:
  - name: "{{FQDN}}"
    type: TLSA

    matchers:
      - type: word
        words:
          - "IN\tTLSA"

    extractors:
      - type: regex
        group: 1
        regex:
          - "IN\tTLSA\t(.+)"
```

```
echo nothinux.id | go18 run cmd/nuclei/main.go -t tps.yaml 

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v2.8.4-dev

                projectdiscovery.io

[INF] Using Nuclei Engine 2.8.4-dev (development)
[INF] Using Nuclei Templates 9.3.1 (latest)
[INF] Templates added in last update: 2
[INF] Templates loaded for scan: 1
[INF] Targets loaded for scan: 1
[tlsa-fingerprinting] [dns] [info] nothinux.id [3 1 1 4133f5556d31eaa151aee054efafe5f2a3cb0f4f7764cf320fd1a8427b532f8b]
```

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)