### PR TITLE
fix oob ruleindex

### DIFF
--- a/v2/pkg/reporting/exporters/sarif/sarif.go
+++ b/v2/pkg/reporting/exporters/sarif/sarif.go
@@ -2,6 +2,7 @@ package sarif
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"path"
 	"sync"
@@ -125,7 +126,7 @@ func (exporter *Exporter) Export(event *output.ResultEvent) error {
 	}
 
 	// If rule is added
-	ruleIndex := len(exporter.rules) - 1
+	ruleIndex := int(math.Max(0, float64(len(exporter.rules)-1)))
 	if exporter.rulemap[rule.Id] == nil {
 		exporter.rulemap[rule.Id] = &ruleIndex
 		exporter.rules = append(exporter.rules, rule)


### PR DESCRIPTION
## Proposed changes

It makes sure the index starts from 0. Closes #3221.

## Checklist

- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)