### PR TITLE
Adding content length edge cases

### DIFF
--- a/integration_tests/http/cl-body-with-header.yaml
+++ b/integration_tests/http/cl-body-with-header.yaml
@@ -1,7 +1,7 @@
-id: cl-body-without-header
+id: cl-body-with-header
 
 info:
-  name: CL Get Request - Body without header
+  name: CL Get Request - Body with header
   author: pdteam
   severity: info
 
@@ -12,4 +12,4 @@ requests:
     matchers:
       - type: dsl
         dsl:
-          - "content_length==14"
+          - "content_length==50000 && len(body)==14"

--- a/integration_tests/http/cl-body-with-wrong-header.yaml
+++ b/integration_tests/http/cl-body-with-wrong-header.yaml
@@ -1,0 +1,15 @@
+id: cl-body-without-header
+
+info:
+  name: CL Get Request - Body without header
+  author: pdteam
+  severity: info
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    matchers:
+      - type: dsl
+        dsl:
+          - "content_length==14"

--- a/integration_tests/http/cl-body-without-header.yaml
+++ b/integration_tests/http/cl-body-without-header.yaml
@@ -1,0 +1,15 @@
+id: cl-body-without-header
+
+info:
+  name: CL Get Request - Body without header
+  author: pdteam
+  severity: info
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    matchers:
+      - type: dsl
+        dsl:
+          - "content_length==14"

--- a/v2/cmd/integration-test/http.go
+++ b/v2/cmd/integration-test/http.go
@@ -14,6 +14,7 @@ import (
 	"github.com/julienschmidt/httprouter"
 
 	"github.com/projectdiscovery/nuclei/v2/pkg/testutils"
+	logutil "github.com/projectdiscovery/utils/logs"
 	stringsutil "github.com/projectdiscovery/utils/strings"
 )
 
@@ -1045,6 +1046,9 @@ type httpCLBodyWithoutHeader struct{}
 
 // Execute executes a test case and returns an error if occurred
 func (h *httpCLBodyWithoutHeader) Execute(filePath string) error {
+	logutil.DisableDefaultLogger()
+	defer logutil.EnableDefaultLogger()
+
 	router := httprouter.New()
 	router.GET("/", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 		w.Header()["Content-Length"] = []string{"-1"}

--- a/v2/cmd/integration-test/http.go
+++ b/v2/cmd/integration-test/http.go
@@ -60,7 +60,7 @@ var httpTestcases = map[string]testutils.TestCase{
 	"http/get-all-ips.yaml":                         &scanAllIPS{},
 	"http/get-without-scheme.yaml":                  &httpGetWithoutScheme{},
 	"http/cl-body-without-header.yaml":              &httpCLBodyWithoutHeader{},
-	"http/cl-body-with-wrong-header.yaml":           &httpCLBodyWithWrongHeader{},
+	"http/cl-body-with-header.yaml":                 &httpCLBodyWithHeader{},
 }
 
 type httpInteractshRequest struct{}
@@ -1060,11 +1060,11 @@ func (h *httpCLBodyWithoutHeader) Execute(filePath string) error {
 	return expectResultsCount(got, 1)
 }
 
-// content-length in case the response has wrong content-length header and a body
-type httpCLBodyWithWrongHeader struct{}
+// content-length in case the response has content-length header and a body
+type httpCLBodyWithHeader struct{}
 
 // Execute executes a test case and returns an error if occurred
-func (h *httpCLBodyWithWrongHeader) Execute(filePath string) error {
+func (h *httpCLBodyWithHeader) Execute(filePath string) error {
 	router := httprouter.New()
 	router.GET("/", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 		w.Header()["Content-Length"] = []string{"50000"}

--- a/v2/cmd/integration-test/http.go
+++ b/v2/cmd/integration-test/http.go
@@ -14,7 +14,7 @@ import (
 	"github.com/julienschmidt/httprouter"
 
 	"github.com/projectdiscovery/nuclei/v2/pkg/testutils"
-	logutil "github.com/projectdiscovery/utils/logs"
+	logutil "github.com/projectdiscovery/utils/log"
 	stringsutil "github.com/projectdiscovery/utils/strings"
 )
 


### PR DESCRIPTION
## Proposed changes
Closes #2757 

## Notes
Apparently the behavior described in #2757 and https://github.com/projectdiscovery/nuclei/issues/2314 might cause issues to templates requiring to exactly verify the presence and realistic value of the response `Content-Length` as it was provided by the server (eg. for smuggling templates - actually not working correctly).
In particular `cl-body-without-header.yaml` should probably fail if the header was not present, actually it behaves as if the server returned CL header with zero value.

## Checklist
- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)