### PR TITLE
Fix the error of obtaining the latest version on other OS

### DIFF
--- a/v2/internal/installer/versioncheck.go
+++ b/v2/internal/installer/versioncheck.go
@@ -67,7 +67,12 @@ func NucleiVersionCheck() error {
 // getpdtmParams returns encoded query parameters sent to update check endpoint
 func getpdtmParams() string {
 	params := &url.Values{}
-	params.Add("os", runtime.GOOS)
+	switch runtime.GOOS {
+	// Currently, only binary downloads for Linux, macOS, and Windows are officially provided,
+	// other platforms like BSD do not provide an 'os' parameter.
+	case "windows", "linux", "darwin":
+		params.Add("os", runtime.GOOS)
+	}
 	params.Add("arch", runtime.GOARCH)
 	params.Add("go_version", runtime.Version())
 	params.Add("v", config.Version)


### PR DESCRIPTION
Fix the error of obtaining the latest version on other OS, for example, on the OpenBSD, even the latest version of Nuclei still indicates that the version is too low:

```
my-openbsd$ ./nuclei

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v2.9.6

                projectdiscovery.io

[INF] Your current nuclei-templates  are outdated. Latest is v9.5.2
[INF] Current nuclei version: v2.9.6 (outdated)                                      <-- version is too low, but v2.9.6 is latest version
...
```

Because the 'getpdtmParams' function will take the OS name as the value of the 'os' parameter when calling the API, the API will return an error when the official binary file for the OS is not provided:

```
$ curl --silent https://api.pdtm.sh/api/v1/tools/nuclei\?arch\=amd64\&go_version\=go1.20.1\&os\=openbsd\&v\=v2.9.6 |jq
{
  "error": "could not find tool: nuclei, with the specified parameters: arch=amd64, os=openbsd",
  "status": 400
}
```

So in other OS, the problem can be solved by not providing the 'os' parameter:

```
$ curl --silent https://api.pdtm.sh/api/v1/tools/nuclei\?arch\=amd64\&go_version\=go1.20.1\&v\=v2.9.6 |jq         
{
  "ignore-hash": "55f00e3397d5b1174c2f35a1f253ec03",
  "tools": [
    {
      "name": "nuclei",
      "repo": "nuclei",
      "requirements": null,
      "version": "2.9.6",
      "assets": {
        "nuclei_2.9.6_linux_amd64.zip": "110794900",
        "nuclei_2.9.6_macOS_amd64.zip": "110794904",
        "nuclei_2.9.6_windows_amd64.zip": "110794902"
      }
    },
    {
      "name": "nuclei-templates",
      "repo": "nuclei-templates",
      "requirements": null,
      "version": "9.5.2",
      "assets": {}
    }
  ]
}
```