### PR TITLE
fix aws signer missing template variables

### DIFF
--- a/v2/pkg/protocols/http/build_request.go
+++ b/v2/pkg/protocols/http/build_request.go
@@ -138,11 +138,6 @@ func (r *requestGenerator) makeSelfContainedRequest(ctx context.Context, data st
 			generators.BuildPayloadFromOptions(r.request.options.Options),
 		)
 
-		// in case cases (eg requests signing, some variables uses default values if missing)
-		if defaultList := GetVariablesDefault(r.request.Signature.Value); defaultList != nil {
-			values = generators.MergeMaps(defaultList, values)
-		}
-
 		parts[1] = replacer.Replace(parts[1], values)
 		if len(dynamicValues) > 0 {
 			parts[1] = replacer.Replace(parts[1], dynamicValues)
@@ -211,7 +206,7 @@ func baseURLWithTemplatePrefs(data string, parsed *url.URL, isRaw bool) (string,
 	// parsed.RawQuery = ""
 
 	// ex: {{BaseURL}}/metrics?user=xxx
-	dataURLrelpath := strings.TrimLeft(data, "{{BaseURL}}") //nolint:all
+	dataURLrelpath := strings.TrimPrefix(data, "{{BaseURL}}")
 
 	if dataURLrelpath == "" || dataURLrelpath == "/" {
 		// just attach raw query to data

--- a/v2/pkg/protocols/http/request.go
+++ b/v2/pkg/protocols/http/request.go
@@ -769,20 +769,15 @@ func (request *Request) handleSignature(generatedRequest *generatedRequest) erro
 	case AWSSignature:
 		var awsSigner signer.Signer
 		allvars := generators.MergeMaps(request.options.Options.Vars.AsMap(), generatedRequest.dynamicValues)
-		// adds default values to variables if missing
-		signer.AddDefaults(allvars)
 		awsopts := signer.AWSOptions{
 			AwsID:          types.ToString(allvars["aws-id"]),
 			AwsSecretToken: types.ToString(allvars["aws-secret"]),
 		}
-		// type ctxkey string
-		ctx := context.WithValue(context.Background(), signer.SignerArg("service"), allvars["service"])
-		ctx = context.WithValue(ctx, signer.SignerArg("region"), allvars["region"])
-
 		awsSigner, err := signerpool.Get(request.options.Options, &signerpool.Configuration{SignerArgs: &awsopts})
 		if err != nil {
 			return err
 		}
+		ctx := signer.GetCtxWithArgs(allvars, signer.AwsDefaultVars)
 		err = awsSigner.SignHTTP(ctx, generatedRequest.request.Request)
 		if err != nil {
 			return err

--- a/v2/pkg/protocols/http/request.go
+++ b/v2/pkg/protocols/http/request.go
@@ -769,6 +769,8 @@ func (request *Request) handleSignature(generatedRequest *generatedRequest) erro
 	case AWSSignature:
 		var awsSigner signer.Signer
 		allvars := generators.MergeMaps(request.options.Options.Vars.AsMap(), generatedRequest.dynamicValues)
+		// adds default values to variables if missing
+		signer.AddDefaults(allvars)
 		awsopts := signer.AWSOptions{
 			AwsID:          types.ToString(allvars["aws-id"]),
 			AwsSecretToken: types.ToString(allvars["aws-secret"]),

--- a/v2/pkg/protocols/http/request.go
+++ b/v2/pkg/protocols/http/request.go
@@ -768,14 +768,14 @@ func (request *Request) handleSignature(generatedRequest *generatedRequest) erro
 	switch request.Signature.Value {
 	case AWSSignature:
 		var awsSigner signer.Signer
-		vars := request.options.Options.Vars.AsMap()
+		allvars := generators.MergeMaps(request.options.Options.Vars.AsMap(), generatedRequest.dynamicValues)
 		awsopts := signer.AWSOptions{
-			AwsID:          types.ToString(vars["aws-id"]),
-			AwsSecretToken: types.ToString(vars["aws-secret"]),
+			AwsID:          types.ToString(allvars["aws-id"]),
+			AwsSecretToken: types.ToString(allvars["aws-secret"]),
 		}
 		// type ctxkey string
-		ctx := context.WithValue(context.Background(), signer.SignerArg("service"), generatedRequest.dynamicValues["service"])
-		ctx = context.WithValue(ctx, signer.SignerArg("region"), generatedRequest.dynamicValues["region"])
+		ctx := context.WithValue(context.Background(), signer.SignerArg("service"), allvars["service"])
+		ctx = context.WithValue(ctx, signer.SignerArg("region"), allvars["region"])
 
 		awsSigner, err := signerpool.Get(request.options.Options, &signerpool.Configuration{SignerArgs: &awsopts})
 		if err != nil {

--- a/v2/pkg/protocols/http/signature.go
+++ b/v2/pkg/protocols/http/signature.go
@@ -96,13 +96,3 @@ func GetVariablesNamesSkipList(signature SignatureType) map[string]interface{} {
 		return nil
 	}
 }
-
-// GetVariablesNamesSkipList depending on the signature type
-func GetVariablesDefault(signature SignatureType) map[string]interface{} {
-	switch signature {
-	case AWSSignature:
-		return signer.AwsDefaultVars
-	default:
-		return nil
-	}
-}

--- a/v2/pkg/protocols/http/signer/aws-sign.go
+++ b/v2/pkg/protocols/http/signer/aws-sign.go
@@ -113,10 +113,6 @@ var AwsSkipList = map[string]interface{}{
 	"region": struct{}{},
 }
 
-var AwsDefaultVars = map[string]interface{}{
-	"region": "us-east-2",
-}
-
 var AwsInternalOnlyVars = map[string]interface{}{
 	"aws-id":     struct{}{},
 	"aws-secret": struct{}{},

--- a/v2/pkg/protocols/http/signer/aws-sign.go
+++ b/v2/pkg/protocols/http/signer/aws-sign.go
@@ -113,17 +113,12 @@ var AwsSkipList = map[string]interface{}{
 	"region": struct{}{},
 }
 
+var AwsDefaultVars = map[string]interface{}{
+	"region":  "us-east-2",
+	"service": "sts",
+}
+
 var AwsInternalOnlyVars = map[string]interface{}{
 	"aws-id":     struct{}{},
 	"aws-secret": struct{}{},
-}
-
-// AddDefaults adds default values required by signer if missing
-func AddDefaults(x map[string]interface{}) {
-	if _, ok := x["region"]; !ok {
-		x["region"] = "us-east-2"
-	}
-	if _, ok := x["service"]; !ok {
-		x["service"] = "sts"
-	}
 }

--- a/v2/pkg/protocols/http/signer/aws-sign.go
+++ b/v2/pkg/protocols/http/signer/aws-sign.go
@@ -117,3 +117,13 @@ var AwsInternalOnlyVars = map[string]interface{}{
 	"aws-id":     struct{}{},
 	"aws-secret": struct{}{},
 }
+
+// AddDefaults adds default values required by signer if missing
+func AddDefaults(x map[string]interface{}) {
+	if _, ok := x["region"]; !ok {
+		x["region"] = "us-east-2"
+	}
+	if _, ok := x["service"]; !ok {
+		x["service"] = "sts"
+	}
+}

--- a/v2/pkg/protocols/http/signer/signer.go
+++ b/v2/pkg/protocols/http/signer/signer.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"net/http"
+
+	"github.com/projectdiscovery/nuclei/v2/pkg/types"
 )
 
 // An Argument that can be passed to Signer
@@ -31,4 +33,22 @@ func NewSigner(args SignerArgs) (signer Signer, err error) {
 	default:
 		return nil, errors.New("unknown signature arguments type")
 	}
+}
+
+// GetCtxWithArgs creates and returns context with signature args
+func GetCtxWithArgs(maps ...map[string]interface{}) context.Context {
+	var region, service string
+	for _, v := range maps {
+		for key, val := range v {
+			if key == "region" && region == "" {
+				region = types.ToString(val)
+			}
+			if key == "service" && service == "" {
+				service = types.ToString(val)
+			}
+		}
+	}
+	// type ctxkey string
+	ctx := context.WithValue(context.Background(), SignerArg("service"), service)
+	return context.WithValue(ctx, SignerArg("region"), region)
 }


### PR DESCRIPTION
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->

- Fix issue where aws signer did not use variables from template
- AWS Signer now uses variables from both template itself and CLI with preference given to CLI (i.e can override with CLI option)

closes #3202 

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)