### PR TITLE
fix memory leak in dns templates

### DIFF
--- a/v2/pkg/protocols/dns/operators_test.go
+++ b/v2/pkg/protocols/dns/operators_test.go
@@ -43,12 +43,12 @@ func TestResponseToDSLMap(t *testing.T) {
 
 	resp := new(dns.Msg)
 	resp.Rcode = dns.RcodeSuccess
-	resp.Answer = append(resp.Answer, &dns.A{A: net.ParseIP("1.1.1.1"), Hdr: dns.RR_Header{Name: "one.one.one.one.", Rrtype: dns.TypeA}}, &dns.A{A: net.ParseIP("2.2.2.2"), Hdr: dns.RR_Header{Name: "one.one.one.one.", Rrtype: dns.TypeA}})
+	resp.Answer = append(resp.Answer, &dns.A{A: net.ParseIP("1.1.1.1"), Hdr: dns.RR_Header{Name: "one.one.one.one.", Rrtype: dns.TypeA}}, &dns.A{A: net.ParseIP("2.2.2.2"), Hdr: dns.RR_Header{Name: "one.one.one.one.", Rrtype: dns.TypeA}}, &dns.A{A: net.ParseIP("3.3.3.3"), Hdr: dns.RR_Header{Name: "one.one.one.one.", Rrtype: dns.TypeA}})
 
 	event := request.responseToDSLMap(req, resp, "one.one.one.one", "one.one.one.one", nil)
 	require.Len(t, event, 15, "could not get correct number of items in dsl map")
 	require.Equal(t, dns.RcodeSuccess, event["rcode"], "could not get correct rcode")
-	require.ElementsMatch(t, []string{net.ParseIP("1.1.1.1").String(), net.ParseIP("2.2.2.2").String()}, event["a"], "could not get correct a record")
+	require.ElementsMatch(t, []string{net.ParseIP("1.1.1.1").String(), net.ParseIP("2.2.2.2").String(), net.ParseIP("3.3.3.3").String()}, event["a"], "could not get correct a record")
 }
 
 func TestDNSOperatorMatch(t *testing.T) {


### PR DESCRIPTION
```
❯ time ./nuclei -u identity.aliyun.com -tags takeover

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v2.9.4-dev

		projectdiscovery.io

[WRN] Found 24 templates loaded with deprecated paths, update before v2.9.5 for continued support.
[WRN] Found 5709 templates loaded with deprecated protocol syntax, update before v2.9.5 for continued support.
[INF] Current nuclei version: v2.9.4-dev (outdated)
[INF] Current nuclei-templates version: v9.5.0 (latest)
[INF] New templates added in latest release: 62
[INF] Templates loaded for current scan: 142
[INF] Targets loaded for current scan: 1
[INF] Running httpx on input host
[INF] Found 1 URL from httpx
[INF] Templates clustered: 141 (Reduced 139 Requests)
[INF] No results found. Better luck next time!

real	0m6.792s
user	0m3.090s
sys	0m0.525s
```