### PR TITLE
Added clustering support for DNS protocol templates

### DIFF
--- a/v2/internal/runner/runner.go
+++ b/v2/internal/runner/runner.go
@@ -634,7 +634,7 @@ func (r *Runner) executeTemplatesInput(store *loader.Store, engine *core.Engine)
 		totalRequests += int64(t.Executer.Requests()) * r.hmapInputProvider.Count()
 	}
 	if totalRequests < unclusteredRequests {
-		gologger.Info().Msgf("Templates clustered: %d (Reduced %d HTTP Requests)", clusterCount, unclusteredRequests-totalRequests)
+		gologger.Info().Msgf("Templates clustered: %d (Reduced %d Requests)", clusterCount, unclusteredRequests-totalRequests)
 	}
 	workflowCount := len(store.Workflows())
 	templateCount := originalTemplatesCount + workflowCount

--- a/v2/pkg/protocols/dns/cluster.go
+++ b/v2/pkg/protocols/dns/cluster.go
@@ -1,0 +1,20 @@
+package dns
+
+// CanCluster returns true if the request can be clustered.
+//
+// This used by the clustering engine to decide whether two requests
+// are similar enough to be considered one and can be checked by
+// just adding the matcher/extractors for the request and the correct IDs.
+func (request *Request) CanCluster(other *Request) bool {
+	if len(request.Resolvers) > 0 || request.Trace || request.ID != "" {
+		return false
+	}
+	if request.Name != other.Name ||
+		request.class != other.class ||
+		request.Retries != other.Retries ||
+		request.question != other.question ||
+		*request.Recursion != *other.Recursion {
+		return false
+	}
+	return true
+}

--- a/v2/pkg/protocols/dns/dns.go
+++ b/v2/pkg/protocols/dns/dns.go
@@ -106,6 +106,11 @@ func (request *Request) GetID() string {
 	return request.ID
 }
 
+// Options returns executer options for http request
+func (r *Request) Options() *protocols.ExecuterOptions {
+	return r.options
+}
+
 // Compile compiles the protocol request for further execution.
 func (request *Request) Compile(options *protocols.ExecuterOptions) error {
 	if request.Retries == 0 {

--- a/v2/pkg/templates/cluster_test.go
+++ b/v2/pkg/templates/cluster_test.go
@@ -1,0 +1,1 @@
+package templates


### PR DESCRIPTION
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->
Closes #2439

Example run - 

```bash
./nuclei -t report/ -u docs.hackerone.com -debug

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v2.8.7

                projectdiscovery.io

[INF] Using Nuclei Engine 2.8.7 (latest)
[INF] Using Nuclei Templates 9.3.4 (latest)
[INF] Templates added in last update: 15
[INF] Templates loaded for scan: 2
[INF] Targets loaded for scan: 1
[INF] Templates clustered: 2 (Reduced 1 Requests)
[INF] [cluster-ed24673ad80cef5f7ee072bb10b0dfd0ad1a9f720a9bc99f8ffad559b0fe9183] Dumped DNS request for docs.hackerone.com. domain=docs.hackerone.com.
;; opcode: QUERY, status: NOERROR, id: 1728
;; flags: rd; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version 0; flags: ; udp: 4096

;; QUESTION SECTION:
;docs.hackerone.com.    IN       A
[DBG] [cluster-ed24673ad80cef5f7ee072bb10b0dfd0ad1a9f720a9bc99f8ffad559b0fe9183] Dumped DNS response for docs.hackerone.com.

;; opcode: QUERY, status: NOERROR, id: 1728
;; flags: qr rd ra; QUERY: 1, ANSWER: 5, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version 0; flags: ; udp: 1232

;; QUESTION SECTION:
;docs.hackerone.com.    IN       A

;; ANSWER SECTION:
docs.hackerone.com.     300     IN      CNAME   hacker0x01.github.io.
hacker0x01.github.io.   3600    IN      A       185.199.109.153
hacker0x01.github.io.   3600    IN      A       185.199.111.153
hacker0x01.github.io.   3600    IN      A       185.199.108.153
hacker0x01.github.io.   3600    IN      A       185.199.110.153
[azure-takeover-detection:word-1] [dns] [high] docs.hackerone.com [hacker0x01.github.io.]
[elasticbeantalk-takeover:word-1] [dns] [high] docs.hackerone.com
```


## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)