### PR TITLE
Fixing host skipping error

### DIFF
--- a/v2/pkg/catalog/config/config.go
+++ b/v2/pkg/catalog/config/config.go
@@ -32,7 +32,7 @@ type Config struct {
 const nucleiConfigFilename = ".templates-config.json"
 
 // Version is the current version of nuclei
-const Version = `2.8.4`
+const Version = `2.8.5`
 
 var customConfigDirectory string
 

--- a/v2/pkg/protocols/common/hosterrorscache/hosterrorscache.go
+++ b/v2/pkg/protocols/common/hosterrorscache/hosterrorscache.go
@@ -126,7 +126,7 @@ func (c *Cache) MarkFailed(value string, err error) {
 	_ = c.failedTargets.Set(finalValue, existingCacheItemValue)
 }
 
-var reCheckError = regexp.MustCompile(`(no address found for host|could not connect to any address|Client\.Timeout exceeded while awaiting headers|could not resolve host|connection refused|context deadline exceeded)`)
+var reCheckError = regexp.MustCompile(`(no address found for host|Client\.Timeout exceeded while awaiting headers|could not resolve host|connection refused)`)
 
 // checkError checks if an error represents a type that should be
 // added to the host skipping table.


### PR DESCRIPTION
## Proposed changes

1. `context deadline exceeded` is not reliable to use against the error counter to skip the host as it can be generated for multiple engines.
2. `could not connect to any address found for host` is not reliable as currently it's expected to get this error while running a network template with invalid port input.


## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)