### PR TITLE
fix missing trailing slash

### DIFF
--- a/integration_tests/http/raw-path-trailing-slash.yaml
+++ b/integration_tests/http/raw-path-trailing-slash.yaml
@@ -1,7 +1,7 @@
-id: basic-raw-example
+id: raw-path-trailing-slash
 
 info:
-  name: Test RAW Template
+  name: Test RAW HTTP Template with trailing slash
   author: pdteam
   severity: info
 

--- a/integration_tests/http/raw-path.yaml
+++ b/integration_tests/http/raw-path.yaml
@@ -1,0 +1,13 @@
+id: basic-raw-example
+
+info:
+  name: Test RAW Template
+  author: pdteam
+  severity: info
+
+requests:
+  - raw:
+      - |
+        GET /test/..;/..;/ HTTP/1.1
+        Host: {{Hostname}}
+        Origin: {{BaseURL}}

--- a/v2/cmd/integration-test/http.go
+++ b/v2/cmd/integration-test/http.go
@@ -33,7 +33,7 @@ var httpTestcases = map[string]testutils.TestCase{
 	"http/raw-dynamic-extractor.yaml":               &httpRawDynamicExtractor{},
 	"http/raw-get-query.yaml":                       &httpRawGetQuery{},
 	"http/raw-get.yaml":                             &httpRawGet{},
-	"http/raw-path.yaml":                            &httpRawPath{},
+	"http/raw-path-trailing-slash.yaml":             &httpRawPathTrailingSlash{},
 	"http/raw-payload.yaml":                         &httpRawPayload{},
 	"http/raw-post-body.yaml":                       &httpRawPostBody{},
 	"http/request-condition.yaml":                   &httpRequestCondition{},
@@ -506,9 +506,9 @@ func (h *httpRawGet) Execute(filePath string) error {
 	return expectResultsCount(results, 1)
 }
 
-type httpRawPath struct{}
+type httpRawPathTrailingSlash struct{}
 
-func (h *httpRawPath) Execute(filepath string) error {
+func (h *httpRawPathTrailingSlash) Execute(filepath string) error {
 	router := httprouter.New()
 	var routerErr error
 

--- a/v2/pkg/protocols/http/utils/url.go
+++ b/v2/pkg/protocols/http/utils/url.go
@@ -13,8 +13,11 @@ func JoinURLPath(elem1 string, elem2 string) string {
 		Path.Join converts /test/ to /test
 		this should be handled manually
 	*/
+	// if any one of path is empty path.Join removes trailing slash
 	if elem2 == "" {
 		return elem1
+	} else if elem1 == "" {
+		return elem2
 	}
 	if elem2 == "/" || elem2 == "/?" {
 		// check for extra slash


### PR DESCRIPTION
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->

- Fix Missing trailing slash caused by `Path.Join`

closes #3126 

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)