### PR TITLE
extending request/response hijacking with native calls

### DIFF
--- a/integration_tests/headless/file-upload.yaml
+++ b/integration_tests/headless/file-upload.yaml
@@ -1,0 +1,29 @@
+id: file-upload
+
+info:
+  name: Basic File Upload
+  author: pdteam
+  severity: info
+
+headless:
+  - steps:
+    - action: navigate
+      args:
+        url: "{{BaseURL}}"
+    - action: waitload
+    - action: files
+      args:
+        by: xpath
+        xpath: /html/body/form/input[1]
+        value: file-upload.yaml
+    - action: sleep
+      args:
+        duration: 2
+    - action: click
+      args:
+        by: x
+        xpath: /html/body/form/input[2]
+    matchers:
+      - type: word
+        words:
+          - "Basic File Upload"

--- a/integration_tests/headless/file-upload.yaml
+++ b/integration_tests/headless/file-upload.yaml
@@ -15,7 +15,7 @@ headless:
       args:
         by: xpath
         xpath: /html/body/form/input[1]
-        value: file-upload.yaml
+        value: headless/file-upload.yaml
     - action: sleep
       args:
         duration: 2

--- a/v2/pkg/protocols/headless/engine/hijack.go
+++ b/v2/pkg/protocols/headless/engine/hijack.go
@@ -1,0 +1,99 @@
+package engine
+
+// TODO: redundant from katana - the whole headless package should be replace with katana
+
+import (
+	"encoding/base64"
+
+	"github.com/go-rod/rod"
+	"github.com/go-rod/rod/lib/proto"
+)
+
+// NewHijack create hijack from page.
+func NewHijack(page *rod.Page) *Hijack {
+	return &Hijack{
+		page:    page,
+		disable: &proto.FetchDisable{},
+	}
+}
+
+// HijackHandler type
+type HijackHandler = func(e *proto.FetchRequestPaused) error
+
+// Hijack is a hijack handler
+type Hijack struct {
+	page    *rod.Page
+	enable  *proto.FetchEnable
+	disable *proto.FetchDisable
+	cancel  func()
+}
+
+// SetPattern set pattern directly
+func (h *Hijack) SetPattern(pattern *proto.FetchRequestPattern) {
+	h.enable = &proto.FetchEnable{
+		Patterns: []*proto.FetchRequestPattern{pattern},
+	}
+}
+
+// Start hijack.
+func (h *Hijack) Start(handler HijackHandler) func() error {
+	if h.enable == nil {
+		panic("hijack pattern not set")
+	}
+
+	p, cancel := h.page.WithCancel()
+	h.cancel = cancel
+
+	err := h.enable.Call(p)
+	if err != nil {
+		return func() error { return err }
+	}
+
+	wait := p.EachEvent(func(e *proto.FetchRequestPaused) {
+		if handler != nil {
+			err = handler(e)
+		}
+	})
+
+	return func() error {
+		wait()
+		return err
+	}
+}
+
+// Stop
+func (h *Hijack) Stop() error {
+	if h.cancel != nil {
+		h.cancel()
+	}
+	return h.disable.Call(h.page)
+}
+
+// FetchGetResponseBody get request body.
+func FetchGetResponseBody(page *rod.Page, e *proto.FetchRequestPaused) ([]byte, error) {
+	m := proto.FetchGetResponseBody{
+		RequestID: e.RequestID,
+	}
+	r, err := m.Call(page)
+	if err != nil {
+		return nil, err
+	}
+
+	if !r.Base64Encoded {
+		return []byte(r.Body), nil
+	}
+
+	bs, err := base64.StdEncoding.DecodeString(r.Body)
+	if err != nil {
+		return nil, err
+	}
+	return bs, nil
+}
+
+// FetchContinueRequest continue request
+func FetchContinueRequest(page *rod.Page, e *proto.FetchRequestPaused) error {
+	m := proto.FetchContinueRequest{
+		RequestID: e.RequestID,
+	}
+	return m.Call(page)
+}

--- a/v2/pkg/protocols/headless/engine/page_actions_test.go
+++ b/v2/pkg/protocols/headless/engine/page_actions_test.go
@@ -537,3 +537,18 @@ func testHeadless(t *testing.T, actions []*Action, timeout time.Duration, handle
 		page.Close()
 	}
 }
+
+func TestContainsAnyModificationActionType(t *testing.T) {
+	if containsAnyModificationActionType() {
+		t.Error("Expected false, got true")
+	}
+	if containsAnyModificationActionType(ActionClick) {
+		t.Error("Expected false, got true")
+	}
+	if !containsAnyModificationActionType(ActionSetMethod, ActionAddHeader, ActionExtract) {
+		t.Error("Expected true, got false")
+	}
+	if !containsAnyModificationActionType(ActionSetMethod, ActionAddHeader, ActionSetHeader, ActionDeleteHeader, ActionSetBody) {
+		t.Error("Expected true, got false")
+	}
+}

--- a/v2/pkg/protocols/headless/request.go
+++ b/v2/pkg/protocols/headless/request.go
@@ -23,7 +23,7 @@ import (
 
 var _ protocols.Request = &Request{}
 
-const couldGetHtmlElementErrorMessage = "could get html element"
+const errCouldGetHtmlElement = "could get html element"
 
 // Type returns the type of the protocol request
 func (request *Request) Type() templateTypes.ProtocolType {
@@ -81,7 +81,7 @@ func (request *Request) executeRequestWithPayloads(inputURL string, payloads map
 	if err != nil {
 		request.options.Output.Request(request.options.TemplatePath, inputURL, request.Type().String(), err)
 		request.options.Progress.IncrementFailedRequestsBy(1)
-		return errors.Wrap(err, couldGetHtmlElementErrorMessage)
+		return errors.Wrap(err, errCouldGetHtmlElement)
 	}
 	defer instance.Close()
 
@@ -95,14 +95,14 @@ func (request *Request) executeRequestWithPayloads(inputURL string, payloads map
 	if err != nil {
 		request.options.Output.Request(request.options.TemplatePath, inputURL, request.Type().String(), err)
 		request.options.Progress.IncrementFailedRequestsBy(1)
-		return errors.Wrap(err, couldGetHtmlElementErrorMessage)
+		return errors.Wrap(err, errCouldGetHtmlElement)
 	}
 	timeout := time.Duration(request.options.Options.PageTimeout) * time.Second
 	out, page, err := instance.Run(parsedURL, request.Steps, payloads, timeout)
 	if err != nil {
 		request.options.Output.Request(request.options.TemplatePath, inputURL, request.Type().String(), err)
 		request.options.Progress.IncrementFailedRequestsBy(1)
-		return errors.Wrap(err, couldGetHtmlElementErrorMessage)
+		return errors.Wrap(err, errCouldGetHtmlElement)
 	}
 	defer page.Close()
 


### PR DESCRIPTION
## Proposed changes
This PR improves headless request/response hijacking through chrome native api (reuses katana hijack implementation)

## Checklist
- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)