### PR TITLE
Adding one-time method override

### DIFF
--- a/v2/pkg/protocols/headless/engine/page.go
+++ b/v2/pkg/protocols/headless/engine/page.go
@@ -148,7 +148,6 @@ func (p *Page) hasModificationRules() bool {
 		if containsAnyModificationActionType(rule.Action) {
 			return true
 		}
-
 	}
 	return false
 }

--- a/v2/pkg/protocols/headless/engine/page_actions.go
+++ b/v2/pkg/protocols/headless/engine/page_actions.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-rod/rod"
@@ -92,6 +93,7 @@ func (p *Page) ExecuteActions(baseURL *url.URL, actions []*Action) (map[string]s
 }
 
 type rule struct {
+	*sync.Once
 	Action ActionType
 	Part   string
 	Args   map[string]string
@@ -215,12 +217,12 @@ func (p *Page) ActionSetBody(act *Action, out map[string]string /*TODO review un
 }
 
 // ActionSetMethod executes an SetMethod action.
-func (p *Page) ActionSetMethod(act *Action, out map[string]string /*TODO review unused parameter*/) error {
+func (p *Page) ActionSetMethod(act *Action, out map[string]string) error {
 	in := p.getActionArgWithDefaultValues(act, "part")
 
 	args := make(map[string]string)
 	args["method"] = p.getActionArgWithDefaultValues(act, "method")
-	p.rules = append(p.rules, rule{Action: ActionSetMethod, Part: in, Args: args})
+	p.rules = append(p.rules, rule{Action: ActionSetMethod, Part: in, Args: args, Once: &sync.Once{}})
 	return nil
 }
 

--- a/v2/pkg/protocols/headless/engine/rules.go
+++ b/v2/pkg/protocols/headless/engine/rules.go
@@ -20,7 +20,9 @@ func (p *Page) routingRuleHandler(ctx *rod.Hijack) {
 
 		switch rule.Action {
 		case ActionSetMethod:
-			ctx.Request.Req().Method = rule.Args["method"]
+			rule.Do(func() {
+				ctx.Request.Req().Method = rule.Args["method"]
+			})
 		case ActionAddHeader:
 			ctx.Request.Req().Header.Add(rule.Args["key"], rule.Args["value"])
 		case ActionSetHeader:


### PR DESCRIPTION
## Proposed changes
This PR adds support for one-time headless page action override (currently only for `setmethod`

Closes https://github.com/projectdiscovery/nuclei/issues/2383

## Checklist
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Example
```
$ cat t.yaml
id: dvwa-headless-automatic-login

info:
  name: DVWA Headless Automatic Login
  author: pdteam
  severity: high
  tags: headless,dvwa

headless:
  - steps:
      - args:
          part: request
          method: CIPPO
        action: setmethod
      - args:
          url: "{{BaseURL}}/"
        action: navigate
      - action: waitload
      - args:
          url: "{{BaseURL}}/"
        action: navigate
      - action: waitload
$ go run . -u http://192.168.1.1 -headless -t .\test.yaml -show-browser -v -proxy http://127.0.0.1:8080
```
![image](https://user-images.githubusercontent.com/13421144/221640532-80f13eba-62e2-4d0d-bada-9d30e9af7ceb.png)
