### PR TITLE
urlencode key characters only

### DIFF
--- a/v2/go.mod
+++ b/v2/go.mod
@@ -79,7 +79,7 @@ require (
 	github.com/projectdiscovery/sarif v0.0.1
 	github.com/projectdiscovery/tlsx v1.0.2
 	github.com/projectdiscovery/uncover v1.0.2
-	github.com/projectdiscovery/utils v0.0.4-0.20221214110533-9f95ee986a54
+	github.com/projectdiscovery/utils v0.0.4-0.20230104145529-50cace956b0a
 	github.com/projectdiscovery/wappalyzergo v0.0.76
 	github.com/stretchr/testify v1.8.1
 	gopkg.in/src-d/go-git.v4 v4.13.1

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -591,6 +591,10 @@ github.com/projectdiscovery/uncover v1.0.2 h1:mRFzflYyvwKkHd3XKufMlDRrb6p1mjFZTS
 github.com/projectdiscovery/uncover v1.0.2/go.mod h1:lz4QYfArSA6jJkXyB71kN2/Pc7IW7nJB8c95n7xtwqY=
 github.com/projectdiscovery/utils v0.0.4-0.20221214110533-9f95ee986a54 h1:/fZvw6gT1fzdmMLMBBw75OrJ0Z6g7dulQrxM9FRp1qU=
 github.com/projectdiscovery/utils v0.0.4-0.20221214110533-9f95ee986a54/go.mod h1:PCwA5YuCYWPgHaGiZmr53/SA9iGQmAnw7DSHuhr8VPQ=
+github.com/projectdiscovery/utils v0.0.4-0.20230104141936-c1df9b3db3bb h1:D+qWSHUo1KPI1UUbjvzo8ffMYCNFF3bTm4ProaQjMDs=
+github.com/projectdiscovery/utils v0.0.4-0.20230104141936-c1df9b3db3bb/go.mod h1:PCwA5YuCYWPgHaGiZmr53/SA9iGQmAnw7DSHuhr8VPQ=
+github.com/projectdiscovery/utils v0.0.4-0.20230104145529-50cace956b0a h1:fHztw99lR4QO931no6Zsj8/RYGA4otFQH5BF8OqfTss=
+github.com/projectdiscovery/utils v0.0.4-0.20230104145529-50cace956b0a/go.mod h1:PCwA5YuCYWPgHaGiZmr53/SA9iGQmAnw7DSHuhr8VPQ=
 github.com/projectdiscovery/wappalyzergo v0.0.76 h1:aG15xPhVY5sK/o3GlGiHrGLpmIkDSUmpbLTGnjVpeAc=
 github.com/projectdiscovery/wappalyzergo v0.0.76/go.mod h1:HvYuW0Be4JCjVds/+XAEaMSqRG9yrI97UmZq0TPk6A0=
 github.com/projectdiscovery/yamldoc-go v1.0.3-0.20211126104922-00d2c6bb43b6 h1:DvWRQpw7Ib2CRL3ogYm/BWM+X0UGPfz1n9Ix9YKgFM8=

--- a/v2/pkg/protocols/http/build_request.go
+++ b/v2/pkg/protocols/http/build_request.go
@@ -28,6 +28,7 @@ import (
 	"github.com/projectdiscovery/rawhttp"
 	"github.com/projectdiscovery/retryablehttp-go"
 	stringsutil "github.com/projectdiscovery/utils/strings"
+	urlutil "github.com/projectdiscovery/utils/url"
 )
 
 var (
@@ -202,7 +203,7 @@ func baseURLWithTemplatePrefs(data string, parsed *url.URL, isRaw bool) (string,
 	}
 
 	// transfer any parmas from URL to data( i.e {{BaseURL}} )
-	params := parsed.Query()
+	params := urlutil.GetParams(parsed.Query())
 	if len(params) == 0 {
 		return data, parsed
 	}
@@ -222,7 +223,7 @@ func baseURLWithTemplatePrefs(data string, parsed *url.URL, isRaw bool) (string,
 			// payload not possible to parse (edgecase)
 			dataURLrelpath += "?" + params.Encode()
 		} else {
-			payloadparams := payloadpath.Query()
+			payloadparams := urlutil.GetParams(payloadpath.Query())
 			if len(payloadparams) != 0 {
 				// ex: /?action=x
 				for k := range payloadparams {

--- a/v2/pkg/protocols/http/fuzz/parts.go
+++ b/v2/pkg/protocols/http/fuzz/parts.go
@@ -11,6 +11,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/expressions"
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/generators"
 	"github.com/projectdiscovery/retryablehttp-go"
+	urlutil "github.com/projectdiscovery/utils/url"
 )
 
 // executePartRule executes part rules based on type
@@ -25,7 +26,7 @@ func (rule *Rule) executePartRule(input *ExecuteRuleInput, payload string) error
 // executeQueryPartRule executes query part rules
 func (rule *Rule) executeQueryPartRule(input *ExecuteRuleInput, payload string) error {
 	requestURL := *input.URL
-	temp := url.Values{}
+	temp := urlutil.NewParams()
 	for k, v := range input.URL.Query() {
 		temp[k] = v
 	}

--- a/v2/pkg/protocols/http/fuzz/parts_test.go
+++ b/v2/pkg/protocols/http/fuzz/parts_test.go
@@ -31,9 +31,9 @@ func TestExecuteQueryPartRule(t *testing.T) {
 		}, "1337'")
 		require.NoError(t, err, "could not execute part rule")
 		require.ElementsMatch(t, []string{
-			"http://localhost:8080/?file=passwdfile&mode=multiple&url=localhost1337%27",
-			"http://localhost:8080/?file=passwdfile&mode=multiple1337%27&url=localhost",
-			"http://localhost:8080/?file=passwdfile1337%27&mode=multiple&url=localhost",
+			"http://localhost:8080/?file=passwdfile&mode=multiple&url=localhost1337'",
+			"http://localhost:8080/?file=passwdfile&mode=multiple1337'&url=localhost",
+			"http://localhost:8080/?file=passwdfile1337'&mode=multiple&url=localhost",
 		}, generatedURL, "could not get generated url")
 	})
 	t.Run("multiple", func(t *testing.T) {
@@ -52,7 +52,7 @@ func TestExecuteQueryPartRule(t *testing.T) {
 			},
 		}, "1337'")
 		require.NoError(t, err, "could not execute part rule")
-		require.Equal(t, "http://localhost:8080/?file=passwdfile1337%27&mode=multiple1337%27&url=localhost1337%27", generatedURL, "could not get generated url")
+		require.Equal(t, "http://localhost:8080/?file=passwdfile1337'&mode=multiple1337'&url=localhost1337'", generatedURL, "could not get generated url")
 	})
 }
 

--- a/v2/pkg/protocols/http/raw/raw.go
+++ b/v2/pkg/protocols/http/raw/raw.go
@@ -12,6 +12,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/http/utils"
 	"github.com/projectdiscovery/rawhttp/client"
 	stringsutil "github.com/projectdiscovery/utils/strings"
+	urlutil "github.com/projectdiscovery/utils/url"
 )
 
 // Request defines a basic HTTP raw request
@@ -32,7 +33,7 @@ func Parse(request, baseURL string, unsafe bool) (*Request, error) {
 	if err != nil {
 		return nil, fmt.Errorf("could not parse request URL: %w", err)
 	}
-	inputParams := inputURL.Query()
+	inputParams := urlutil.GetParams(inputURL.Query())
 
 	// Joins input url and new url preserving query parameters
 	joinPath := func(relpath string) (string, error) {
@@ -45,7 +46,7 @@ func Parse(request, baseURL string, unsafe bool) (*Request, error) {
 		} else {
 			newpath = utils.JoinURLPath(inputURL.Path, relUrl.Path)
 			if len(relUrl.Query()) > 0 {
-				relParam := relUrl.Query()
+				relParam := urlutil.GetParams(relUrl.Query())
 				for k := range relParam {
 					inputParams.Add(k, relParam.Get(k))
 				}

--- a/v2/pkg/protocols/websocket/websocket.go
+++ b/v2/pkg/protocols/websocket/websocket.go
@@ -32,6 +32,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/network/networkclientpool"
 	templateTypes "github.com/projectdiscovery/nuclei/v2/pkg/templates/types"
 	"github.com/projectdiscovery/nuclei/v2/pkg/types"
+	urlutil "github.com/projectdiscovery/utils/url"
 )
 
 // Request is a request for the Websocket protocol
@@ -179,7 +180,7 @@ func (request *Request) executeRequestWithPayloads(input, hostname string, dynam
 	payloadValues["Host"] = parsed.Hostname()
 	payloadValues["Scheme"] = parsed.Scheme
 	requestPath := parsed.Path
-	if values := parsed.Query(); len(values) > 0 {
+	if values := urlutil.GetParams(parsed.Query()); len(values) > 0 {
 		requestPath = requestPath + "?" + values.Encode()
 	}
 	payloadValues["Path"] = requestPath


### PR DESCRIPTION
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->

- The Default `url.values` encoded any/all reserved characters  which certain payloads ex: sqli , xss etc
   -  Example template `CVE-2022-0785`
- `urlutil.Params` is used instead of `url.values` which only encodes key characters (similar to burp and xss tools https://github.com/projectdiscovery/utils/pull/42 ) 
    - Only Certain char are encoded which are necessary/breaking ex: `space,[] etc`
    - Now it is possible to send raw payloads ex: `?xss="><script>alert(1)</script>` without encoding `<,'` and other breaking payload logic

closes #2698 

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)