### PR TITLE
Add headless header and status matchers

### DIFF
--- a/v2/pkg/protocols/headless/request.go
+++ b/v2/pkg/protocols/headless/request.go
@@ -129,7 +129,7 @@ func (request *Request) executeRequestWithPayloads(inputURL string, payloads map
 		responseBody, _ = html.HTML()
 	}
 
-	outputEvent := request.responseToDSLMap(responseBody, reqBuilder.String(), inputURL, inputURL, page.DumpHistory())
+	outputEvent := request.responseToDSLMap(responseBody, out["headers"], out["status_code"], reqBuilder.String(), inputURL, inputURL, page.DumpHistory())
 	for k, v := range out {
 		outputEvent[k] = v
 	}


### PR DESCRIPTION
## Proposed changes
This PR adds header and status matchers for the headless mode. Closes #3715.


## Checklist
- [X] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)