### PR TITLE
Enable `-no-httpx` when `-passive` scan is launched

### DIFF
--- a/v2/internal/runner/options.go
+++ b/v2/internal/runner/options.go
@@ -90,6 +90,10 @@ func ParseOptions(options *types.Options) {
 			options.UncoverEngine = append(options.UncoverEngine, "shodan")
 		}
 	}
+
+	if options.OfflineHTTP {
+		options.DisableHTTPProbe = true
+	}
 }
 
 // validateOptions validates the configuration options passed


### PR DESCRIPTION
## Proposed changes
This PR will enable `-no-httpx` when the scan is launched with a `-passive` flag. Closes #3646.


## Checklist

- [X] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)