### PR TITLE
Issue 3547 ratelimit per host

### DIFF
--- a/v2/cmd/nuclei/main.go
+++ b/v2/cmd/nuclei/main.go
@@ -241,6 +241,7 @@ on extensive configurability, massive extensibility and ease of use.`)
 		flagSet.IntVarP(&options.TemplateThreads, "concurrency", "c", 25, "maximum number of templates to be executed in parallel"),
 		flagSet.IntVarP(&options.HeadlessBulkSize, "headless-bulk-size", "hbs", 10, "maximum number of headless hosts to be analyzed in parallel per template"),
 		flagSet.IntVarP(&options.HeadlessTemplateThreads, "headless-concurrency", "headc", 10, "maximum number of headless templates to be executed in parallel"),
+		flagSet.IntVarP(&options.RateLimitHost, "ratelimit-host", "rlh", 60, "maximum number of requests to send per minute (only supported in host-spray scan strategy)"),
 	)
 	flagSet.CreateGroup("optimization", "Optimizations",
 		flagSet.IntVar(&options.Timeout, "timeout", 10, "time to wait in seconds before timeout"),

--- a/v2/pkg/types/types.go
+++ b/v2/pkg/types/types.go
@@ -159,6 +159,10 @@ type Options struct {
 	RateLimit int
 	// Rate-Limit is the maximum number of requests per minute for specified target
 	RateLimitMinute int
+	// TODO: Is it okay to add fields in the middle of the struct?
+	// TODO: Is the comment desc the field okay?
+	// Rate-Limit-Host is the maximum number of requests per host per minute (only supported in host-spray scan strategy)
+	RateLimitHost int
 	// PageTimeout is the maximum time to wait for a page in seconds
 	PageTimeout int
 	// InteractionsCacheSize is the number of interaction-url->req to keep in cache at a time.


### PR DESCRIPTION
## Proposed changes
- Add `-rlh` flag to options.
- Add ratelimit to executeHostSpray using value set in flag.

## Checklist
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)