### PR TITLE
update golang example input

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,7 @@ import (
    "github.com/projectdiscovery/nuclei/v2/pkg/output"
    "github.com/projectdiscovery/nuclei/v2/pkg/parsers"
    "github.com/projectdiscovery/nuclei/v2/pkg/protocols"
+   "github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/contextargs"
    "github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/hosterrorscache"
    "github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/interactsh"
    "github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/protocolinit"
@@ -439,7 +440,13 @@ func main() {
    }
    store.Load()
 
-   input := &inputs.SimpleInputProvider{Inputs: []string{"docs.hackerone.com"}}
+   inputArgs := []*contextargs.MetaInput{
+      &contextargs.MetaInput{
+         Input: "docs.hackerone.com",
+      },
+   }
+
+   input := &inputs.SimpleInputProvider{Inputs: inputArgs}
    _ = engine.Execute(store.Templates(), input)
    engine.WorkPool().Wait() // Wait for the scan to finish
 }


### PR DESCRIPTION
## Proposed changes

Updated golang example in the `Using Nuclei From Go Code` section as []string{"docs.hackerone.com"} is not a valid input. It requires type `[]*contextargs.MetaInput`. Confirmed working example. 

Also noted that [pkg.go.dev](https://pkg.go.dev/github.com/projectdiscovery/nuclei/v2@v2.8.3/pkg/core) fails to interpret the MIT license, probably due to license file name being updated. 

## Checklist

Updating README so performed no checks, tests, and documentation

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)