### PR TITLE
Replacing unstable interactsh with scanme.sh

### DIFF
--- a/integration_tests/http/dsl-functions.yaml
+++ b/integration_tests/http/dsl-functions.yaml
@@ -26,7 +26,7 @@ requests:
         13: {{date_time("02-01-2006 15:04")}}
         14: {{date_time("02-01-2006 15:04", unix_time())}}
         15: {{dec_to_hex(11111)}}
-        16: {{generate_java_gadget("commons-collections3.1", "wget http://{{interactsh-url}}", "base64")}}
+        16: {{generate_java_gadget("commons-collections3.1", "wget http://scanme.sh", "base64")}}
         17: {{gzip("Hello")}}
         18: {{gzip_decode(hex_decode("1f8b08000000000000fff248cdc9c907040000ffff8289d1f705000000"))}}
         19: {{hex_decode("6161")}}


### PR DESCRIPTION
## Proposed changes
This PR replaces unstable `interactsh-url` with hardcoded `scanme.sh`, hopefully reducing the frequency of random failures.

## Checklist
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)