### PR TITLE
lowering hmap storage requirement via omitempty

### DIFF
--- a/v2/pkg/protocols/common/contextargs/metainput.go
+++ b/v2/pkg/protocols/common/contextargs/metainput.go
@@ -11,9 +11,9 @@ import (
 // MetaInput represents a target with metadata (TODO: replace with https://github.com/projectdiscovery/metainput)
 type MetaInput struct {
 	// Input represent the target
-	Input string
+	Input string `json:"input,omitempty"`
 	// CustomIP to use for connection
-	CustomIP string
+	CustomIP string `json:"customIP,omitempty"`
 }
 
 func (metaInput *MetaInput) marshalToBuffer() (bytes.Buffer, error) {


### PR DESCRIPTION
## Proposed changes
This PR lowers hmap storage by skipping empty fields in MetaInput struct during marshaling.

## Notes
Full runtime CIDR expansion is a **won't fix** as the current implementation is used by [cloud](https://github.com/projectdiscovery/nuclei/blob/6d7968b1055a5faae4242ba39938365c8891a0cf/v2/internal/runner/enumerate.go#L47)


## Checklist
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)