### PR TITLE
more error coverage + display skipped host on default run for more visibility

### DIFF
--- a/v2/pkg/protocols/common/hosterrorscache/hosterrorscache.go
+++ b/v2/pkg/protocols/common/hosterrorscache/hosterrorscache.go
@@ -100,11 +100,9 @@ func (c *Cache) Check(value string) bool {
 	existingCacheItemValue := existingCacheItem.(*cacheItem)
 
 	if existingCacheItemValue.errors.Load() >= int32(c.MaxHostError) {
-		if c.verbose {
-			existingCacheItemValue.Do(func() {
-				gologger.Verbose().Msgf("Skipping %s as previously unresponsive %d times", finalValue, existingCacheItemValue.errors.Load())
-			})
-		}
+		existingCacheItemValue.Do(func() {
+			gologger.Info().Msgf("Skipped %s from target list as found unresponsive %d times", finalValue, existingCacheItemValue.errors.Load())
+		})
 		return true
 	}
 	return false
@@ -128,7 +126,7 @@ func (c *Cache) MarkFailed(value string, err error) {
 	_ = c.failedTargets.Set(finalValue, existingCacheItemValue)
 }
 
-var reCheckError = regexp.MustCompile(`(no address found for host|Client\.Timeout exceeded while awaiting headers|could not resolve host|connection refused|context deadline exceeded)`)
+var reCheckError = regexp.MustCompile(`(no address found for host|could not connect to any address|Client\.Timeout exceeded while awaiting headers|could not resolve host|connection refused|context deadline exceeded)`)
 
 // checkError checks if an error represents a type that should be
 // added to the host skipping table.


### PR DESCRIPTION
## Proposed changes

Fixes #2065

```console
./nuclei -mhe 3 -c 1 -bs 1 -duc -ni -s critical -l list.txt

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v2.8.4

		projectdiscovery.io

[INF] Using Nuclei Engine 2.8.4 (outdated)
[INF] Using Nuclei Templates 9.3.3 (latest)
[INF] Templates added in last update: 238
[INF] Templates loaded for scan: 563
[INF] Targets loaded for scan: 3
[INF] Templates clustered: 2 (Reduced 3 HTTP Requests)
[INF] Skipped google.com:6969 from target list as found unresponsive 3 times
[INF] Skipped 127.0.0.1:4443 from target list as found unresponsive 3 times
[INF] Skipped 127.0.0.1:8880 from target list as found unresponsive 3 times
[INF] No results found. Better luck next time!

```

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->


## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)