### PR TITLE
Added noise parameter for http payload conditional fuzzing support

### DIFF
--- a/v2/cmd/nuclei/main.go
+++ b/v2/cmd/nuclei/main.go
@@ -195,6 +195,7 @@ on extensive configurability, massive extensibility and ease of use.`)
 		flagSet.BoolVarP(&options.ForceAttemptHTTP2, "force-http2", "fh2", false, "force http2 connection on requests"),
 		flagSet.BoolVarP(&options.EnvironmentVariables, "env-vars", "ev", false, "enable environment variables to be used in template"),
 		flagSet.StringVarP(&options.ClientCertFile, "client-cert", "cc", "", "client certificate file (PEM-encoded) used for authenticating against scanned hosts"),
+		flagSet.StringVarP(&options.Noise, "noise", "ne", "low", "noise level for http fuzzing (accepted: low,medium,high)"),
 		flagSet.StringVarP(&options.ClientKeyFile, "client-key", "ck", "", "client key file (PEM-encoded) used for authenticating against scanned hosts"),
 		flagSet.StringVarP(&options.ClientCAFile, "client-ca", "ca", "", "client certificate authority file (PEM-encoded) used for authenticating against scanned hosts"),
 		flagSet.BoolVarP(&options.ShowMatchLine, "show-match-line", "sml", false, "show match lines for file templates, works with extractors only"),

--- a/v2/pkg/protocols/common/generators/generators.go
+++ b/v2/pkg/protocols/common/generators/generators.go
@@ -16,7 +16,7 @@ type PayloadGenerator struct {
 }
 
 // New creates a new generator structure for payload generation
-func New(payloads map[string]interface{}, attackType AttackType, templatePath, templateDirectory string, sandbox bool, catalog catalog.Catalog, customAttackType string) (*PayloadGenerator, error) {
+func New(payloads map[string]interface{}, attackType AttackType, templatePath, templateDirectory, noise string, sandbox bool, catalog catalog.Catalog, customAttackType string) (*PayloadGenerator, error) {
 	if attackType.String() == "" {
 		attackType = BatteringRamAttack
 	}
@@ -42,7 +42,7 @@ func New(payloads map[string]interface{}, attackType AttackType, templatePath, t
 		return nil, err
 	}
 
-	compiled, err := generator.loadPayloads(payloadsFinal, templatePath, templateDirectory, sandbox)
+	compiled, err := generator.loadPayloads(payloadsFinal, templatePath, templateDirectory, noise, sandbox)
 	if err != nil {
 		return nil, err
 	}

--- a/v2/pkg/protocols/common/generators/generators_test.go
+++ b/v2/pkg/protocols/common/generators/generators_test.go
@@ -12,7 +12,7 @@ func TestBatteringRamGenerator(t *testing.T) {
 	usernames := []string{"admin", "password"}
 
 	catalogInstance := disk.NewCatalog("")
-	generator, err := New(map[string]interface{}{"username": usernames}, BatteringRamAttack, "", "", false, catalogInstance, "")
+	generator, err := New(map[string]interface{}{"username": usernames}, BatteringRamAttack, "", "", "", false, catalogInstance, "")
 	require.Nil(t, err, "could not create generator")
 
 	iterator := generator.NewIterator()
@@ -32,7 +32,7 @@ func TestPitchforkGenerator(t *testing.T) {
 	passwords := []string{"password1", "password2", "password3"}
 
 	catalogInstance := disk.NewCatalog("")
-	generator, err := New(map[string]interface{}{"username": usernames, "password": passwords}, PitchForkAttack, "", "", false, catalogInstance, "")
+	generator, err := New(map[string]interface{}{"username": usernames, "password": passwords}, PitchForkAttack, "", "", "", false, catalogInstance, "")
 	require.Nil(t, err, "could not create generator")
 
 	iterator := generator.NewIterator()
@@ -54,7 +54,7 @@ func TestClusterbombGenerator(t *testing.T) {
 	passwords := []string{"admin", "password", "token"}
 
 	catalogInstance := disk.NewCatalog("")
-	generator, err := New(map[string]interface{}{"username": usernames, "password": passwords}, ClusterBombAttack, "", "", false, catalogInstance, "")
+	generator, err := New(map[string]interface{}{"username": usernames, "password": passwords}, ClusterBombAttack, "", "", "", false, catalogInstance, "")
 	require.Nil(t, err, "could not create generator")
 
 	iterator := generator.NewIterator()

--- a/v2/pkg/protocols/headless/headless.go
+++ b/v2/pkg/protocols/headless/headless.go
@@ -98,7 +98,7 @@ func (request *Request) Compile(options *protocols.ExecuterOptions) error {
 
 	if len(request.Payloads) > 0 {
 		var err error
-		request.generator, err = generators.New(request.Payloads, request.AttackType.Value, options.TemplatePath, options.Options.TemplatesDirectory, options.Options.Sandbox, options.Catalog, options.Options.AttackType)
+		request.generator, err = generators.New(request.Payloads, request.AttackType.Value, options.TemplatePath, options.Options.TemplatesDirectory, "", options.Options.Sandbox, options.Catalog, options.Options.AttackType)
 		if err != nil {
 			return errors.Wrap(err, "could not parse payloads")
 		}

--- a/v2/pkg/protocols/http/http.go
+++ b/v2/pkg/protocols/http/http.go
@@ -350,7 +350,12 @@ func (request *Request) Compile(options *protocols.ExecuterOptions) error {
 	}
 
 	if len(request.Payloads) > 0 {
-		request.generator, err = generators.New(request.Payloads, request.AttackType.Value, request.options.TemplatePath, request.options.Options.TemplatesDirectory, request.options.Options.Sandbox, request.options.Catalog, request.options.Options.AttackType)
+		// Use a noise value if http fuzzing is being used
+		var noiseValue string
+		if len(request.Fuzzing) > 0 {
+			noiseValue = options.Options.Noise
+		}
+		request.generator, err = generators.New(request.Payloads, request.AttackType.Value, request.options.TemplatePath, request.options.Options.TemplatesDirectory, noiseValue, request.options.Options.Sandbox, request.options.Catalog, request.options.Options.AttackType)
 		if err != nil {
 			return errors.Wrap(err, "could not parse payloads")
 		}

--- a/v2/pkg/protocols/http/request_generator_test.go
+++ b/v2/pkg/protocols/http/request_generator_test.go
@@ -34,7 +34,7 @@ func TestRequestGeneratorClusterBombSingle(t *testing.T) {
 		Raw:        []string{`GET /{{username}}:{{password}} HTTP/1.1`},
 	}
 	catalogInstance := disk.NewCatalog("")
-	req.generator, err = generators.New(req.Payloads, req.AttackType.Value, "", "", false, catalogInstance, "")
+	req.generator, err = generators.New(req.Payloads, req.AttackType.Value, "", "", "", false, catalogInstance, "")
 	require.Nil(t, err, "could not create generator")
 
 	generator := req.newGenerator(false)
@@ -58,7 +58,7 @@ func TestRequestGeneratorClusterBombMultipleRaw(t *testing.T) {
 		Raw:        []string{`GET /{{username}}:{{password}} HTTP/1.1`, `GET /{{username}}@{{password}} HTTP/1.1`},
 	}
 	catalogInstance := disk.NewCatalog("")
-	req.generator, err = generators.New(req.Payloads, req.AttackType.Value, "", "", false, catalogInstance, "")
+	req.generator, err = generators.New(req.Payloads, req.AttackType.Value, "", "", "", false, catalogInstance, "")
 	require.Nil(t, err, "could not create generator")
 
 	generator := req.newGenerator(false)

--- a/v2/pkg/protocols/network/network.go
+++ b/v2/pkg/protocols/network/network.go
@@ -184,7 +184,7 @@ func (request *Request) Compile(options *protocols.ExecuterOptions) error {
 	}
 
 	if len(request.Payloads) > 0 {
-		request.generator, err = generators.New(request.Payloads, request.AttackType.Value, request.options.TemplatePath, request.options.Options.TemplatesDirectory, request.options.Options.Sandbox, request.options.Catalog, request.options.Options.AttackType)
+		request.generator, err = generators.New(request.Payloads, request.AttackType.Value, request.options.TemplatePath, request.options.Options.TemplatesDirectory, "", request.options.Options.Sandbox, request.options.Catalog, request.options.Options.AttackType)
 		if err != nil {
 			return errors.Wrap(err, "could not parse payloads")
 		}

--- a/v2/pkg/protocols/websocket/websocket.go
+++ b/v2/pkg/protocols/websocket/websocket.go
@@ -104,7 +104,7 @@ func (request *Request) Compile(options *protocols.ExecuterOptions) error {
 	request.dialer = client
 
 	if len(request.Payloads) > 0 {
-		request.generator, err = generators.New(request.Payloads, request.AttackType.Value, request.options.TemplatePath, request.options.Options.TemplatesDirectory, request.options.Options.Sandbox, options.Catalog, options.Options.AttackType)
+		request.generator, err = generators.New(request.Payloads, request.AttackType.Value, request.options.TemplatePath, request.options.Options.TemplatesDirectory, "", request.options.Options.Sandbox, options.Catalog, options.Options.AttackType)
 		if err != nil {
 			return errors.Wrap(err, "could not parse payloads")
 		}

--- a/v2/pkg/types/types.go
+++ b/v2/pkg/types/types.go
@@ -270,6 +270,8 @@ type Options struct {
 	ClientKeyFile string
 	// ClientCAFile client certificate authority file (PEM-encoded) used for authenticating against scanned hosts
 	ClientCAFile string
+	// Noise is the noise to generate while http fuzzing
+	Noise string
 	// Use ZTLS library
 	ZTLS bool
 	// Sandbox enables sandboxed nuclei template execution


### PR DESCRIPTION
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->
Closes #3005

```yaml
id: crlf-injection

info:
  name: CRLF Injection
  author: pdteam
  severity: low
  tags: crlf,dast

requests:
  - method: GET
    path:
      - "{{BaseURL}}"

    payloads:
      escape:
        low: 
          - "%00"
          - "%0a"
          - "%0a%20"
          - "%0d"
        medium:
          - "%0d%09"
          - "%0d%0a"
          - "%0d%0a%09"
          - "%0d%0a%20"
          - "%0d%20"
          - "%20"
          - "%20%0a"
          - "%20%0d"
          - "%20%0d%0a"
          - "%23%0a"
          - "%23%0a%20"
          - "%23%0d"
          - "%23%0d%0a"
          - "%23%oa"
          - "%25%30"
        high:
          - "%25%30%61"
          - "%2e%2e%2f%0d%0a"
          - "%2f%2e%2e%0d%0a"
          - "%2f..%0d%0a"
          - "%3f"
          - "%3f%0a"
          - "%3f%0d"
          - "%3f%0d%0a"
          - "%e5%98%8a%e5%98%8d"
          - "%e5%98%8a%e5%98%8d%0a"
          - "%e5%98%8a%e5%98%8d%0d"
          - "%e5%98%8a%e5%98%8d%0d%0a"
          - "%e5%98%8a%e5%98%8d%e5%98%8a%e5%98%8d"
          - "%u0000"
          - "%u000a"
          - "%u000d"
          - "\r"
          - "\r%20"
          - "\r\n"
          - "\r\n%20"
          - "\r\n\t"
          - "\r\t"

    fuzzing:
      - part: query
        type: postfix
        fuzz:
          - "{{escape}}Set-Cookie:crlfinjection=crlfinjection"

    stop-at-first-match: true
    matchers:
      - type: regex
        part: header
        regex:
          - '(?m)^(?:Set-Cookie\s*?:(?:\s*?|.*?;\s*?))(crlfinjection=crlfinjection)(?:\s*?)(?:$|;)'
```

Example run

```bash
./nuclei -t template.yaml -u "https://example.com/?test=value" -v

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v2.8.4-dev

                projectdiscovery.io

[INF] Using Nuclei Engine 2.8.4-dev (development)
[INF] Using Nuclei Templates 9.3.3 (latest)
[INF] Templates added in last update: 238
[INF] Templates loaded for scan: 1
[INF] Targets loaded for scan: 1
[VER] [crlf-injection] Sent HTTP request to https://example.com/?test=value%2500Set-Cookie%3Acrlfinjection%3Dcrlfinjection
[VER] [crlf-injection] Sent HTTP request to https://example.com/?test=value%250aSet-Cookie%3Acrlfinjection%3Dcrlfinjection
[VER] [crlf-injection] Sent HTTP request to https://example.com/?test=value%250a%2520Set-Cookie%3Acrlfinjection%3Dcrlfinjection
[VER] [crlf-injection] Sent HTTP request to https://example.com/?test=value%250dSet-Cookie%3Acrlfinjection%3Dcrlfinjection
[INF] No results found. Better luck next time!
 
 ./nuclei -t template.yaml -u "https://example.com/?test=value" -v -noise medium

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v2.8.4-dev

                projectdiscovery.io

[INF] Using Nuclei Engine 2.8.4-dev (development)
[INF] Using Nuclei Templates 9.3.3 (latest)
[INF] Templates added in last update: 238
[INF] Templates loaded for scan: 1
[INF] Targets loaded for scan: 1
[VER] [crlf-injection] Sent HTTP request to https://example.com/?test=value%2500Set-Cookie%3Acrlfinjection%3Dcrlfinjection
[VER] [crlf-injection] Sent HTTP request to https://example.com/?test=value%250aSet-Cookie%3Acrlfinjection%3Dcrlfinjection
[VER] [crlf-injection] Sent HTTP request to https://example.com/?test=value%250a%2520Set-Cookie%3Acrlfinjection%3Dcrlfinjection
[VER] [crlf-injection] Sent HTTP request to https://example.com/?test=value%250dSet-Cookie%3Acrlfinjection%3Dcrlfinjection
[VER] [crlf-injection] Sent HTTP request to https://example.com/?test=value%250d%2509Set-Cookie%3Acrlfinjection%3Dcrlfinjection
[VER] [crlf-injection] Sent HTTP request to https://example.com/?test=value%250d%250aSet-Cookie%3Acrlfinjection%3Dcrlfinjection
...
```

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)