### PR TITLE
adds scan strategy 

### DIFF
--- a/v2/cmd/nuclei/main.go
+++ b/v2/cmd/nuclei/main.go
@@ -245,6 +245,11 @@ on extensive configurability, massive extensibility and ease of use.`)
 		flagSet.StringVar(&options.ProjectPath, "project-path", os.TempDir(), "set a specific project path"),
 		flagSet.BoolVarP(&options.StopAtFirstMatch, "stop-at-first-match", "spm", false, "stop processing HTTP requests after the first match (may break template/workflow logic)"),
 		flagSet.BoolVar(&options.Stream, "stream", false, "stream mode - start elaborating without sorting the input"),
+		flagSet.EnumVarP(&options.ScanStrategy, "scan-strategy", "ss", goflags.EnumVariable(0), "strategy to use while scanning(auto/host-spray/template-spray)", goflags.AllowdTypes{
+			"auto":           goflags.EnumVariable(0),
+			"host-spray":     goflags.EnumVariable(1),
+			"template-spray": goflags.EnumVariable(2),
+		}),
 		flagSet.DurationVarP(&options.InputReadTimeout, "input-read-timeout", "irt", time.Duration(3*time.Minute), "timeout on input read"),
 		flagSet.BoolVarP(&options.DisableHTTPProbe, "no-httpx", "nh", false, "disable httpx probing for non-url input"),
 		flagSet.BoolVar(&options.DisableStdin, "no-stdin", false, "disable stdin processing"),

--- a/v2/internal/runner/runner.go
+++ b/v2/internal/runner/runner.go
@@ -624,7 +624,7 @@ func (r *Runner) executeTemplatesInput(store *loader.Store, engine *core.Engine)
 	// tracks global progress and captures stdout/stderr until p.Wait finishes
 	r.progress.Init(r.hmapInputProvider.Count(), templateCount, totalRequests)
 
-	results := engine.ExecuteWithOpts(finalTemplates, r.hmapInputProvider, true)
+	results := engine.ExecuteScanWithOpts(finalTemplates, r.hmapInputProvider, true)
 	return results, nil
 }
 

--- a/v2/pkg/types/types.go
+++ b/v2/pkg/types/types.go
@@ -336,6 +336,8 @@ type Options struct {
 	AwsBucketName string
 	// AWS Region name where aws s3 bucket is located
 	AwsRegion string
+	// Scan Strategy (auto,hosts-spray,templates-spray)
+	ScanStrategy string
 }
 
 func (options *Options) AddVarPayload(key string, value interface{}) {


### PR DESCRIPTION
## Proposed changes

- Adds `scan-strategy` flag to nuclei
   -  If value is `host-spray` all templates are iterated over each host
   -  If value is `template-spray` all hosts are iterated over each template
   -  If value is `auto` . [This is only a placeholder of `template-spray` for now] strategy should be selected based on given parameters and inputs.

Before this PR `template-spray` strategy was used and current default is `template-spray`

closes #3065 


## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)