### PR TITLE
fix data race in race requests

### DIFF
--- a/integration_tests/debug.sh
+++ b/integration_tests/debug.sh
@@ -12,15 +12,16 @@ if [ $1 = "-h" ]; then
  exit 0
 fi
 
+# Stop execution if race condition is found
+export GORACE="halt_on_error=1"
 
 echo "::group::Build nuclei"
 rm nuclei 2>/dev/null
 cd ../v2/cmd/nuclei
-go build .
+go build -race .
 mv nuclei ../../../integration_tests/nuclei 
 echo -e "::endgroup::\n"
 cd ../../../integration_tests
-
 cmdstring=""
 
 if [ -n "$1" ]; then

--- a/v2/pkg/protocols/common/executer/executer.go
+++ b/v2/pkg/protocols/common/executer/executer.go
@@ -3,6 +3,7 @@ package executer
 import (
 	"fmt"
 	"strings"
+	"sync/atomic"
 
 	"github.com/pkg/errors"
 
@@ -60,7 +61,7 @@ func (e *Executer) Requests() int {
 
 // Execute executes the protocol group and returns true or false if results were found.
 func (e *Executer) Execute(input *contextargs.Context) (bool, error) {
-	var results bool
+	results := &atomic.Bool{}
 
 	dynamicValues := make(map[string]interface{})
 	if input.HasArgs() {
@@ -98,7 +99,7 @@ func (e *Executer) Execute(input *contextargs.Context) (bool, error) {
 				}
 			} else {
 				if writer.WriteResult(event, e.options.Output, e.options.Progress, e.options.IssuesClient) {
-					results = true
+					results.CompareAndSwap(false, true)
 				} else {
 					if err := e.options.Output.WriteFailure(event.InternalEvent); err != nil {
 						gologger.Warning().Msgf("Could not write failure event to output: %s\n", err)
@@ -113,11 +114,11 @@ func (e *Executer) Execute(input *contextargs.Context) (bool, error) {
 			gologger.Warning().Msgf("[%s] Could not execute request for %s: %s\n", e.options.TemplateID, input.MetaInput.PrettyPrint(), err)
 		}
 		// If a match was found and stop at first match is set, break out of the loop and return
-		if results && (e.options.StopAtFirstMatch || e.options.Options.StopAtFirstMatch) {
+		if results.Load() && (e.options.StopAtFirstMatch || e.options.Options.StopAtFirstMatch) {
 			break
 		}
 	}
-	return results, nil
+	return results.Load(), nil
 }
 
 // ExecuteWithResults executes the protocol requests and returns results instead of writing them.
@@ -129,7 +130,7 @@ func (e *Executer) ExecuteWithResults(input *contextargs.Context, callback proto
 		})
 	}
 	previous := make(map[string]interface{})
-	var results bool
+	results := &atomic.Bool{}
 
 	for _, req := range e.requests {
 		req := req
@@ -156,7 +157,7 @@ func (e *Executer) ExecuteWithResults(input *contextargs.Context, callback proto
 			if event.OperatorsResult == nil {
 				return
 			}
-			results = true
+			results.CompareAndSwap(false, true)
 			callback(event)
 		})
 		if err != nil {
@@ -166,7 +167,7 @@ func (e *Executer) ExecuteWithResults(input *contextargs.Context, callback proto
 			gologger.Warning().Msgf("[%s] Could not execute request for %s: %s\n", e.options.TemplateID, input.MetaInput.PrettyPrint(), err)
 		}
 		// If a match was found and stop at first match is set, break out of the loop and return
-		if results && (e.options.StopAtFirstMatch || e.options.Options.StopAtFirstMatch) {
+		if results.Load() && (e.options.StopAtFirstMatch || e.options.Options.StopAtFirstMatch) {
 			break
 		}
 	}


### PR DESCRIPTION
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->

- while  `atomic.Bool{}` to track match status etc . The actual protocol executor in `pkg/protocols/common/executor/*` used `bool` which is not concurrency safe and caused panic randomly with race requests (or other conditions were matcher status is used in parallel)
- this PR fixes above issue and closes #3274 

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)