### PR TITLE
add no-sandbox flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ CONFIGURATIONS:
    -sml, -show-match-line         show match lines for file templates, works with extractors only
    -ztls                          use ztls library with autofallback to standard one for tls13
    -sni string                    tls sni hostname to use (default: input domain name)
-   -sandbox                       sandbox nuclei for safe templates execution
+   -no-sandbox                    disables sandbox(default) mode of nuclei for safe templates execution
    -i, -interface string          network interface to use for network scan
    -at, -attack-type string       type of payload combinations to perform (batteringram,pitchfork,clusterbomb)
    -sip, -source-ip string        source ip address to use for network scan

--- a/v2/cmd/integration-test/code.go
+++ b/v2/cmd/integration-test/code.go
@@ -82,6 +82,7 @@ func executeNucleiAsCode(templatePath, templateURL string) ([]string, error) {
 	}
 
 	defaultOpts := types.DefaultOptions()
+	defaultOpts.NoSandbox = true
 	_ = protocolstate.Init(defaultOpts)
 	_ = protocolinit.Init(defaultOpts)
 

--- a/v2/cmd/nuclei/main.go
+++ b/v2/cmd/nuclei/main.go
@@ -202,7 +202,7 @@ on extensive configurability, massive extensibility and ease of use.`)
 		flagSet.BoolVarP(&options.ShowMatchLine, "show-match-line", "sml", false, "show match lines for file templates, works with extractors only"),
 		flagSet.BoolVar(&options.ZTLS, "ztls", false, "use ztls library with autofallback to standard one for tls13"),
 		flagSet.StringVar(&options.SNI, "sni", "", "tls sni hostname to use (default: input domain name)"),
-		flagSet.BoolVar(&options.Sandbox, "sandbox", false, "sandbox nuclei for safe templates execution"),
+		flagSet.BoolVar(&options.NoSandbox, "no-sandbox", false, "disables sandbox(default) mode of nuclei for safe templates execution"),
 		flagSet.StringVarP(&options.Interface, "interface", "i", "", "network interface to use for network scan"),
 		flagSet.StringVarP(&options.AttackType, "attack-type", "at", "", "type of payload combinations to perform (batteringram,pitchfork,clusterbomb)"),
 		flagSet.StringVarP(&options.SourceIP, "source-ip", "sip", "", "source ip address to use for network scan"),

--- a/v2/pkg/protocols/common/protocolstate/state.go
+++ b/v2/pkg/protocols/common/protocolstate/state.go
@@ -91,9 +91,10 @@ func Init(options *types.Options) error {
 	if options.ResolversFile != "" {
 		opts.BaseResolvers = options.InternalResolversList
 	}
-	if options.Sandbox {
+	if !options.NoSandbox {
 		opts.Deny = append(networkpolicy.DefaultIPv4DenylistRanges, networkpolicy.DefaultIPv6DenylistRanges...)
 	}
+
 	opts.WithDialerHistory = true
 	opts.WithZTLS = options.ZTLS
 	opts.SNIName = options.SNI

--- a/v2/pkg/protocols/dns/dns.go
+++ b/v2/pkg/protocols/dns/dns.go
@@ -172,7 +172,7 @@ func (request *Request) Compile(options *protocols.ExecutorOptions) error {
 	}
 
 	if len(request.Payloads) > 0 {
-		request.generator, err = generators.New(request.Payloads, request.AttackType.Value, request.options.TemplatePath, request.options.Options.Sandbox, request.options.Catalog, request.options.Options.AttackType)
+		request.generator, err = generators.New(request.Payloads, request.AttackType.Value, request.options.TemplatePath, !request.options.Options.NoSandbox, request.options.Catalog, request.options.Options.AttackType)
 		if err != nil {
 			return errors.Wrap(err, "could not parse payloads")
 		}

--- a/v2/pkg/protocols/headless/engine/page_actions_test.go
+++ b/v2/pkg/protocols/headless/engine/page_actions_test.go
@@ -551,9 +551,9 @@ func testHeadlessSimpleResponse(t *testing.T, response string, actions []*Action
 
 func testHeadless(t *testing.T, actions []*Action, timeout time.Duration, handler func(w http.ResponseWriter, r *http.Request), assert func(page *Page, pageErr error, extractedData map[string]string)) {
 	t.Helper()
-	_ = protocolstate.Init(&types.Options{})
+	_ = protocolstate.Init(&types.Options{NoSandbox: true})
 
-	browser, err := New(&types.Options{ShowBrowser: false, UseInstalledChrome: testheadless.HeadlessLocal})
+	browser, err := New(&types.Options{ShowBrowser: false, UseInstalledChrome: testheadless.HeadlessLocal, NoSandbox: true})
 	require.Nil(t, err, "could not create browser")
 	defer browser.Close()
 

--- a/v2/pkg/protocols/headless/headless.go
+++ b/v2/pkg/protocols/headless/headless.go
@@ -102,7 +102,7 @@ func (request *Request) Compile(options *protocols.ExecutorOptions) error {
 
 	if len(request.Payloads) > 0 {
 		var err error
-		request.generator, err = generators.New(request.Payloads, request.AttackType.Value, options.TemplatePath, options.Options.Sandbox, options.Catalog, options.Options.AttackType)
+		request.generator, err = generators.New(request.Payloads, request.AttackType.Value, options.TemplatePath, !options.Options.NoSandbox, options.Catalog, options.Options.AttackType)
 		if err != nil {
 			return errors.Wrap(err, "could not parse payloads")
 		}

--- a/v2/pkg/protocols/http/http.go
+++ b/v2/pkg/protocols/http/http.go
@@ -353,7 +353,7 @@ func (request *Request) Compile(options *protocols.ExecutorOptions) error {
 	}
 
 	if len(request.Payloads) > 0 {
-		request.generator, err = generators.New(request.Payloads, request.AttackType.Value, request.options.TemplatePath, request.options.Options.Sandbox, request.options.Catalog, request.options.Options.AttackType)
+		request.generator, err = generators.New(request.Payloads, request.AttackType.Value, request.options.TemplatePath, !request.options.Options.NoSandbox, request.options.Catalog, request.options.Options.AttackType)
 		if err != nil {
 			return errors.Wrap(err, "could not parse payloads")
 		}

--- a/v2/pkg/protocols/network/network.go
+++ b/v2/pkg/protocols/network/network.go
@@ -184,7 +184,7 @@ func (request *Request) Compile(options *protocols.ExecutorOptions) error {
 	}
 
 	if len(request.Payloads) > 0 {
-		request.generator, err = generators.New(request.Payloads, request.AttackType.Value, request.options.TemplatePath, request.options.Options.Sandbox, request.options.Catalog, request.options.Options.AttackType)
+		request.generator, err = generators.New(request.Payloads, request.AttackType.Value, request.options.TemplatePath, !request.options.Options.NoSandbox, request.options.Catalog, request.options.Options.AttackType)
 		if err != nil {
 			return errors.Wrap(err, "could not parse payloads")
 		}

--- a/v2/pkg/protocols/websocket/websocket.go
+++ b/v2/pkg/protocols/websocket/websocket.go
@@ -106,7 +106,7 @@ func (request *Request) Compile(options *protocols.ExecutorOptions) error {
 	request.dialer = client
 
 	if len(request.Payloads) > 0 {
-		request.generator, err = generators.New(request.Payloads, request.AttackType.Value, request.options.TemplatePath, request.options.Options.Sandbox, options.Catalog, options.Options.AttackType)
+		request.generator, err = generators.New(request.Payloads, request.AttackType.Value, request.options.TemplatePath, !request.options.Options.NoSandbox, options.Catalog, options.Options.AttackType)
 		if err != nil {
 			return errors.Wrap(err, "could not parse payloads")
 		}

--- a/v2/pkg/testutils/integration.go
+++ b/v2/pkg/testutils/integration.go
@@ -52,6 +52,7 @@ func RunNucleiBareArgsAndGetResults(debug bool, extra ...string) ([]string, erro
 	cmd.Args = append(cmd.Args, "-duc") // disable auto updates
 	cmd.Args = append(cmd.Args, "-interactions-poll-duration", "1")
 	cmd.Args = append(cmd.Args, "-interactions-cooldown-period", "10")
+	cmd.Args = append(cmd.Args, "-no-sandbox", "true")
 	if debug {
 		cmd.Args = append(cmd.Args, "-debug")
 		cmd.Stderr = os.Stderr

--- a/v2/pkg/testutils/testutils.go
+++ b/v2/pkg/testutils/testutils.go
@@ -66,6 +66,7 @@ var DefaultOptions = &types.Options{
 	InteractionsPollDuration:   5,
 	GithubTemplateRepo:         []string{},
 	GithubToken:                "",
+	NoSandbox:                  true,
 }
 
 // TemplateInfo contains info for a mock executed template.

--- a/v2/pkg/types/types.go
+++ b/v2/pkg/types/types.go
@@ -276,7 +276,7 @@ type Options struct {
 	ClientCAFile string
 	// Use ZTLS library
 	ZTLS bool
-	// Sandbox enables sandboxed nuclei template execution
+	// Disable sandboxed nuclei template execution
 	NoSandbox bool
 	// ShowMatchLine enables display of match line number
 	ShowMatchLine bool

--- a/v2/pkg/types/types.go
+++ b/v2/pkg/types/types.go
@@ -277,7 +277,7 @@ type Options struct {
 	// Use ZTLS library
 	ZTLS bool
 	// Sandbox enables sandboxed nuclei template execution
-	Sandbox bool
+	NoSandbox bool
 	// ShowMatchLine enables display of match line number
 	ShowMatchLine bool
 	// EnablePprof enables exposing pprof runtime information with a webserver.


### PR DESCRIPTION
## Proposed changes
The PR removes the sandbox flag and makes the sandbox mode default. In addition, it adds a no-sandbox flag to allow users to turn off the default sandbox mode if they choose to do so. Closes #3784.


## Checklist

- [X] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)