### PR TITLE
Expose headers as `key:value` to DSL

### DIFF
--- a/integration_tests/headless/headless-header-key.yaml
+++ b/integration_tests/headless/headless-header-key.yaml
@@ -1,0 +1,18 @@
+id: headless-header-key
+
+info:
+  name: headless header key
+  author: pdteam
+  severity: info
+
+headless:
+  - steps:
+      - args:
+          url: "{{BaseURL}}"
+        action: navigate
+      - action: waitload
+
+    extractors:
+      - type: dsl
+        dsl:
+          - content_type

--- a/v2/cmd/integration-test/headless.go
+++ b/v2/cmd/integration-test/headless.go
@@ -18,6 +18,7 @@ var headlessTestcases = map[string]testutils.TestCase{
 	"headless/variables.yaml":                   &headlessVariables{},
 	"headless/file-upload.yaml":                 &headlessFileUpload{},
 	"headless/headless-header-status-test.yaml": &headlessHeaderStatus{},
+	"headless/headless-header-key.yaml":         &headlessHeaderKey{},
 }
 
 type headlessBasic struct{}
@@ -164,6 +165,18 @@ type headlessHeaderStatus struct{}
 
 // Execute executes a test case and returns an error if occurred
 func (h *headlessHeaderStatus) Execute(filePath string) error {
+	results, err := testutils.RunNucleiTemplateAndGetResults(filePath, "https://scanme.sh", debug, "-headless")
+	if err != nil {
+		return err
+	}
+
+	return expectResultsCount(results, 1)
+}
+
+type headlessHeaderKey struct{}
+
+// Execute executes a test case and returns an error if occurred
+func (h *headlessHeaderKey) Execute(filePath string) error {
 	results, err := testutils.RunNucleiTemplateAndGetResults(filePath, "https://scanme.sh", debug, "-headless")
 	if err != nil {
 		return err

--- a/v2/pkg/protocols/headless/engine/page.go
+++ b/v2/pkg/protocols/headless/engine/page.go
@@ -191,7 +191,7 @@ func containsAnyModificationActionType(actionTypes ...ActionType) bool {
 	return false
 }
 
-// headersToString converts proto.NetworkHeaders to http.Header
+// networkHeadersToHttpHeaders converts proto.NetworkHeaders to http.Header
 func networkHeadersToHttpHeaders(headers proto.NetworkHeaders) http.Header {
 	httpHeaders := http.Header{}
 	for k, v := range headers {

--- a/v2/pkg/protocols/headless/request.go
+++ b/v2/pkg/protocols/headless/request.go
@@ -135,7 +135,7 @@ func (request *Request) executeRequestWithPayloads(inputURL string, payloads map
 		responseBody, _ = html.HTML()
 	}
 
-	outputEvent := request.responseToDSLMap(responseBody, out["header"], out["status_code"], reqBuilder.String(), inputURL, inputURL, page.DumpHistory())
+	outputEvent := request.responseToDSLMap(responseBody, reqBuilder.String(), inputURL, inputURL, page.DumpHistory(), page.StatusCode, page.Headers)
 	for k, v := range out {
 		outputEvent[k] = v
 	}


### PR DESCRIPTION
## Proposed changes
This PR exposes headers as `key:value` to DSL. Closes #3796.


## Checklist
- [X] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)