### PR TITLE
S3 Template Downloader Typo

### DIFF
--- a/v2/pkg/external/customtemplates/s3.go
+++ b/v2/pkg/external/customtemplates/s3.go
@@ -21,11 +21,11 @@ type customTemplateS3Bucket struct {
 	Location   string
 }
 
-// download custom templates from s3 bucket
+// Download retrieves all custom templates from s3 bucket
 func (bk *customTemplateS3Bucket) Download(location string, ctx context.Context) {
 	downloadPath := filepath.Join(location, CustomS3TemplateDirectory, bk.bucketName)
 
-	manager := manager.NewDownloader(bk.s3Client)
+	s3Manager := manager.NewDownloader(bk.s3Client)
 	paginator := s3.NewListObjectsV2Paginator(bk.s3Client, &s3.ListObjectsV2Input{
 		Bucket: &bk.bucketName,
 		Prefix: &bk.prefix,
@@ -38,16 +38,16 @@ func (bk *customTemplateS3Bucket) Download(location string, ctx context.Context)
 			return
 		}
 		for _, obj := range page.Contents {
-			if err := downloadToFile(manager, downloadPath, bk.bucketName, aws.ToString(obj.Key)); err != nil {
+			if err := downloadToFile(s3Manager, downloadPath, bk.bucketName, aws.ToString(obj.Key)); err != nil {
 				gologger.Error().Msgf("error downloading s3 bucket %s %s", bk.bucketName, err)
 				return
 			}
 		}
 	}
-	gologger.Info().Msgf("AWS bucket %s successfully cloned successfully at %s", bk.bucketName, downloadPath)
+	gologger.Info().Msgf("AWS bucket %s was cloned successfully at %s", bk.bucketName, downloadPath)
 }
 
-// download custom templates from s3 bucket
+// Update download custom templates from s3 bucket
 func (bk *customTemplateS3Bucket) Update(location string, ctx context.Context) {
 	bk.Download(location, ctx)
 }


### PR DESCRIPTION
## Proposed changes
While working on another pull request (coming soon) the following changes were found/made in the S3 custom template downloader class.

- Removed duplicate "successfully" in "AWS bucket %s successfully cloned successfully at %s"
- Updated method documentation comments with method name
- Renamed colliding local variable `manager` with the imported package `"github.com/aws/aws-sdk-go-v2/feature/s3/manager"`


## Checklist

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (N/A)
- [x] I have added necessary documentation (if appropriate) (N/A)