### PR TITLE
Adding interactsh support to sni

### DIFF
--- a/v2/pkg/protocols/common/variables/variables.go
+++ b/v2/pkg/protocols/common/variables/variables.go
@@ -56,7 +56,7 @@ func (variables *Variable) EvaluateWithInteractsh(values map[string]interface{},
 	variables.ForEach(func(key string, value interface{}) {
 		valueString := types.ToString(value)
 		if strings.Contains(valueString, "interactsh-url") {
-			valueString, interactURLs = interact.ReplaceMarkers(valueString, interactURLs)
+			valueString, interactURLs = interact.Replace(valueString, interactURLs)
 		}
 		result[key] = evaluateVariableValue(valueString, generators.MergeMaps(values, result), result)
 	})

--- a/v2/pkg/protocols/headless/engine/page_actions.go
+++ b/v2/pkg/protocols/headless/engine/page_actions.go
@@ -613,7 +613,7 @@ func (p *Page) getActionArgWithValues(action *Action, arg string, values map[str
 	argValue = replaceWithValues(argValue, values)
 	if p.instance.interactsh != nil {
 		var interactshURLs []string
-		argValue, interactshURLs = p.instance.interactsh.ReplaceMarkers(argValue, p.InteractshURLs)
+		argValue, interactshURLs = p.instance.interactsh.Replace(argValue, p.InteractshURLs)
 		p.addInteractshURL(interactshURLs...)
 	}
 	return argValue

--- a/v2/pkg/protocols/http/fuzz/parts.go
+++ b/v2/pkg/protocols/http/fuzz/parts.go
@@ -98,7 +98,7 @@ func (rule *Rule) executeEvaluate(input *ExecuteRuleInput, key, value, payload s
 		"value": value,
 	})
 	firstpass, _ := expressions.Evaluate(payload, values)
-	interactData, interactshURLs := rule.options.Interactsh.ReplaceMarkers(firstpass, interactshURLs)
+	interactData, interactshURLs := rule.options.Interactsh.Replace(firstpass, interactshURLs)
 	evaluated, _ := expressions.Evaluate(interactData, values)
 	replaced := rule.executeReplaceRule(input, value, evaluated)
 	return replaced, interactshURLs

--- a/v2/pkg/protocols/http/request_annotations.go
+++ b/v2/pkg/protocols/http/request_annotations.go
@@ -47,12 +47,14 @@ func parseFlowAnnotations(rawRequest string) (flowMark, bool) {
 	return fm, hasFlowOveride
 }
 
+type annotationOverrides struct {
+	request        *retryablehttp.Request
+	cancelFunc     context.CancelFunc
+	interactshURLs []string
+}
+
 // parseAnnotations and override requests settings
-func (r *Request) parseAnnotations(rawRequest string, request *retryablehttp.Request) (*retryablehttp.Request, context.CancelFunc, bool) {
-	var (
-		modified   bool
-		cancelFunc context.CancelFunc
-	)
+func (r *Request) parseAnnotations(rawRequest string, request *retryablehttp.Request) (overrides annotationOverrides, modified bool) {
 	// parse request for known ovverride annotations
 
 	// @Host:target
@@ -89,8 +91,14 @@ func (r *Request) parseAnnotations(rawRequest string, request *retryablehttp.Req
 			value = value[:idxForwardSlash]
 		}
 
-		if stringsutil.EqualFoldAny(value, "request.host") {
+		switch value {
+		case "request.host":
 			value = request.Host
+		case "interactsh-url":
+			if interactshURL, err := r.options.Interactsh.NewURLWithData("interactsh-url"); err == nil {
+				value = interactshURL
+			}
+			overrides.interactshURLs = append(overrides.interactshURLs, value)
 		}
 		ctx := context.WithValue(request.Context(), fastdialer.SniName, value)
 		request = request.Clone(ctx)
@@ -106,16 +114,19 @@ func (r *Request) parseAnnotations(rawRequest string, request *retryablehttp.Req
 			value := strings.TrimSpace(duration[1])
 			if parsed, err := time.ParseDuration(value); err == nil {
 				//nolint:govet // cancelled automatically by withTimeout
-				ctx, cancelFunc = context.WithTimeout(context.Background(), parsed)
+				ctx, overrides.cancelFunc = context.WithTimeout(context.Background(), parsed)
 				request = request.Clone(ctx)
 			}
 		} else {
 			//nolint:govet // cancelled automatically by withTimeout
-			ctx, cancelFunc = context.WithTimeout(context.Background(), time.Duration(r.options.Options.Timeout)*time.Second)
+			ctx, overrides.cancelFunc = context.WithTimeout(context.Background(), time.Duration(r.options.Options.Timeout)*time.Second)
 			request = request.Clone(ctx)
 		}
 	}
-	return request, cancelFunc, modified
+
+	overrides.request = request
+
+	return
 }
 
 func isHostPort(value string) bool {

--- a/v2/pkg/protocols/http/request_annotations_test.go
+++ b/v2/pkg/protocols/http/request_annotations_test.go
@@ -22,10 +22,10 @@ func TestRequestParseAnnotationsTimeout(t *testing.T) {
 		httpReq, err := retryablehttp.NewRequest(http.MethodGet, "https://example.com", nil)
 		require.Nil(t, err, "could not create http request")
 
-		newRequest, cancelFunc, modified := request.parseAnnotations(rawRequest, httpReq)
-		require.NotNil(t, cancelFunc, "could not initialize valid cancel function")
+		overrides, modified := request.parseAnnotations(rawRequest, httpReq)
+		require.NotNil(t, overrides.cancelFunc, "could not initialize valid cancel function")
 		require.True(t, modified, "could not get correct modified value")
-		_, deadlined := newRequest.Context().Deadline()
+		_, deadlined := overrides.request.Context().Deadline()
 		require.True(t, deadlined, "could not get set request deadline")
 	})
 
@@ -39,10 +39,10 @@ func TestRequestParseAnnotationsTimeout(t *testing.T) {
 		httpReq, err := retryablehttp.NewRequestWithContext(context.Background(), http.MethodGet, "https://example.com", nil)
 		require.Nil(t, err, "could not create http request")
 
-		newRequest, cancelFunc, modified := request.parseAnnotations(rawRequest, httpReq)
-		require.Nil(t, cancelFunc, "cancel function should be nil")
+		newRequestWithOverrides, modified := request.parseAnnotations(rawRequest, httpReq)
+		require.Nil(t, newRequestWithOverrides.cancelFunc, "cancel function should be nil")
 		require.False(t, modified, "could not get correct modified value")
-		_, deadlined := newRequest.Context().Deadline()
+		_, deadlined := newRequestWithOverrides.request.Context().Deadline()
 		require.False(t, deadlined, "could not get set request deadline")
 	})
 }

--- a/v2/pkg/protocols/network/request.go
+++ b/v2/pkg/protocols/network/request.go
@@ -154,7 +154,7 @@ func (request *Request) executeRequestWithPayloads(variables map[string]interfac
 
 		if request.options.Interactsh != nil {
 			var transformedData string
-			transformedData, interactshURLs = request.options.Interactsh.ReplaceMarkers(string(data), []string{})
+			transformedData, interactshURLs = request.options.Interactsh.Replace(string(data), []string{})
 			data = []byte(transformedData)
 		}
 


### PR DESCRIPTION
## Proposed changes
This PR adds interactsh support to SNI override. Example template:
```yaml
id: basic-raw-http-example

info:
  name: Test RAW GET Template
  author: pdteam
  severity: info

requests:
  - raw:
      - |
        @tls-sni: interactsh-url
        GET / HTTP/1.1
        Host: test

    matchers:
      - type: word
        part: interactsh_protocol # Confirms the HTTP Interaction
        words:
          - "http"
```

![image](https://user-images.githubusercontent.com/13421144/216955072-2897a730-812c-4d53-847f-0d49b93c5c60.png)

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate) - https://github.com/projectdiscovery/nuclei-docs/pull/118