### PR TITLE
Automate merging of dependabot PRs to dep branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    target-branch: "dev"
+    target-branch: "dep"
     commit-message:
       prefix: "chore"
       include: "scope"
@@ -23,7 +23,7 @@ updates:
     directory: "v2/"
     schedule:
       interval: "weekly"
-    target-branch: "dev"
+    target-branch: "dep"
     commit-message:
       prefix: "chore"
       include: "scope"
@@ -35,7 +35,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    target-branch: "dev"
+    target-branch: "dep"
     commit-message:
       prefix: "chore"
       include: "scope"

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,16 +1,25 @@
-name: auto-merge
+name: 🤖 dep auto merge
 
 on:
   pull_request:
     branches:
       - dep
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write
+  issues: write
+  repository-projects: write
 
 jobs:
   automerge:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.DEPENDABOT_PAT }}
+
       - uses: ahmadnassri/action-dependabot-auto-merge@v2
         with:
-          github-token: ${{ secrets.PDTEAMX_PAT }}
+          github-token: ${{ secrets.DEPENDABOT_PAT }}
           target: all

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,16 @@
+name: auto-merge
+
+on:
+  pull_request:
+    branches:
+      - dep
+
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ahmadnassri/action-dependabot-auto-merge@v2
+        with:
+          github-token: ${{ secrets.PDTEAMX_PAT }}
+          target: all

--- a/.github/workflows/sync-dep.yml
+++ b/.github/workflows/sync-dep.yml
@@ -1,11 +1,17 @@
-name: sync-dep
+name: 🤖 sync dep
+
 on:
   push:
     branches:
       - dev
 
+permissions:
+  pull-requests: write
+  issues: write
+  repository-projects: write
+
 jobs:
-  sync-dep-with-main:
+  sync-dep-with-dev:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -14,10 +20,11 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 12
+
       - name: Opening pull request
         id: pull
         uses: tretuna/sync-branches@1.4.0
         with:
-          GITHUB_TOKEN: ${{ secrets.PDTEAMX_PAT }}
+          GITHUB_TOKEN: ${{ secrets.DEPENDABOT_PAT }}
           FROM_BRANCH: "${{ github.ref_name }}"
           TO_BRANCH: "dep"

--- a/.github/workflows/sync-dep.yml
+++ b/.github/workflows/sync-dep.yml
@@ -1,0 +1,23 @@
+name: sync-dep
+on:
+  push:
+    branches:
+      - dev
+
+jobs:
+  sync-dep-with-main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 12
+      - name: Opening pull request
+        id: pull
+        uses: tretuna/sync-branches@1.4.0
+        with:
+          GITHUB_TOKEN: ${{ secrets.PDTEAMX_PAT }}
+          FROM_BRANCH: "${{ github.ref_name }}"
+          TO_BRANCH: "dep"


### PR DESCRIPTION
## Proposed changes
This PR automates branch sync between the dev and dep branches. Also, it auto merges dependabot PRs to the dep branch.

This PR requires a branch named `dep` to be created from `dev`.

## Checklist

- [X] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)