### PR TITLE
Adding more error for host to ignore

### DIFF
--- a/v2/pkg/protocols/common/hosterrorscache/hosterrorscache.go
+++ b/v2/pkg/protocols/common/hosterrorscache/hosterrorscache.go
@@ -128,7 +128,7 @@ func (c *Cache) MarkFailed(value string, err error) {
 	_ = c.failedTargets.Set(finalValue, existingCacheItemValue)
 }
 
-var reCheckError = regexp.MustCompile(`(no address found for host|Client\.Timeout exceeded while awaiting headers|could not resolve host|connection refused)`)
+var reCheckError = regexp.MustCompile(`(no address found for host|Client\.Timeout exceeded while awaiting headers|could not resolve host|connection refused|context deadline exceeded)`)
 
 // checkError checks if an error represents a type that should be
 // added to the host skipping table.


### PR DESCRIPTION
## Proposed changes

Fixed #3119

```console
./nuclei -s low,medium -l l.txt  -max-host-error 3 -v -timeout 3 -c 1 -bs 1
...
...
[VER] Skipping google.com:6969 as previously unresponsive 3 times
[VER] Skipping 127.0.0.1:4443 as previously unresponsive 3 times
[VER] Skipping 127.0.0.1:8880 as previously unresponsive 3 times
[INF] No results found. Better luck next time!
```

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)