### PR TITLE
S3 Argument Spelling

### DIFF
--- a/v2/pkg/external/customtemplates/s3.go
+++ b/v2/pkg/external/customtemplates/s3.go
@@ -76,8 +76,8 @@ func downloadToFile(downloader *manager.Downloader, targetDirectory, bucket, key
 	return err
 }
 
-func getS3Client(ctx context.Context, acccessKey, secretKey, region string) (*s3.Client, error) {
-	cfg, err := config.LoadDefaultConfig(ctx, config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(acccessKey, secretKey, "")), config.WithRegion(region))
+func getS3Client(ctx context.Context, accessKey string, secretKey string, region string) (*s3.Client, error) {
+	cfg, err := config.LoadDefaultConfig(ctx, config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(accessKey, secretKey, "")), config.WithRegion(region))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Proposed changes

While beginning work on another issue, the misspelling of "acccessKey" was identified.

- Change `"acccessKey"` to `"accessKey"`
- Add `string` property types to `accessKey` and `secretKey` as the type of the arguments passed is defined to be `string` in https://github.com/projectdiscovery/nuclei/blob/dev/v2/pkg/types/types.go#L344

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (N/A)
- [x] I have added necessary documentation (if appropriate) (N/A)