### PR TITLE
Adding proxy use in headless binary download

### DIFF
--- a/v2/pkg/protocols/headless/engine/engine.go
+++ b/v2/pkg/protocols/headless/engine/engine.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/projectdiscovery/nuclei/v2/pkg/types"
 	fileutil "github.com/projectdiscovery/utils/file"
+	reflectutil "github.com/projectdiscovery/utils/reflect"
 	stringsutil "github.com/projectdiscovery/utils/strings"
 )
 
@@ -51,6 +52,12 @@ func New(options *types.Options) (*Browser, error) {
 
 	if MustDisableSandbox() {
 		chromeLauncher = chromeLauncher.NoSandbox(true)
+	}
+
+	// we need to set go rod internal value with reflection
+	launcherInternalBrowser := reflectutil.GetUnexportedField(chromeLauncher, "browser")
+	if internalInstance, ok := launcherInternalBrowser.(*launcher.Browser); ok {
+		internalInstance.IgnoreCerts = true
 	}
 
 	executablePath, err := os.Executable()


### PR DESCRIPTION
## Proposed changes
This PR forces ignore TLS certificates via reflection within go rod (partial patch at https://github.com/go-rod/rod/pull/763)

Depends on https://github.com/projectdiscovery/utils/issues/78

## Checklist
- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)