### PR TITLE
Using retryablehttp for templates loading

### DIFF
--- a/v2/pkg/templates/compile.go
+++ b/v2/pkg/templates/compile.go
@@ -3,7 +3,6 @@ package templates
 import (
 	"fmt"
 	"io"
-	"net/http"
 	"reflect"
 
 	"github.com/pkg/errors"
@@ -15,6 +14,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/offlinehttp"
 	"github.com/projectdiscovery/nuclei/v2/pkg/templates/cache"
 	"github.com/projectdiscovery/nuclei/v2/pkg/utils"
+	"github.com/projectdiscovery/retryablehttp-go"
 	stringsutil "github.com/projectdiscovery/utils/strings"
 )
 
@@ -40,7 +40,9 @@ func Parse(filePath string, preprocessor Preprocessor, options protocols.Execute
 
 	var reader io.ReadCloser
 	if utils.IsURL(filePath) {
-		resp, err := http.Get(filePath)
+		//todo:instead of creating a new client each time, a default one should be reused (same as the standard library)
+		// use retryablehttp (tls verification is enabled by default in the standard library)
+		resp, err := retryablehttp.DefaultClient().Get(filePath)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/pkg/templates/compile_test.go
+++ b/v2/pkg/templates/compile_test.go
@@ -2,6 +2,7 @@ package templates_test
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"testing"
 	"time"
@@ -80,7 +81,7 @@ func Test_ParseFromURL(t *testing.T) {
 	}
 	setup()
 	got, err := templates.Parse(filePath, nil, executerOpts)
-	require.Nilf(t, err, "could not parse template (%s)", err.Error())
+	require.Nilf(t, err, "could not parse template (%s)", fmt.Sprint(err))
 	require.Equal(t, expectedTemplate.ID, got.ID)
 	require.Equal(t, expectedTemplate.Info, got.Info)
 	require.Equal(t, expectedTemplate.TotalRequests, got.TotalRequests)

--- a/v2/pkg/templates/compile_test.go
+++ b/v2/pkg/templates/compile_test.go
@@ -80,7 +80,7 @@ func Test_ParseFromURL(t *testing.T) {
 	}
 	setup()
 	got, err := templates.Parse(filePath, nil, executerOpts)
-	require.Nil(t, err, "could not parse template")
+	require.Nilf(t, err, "could not parse template (%s)", err.Error())
 	require.Equal(t, expectedTemplate.ID, got.ID)
 	require.Equal(t, expectedTemplate.Info, got.Info)
 	require.Equal(t, expectedTemplate.TotalRequests, got.TotalRequests)


### PR DESCRIPTION
## Proposed changes
Using retryablehttp instead of net.http with tls verify enabled by default.

## Checklist
- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

@ehsandeep this might fix the tls loading error (hopefully)