### PR TITLE
add support for resolving old template paths

### DIFF
--- a/v2/internal/runner/runner.go
+++ b/v2/internal/runner/runner.go
@@ -483,6 +483,7 @@ func (r *Runner) RunEnumeration() error {
 		return nil // exit
 	}
 	store.Load()
+	disk.PrintDeprecatedPathsMsgIfApplicable()
 
 	// add the hosts from the metadata queries of loaded templates into input provider
 	if r.options.Uncover && len(r.options.UncoverQuery) == 0 {

--- a/v2/internal/runner/runner.go
+++ b/v2/internal/runner/runner.go
@@ -483,7 +483,9 @@ func (r *Runner) RunEnumeration() error {
 		return nil // exit
 	}
 	store.Load()
-	disk.PrintDeprecatedPathsMsgIfApplicable()
+	// TODO: remove below functions after v2.9.5 or update warning messages
+	disk.PrintDeprecatedPathsMsgIfApplicable(r.options.Silent)
+	templates.PrintDeprecatedProtocolNameMsgIfApplicable(r.options.Silent, r.options.Verbose)
 
 	// add the hosts from the metadata queries of loaded templates into input provider
 	if r.options.Uncover && len(r.options.UncoverQuery) == 0 {

--- a/v2/pkg/catalog/disk/catalog.go
+++ b/v2/pkg/catalog/disk/catalog.go
@@ -2,18 +2,25 @@ package disk
 
 import (
 	"io"
+	"io/fs"
 	"os"
 )
 
 // DiskCatalog is a template catalog helper implementation based on disk
 type DiskCatalog struct {
 	templatesDirectory string
+	templatesFS        fs.FS // TODO: Refactor to use this
 }
 
 // NewCatalog creates a new Catalog structure using provided input items
 // using disk based items
 func NewCatalog(directory string) *DiskCatalog {
 	catalog := &DiskCatalog{templatesDirectory: directory}
+	if directory != "" {
+		catalog.templatesFS = os.DirFS(directory)
+	} else {
+		catalog.templatesFS = os.DirFS("./")
+	}
 	return catalog
 }
 
@@ -21,5 +28,10 @@ func NewCatalog(directory string) *DiskCatalog {
 // It is used to read template and payload files based on catalog responses.
 func (d *DiskCatalog) OpenFile(filename string) (io.ReadCloser, error) {
 	file, err := os.Open(filename)
+	if err != nil {
+		if file, errx := os.Open(BackwardsCompatiblePaths(d.templatesDirectory, filename)); errx == nil {
+			return file, nil
+		}
+	}
 	return file, err
 }

--- a/v2/pkg/catalog/disk/find.go
+++ b/v2/pkg/catalog/disk/find.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/nuclei/v2/pkg/catalog/config"
 	stringsutil "github.com/projectdiscovery/utils/strings"
 	urlutil "github.com/projectdiscovery/utils/url"
@@ -75,6 +76,7 @@ func (c *DiskCatalog) GetTemplatePath(target string) ([]string, error) {
 
 	// try to handle deprecated template paths
 	absPath := BackwardsCompatiblePaths(c.templatesDirectory, target)
+	gologger.Debug().Msgf("converted path %s to %s", target, absPath)
 
 	absPath, err := c.convertPathToAbsolute(absPath)
 	if err != nil {

--- a/v2/pkg/catalog/disk/find.go
+++ b/v2/pkg/catalog/disk/find.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/nuclei/v2/pkg/catalog/config"
 	stringsutil "github.com/projectdiscovery/utils/strings"
 	urlutil "github.com/projectdiscovery/utils/url"
@@ -76,7 +75,6 @@ func (c *DiskCatalog) GetTemplatePath(target string) ([]string, error) {
 
 	// try to handle deprecated template paths
 	absPath := BackwardsCompatiblePaths(c.templatesDirectory, target)
-	gologger.Debug().Msgf("converted path %s to %s", target, absPath)
 
 	absPath, err := c.convertPathToAbsolute(absPath)
 	if err != nil {

--- a/v2/pkg/catalog/disk/find.go
+++ b/v2/pkg/catalog/disk/find.go
@@ -216,6 +216,6 @@ func PrintDeprecatedPathsMsgIfApplicable(isSilent bool) {
 		return
 	}
 	if deprecatedPathsCounter > 0 && !isSilent {
-		gologger.Print().Msgf("[%v] Found %v templates loaded with deprecated paths, update before v2.9.5 for continued support\n", aurora.Yellow("WRN").String(), deprecatedPathsCounter)
+		gologger.Print().Msgf("[%v] Found %v templates loaded with deprecated paths, update before v2.9.5 for continued support.\n", aurora.Yellow("WRN").String(), deprecatedPathsCounter)
 	}
 }

--- a/v2/pkg/catalog/disk/find.go
+++ b/v2/pkg/catalog/disk/find.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/logrusorgru/aurora"
 	"github.com/pkg/errors"
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/nuclei/v2/pkg/catalog/config"
@@ -208,13 +209,13 @@ func (c *DiskCatalog) findDirectoryMatches(absPath string, processed map[string]
 }
 
 // PrintDeprecatedPathsMsgIfApplicable prints a warning message if any deprecated paths are found
-func PrintDeprecatedPathsMsgIfApplicable() {
-	tversion := config.DefaultConfig.TemplateVersion
-	if !updateutils.IsOutdated("v9.4.3", tversion) {
+// Unless mode is silent warning message is printed
+func PrintDeprecatedPathsMsgIfApplicable(isSilent bool) {
+	if !updateutils.IsOutdated("v9.4.3", config.DefaultConfig.TemplateVersion) {
 		// template version is not older than 9.4.3
 		return
 	}
-	if deprecatedPathsCounter > 0 {
-		gologger.Warning().Msgf("Found %v templates loaded with deprecated paths, update by v2.9.5 for continued support", deprecatedPathsCounter)
+	if deprecatedPathsCounter > 0 && !isSilent {
+		gologger.Print().Msgf("[%v] Found %v templates loaded with deprecated paths, update before v2.9.5 for continued support\n", aurora.Yellow("WRN").String(), deprecatedPathsCounter)
 	}
 }

--- a/v2/pkg/catalog/disk/path.go
+++ b/v2/pkg/catalog/disk/path.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/projectdiscovery/gologger"
 	fileutil "github.com/projectdiscovery/utils/file"
 	urlutil "github.com/projectdiscovery/utils/url"
 )
@@ -65,18 +66,16 @@ func BackwardsCompatiblePaths(templateDir string, oldPath string) string {
 	newPathCallback := func(path string) string {
 		// trim prefix slash if any
 		path = strings.TrimPrefix(path, "/")
-		// check if filepath exists else
-		if !fileutil.FileOrFolderExists(filepath.Join(templateDir, path)) {
-			// try to resolve path at /http subdirectory
-			if fileutil.FileOrFolderExists(filepath.Join(templateDir, "http", path)) {
-				return filepath.Join(templateDir, "http", path)
-				// try to resolve path at /network/cves subdirectory
-			} else if strings.HasPrefix(path, "cves") && fileutil.FileOrFolderExists(filepath.Join(templateDir, "network", "cves", path)) {
-				return filepath.Join(templateDir, "network", "cves", path)
-			}
-			// most likely the path is not found
-			return filepath.Join(templateDir, path)
+		// try to resolve path at /http subdirectory
+		if fileutil.FileOrFolderExists(filepath.Join(templateDir, "http", path)) {
+			return filepath.Join(templateDir, "http", path)
+			// try to resolve path at /network/cves subdirectory
+		} else if strings.HasPrefix(path, "cves") && fileutil.FileOrFolderExists(filepath.Join(templateDir, "network", "cves", path)) {
+			return filepath.Join(templateDir, "network", "cves", path)
+		} else {
+			gologger.Error().Msgf("fallback paths %v & %v does not exist. skipping", filepath.Join(templateDir, "http", path), filepath.Join(templateDir, "network", "cves", path))
 		}
+		// most likely the path is not found
 		return filepath.Join(templateDir, path)
 	}
 	switch {

--- a/v2/pkg/catalog/disk/path.go
+++ b/v2/pkg/catalog/disk/path.go
@@ -61,7 +61,7 @@ func (c *DiskCatalog) tryResolve(fullPath string) (string, error) {
 func BackwardsCompatiblePaths(templateDir string, oldPath string) string {
 	// TODO: remove this function in the future release
 	// 1. all http related paths are now moved at path /http
-	// 2. netwok related CVES are now moved at path /network/cves
+	// 2. network related CVES are now moved at path /network/cves
 	newPathCallback := func(path string) string {
 		// trim prefix slash if any
 		path = strings.TrimPrefix(path, "/")
@@ -80,7 +80,16 @@ func BackwardsCompatiblePaths(templateDir string, oldPath string) string {
 		return filepath.Join(templateDir, path)
 	}
 	switch {
+	case fileutil.FileOrFolderExists(oldPath):
+		// new path specified skip processing
+		return oldPath
 	case filepath.IsAbs(oldPath):
+		tmp := strings.TrimPrefix(oldPath, templateDir)
+		if tmp == oldPath {
+			// user provided absolute path which is not in template directory
+			// skip processing
+			return oldPath
+		}
 		// trim the template directory from the path
 		return newPathCallback(strings.TrimPrefix(oldPath, templateDir))
 	case strings.Contains(oldPath, urlutil.SchemeSeparator):

--- a/v2/pkg/catalog/disk/path.go
+++ b/v2/pkg/catalog/disk/path.go
@@ -91,7 +91,7 @@ func BackwardsCompatiblePaths(templateDir string, oldPath string) string {
 			return oldPath
 		}
 		// trim the template directory from the path
-		return newPathCallback(strings.TrimPrefix(oldPath, templateDir))
+		return newPathCallback(tmp)
 	case strings.Contains(oldPath, urlutil.SchemeSeparator):
 		// scheme seperator is used to identify the path as url
 		// TBD: add support for url directories ??

--- a/v2/pkg/catalog/disk/path.go
+++ b/v2/pkg/catalog/disk/path.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"github.com/projectdiscovery/gologger"
 	fileutil "github.com/projectdiscovery/utils/file"
 	urlutil "github.com/projectdiscovery/utils/url"
 )
@@ -72,8 +71,6 @@ func BackwardsCompatiblePaths(templateDir string, oldPath string) string {
 			// try to resolve path at /network/cves subdirectory
 		} else if strings.HasPrefix(path, "cves") && fileutil.FileOrFolderExists(filepath.Join(templateDir, "network", "cves", path)) {
 			return filepath.Join(templateDir, "network", "cves", path)
-		} else {
-			gologger.Error().Msgf("fallback paths %v & %v does not exist. skipping", filepath.Join(templateDir, "http", path), filepath.Join(templateDir, "network", "cves", path))
 		}
 		// most likely the path is not found
 		return filepath.Join(templateDir, path)

--- a/v2/pkg/templates/log.go
+++ b/v2/pkg/templates/log.go
@@ -5,12 +5,14 @@ import (
 	"strings"
 
 	"github.com/logrusorgru/aurora"
+	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/nuclei/v2/pkg/model/types/severity"
 )
 
 var (
-	Colorizer         aurora.Aurora
-	SeverityColorizer func(severity.Severity) string
+	Colorizer                       aurora.Aurora
+	SeverityColorizer               func(severity.Severity) string
+	deprecatedProtocolNameTemplates = map[string]struct{}{} //templates that still use deprecated protocol names
 )
 
 // TemplateLogMessage returns a beautified log string for a template
@@ -41,4 +43,18 @@ func appendAtSignToAuthors(authors []string) string {
 		}
 	}
 	return strings.Join(values, ",")
+}
+
+// PrintDeprecatedProtocolNameMsgIfApplicable prints a message if deprecated protocol names are used
+// Unless mode is silent we print a message for deprecated protocol name
+func PrintDeprecatedProtocolNameMsgIfApplicable(isSilent bool, verbose bool) {
+	if len(deprecatedProtocolNameTemplates) > 0 && !isSilent {
+		gologger.Print().Msgf("[%v] Found %v templates loaded with deprecated protocol syntax, update before v2.9.5 for continued support\n", aurora.Yellow("WRN").String(), len(deprecatedProtocolNameTemplates))
+	}
+	if verbose {
+		for template := range deprecatedProtocolNameTemplates {
+			gologger.Print().Msgf("  - %s\n", template)
+		}
+	}
+	deprecatedProtocolNameTemplates = map[string]struct{}{}
 }

--- a/v2/pkg/templates/log.go
+++ b/v2/pkg/templates/log.go
@@ -49,7 +49,7 @@ func appendAtSignToAuthors(authors []string) string {
 // Unless mode is silent we print a message for deprecated protocol name
 func PrintDeprecatedProtocolNameMsgIfApplicable(isSilent bool, verbose bool) {
 	if len(deprecatedProtocolNameTemplates) > 0 && !isSilent {
-		gologger.Print().Msgf("[%v] Found %v templates loaded with deprecated protocol syntax, update before v2.9.5 for continued support\n", aurora.Yellow("WRN").String(), len(deprecatedProtocolNameTemplates))
+		gologger.Print().Msgf("[%v] Found %v templates loaded with deprecated protocol syntax, update before v2.9.5 for continued support.\n", aurora.Yellow("WRN").String(), len(deprecatedProtocolNameTemplates))
 	}
 	if verbose {
 		for template := range deprecatedProtocolNameTemplates {

--- a/v2/pkg/templates/templates.go
+++ b/v2/pkg/templates/templates.go
@@ -180,6 +180,10 @@ func (template *Template) UnmarshalYAML(unmarshal func(interface{}) error) error
 	}
 	*template = Template(*alias)
 
+	if len(template.RequestsHTTP) > 0 || len(template.RequestsNetwork) > 0 {
+		deprecatedProtocolNameTemplates[template.ID] = struct{}{}
+	}
+
 	if len(alias.RequestsHTTP) > 0 && len(alias.RequestsWithHTTP) > 0 {
 		return errorutil.New("use http or requests, both are not supported").WithTag("invalid template")
 	}


### PR DESCRIPTION
## Proposed Changes
- add support for resolving & loading templates after templates dir structure change
- this PR does not add any fallback resolving support for templates outside of template directory (i.e private/custom templates)
- closes #3622 

### Notes
- running command `nuclei -t cves` will only load http cves and not network cves