### PR TITLE
fix data race when using interactsh_matchers

### DIFF
--- a/v2/pkg/catalog/disk/find.go
+++ b/v2/pkg/catalog/disk/find.go
@@ -2,7 +2,6 @@ package disk
 
 import (
 	"io/fs"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -19,7 +18,6 @@ func (c *DiskCatalog) GetTemplatesPath(definitions []string) ([]string, map[stri
 	allTemplates := []string{}
 	erred := make(map[string]error)
 
-	log.Println(definitions)
 	for _, t := range definitions {
 		if stringsutil.ContainsAny(t, knownConfigFiles...) {
 			// TODO: this is a temporary fix to avoid treating these files as templates

--- a/v2/pkg/output/output.go
+++ b/v2/pkg/output/output.go
@@ -70,6 +70,10 @@ type InternalWrappedEvent struct {
 	Results         []*ResultEvent
 	OperatorsResult *operators.Result
 	UsesInteractsh  bool
+	// Mutex is internal field which is implicitly used
+	// to synchronize callback(event) and interactsh polling updates
+	// Refer protocols/http.Request.ExecuteWithResults for more details
+	Mutex sync.Mutex
 }
 
 // ResultEvent is a wrapped result event for a single nuclei output.

--- a/v2/pkg/protocols/common/interactsh/interactsh.go
+++ b/v2/pkg/protocols/common/interactsh/interactsh.go
@@ -262,7 +262,7 @@ func (c *Client) Close() bool {
 		time.Sleep(c.cooldownDuration)
 	}
 	if c.interactsh != nil {
-	    _ = c.interactsh.StopPolling()
+		_ = c.interactsh.StopPolling()
 		c.interactsh.Close()
 	}
 
@@ -351,6 +351,8 @@ type RequestData struct {
 
 // RequestEvent is the event for a network request sent by nuclei.
 func (c *Client) RequestEvent(interactshURLs []string, data *RequestData) {
+	data.Event.Mutex.Lock()
+	defer data.Event.Mutex.Unlock()
 	for _, interactshURL := range interactshURLs {
 		id := strings.TrimRight(strings.TrimSuffix(interactshURL, c.hostname), ".")
 

--- a/v2/pkg/protocols/http/request.go
+++ b/v2/pkg/protocols/http/request.go
@@ -394,7 +394,14 @@ func (request *Request) ExecuteWithResults(input *contextargs.Context, dynamicVa
 						ExtractFunc:    request.Extract,
 					})
 				}
+				// Note: This is a race condition prone zone i.e when request has interactsh_matchers
+				// Interactsh.RequestEvent tries to access/update output.InternalWrappedEvent depending on logic
+				// to avoid conflicts with `callback` mutex is used here and in Interactsh.RequestEvent
+				// Note: this only happens if requests > 1 and interactsh matcher is used
+				// TODO: interactsh logic in nuclei needs to be refactored to avoid such situations
+				event.Mutex.Lock()
 				callback(event)
+				event.Mutex.Unlock()
 			}, generator.currentIndex)
 
 			// If a variable is unresolved, skip all further requests


### PR DESCRIPTION
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->
- fix data race  when requests > 1 and interactsh matchers were used (refer diff for more detail explaination)
- closes #3427 


## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)