### PR TITLE
detect data race panics in integration_tests

### DIFF
--- a/integration_tests/run.sh
+++ b/integration_tests/run.sh
@@ -3,7 +3,7 @@
 echo "::group::Build nuclei"
 rm integration-test nuclei 2>/dev/null
 cd ../v2/cmd/nuclei
-go build
+go build -race .
 mv nuclei ../../../integration_tests/nuclei 
 echo "::endgroup::"
 


### PR DESCRIPTION
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->

- Integration tests are run using nuclei binary with `exec.Command` . 
- If we build nuclei binary with `-race` support . it would be able to detect data races with the help of integration tests
- go programs returns `failed: exit status 66` when there is a data race and it also has additional configs [doc](https://go.dev/doc/articles/race_detector)

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)