### PR TITLE
fix make http request inconsistencies

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -46,4 +46,3 @@ jobs:
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{ github.ref }}

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -46,3 +46,4 @@ jobs:
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref }}

--- a/integration_tests/debug.sh
+++ b/integration_tests/debug.sh
@@ -1,17 +1,49 @@
 #!/bin/bash
 
+if [ $1 = "-h" ]; then
+ echo "Help for ./debug.sh"
+ printf "\n1. To run all integration tests of 'x' protocol:\n"
+ printf " \$ ./debug.sh http\n\n"
+ printf "2. To run all integration tests of 'x' protocol that contains 'y' in template name:\n"
+ printf " \$ ./debug.sh http self\n\n"
+ printf "3. To run all integration tests of 'x' protocol that contains 'y' in template name and pass extra args to nuclei:\n"
+ printf " \$ ./debug.sh http self -svd -debug-req\n\n"
+ printf "nuclei binary is created everytime script is run but integration-test binary is not"
+ exit 0
+fi
+
+
 echo "::group::Build nuclei"
 rm nuclei 2>/dev/null
 cd ../v2/cmd/nuclei
 go build .
 mv nuclei ../../../integration_tests/nuclei 
-echo "::endgroup::"
+echo -e "::endgroup::\n"
 cd ../../../integration_tests
-pwd
-./integration-test -protocol $1 -template $2
+
+cmdstring=""
+
+if [ -n "$1" ]; then
+ cmdstring+=" -protocol $1 "
+fi
+
+if [ -n "$2" ]; then
+ cmdstring+=" -template $2 "
+fi
+
+# Parse any extra args that are directly passed to nuclei
+if [ -n $debugArgs ]; then
+ export DebugExtraArgs="${@:3}"
+fi
+
+echo "$DebugExtraArgs"
+
+echo -e "::group::Run Integration Test\n"
+./integration-test $cmdstring
 
 if [ $? -eq 0 ]
 then
+  echo -e "::endgroup::\n"
   exit 0
 else
   exit 1

--- a/v2/cmd/integration-test/integration-test.go
+++ b/v2/cmd/integration-test/integration-test.go
@@ -40,12 +40,20 @@ var (
 	// For debug purposes
 	runProtocol = ""
 	runTemplate = ""
+	extraArgs   = []string{}
 )
 
 func main() {
 	flag.StringVar(&runProtocol, "protocol", "", "run integration tests of given protocol")
 	flag.StringVar(&runTemplate, "template", "", "run integration test of given template")
 	flag.Parse()
+
+	// allows passing extra args to nuclei
+	eargs := os.Getenv("DebugExtraArgs")
+	if eargs != "" {
+		extraArgs = strings.Split(eargs, " ")
+		testutils.ExtraDebugArgs = extraArgs
+	}
 
 	if runProtocol != "" {
 		debug = true
@@ -73,7 +81,7 @@ func debugTests() {
 			continue
 		}
 		if err := testcase.Execute(tpath); err != nil {
-			panic(err)
+			fmt.Printf("\n%v", err.Error())
 		}
 	}
 }

--- a/v2/pkg/protocols/http/build_request_test.go
+++ b/v2/pkg/protocols/http/build_request_test.go
@@ -13,18 +13,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/generators"
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/interactsh"
 	"github.com/projectdiscovery/nuclei/v2/pkg/testutils"
-	urlutil "github.com/projectdiscovery/utils/url"
 )
-
-func TestBaseURLWithTemplatePrefs(t *testing.T) {
-	baseURL := "http://localhost:53/test"
-	parsed, _ := urlutil.Parse(baseURL)
-
-	data := "{{BaseURL}}:8000/newpath"
-	parsed, data = UsePortFromPayload(parsed, data)
-	require.Equal(t, "http://localhost:8000/test", parsed.String(), "could not get correct value")
-	require.Equal(t, "{{BaseURL}}/newpath", data, "could not get correct data")
-}
 
 func TestMakeRequestFromModal(t *testing.T) {
 	options := testutils.DefaultOptions

--- a/v2/pkg/protocols/http/raw/raw.go
+++ b/v2/pkg/protocols/http/raw/raw.go
@@ -26,12 +26,7 @@ type Request struct {
 }
 
 // Parse parses the raw request as supplied by the user
-func Parse(request, baseURL string, unsafe bool) (*Request, error) {
-	// parse Input URL
-	inputURL, err := urlutil.ParseURL(baseURL, unsafe)
-	if err != nil {
-		return nil, errorutil.NewWithErr(err).Msgf("could not parse request URL").WithTag("raw")
-	}
+func Parse(request string, inputURL *urlutil.URL, unsafe bool) (*Request, error) {
 	rawrequest, err := readRawRequest(request, unsafe)
 	if err != nil {
 		return nil, err

--- a/v2/pkg/protocols/http/raw/raw_test.go
+++ b/v2/pkg/protocols/http/raw/raw_test.go
@@ -3,6 +3,7 @@ package raw
 import (
 	"testing"
 
+	urlutil "github.com/projectdiscovery/utils/url"
 	"github.com/stretchr/testify/require"
 )
 
@@ -13,32 +14,32 @@ Origin: {{BaseURL}}
 Connection: close
 User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko)
 Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8
-Accept-Language: en-US,en;q=0.9`, "https://example.com:8080", false)
+Accept-Language: en-US,en;q=0.9`, parseurl(t, "https://example.com:8080"), false)
 	require.Nil(t, err, "could not parse GET request")
 	require.Equal(t, "https://example.com:8080/gg/phpinfo.php", request.FullURL, "Could not parse request url correctly")
 	require.Equal(t, "/gg/phpinfo.php", request.Path, "Could not parse request path correctly")
 
 	t.Run("path-suffix", func(t *testing.T) {
 		request, err := Parse(`GET /hello HTTP/1.1
-Host: {{Hostname}}`, "https://example.com:8080/test", false)
+Host: {{Hostname}}`, parseurl(t, "https://example.com:8080/test"), false)
 		require.Nil(t, err, "could not parse GET request")
 		require.Equal(t, "https://example.com:8080/test/hello", request.FullURL, "Could not parse request url correctly")
 	})
 
 	t.Run("query-values", func(t *testing.T) {
 		request, err := Parse(`GET ?username=test&password=test HTTP/1.1
-Host: {{Hostname}}:123`, "https://example.com:8080/test", false)
+Host: {{Hostname}}:123`, parseurl(t, "https://example.com:8080/test"), false)
 		require.Nil(t, err, "could not parse GET request")
 		// url.values are sorted to avoid randomness of using maps
 		require.Equal(t, "https://example.com:8080/test?password=test&username=test", request.FullURL, "Could not parse request url correctly")
 
 		request, err = Parse(`GET ?username=test&password=test HTTP/1.1
-Host: {{Hostname}}:123`, "https://example.com:8080/test/", false)
+Host: {{Hostname}}:123`, parseurl(t, "https://example.com:8080/test/"), false)
 		require.Nil(t, err, "could not parse GET request")
 		require.Equal(t, "https://example.com:8080/test/?password=test&username=test", request.FullURL, "Could not parse request url correctly")
 
 		request, err = Parse(`GET /?username=test&password=test HTTP/1.1
-		Host: {{Hostname}}:123`, "https://example.com:8080/test/", false)
+		Host: {{Hostname}}:123`, parseurl(t, "https://example.com:8080/test/"), false)
 		require.Nil(t, err, "could not parse GET request")
 		require.Equal(t, "https://example.com:8080/test/?password=test&username=test", request.FullURL, "Could not parse request url correctly")
 	})
@@ -50,7 +51,7 @@ Host: {{Hostname}}
 Authorization: Basic {{base64('username:password')}}
 User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0
 Accept-Language: en-US,en;q=0.9
-Connection: close`, "https://test.com", false)
+Connection: close`, parseurl(t, "https://test.com"), false)
 	require.Nil(t, err, "could not parse GET request")
 	require.Equal(t, "GET", request.Method, "Could not parse GET method request correctly")
 	require.Equal(t, "/manager/html", request.Path, "Could not parse request path correctly")
@@ -60,7 +61,7 @@ Host: {{Hostname}}
 Content-Type: application/x-www-form-urlencoded
 Connection: close
 
-username=admin&password=login`, "https://test.com", false)
+username=admin&password=login`, parseurl(t, "https://test.com"), false)
 	require.Nil(t, err, "could not parse POST request")
 	require.Equal(t, "POST", request.Method, "Could not parse POST method request correctly")
 	require.Equal(t, "username=admin&password=login", request.Data, "Could not parse request data correctly")
@@ -72,13 +73,13 @@ Host: {{Hostname}}
 Authorization: Basic {{base64('username:password')}}
 User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0
 Accept-Language: en-US,en;q=0.9
-Connection: close`, "https://test.com/test/", true)
+Connection: close`, parseurl(t, "https://test.com/test/"), true)
 	require.Nil(t, err, "could not parse unsafe request")
 	require.Contains(t, string(request.UnsafeRawBytes), "GET /test/manager/html", "Could not parse unsafe method request path correctly")
 
 	request, err = Parse(`GET ?a=b HTTP/1.1
 	Host: {{Hostname}}
-	Origin: {{BaseURL}}`, "https://test.com/test.js", true)
+	Origin: {{BaseURL}}`, parseurl(t, "https://test.com/test.js"), true)
 	require.Nil(t, err, "could not parse unsafe request")
 	require.Contains(t, string(request.UnsafeRawBytes), "GET /test.js?a=b", "Could not parse unsafe method request path correctly")
 }
@@ -86,9 +87,17 @@ Connection: close`, "https://test.com/test/", true)
 func TestTryFillCustomHeaders(t *testing.T) {
 	testValue := "GET /manager/html HTTP/1.1\r\nHost: Test\r\n"
 	expected := "GET /test/manager/html HTTP/1.1\r\nHost: Test\r\ntest: test\r\n"
-	request, err := Parse(testValue, "https://test.com/test/", true)
+	request, err := Parse(testValue, parseurl(t, "https://test.com/test/"), true)
 	require.Nil(t, err, "could not parse unsafe request")
 	err = request.TryFillCustomHeaders([]string{"test: test"})
 	require.Nil(t, err, "could not add custom headers")
 	require.Equal(t, expected, string(request.UnsafeRawBytes), "actual value and expected value are different")
+}
+
+func parseurl(t *testing.T, inputurl string) *urlutil.URL {
+	urlx, err := urlutil.Parse(inputurl)
+	if err != nil {
+		t.Fatalf("failed to parse url %v", urlx)
+	}
+	return urlx
 }

--- a/v2/pkg/protocols/http/raw/raw_test.go
+++ b/v2/pkg/protocols/http/raw/raw_test.go
@@ -14,32 +14,32 @@ Origin: {{BaseURL}}
 Connection: close
 User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko)
 Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8
-Accept-Language: en-US,en;q=0.9`, parseurl(t, "https://example.com:8080"), false)
+Accept-Language: en-US,en;q=0.9`, parseURL(t, "https://example.com:8080"), false)
 	require.Nil(t, err, "could not parse GET request")
 	require.Equal(t, "https://example.com:8080/gg/phpinfo.php", request.FullURL, "Could not parse request url correctly")
 	require.Equal(t, "/gg/phpinfo.php", request.Path, "Could not parse request path correctly")
 
 	t.Run("path-suffix", func(t *testing.T) {
 		request, err := Parse(`GET /hello HTTP/1.1
-Host: {{Hostname}}`, parseurl(t, "https://example.com:8080/test"), false)
+Host: {{Hostname}}`, parseURL(t, "https://example.com:8080/test"), false)
 		require.Nil(t, err, "could not parse GET request")
 		require.Equal(t, "https://example.com:8080/test/hello", request.FullURL, "Could not parse request url correctly")
 	})
 
 	t.Run("query-values", func(t *testing.T) {
 		request, err := Parse(`GET ?username=test&password=test HTTP/1.1
-Host: {{Hostname}}:123`, parseurl(t, "https://example.com:8080/test"), false)
+Host: {{Hostname}}:123`, parseURL(t, "https://example.com:8080/test"), false)
 		require.Nil(t, err, "could not parse GET request")
 		// url.values are sorted to avoid randomness of using maps
 		require.Equal(t, "https://example.com:8080/test?password=test&username=test", request.FullURL, "Could not parse request url correctly")
 
 		request, err = Parse(`GET ?username=test&password=test HTTP/1.1
-Host: {{Hostname}}:123`, parseurl(t, "https://example.com:8080/test/"), false)
+Host: {{Hostname}}:123`, parseURL(t, "https://example.com:8080/test/"), false)
 		require.Nil(t, err, "could not parse GET request")
 		require.Equal(t, "https://example.com:8080/test/?password=test&username=test", request.FullURL, "Could not parse request url correctly")
 
 		request, err = Parse(`GET /?username=test&password=test HTTP/1.1
-		Host: {{Hostname}}:123`, parseurl(t, "https://example.com:8080/test/"), false)
+		Host: {{Hostname}}:123`, parseURL(t, "https://example.com:8080/test/"), false)
 		require.Nil(t, err, "could not parse GET request")
 		require.Equal(t, "https://example.com:8080/test/?password=test&username=test", request.FullURL, "Could not parse request url correctly")
 	})
@@ -51,7 +51,7 @@ Host: {{Hostname}}
 Authorization: Basic {{base64('username:password')}}
 User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0
 Accept-Language: en-US,en;q=0.9
-Connection: close`, parseurl(t, "https://test.com"), false)
+Connection: close`, parseURL(t, "https://test.com"), false)
 	require.Nil(t, err, "could not parse GET request")
 	require.Equal(t, "GET", request.Method, "Could not parse GET method request correctly")
 	require.Equal(t, "/manager/html", request.Path, "Could not parse request path correctly")
@@ -61,7 +61,7 @@ Host: {{Hostname}}
 Content-Type: application/x-www-form-urlencoded
 Connection: close
 
-username=admin&password=login`, parseurl(t, "https://test.com"), false)
+username=admin&password=login`, parseURL(t, "https://test.com"), false)
 	require.Nil(t, err, "could not parse POST request")
 	require.Equal(t, "POST", request.Method, "Could not parse POST method request correctly")
 	require.Equal(t, "username=admin&password=login", request.Data, "Could not parse request data correctly")
@@ -73,13 +73,13 @@ Host: {{Hostname}}
 Authorization: Basic {{base64('username:password')}}
 User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0
 Accept-Language: en-US,en;q=0.9
-Connection: close`, parseurl(t, "https://test.com/test/"), true)
+Connection: close`, parseURL(t, "https://test.com/test/"), true)
 	require.Nil(t, err, "could not parse unsafe request")
 	require.Contains(t, string(request.UnsafeRawBytes), "GET /test/manager/html", "Could not parse unsafe method request path correctly")
 
 	request, err = Parse(`GET ?a=b HTTP/1.1
 	Host: {{Hostname}}
-	Origin: {{BaseURL}}`, parseurl(t, "https://test.com/test.js"), true)
+	Origin: {{BaseURL}}`, parseURL(t, "https://test.com/test.js"), true)
 	require.Nil(t, err, "could not parse unsafe request")
 	require.Contains(t, string(request.UnsafeRawBytes), "GET /test.js?a=b", "Could not parse unsafe method request path correctly")
 }
@@ -87,14 +87,14 @@ Connection: close`, parseurl(t, "https://test.com/test/"), true)
 func TestTryFillCustomHeaders(t *testing.T) {
 	testValue := "GET /manager/html HTTP/1.1\r\nHost: Test\r\n"
 	expected := "GET /test/manager/html HTTP/1.1\r\nHost: Test\r\ntest: test\r\n"
-	request, err := Parse(testValue, parseurl(t, "https://test.com/test/"), true)
+	request, err := Parse(testValue, parseURL(t, "https://test.com/test/"), true)
 	require.Nil(t, err, "could not parse unsafe request")
 	err = request.TryFillCustomHeaders([]string{"test: test"})
 	require.Nil(t, err, "could not add custom headers")
 	require.Equal(t, expected, string(request.UnsafeRawBytes), "actual value and expected value are different")
 }
 
-func parseurl(t *testing.T, inputurl string) *urlutil.URL {
+func parseURL(t *testing.T, inputurl string) *urlutil.URL {
 	urlx, err := urlutil.Parse(inputurl)
 	if err != nil {
 		t.Fatalf("failed to parse url %v", urlx)

--- a/v2/pkg/protocols/http/utils/requtils.go
+++ b/v2/pkg/protocols/http/utils/requtils.go
@@ -1,0 +1,43 @@
+package utils
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/projectdiscovery/retryablehttp-go"
+	urlutil "github.com/projectdiscovery/utils/url"
+)
+
+var (
+	// TODO: adapt regex for cases where port is updated
+	urlWithPortRegex = regexp.MustCompile(`^{{(BaseURL|RootURL)}}:(\d+)`)
+	// regex to detect traling slash in path (not applicable to raw requests)
+	trailingSlashregex = regexp.MustCompile(`^\Q{{\E[a-zA-Z]+\Q}}/\E`)
+)
+
+// HasTrailingSlash returns true if path(that has default variables) has trailing slash
+func HasTrailingSlash(data string) bool {
+	return trailingSlashregex.MatchString(data)
+}
+
+// UpdateURLPortFromPayload overrides input port if specified in payload(ex: {{BaseURL}}:8080)
+func UpdateURLPortFromPayload(parsed *urlutil.URL, data string) (*urlutil.URL, string) {
+	matches := urlWithPortRegex.FindAllStringSubmatch(data, -1)
+	if len(matches) > 0 {
+		port := matches[0][2]
+		parsed.UpdatePort(port)
+		// remove it from dsl
+		data = strings.Replace(data, ":"+port, "", 1)
+	}
+	return parsed, data
+}
+
+// setHeader sets some headers only if the header wasn't supplied by the user
+func SetHeader(req *retryablehttp.Request, name, value string) {
+	if _, ok := req.Header[name]; !ok {
+		req.Header.Set(name, value)
+	}
+	if name == "Host" {
+		req.Host = value
+	}
+}

--- a/v2/pkg/protocols/http/utils/requtils_test.go
+++ b/v2/pkg/protocols/http/utils/requtils_test.go
@@ -1,0 +1,50 @@
+package utils
+
+import (
+	"testing"
+
+	urlutil "github.com/projectdiscovery/utils/url"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTrailingSlash(t *testing.T) {
+	testcases := []struct {
+		payload  string
+		hasSlash bool
+	}{
+		{"{{BaseURL}}", false},
+		{"{{BaseURL}}/", true},
+		{"{{RootURL}}", false},
+		{"{{RootURL}}/", true},
+		{"{{randomvar}}", false},
+		{"{{randomvar}}/", true},
+		{"later/{{randomvar}}/", false},
+	}
+
+	for _, v := range testcases {
+		if v.hasSlash != HasTrailingSlash(v.payload) {
+			t.Errorf("expected %v but got %v for %v", v.hasSlash, HasTrailingSlash(v.payload), v.payload)
+		}
+	}
+}
+
+func TestPortUpdate(t *testing.T) {
+	testcases := []struct {
+		inputURL        string // input url
+		CleanedInputURL string
+		RequestPath     string // path which contains port
+		CleanedPath     string // path after processing
+	}{
+		{"http://localhost:53/test", "http://localhost:8000/test", "{{BaseURL}}:8000/newpath", "{{BaseURL}}/newpath"},
+		{"http://localhost:53/test", "http://localhost:8000/test", "{{RootURL}}:8000/newpath", "{{RootURL}}/newpath"},
+		{"http://localhost:53/test", "http://localhost:53/test", "{{RootURL}}/newpath", "{{RootURL}}/newpath"},
+		{"http://localhost/test", "http://localhost:8000/test", "{{RootURL}}:8000/newpath", "{{RootURL}}/newpath"},
+		{"http://localhost/test", "http://localhost/test", "{{RootURL}}/newpath", "{{RootURL}}/newpath"},
+	}
+	for _, v := range testcases {
+		parsed, _ := urlutil.Parse(v.inputURL)
+		parsed, v.RequestPath = UpdateURLPortFromPayload(parsed, v.RequestPath)
+		require.Equal(t, v.CleanedInputURL, parsed.String(), "could not get correct value")
+		require.Equal(t, v.CleanedPath, v.RequestPath, "could not get correct data")
+	}
+}

--- a/v2/pkg/protocols/http/utils/variables.go
+++ b/v2/pkg/protocols/http/utils/variables.go
@@ -23,7 +23,7 @@ func GenerateVariablesWithContextArgs(input *contextargs.Context, trailingSlash 
 // GenerateVariables will create default variables after parsing a url with additional variables
 func GenerateVariablesWithURL(inputURL *urlutil.URL, trailingSlash bool, additionalVars map[string]interface{}) map[string]interface{} {
 	parsed := inputURL.Clone()
-	// Query parameter merging is handled elsewhere and should not be present in VariableMap
+	// Query parameter merging is handled elsewhere and should not be included in {{BaseURL}} or other httpVariables
 	parsed.Params = make(urlutil.Params)
 	domain := parsed.Host
 	if strings.Contains(parsed.Host, ":") {

--- a/v2/pkg/protocols/http/utils/variables.go
+++ b/v2/pkg/protocols/http/utils/variables.go
@@ -21,7 +21,10 @@ func GenerateVariablesWithContextArgs(input *contextargs.Context, trailingSlash 
 }
 
 // GenerateVariables will create default variables after parsing a url with additional variables
-func GenerateVariablesWithURL(parsed *urlutil.URL, trailingSlash bool, additionalVars map[string]interface{}) map[string]interface{} {
+func GenerateVariablesWithURL(inputURL *urlutil.URL, trailingSlash bool, additionalVars map[string]interface{}) map[string]interface{} {
+	parsed := inputURL.Clone()
+	// Query parameter merging is handled elsewhere and should not be present in VariableMap
+	parsed.Params = make(urlutil.Params)
 	domain := parsed.Host
 	if strings.Contains(parsed.Host, ":") {
 		domain = strings.Split(parsed.Host, ":")[0]

--- a/v2/pkg/protocols/http/utils/variables_test.go
+++ b/v2/pkg/protocols/http/utils/variables_test.go
@@ -11,7 +11,8 @@ import (
 func TestVariables(t *testing.T) {
 	baseURL := "http://localhost:9001/test/123"
 	parsed, _ := urlutil.Parse(baseURL)
-	values := GenerateVariablesWithURL(parsed, true, nil)
+	// trailingslash is only true when both target/inputURL and payload {{BaseURL}}/xyz both have slash
+	values := GenerateVariablesWithURL(parsed, false, nil)
 
 	require.Equal(t, values["BaseURL"], parsed.String(), "incorrect baseurl")
 	require.Equal(t, values["RootURL"], "http://localhost:9001", "incorrect rootURL")
@@ -36,12 +37,12 @@ func TestVariables(t *testing.T) {
 
 	baseURL = "ftp://foobar.com/"
 	parsed, _ = urlutil.Parse(baseURL)
-	values = GenerateVariablesWithURL(parsed, true, nil)
+	values = GenerateVariablesWithURL(parsed, false, nil)
 
 	require.Equal(t, values["BaseURL"], parsed.String(), "incorrect baseurl")
 	require.Equal(t, values["Host"], "foobar.com", "incorrect domain name")
 	require.Equal(t, values["RootURL"], "ftp://foobar.com", "incorrect rootURL")
-	require.Equal(t, values["Path"], "", "incorrect path")
+	require.Equal(t, values["Path"], "/", "incorrect path")
 	require.Equal(t, values["Port"], "", "incorrect port number") // Unsupported protocol results in a blank port
 	require.Equal(t, values["Scheme"], "ftp", "incorrect scheme")
 	require.Equal(t, values["Hostname"], "foobar.com", "incorrect hostname")

--- a/v2/pkg/testutils/integration.go
+++ b/v2/pkg/testutils/integration.go
@@ -16,6 +16,9 @@ import (
 	"github.com/julienschmidt/httprouter"
 )
 
+// ExtraArgs
+var ExtraDebugArgs = []string{}
+
 // RunNucleiTemplateAndGetResults returns a list of results for a template
 func RunNucleiTemplateAndGetResults(template, url string, debug bool, extra ...string) ([]string, error) {
 	return RunNucleiAndGetResults(true, template, url, debug, extra...)
@@ -44,6 +47,7 @@ func RunNucleiAndGetResults(isTemplate bool, template, url string, debug bool, e
 
 func RunNucleiBareArgsAndGetResults(debug bool, extra ...string) ([]string, error) {
 	cmd := exec.Command("./nuclei")
+	extra = append(extra, ExtraDebugArgs...)
 	cmd.Args = append(cmd.Args, extra...)
 	cmd.Args = append(cmd.Args, "-duc") // disable auto updates
 	if debug {


### PR DESCRIPTION
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->
- Most of the `Make` HTTP protocol request logic was centred towards `{{BaseURL}}` (automerge params etc) which caused inconsistencies when  templates used `{{RootURL}}` or any other variable in `Path` section of the template.
   - This was also cause behind #3242 
   - New logic  implemented in this PR does not depend on variables (for automerge etc) and is implemented after variables are evaluated  
- Minor improvements to `debug.sh`  for debugging integration tests
- Other Code refactor and Improvements in `Make` (http protocol)
   -  Improved `trailing slash` logic (uses a proper regex to match) + added unit test
   -  removes unnecessary url parsing

closes #3242 

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)