### PR TITLE
Spelling Cleanup

### DIFF
--- a/v2/internal/installer/template.go
+++ b/v2/internal/installer/template.go
@@ -95,7 +95,7 @@ func (t *TemplateManager) installTemplatesAt(dir string) error {
 			return errorutil.NewWithErr(err).Msgf("failed to create directory at %s", dir)
 		}
 	}
-	ghrd, err := updateutils.NewghReleaseDownloader(config.OfficialNucleiTeamplatesRepoName)
+	ghrd, err := updateutils.NewghReleaseDownloader(config.OfficialNucleiTemplatesRepoName)
 	if err != nil {
 		return errorutil.NewWithErr(err).Msgf("failed to install templates at %s", dir)
 	}
@@ -116,7 +116,7 @@ func (t *TemplateManager) updateTemplatesAt(dir string) error {
 		oldchecksums = make(map[string]string)
 	}
 
-	ghrd, err := updateutils.NewghReleaseDownloader(config.OfficialNucleiTeamplatesRepoName)
+	ghrd, err := updateutils.NewghReleaseDownloader(config.OfficialNucleiTemplatesRepoName)
 	if err != nil {
 		return errorutil.NewWithErr(err).Msgf("failed to install templates at %s", dir)
 	}

--- a/v2/pkg/catalog/config/constants.go
+++ b/v2/pkg/catalog/config/constants.go
@@ -7,14 +7,14 @@ import (
 )
 
 const (
-	TemplateConfigFileName           = ".templates-config.json"
-	NucleiTemplatesDirName           = "nuclei-templates"
-	OfficialNucleiTeamplatesRepoName = "nuclei-templates"
-	NucleiIgnoreFileName             = ".nuclei-ignore"
-	NucleiTemplatesCheckSumFileName  = ".checksum"
-	NewTemplateAdditionsFileName     = ".new-additions"
-	CLIConifgFileName                = "config.yaml"
-	ReportingConfigFilename          = "reporting-config.yaml"
+	TemplateConfigFileName          = ".templates-config.json"
+	NucleiTemplatesDirName          = "nuclei-templates"
+	OfficialNucleiTemplatesRepoName = "nuclei-templates"
+	NucleiIgnoreFileName            = ".nuclei-ignore"
+	NucleiTemplatesCheckSumFileName = ".checksum"
+	NewTemplateAdditionsFileName    = ".new-additions"
+	CLIConfigFileName               = "config.yaml"
+	ReportingConfigFilename         = "reporting-config.yaml"
 	// Version is the current version of nuclei
 	Version = `v2.9.4-dev`
 
@@ -25,8 +25,7 @@ const (
 	CustomGitLabTemplatesDirName = "gitlab"
 )
 
-// IsOutdatedVersion compares two versions and returns true
-// if current version is outdated
+// IsOutdatedVersion compares two versions and returns true if the current version is outdated
 func IsOutdatedVersion(current, latest string) bool {
 	if latest == "" {
 		// if pdtm api call failed it's assumed that current version is outdated
@@ -44,6 +43,7 @@ func IsOutdatedVersion(current, latest string) bool {
 	return newVer.GreaterThan(currentVer)
 }
 
+// trimDevIfExists trims `-dev` suffix from version string if it exists
 func trimDevIfExists(version string) string {
 	if strings.HasSuffix(version, "-dev") {
 		return strings.TrimSuffix(version, "-dev")

--- a/v2/pkg/catalog/config/nucleiconfig.go
+++ b/v2/pkg/catalog/config/nucleiconfig.go
@@ -21,8 +21,8 @@ var DefaultConfig *Config
 type Config struct {
 	TemplatesDirectory string `json:"nuclei-templates-directory,omitempty"`
 
-	// customtemplates exists in templates directory with the name of custom-templates provider
-	// below custom paths are absolute paths to respecitive custom-templates directories
+	// custom-xxx-templates exists in templates directory with the name of custom-templates provider
+	// below custom paths are absolute paths to respective custom-templates directories
 	CustomS3TemplatesDirectory     string `json:"custom-s3-templates-directory"`
 	CustomGithubTemplatesDirectory string `json:"custom-github-templates-directory"`
 	CustomGitLabTemplatesDirectory string `json:"custom-gitlab-templates-directory"`
@@ -46,10 +46,10 @@ type Config struct {
 }
 
 // WriteVersionCheckData writes version check data to config file
-func (c *Config) WriteVersionCheckData(ignorehash, nucleiVersion, templatesVersion string) error {
+func (c *Config) WriteVersionCheckData(ignoreHash, nucleiVersion, templatesVersion string) error {
 	updated := false
-	if ignorehash != "" && c.LatestNucleiIgnoreHash != ignorehash {
-		c.LatestNucleiIgnoreHash = ignorehash
+	if ignoreHash != "" && c.LatestNucleiIgnoreHash != ignoreHash {
+		c.LatestNucleiIgnoreHash = ignoreHash
 		updated = true
 	}
 	if nucleiVersion != "" && c.LatestNucleiVersion != nucleiVersion {
@@ -82,7 +82,7 @@ func (c *Config) NeedsTemplateUpdate() bool {
 	return !c.disableUpdates && (c.TemplateVersion == "" || IsOutdatedVersion(c.TemplateVersion, c.LatestNucleiTemplatesVersion) || !fileutil.FolderExists(c.TemplatesDirectory))
 }
 
-// NeedsIngoreFileUpdate returns true if Ignore file hash is different (aka ignore file is outdated)
+// NeedsIgnoreFileUpdate returns true if Ignore file hash is different (aka ignore file is outdated)
 func (c *Config) NeedsIgnoreFileUpdate() bool {
 	return c.NucleiIgnoreHash == "" || c.NucleiIgnoreHash != c.LatestNucleiIgnoreHash
 }
@@ -123,18 +123,18 @@ func (c *Config) GetIgnoreFilePath() string {
 	return filepath.Join(c.configDir, NucleiIgnoreFileName)
 }
 
-// GetTemplatesConfigFilePath returns checksum file path of nuclei templates
+// GetChecksumFilePath returns checksum file path of nuclei templates
 func (c *Config) GetChecksumFilePath() string {
 	return filepath.Join(c.TemplatesDirectory, NucleiTemplatesCheckSumFileName)
 }
 
-// GetCLIOptsConfigFilePath returns the nuclei cli config file path
+// GetFlagsConfigFilePath returns the nuclei cli config file path
 func (c *Config) GetFlagsConfigFilePath() string {
-	return filepath.Join(c.configDir, CLIConifgFileName)
+	return filepath.Join(c.configDir, CLIConfigFileName)
 }
 
-// GetNewAdditions returns new template additions in current template release
-// if .new-additions file is not present empty slice is returned
+// GetNewAdditions returns new template additions in current template release if .new-additions file is not present
+// empty slice is returned
 func (c *Config) GetNewAdditions() []string {
 	arr := []string{}
 	newAdditionsPath := filepath.Join(c.TemplatesDirectory, NewTemplateAdditionsFileName)
@@ -153,8 +153,7 @@ func (c *Config) GetNewAdditions() []string {
 	return arr
 }
 
-// SetConfigDir sets the nuclei configuration directory
-// and appropriate changes are made to the config
+// SetConfigDir sets the nuclei configuration directory and appropriate changes are made to the config
 func (c *Config) SetConfigDir(dir string) {
 	c.configDir = dir
 	if err := c.createConfigDirIfNotExists(); err != nil {
@@ -252,8 +251,7 @@ func (c *Config) createConfigDirIfNotExists() error {
 	return nil
 }
 
-// copyIgnoreFile copies the nuclei ignore file default config directory
-// to the current config directory
+// copyIgnoreFile copies the nuclei ignore file default config directory to the current config directory
 func (c *Config) copyIgnoreFile() {
 	if err := c.createConfigDirIfNotExists(); err != nil {
 		gologger.Error().Msgf("Could not create nuclei config directory at %s: %s", c.configDir, err)
@@ -308,7 +306,7 @@ func getDefaultConfigDir() string {
 	return filepath.Join(userCfgDir, "nuclei")
 }
 
-// Add Default Config adds default when .templates-config.json file is not present
+// applyDefaultConfig adds default when .templates-config.json file is not present
 func applyDefaultConfig() {
 	DefaultConfig.TemplatesDirectory = filepath.Join(DefaultConfig.homeDir, NucleiTemplatesDirName)
 	// updates all necessary paths

--- a/v2/pkg/external/customtemplates/templates_provider.go
+++ b/v2/pkg/external/customtemplates/templates_provider.go
@@ -40,7 +40,7 @@ func NewCustomTemplatesManager(options *types.Options) (*CustomTemplatesManager,
 		return ctm, nil
 	}
 
-	// Add github providers
+	// Add GitHub providers
 	githubProviders, err := NewGithubProviders(options)
 	if err != nil {
 		return nil, errorutil.NewWithErr(err).Msgf("could not create github providers for custom templates")
@@ -49,7 +49,7 @@ func NewCustomTemplatesManager(options *types.Options) (*CustomTemplatesManager,
 		ctm.providers = append(ctm.providers, v)
 	}
 
-	// Add Aws S3 providers
+	// Add AWS S3 providers
 	s3Providers, err := NewS3Providers(options)
 	if err != nil {
 		return nil, errorutil.NewWithErr(err).Msgf("could not create s3 providers for custom templates")


### PR DESCRIPTION
## Proposed changes
A few variable misspellings were identified while working on another branch and are reflected here.

## Checklist

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)