### PR TITLE
fix aws s3 bucket catalog path mismatch

### DIFF
--- a/v2/pkg/catalog/aws/catalog.go
+++ b/v2/pkg/catalog/aws/catalog.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"path/filepath"
+	"path"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -129,13 +129,14 @@ func (c Catalog) ResolvePath(templateName, second string) (string, error) {
 
 	// if c second path is given, it's c folder and we join the two and check against keys
 	if second != "" {
-		target := filepath.Join(filepath.Dir(second), templateName)
+		// Note: Do not replace `path` with `filepath` since filepath is aware of Os path seperator
+		// and we only see `/` in s3 paths changing it to filepath cause build fail and other errors
+		target := path.Join(path.Dir(second), templateName)
 		for _, key := range keys {
 			if key == target {
 				return key, nil
 			}
 		}
-
 	}
 
 	// check if templateName is already an absolute path to c key

--- a/v2/pkg/catalog/aws/catalog.go
+++ b/v2/pkg/catalog/aws/catalog.go
@@ -135,6 +135,7 @@ func (c Catalog) ResolvePath(templateName, second string) (string, error) {
 				return key, nil
 			}
 		}
+
 	}
 
 	// check if templateName is already an absolute path to c key
@@ -144,7 +145,7 @@ func (c Catalog) ResolvePath(templateName, second string) (string, error) {
 		}
 	}
 
-	return "", fmt.Errorf("no such path found: %s", templateName)
+	return "", fmt.Errorf("no such path found: %s%s for keys: %v", second, templateName, keys)
 }
 
 func (s *s3svc) getAllKeys() ([]string, error) {

--- a/v2/pkg/catalog/aws/catalog_test.go
+++ b/v2/pkg/catalog/aws/catalog_test.go
@@ -1,11 +1,12 @@
 package aws
 
 import (
-	"github.com/pkg/errors"
 	"io"
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/pkg/errors"
 )
 
 func TestCatalog_GetTemplatePath(t *testing.T) {


### PR DESCRIPTION
### Proposed Changes

- using `filepath` when loading templates from s3 buckets causes path mismatch in windows since `filepath` is os specific and s3 paths /URI need `/` . 
- This pr uses `path` for filtering s3 templates instead of `filepath`
- closes #3467 
