### PR TITLE
deprecatedProtocolNameTemplates concurrent map writes

### DIFF
--- a/v2/pkg/templates/templates.go
+++ b/v2/pkg/templates/templates.go
@@ -185,7 +185,7 @@ func (template *Template) UnmarshalYAML(unmarshal func(interface{}) error) error
 	*template = Template(*alias)
 
 	if len(template.RequestsHTTP) > 0 || len(template.RequestsNetwork) > 0 {
-		deprecatedProtocolNameTemplates[template.ID] = struct{}{}
+		deprecatedProtocolNameTemplates.Store(template.ID, struct{}{})
 	}
 
 	if len(alias.RequestsHTTP) > 0 && len(alias.RequestsWithHTTP) > 0 {


### PR DESCRIPTION
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->


## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Reproduction steps

- Copy the latest template

```bash
cp -r nuclei-templates old-nuclei-templates
```
- Batch replace with older versions of templates

```bash
cd old-nuclei-templates/http/vulnerabilities/wordpress
sed -i -e "s/http:/requests:/" *.yaml
```

## Code

``` go
package tests

import (
	"context"
	"fmt"
	"log"
	"os"
	"path"
	"testing"
	"time"

	"github.com/logrusorgru/aurora"
	"github.com/projectdiscovery/goflags"
	"github.com/projectdiscovery/nuclei/v2/pkg/catalog/config"
	"github.com/projectdiscovery/nuclei/v2/pkg/catalog/disk"
	"github.com/projectdiscovery/nuclei/v2/pkg/catalog/loader"
	"github.com/projectdiscovery/nuclei/v2/pkg/core"
	"github.com/projectdiscovery/nuclei/v2/pkg/core/inputs"
	"github.com/projectdiscovery/nuclei/v2/pkg/output"
	"github.com/projectdiscovery/nuclei/v2/pkg/parsers"
	"github.com/projectdiscovery/nuclei/v2/pkg/protocols"
	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/contextargs"
	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/hosterrorscache"
	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/interactsh"
	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/protocolinit"
	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/protocolstate"
	"github.com/projectdiscovery/nuclei/v2/pkg/reporting"
	"github.com/projectdiscovery/nuclei/v2/pkg/testutils"
	"github.com/projectdiscovery/nuclei/v2/pkg/types"
	"github.com/projectdiscovery/ratelimit"
)

func TestOrgNuclei(t *testing.T) {
	go GetOrgNuclei()
	go GetOrgNuclei()
	go GetOrgNuclei()
	go GetOrgNuclei()
	go GetOrgNuclei()
	time.Sleep(30 * time.Second)
}
func GetOrgNuclei() {
	cache := hosterrorscache.New(30, hosterrorscache.DefaultMaxHostsCount, nil)
	defer cache.Close()

	mockProgress := &testutils.MockProgressClient{}
	reportingClient, _ := reporting.New(&reporting.Options{}, "")
	defer reportingClient.Close()

	outputWriter := testutils.NewMockOutputWriter()
	outputWriter.WriteCallback = func(event *output.ResultEvent) {
		fmt.Printf("Got Result: %v\n", event.Info.Name)
	}

	defaultOpts := types.DefaultOptions()
	protocolstate.Init(defaultOpts)
	protocolinit.Init(defaultOpts)

	defaultOpts.ExcludeTags = config.ReadIgnoreFile().Tags
	defaultOpts.IncludeTags = goflags.StringSlice{"wordpress"}
	defaultOpts.Templates = goflags.StringSlice{"/home/kali-team/old-nuclei-templates/http/vulnerabilities/wordpress"}

	interactOpts := interactsh.DefaultOptions(outputWriter, reportingClient, mockProgress)
	interactClient, err := interactsh.New(interactOpts)
	if err != nil {
		log.Fatalf("Could not create interact client: %s\n", err)
	}
	defer interactClient.Close()

	home, _ := os.UserHomeDir()
	catalog := disk.NewCatalog(path.Join(home, "nm"))
	executerOpts := protocols.ExecutorOptions{
		Output:          outputWriter,
		Options:         defaultOpts,
		Progress:        mockProgress,
		Catalog:         catalog,
		IssuesClient:    reportingClient,
		RateLimiter:     ratelimit.New(context.Background(), 150, time.Second),
		Interactsh:      interactClient,
		HostErrorsCache: cache,
		Colorizer:       aurora.NewAurora(true),
		ResumeCfg:       types.NewResumeCfg(),
	}
	engine := core.New(defaultOpts)
	engine.SetExecuterOptions(executerOpts)

	workflowLoader, err := parsers.NewLoader(&executerOpts)
	if err != nil {
		log.Fatalf("Could not create workflow loader: %s\n", err)
	}
	executerOpts.WorkflowLoader = workflowLoader

	store, err := loader.New(loader.NewConfig(defaultOpts, catalog, executerOpts))
	if err != nil {
		log.Fatalf("Could not create loader client: %s\n", err)
	}
	store.Load()

	inputArgs := []*contextargs.MetaInput{{Input: "https://119.23.111.124"}}

	input := &inputs.SimpleInputProvider{Inputs: inputArgs}
	_ = engine.Execute(store.Templates(), input)
	engine.WorkPool().Wait() // Wait for the scan to finish
}

```


- Error Log

<details><summary>点击展开查看</summary>
<p>

```bash
=== RUN   TestOrgNuclei
fatal error: concurrent map writes

goroutine 49 [running]:
github.com/projectdiscovery/nuclei/v2/pkg/templates.(*Template).UnmarshalYAML(0xc0060b58c0, 0xc0060ca420)
        /home/kali-team/.Go/pkg/mod/github.com/projectdiscovery/nuclei/v2@v2.9.6/pkg/templates/templates.go:188 +0xc6
gopkg.in/yaml%2ev2.(*decoder).callUnmarshaler(0xc0060c3ce0, 0xc0060d4a80, {0x7ff3233b8cd8, 0xc0060b58c0})
        /home/kali-team/.Go/pkg/mod/gopkg.in/yaml.v2@v2.4.0/decode.go:270 +0xa4
gopkg.in/yaml%2ev2.(*decoder).prepare(0x8?, 0xc0060d4a80, {0x198c780?, 0xc0060b58c0?, 0x1?})
        /home/kali-team/.Go/pkg/mod/gopkg.in/yaml.v2@v2.4.0/decode.go:313 +0x26a
gopkg.in/yaml%2ev2.(*decoder).unmarshal(0xc0060c3ce0, 0xc0060d4a80, {0x198c780?, 0xc0060b58c0?, 0x2d0?})
        /home/kali-team/.Go/pkg/mod/gopkg.in/yaml.v2@v2.4.0/decode.go:364 +0x105
gopkg.in/yaml%2ev2.(*decoder).document(0xc0060d4a10?, 0xc0060d4a80?, {0x198c780?, 0xc0060b58c0?, 0xc00609ec00?})
        /home/kali-team/.Go/pkg/mod/gopkg.in/yaml.v2@v2.4.0/decode.go:384 +0x5b
gopkg.in/yaml%2ev2.(*decoder).unmarshal(0x1901720?, 0xc0060b58c0?, {0x198c780?, 0xc0060b58c0?, 0x0?})
        /home/kali-team/.Go/pkg/mod/gopkg.in/yaml.v2@v2.4.0/decode.go:360 +0x196
gopkg.in/yaml%2ev2.unmarshal({0xc0060d0380, 0x2e4, 0x380}, {0x1901720?, 0xc0060b58c0}, 0x0)
        /home/kali-team/.Go/pkg/mod/gopkg.in/yaml.v2@v2.4.0/yaml.go:148 +0x41e
gopkg.in/yaml%2ev2.Unmarshal(...)
        /home/kali-team/.Go/pkg/mod/gopkg.in/yaml.v2@v2.4.0/yaml.go:81
github.com/projectdiscovery/nuclei/v2/pkg/templates.ParseTemplateFromReader({_, _}, {_, _}, {{0x0, 0x0}, {0xc000a71ce0, 0x5a}, {{0x0, 0x0}, ...}, ...})
        /home/kali-team/.Go/pkg/mod/github.com/projectdiscovery/nuclei/v2@v2.9.6/pkg/templates/compile.go:215 +0xcc
github.com/projectdiscovery/nuclei/v2/pkg/templates.Parse({_, _}, {_, _}, {{0x0, 0x0}, {0x0, 0x0}, {{0x0, 0x0}, ...}, ...})
        /home/kali-team/.Go/pkg/mod/github.com/projectdiscovery/nuclei/v2@v2.9.6/pkg/templates/compile.go:61 +0x4b0
github.com/projectdiscovery/nuclei/v2/pkg/catalog/loader.(*Store).LoadTemplatesWithTags(0xc004c68480, {0xc000018740?, 0x0?, 0x0?}, {0x0, 0x0, 0x0})
        /home/kali-team/.Go/pkg/mod/github.com/projectdiscovery/nuclei/v2@v2.9.6/pkg/catalog/loader/loader.go:308 +0x42b
github.com/projectdiscovery/nuclei/v2/pkg/catalog/loader.(*Store).LoadTemplates(...)
        /home/kali-team/.Go/pkg/mod/github.com/projectdiscovery/nuclei/v2@v2.9.6/pkg/catalog/loader/loader.go:270
github.com/projectdiscovery/nuclei/v2/pkg/catalog/loader.(*Store).Load(0xc004c68480)
        /home/kali-team/.Go/pkg/mod/github.com/projectdiscovery/nuclei/v2@v2.9.6/pkg/catalog/loader/loader.go:166 +0x36
command-line-arguments.GetOrgNuclei()
        /home/kali-team/Kali-Team/nuclei/tests/nuclei_org_test.go:101 +0xdb9
created by command-line-arguments.TestOrgNuclei
        /home/kali-team/Kali-Team/nuclei/tests/nuclei_org_test.go:38 +0x55

```