### PR TITLE
JSON Export Handling Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ OUTPUT:
    -srd, -store-resp-dir string  store all request/response passed through nuclei to custom directory (default "output")
    -silent                       display findings only
    -nc, -no-color                disable output content coloring (ANSI escape codes)
-   -json                         write output in JSONL(ines) format
+   -jsonl                        write output in JSONL(ines) format
    -irr, -include-rr             include request/response pairs in the JSONL output (for findings only)
    -nm, -no-meta                 disable printing result metadata in cli output
    -ts, -timestamp               enables printing timestamp in cli output

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ OUTPUT:
    -ms, -matcher-status          display match failure status
    -me, -markdown-export string  directory to export results in markdown format
    -se, -sarif-export string     file to export results in SARIF format
+   -je, -json-export string      file to export results in JSON format as a JSON array. This can be memory intensive in larger scans.
 
 CONFIGURATIONS:
    -config string                 path to the nuclei configuration file

--- a/README_CN.md
+++ b/README_CN.md
@@ -132,7 +132,7 @@ Nuclei是一款注重于可配置性、可扩展性和易用性的基于模板�
    -srd, -store-resp-dir string          将nuclei的所有请求和响应输出到指定目录（默认：output）
    -silent                               只显示结果
    -nc, -no-color                        禁用输出内容着色（ANSI转义码）
-   -json                                 输出为jsonL（ines）
+   -jsonl                                输出为jsonL（ines）
    -irr, -include-rr                     在JSONL中输出对应的请求和相应（仅结果）
    -nm, -no-meta                         不显示匹配的元数据
    -nts, -no-timestamp                   不在输出中显示时间戳

--- a/README_ID.md
+++ b/README_ID.md
@@ -140,6 +140,7 @@ OUTPUT:
    -ms, -matcher-status          display match failure status
    -me, -markdown-export string  directory to export results in markdown format
    -se, -sarif-export string     file to export results in SARIF format
+   -je, -json-export string      file to export results in JSON format as a JSON array. This can be memory intensive in larger scans.
 
 CONFIGURATIONS:
    -config string                 path to the nuclei configuration file

--- a/README_ID.md
+++ b/README_ID.md
@@ -132,7 +132,7 @@ OUTPUT:
    -srd, -store-resp-dir string  store all request/response passed through nuclei to custom directory (default "output")
    -silent                       display findings only
    -nc, -no-color                disable output content coloring (ANSI escape codes)
-   -json                         write output in JSONL(ines) format
+   -jsonl                        write output in JSONL(ines) format
    -irr, -include-rr             include request/response pairs in the JSONL output (for findings only)
    -nm, -no-meta                 disable printing result metadata in cli output
    -nts, -no-timestamp           disable printing timestamp in cli output

--- a/README_KR.md
+++ b/README_KR.md
@@ -128,7 +128,7 @@ OUTPUT:
    -srd, -store-resp-dir string  nuclei을 통해 전달된 모든 요청/응답을 사용자 지정 디렉터리에 저장(기본 "output")
    -silent                       결과만 표시
    -nc, -no-color                출력 내용 색상 비활성화 (ANSI escape codes)
-   -json                         JSONL(ines) 형식으로 출력
+   -jsonl                        JSONL(ines) 형식으로 출력
    -irr, -include-rr             JSONL 출력에 요청/응답 쌍 포함(결과만)
    -nm, -no-meta                 cli 출력에서 결과 메타데이터 출력 비활성화
    -nts, -no-timestamp           cli 출력에서 결과 타임스탬프 출력 비활성화

--- a/v2/cmd/nuclei/main.go
+++ b/v2/cmd/nuclei/main.go
@@ -174,6 +174,7 @@ on extensive configurability, massive extensibility and ease of use.`)
 		flagSet.BoolVarP(&options.NoColor, "no-color", "nc", false, "disable output content coloring (ANSI escape codes)"),
 		flagSet.BoolVar(&options.JSONL, "jsonl", false, "write output in JSONL(ines) format"),
 		flagSet.BoolVarP(&options.JSONRequests, "include-rr", "irr", false, "include request/response pairs in the JSONL output (for findings only)"),
+		flagSet.StringVarP(&options.JSONExport, "json-export", "je", "", "file to export results in JSON format"),
 		flagSet.BoolVarP(&options.NoMeta, "no-meta", "nm", false, "disable printing result metadata in cli output"),
 		flagSet.BoolVarP(&options.Timestamp, "timestamp", "ts", false, "enables printing timestamp in cli output"),
 		flagSet.StringVarP(&options.ReportingDB, "report-db", "rdb", "", "nuclei reporting database (always use this to persist report data)"),

--- a/v2/cmd/nuclei/main.go
+++ b/v2/cmd/nuclei/main.go
@@ -172,7 +172,7 @@ on extensive configurability, massive extensibility and ease of use.`)
 		flagSet.StringVarP(&options.StoreResponseDir, "store-resp-dir", "srd", runner.DefaultDumpTrafficOutputFolder, "store all request/response passed through nuclei to custom directory"),
 		flagSet.BoolVar(&options.Silent, "silent", false, "display findings only"),
 		flagSet.BoolVarP(&options.NoColor, "no-color", "nc", false, "disable output content coloring (ANSI escape codes)"),
-		flagSet.BoolVar(&options.JSON, "json", false, "write output in JSONL(ines) format"),
+		flagSet.BoolVar(&options.JSONL, "jsonl", false, "write output in JSONL(ines) format"),
 		flagSet.BoolVarP(&options.JSONRequests, "include-rr", "irr", false, "include request/response pairs in the JSONL output (for findings only)"),
 		flagSet.BoolVarP(&options.NoMeta, "no-meta", "nm", false, "disable printing result metadata in cli output"),
 		flagSet.BoolVarP(&options.Timestamp, "timestamp", "ts", false, "enables printing timestamp in cli output"),

--- a/v2/internal/runner/cloud.go
+++ b/v2/internal/runner/cloud.go
@@ -39,7 +39,7 @@ func (r *Runner) getScanList(limit int) error {
 			count++
 			lastTime = v.CreatedAt.String()
 			res := nucleicloud.PrepareScanListOutput(v)
-			if r.options.JSON {
+			if r.options.JSONL {
 				_ = jsoniter.NewEncoder(os.Stdout).Encode(res)
 			} else if !r.options.NoTables {
 				values = append(values, []string{strconv.FormatInt(res.ScanID, 10), res.Timestamp, strconv.Itoa(res.Target), strconv.Itoa(res.Template), strconv.Itoa(res.ScanResult), res.ScanTime, res.ScanStatus})
@@ -70,7 +70,7 @@ func (r *Runner) listDatasources() error {
 	header := []string{"ID", "UpdatedAt", "Type", "Repo", "Path"}
 	var values [][]string
 	for _, source := range datasources {
-		if r.options.JSON {
+		if r.options.JSONL {
 			_ = jsoniter.NewEncoder(os.Stdout).Encode(source)
 		} else if !r.options.NoTables {
 			values = append(values, []string{strconv.FormatInt(source.ID, 10), source.Updatedat.Format(nucleicloud.DDMMYYYYhhmmss), source.Type, source.Repo, source.Path})
@@ -96,7 +96,7 @@ func (r *Runner) listReportingSources() error {
 	header := []string{"ID", "Type", "ProjectName", "Enabled"}
 	var values [][]string
 	for _, source := range items {
-		if r.options.JSON {
+		if r.options.JSONL {
 			_ = jsoniter.NewEncoder(os.Stdout).Encode(source)
 		} else if !r.options.NoTables {
 			values = append(values, []string{strconv.FormatInt(source.ID, 10), source.Type, source.ProjectName, strconv.FormatBool(source.Enabled)})
@@ -123,7 +123,7 @@ func (r *Runner) listTargets() error {
 	header := []string{"ID", "Reference", "Count"}
 	var values [][]string
 	for _, source := range items {
-		if r.options.JSON {
+		if r.options.JSONL {
 			_ = jsoniter.NewEncoder(os.Stdout).Encode(source)
 		} else if !r.options.NoTables {
 			values = append(values, []string{strconv.FormatInt(source.ID, 10), source.Reference, strconv.FormatInt(source.Count, 10)})
@@ -149,7 +149,7 @@ func (r *Runner) listTemplates() error {
 	header := []string{"ID", "Reference"}
 	var values [][]string
 	for _, source := range items {
-		if r.options.JSON {
+		if r.options.JSONL {
 			_ = jsoniter.NewEncoder(os.Stdout).Encode(source)
 		} else if !r.options.NoTables {
 			values = append(values, []string{strconv.FormatInt(source.ID, 10), source.Reference})

--- a/v2/internal/runner/runner.go
+++ b/v2/internal/runner/runner.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	json_exporter "github.com/projectdiscovery/nuclei/v2/pkg/reporting/exporters/json-exporter"
 	"io"
 	"net/http"
 	_ "net/http/pprof"
@@ -327,6 +328,14 @@ func createReportingOptions(options *types.Options) (*reporting.Options, error) 
 		} else {
 			reportingOptions = &reporting.Options{}
 			reportingOptions.SarifExporter = &sarif.Options{File: options.SarifExport}
+		}
+	}
+	if options.JSONExport != "" {
+		if reportingOptions != nil {
+			reportingOptions.JSONExporter = &json_exporter.Options{File: options.JSONExport}
+		} else {
+			reportingOptions = &reporting.Options{}
+			reportingOptions.JSONExporter = &json_exporter.Options{File: options.JSONExport}
 		}
 	}
 	return reportingOptions, nil

--- a/v2/internal/runner/runner.go
+++ b/v2/internal/runner/runner.go
@@ -217,7 +217,7 @@ func New(options *types.Options) (*Runner, error) {
 	}
 	runner.output = outputWriter
 
-	if options.JSON && options.EnableProgressBar {
+	if options.JSONL && options.EnableProgressBar {
 		options.StatsJSON = true
 	}
 	if options.StatsJSON {

--- a/v2/pkg/output/output.go
+++ b/v2/pkg/output/output.go
@@ -181,7 +181,7 @@ func NewStandardWriter(options *types.Options) (*StandardWriter, error) {
 		}
 	}
 	writer := &StandardWriter{
-		json:             options.JSON,
+		json:             options.JSONL,
 		jsonReqResp:      options.JSONRequests,
 		noMetadata:       options.NoMeta,
 		matcherStatus:    options.MatcherStatus,

--- a/v2/pkg/reporting/exporters/json-exporter/json-exporter.go
+++ b/v2/pkg/reporting/exporters/json-exporter/json-exporter.go
@@ -1,0 +1,63 @@
+package json_exporter
+
+import (
+	"encoding/json"
+	"github.com/pkg/errors"
+	"github.com/projectdiscovery/nuclei/v2/pkg/output"
+	"os"
+	"sync"
+)
+
+type Exporter struct {
+	options *Options
+	mutex   *sync.Mutex
+	rows    []output.ResultEvent
+}
+
+// Options contains the configuration options for JSON exporter client
+type Options struct {
+	// File is the file to export found JSON result to
+	File string `yaml:"file"`
+}
+
+// New creates a new JSON exporter integration client based on options.
+func New(options *Options) (*Exporter, error) {
+	exporter := &Exporter{
+		mutex:   &sync.Mutex{},
+		options: options,
+		rows:    []output.ResultEvent{},
+	}
+	return exporter, nil
+}
+
+// Export appends the passed result event to the list of objects to be exported to
+// the resulting JSON file
+func (exporter *Exporter) Export(event *output.ResultEvent) error {
+	exporter.mutex.Lock()
+	defer exporter.mutex.Unlock()
+
+	// Add the event to the rows
+	exporter.rows = append(exporter.rows, *event)
+
+	return nil
+}
+
+// Close writes the in-memory data to the JSON file specified by options.JSONExport
+// and closes the exporter after operation
+func (exporter *Exporter) Close() error {
+	exporter.mutex.Lock()
+	defer exporter.mutex.Unlock()
+
+	// Convert the rows to JSON byte array
+	obj, err := json.Marshal(exporter.rows)
+	if err != nil {
+		errors.Wrap(err, "failed to generate JSON report")
+	}
+
+	// Attempt to write the JSON to file specified in options.JSONExport
+	if err := os.WriteFile(exporter.options.File, obj, 0644); err != nil {
+		return errors.Wrap(err, "failed to create JSON file")
+	}
+
+	return nil
+}

--- a/v2/pkg/reporting/options.go
+++ b/v2/pkg/reporting/options.go
@@ -2,6 +2,7 @@ package reporting
 
 import (
 	"github.com/projectdiscovery/nuclei/v2/pkg/reporting/exporters/es"
+	"github.com/projectdiscovery/nuclei/v2/pkg/reporting/exporters/json-exporter"
 	"github.com/projectdiscovery/nuclei/v2/pkg/reporting/exporters/markdown"
 	"github.com/projectdiscovery/nuclei/v2/pkg/reporting/exporters/sarif"
 	"github.com/projectdiscovery/nuclei/v2/pkg/reporting/exporters/splunk"
@@ -31,6 +32,8 @@ type Options struct {
 	ElasticsearchExporter *es.Options `yaml:"elasticsearch"`
 	// SplunkExporter contains configuration options for splunkhec Exporter Module
 	SplunkExporter *splunk.Options `yaml:"splunkhec"`
+	// JSONExporter contains configuration options for JSON Exporter Module
+	JSONExporter *json_exporter.Options `yaml:"json-exporter"`
 
 	HttpClient *retryablehttp.Client `yaml:"-"`
 }

--- a/v2/pkg/reporting/reporting.go
+++ b/v2/pkg/reporting/reporting.go
@@ -1,6 +1,7 @@
 package reporting
 
 import (
+	json_exporter "github.com/projectdiscovery/nuclei/v2/pkg/reporting/exporters/json-exporter"
 	"os"
 	"path/filepath"
 
@@ -128,6 +129,13 @@ func New(options *Options, db string) (Client, error) {
 	}
 	if options.SarifExporter != nil {
 		exporter, err := sarif.New(options.SarifExporter)
+		if err != nil {
+			return nil, errorutil.NewWithErr(err).Wrap(ErrExportClientCreation)
+		}
+		client.exporters = append(client.exporters, exporter)
+	}
+	if options.JSONExporter != nil {
+		exporter, err := json_exporter.New(options.JSONExporter)
 		if err != nil {
 			return nil, errorutil.NewWithErr(err).Wrap(ErrExportClientCreation)
 		}

--- a/v2/pkg/testutils/testutils.go
+++ b/v2/pkg/testutils/testutils.go
@@ -35,7 +35,7 @@ var DefaultOptions = &types.Options{
 	Verbose:                    false,
 	NoColor:                    true,
 	UpdateTemplates:            false,
-	JSON:                       false,
+	JSONL:                      false,
 	JSONRequests:               false,
 	EnableProgressBar:          false,
 	TemplatesVersion:           false,

--- a/v2/pkg/types/types.go
+++ b/v2/pkg/types/types.go
@@ -230,8 +230,8 @@ type Options struct {
 	NoColor bool
 	// UpdateTemplates updates the templates installed at startup
 	UpdateTemplates bool
-	// JSON writes json output to files
-	JSON bool
+	// JSON writes json line output to files
+	JSONL bool
 	// JSONRequests writes requests/responses for matches in JSON output
 	JSONRequests bool
 	// Cloud enables nuclei cloud scan execution

--- a/v2/pkg/types/types.go
+++ b/v2/pkg/types/types.go
@@ -234,6 +234,8 @@ type Options struct {
 	JSONL bool
 	// JSONRequests writes requests/responses for matches in JSON output
 	JSONRequests bool
+	// JSONExport is the file to export JSON output format to
+	JSONExport string
 	// Cloud enables nuclei cloud scan execution
 	Cloud bool
 	// EnableProgressBar enables progress bar


### PR DESCRIPTION
## Proposed changes

- Switch the existing `-json` option to `-jsonl` to more accurately reflect the format (#2976) 
- Update test objects and documentation related to switching the `-json` option to `-jsonl`
- Add  `-je, -json-export string` option that exports the results to a JSON file. This is related to #2976 but is intended to be more inline with the `-me, -markdown-export string` and `-se, -sarif-export string` export options


## Checklist

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)