### PR TITLE
Additional nil check on interactsh client

### DIFF
--- a/v2/pkg/protocols/common/interactsh/const.go
+++ b/v2/pkg/protocols/common/interactsh/const.go
@@ -1,6 +1,7 @@
 package interactsh
 
 import (
+	"errors"
 	"regexp"
 	"time"
 )
@@ -8,6 +9,8 @@ import (
 var (
 	defaultInteractionDuration = 60 * time.Second
 	interactshURLMarkerRegex   = regexp.MustCompile(`{{interactsh-url(?:_[0-9]+){0,3}}}`)
+
+	ErrInteractshClientNotInitialized = errors.New("interactsh client not initialized")
 )
 
 const (

--- a/v2/pkg/protocols/common/interactsh/interactsh.go
+++ b/v2/pkg/protocols/common/interactsh/interactsh.go
@@ -202,9 +202,14 @@ func (c *Client) URL() (string, error) {
 			err = c.poll()
 		})
 		if err != nil {
-			return "", errorutil.NewWithErr(err).Msgf("interactsh client not initialized")
+			return "", errorutil.NewWithErr(err).Wrap(ErrInteractshClientNotInitialized)
+		}
+		// ensures interactsh is not nil
+		if c.interactsh == nil {
+			return "", ErrInteractshClientNotInitialized
 		}
 	}
+
 	c.generated.Store(true)
 	return c.interactsh.URL(), nil
 }


### PR DESCRIPTION
## Proposed changes
This PR adds a redundant nil check on interactsh instance to ensure it can be dereferenced

Closes #3584 

## Checklist
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)