### PR TITLE
Adding httpx probe to simple input handing

### DIFF
--- a/v2/internal/runner/inputs.go
+++ b/v2/internal/runner/inputs.go
@@ -1,18 +1,16 @@
 package runner
 
 import (
-	"fmt"
-	"net/http"
-	"strings"
 	"sync/atomic"
 	"time"
 
-	"github.com/corpix/uarand"
 	"github.com/pkg/errors"
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/hmap/store/hybrid"
 	"github.com/projectdiscovery/httpx/common/httpx"
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/contextargs"
+	"github.com/projectdiscovery/nuclei/v2/pkg/utils"
+	stringsutil "github.com/projectdiscovery/utils/strings"
 	"github.com/remeh/sizedwaitgroup"
 )
 
@@ -25,7 +23,6 @@ func (r *Runner) initializeTemplatesHTTPInput() (*hybrid.HybridMap, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "could not create temporary input file")
 	}
-
 	gologger.Info().Msgf("Running httpx on input host")
 
 	var bulkSize = probeBulkSize
@@ -45,7 +42,7 @@ func (r *Runner) initializeTemplatesHTTPInput() (*hybrid.HybridMap, error) {
 	swg := sizedwaitgroup.New(bulkSize)
 	count := int32(0)
 	r.hmapInputProvider.Scan(func(value *contextargs.MetaInput) bool {
-		if strings.HasPrefix(value.Input, "http://") || strings.HasPrefix(value.Input, "https://") {
+		if stringsutil.HasPrefixAny(value.Input, "http://", "https://") {
 			return true
 		}
 
@@ -53,7 +50,7 @@ func (r *Runner) initializeTemplatesHTTPInput() (*hybrid.HybridMap, error) {
 		go func(input *contextargs.MetaInput) {
 			defer swg.Done()
 
-			if result := probeURL(input.Input, httpxClient); result != "" {
+			if result := utils.ProbeURL(input.Input, httpxClient); result != "" {
 				atomic.AddInt32(&count, 1)
 				_ = hm.Set(input.Input, []byte(result))
 			}
@@ -64,28 +61,4 @@ func (r *Runner) initializeTemplatesHTTPInput() (*hybrid.HybridMap, error) {
 
 	gologger.Info().Msgf("Found %d URL from httpx", atomic.LoadInt32(&count))
 	return hm, nil
-}
-
-var (
-	httpSchemes = []string{"https", "http"}
-)
-
-// probeURL probes the scheme for a URL. first HTTPS is tried
-// and if any errors occur http is tried. If none succeeds, probing
-// is abandoned for such URLs.
-func probeURL(input string, httpxclient *httpx.HTTPX) string {
-	for _, scheme := range httpSchemes {
-		formedURL := fmt.Sprintf("%s://%s", scheme, input)
-		req, err := httpxclient.NewRequest(http.MethodHead, formedURL)
-		if err != nil {
-			continue
-		}
-		req.Header.Set("User-Agent", uarand.GetRandom())
-
-		if _, err = httpxclient.Do(req, httpx.UnsafeOptions{}); err != nil {
-			continue
-		}
-		return formedURL
-	}
-	return ""
 }

--- a/v2/pkg/core/inputs/inputs.go
+++ b/v2/pkg/core/inputs/inputs.go
@@ -1,6 +1,10 @@
 package inputs
 
-import "github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/contextargs"
+import (
+	"github.com/projectdiscovery/httpx/common/httpx"
+	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/contextargs"
+	"github.com/projectdiscovery/nuclei/v2/pkg/utils"
+)
 
 type SimpleInputProvider struct {
 	Inputs []*contextargs.MetaInput
@@ -23,4 +27,13 @@ func (s *SimpleInputProvider) Scan(callback func(value *contextargs.MetaInput) b
 // Set adds item to input provider
 func (s *SimpleInputProvider) Set(value string) {
 	s.Inputs = append(s.Inputs, &contextargs.MetaInput{Input: value})
+}
+
+// SetWithProbe adds item to input provider with http probing
+func (s *SimpleInputProvider) SetWithProbe(value string, httpxClient *httpx.HTTPX) {
+	valueToAppend := value
+	if result := utils.ProbeURL(value, httpxClient); result != "" {
+		valueToAppend = result
+	}
+	s.Inputs = append(s.Inputs, &contextargs.MetaInput{Input: valueToAppend})
 }

--- a/v2/pkg/utils/http_probe.go
+++ b/v2/pkg/utils/http_probe.go
@@ -1,0 +1,33 @@
+package utils
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/corpix/uarand"
+	"github.com/projectdiscovery/httpx/common/httpx"
+)
+
+var (
+	HttpSchemes = []string{"https", "http"}
+)
+
+// probeURL probes the scheme for a URL. first HTTPS is tried
+// and if any errors occur http is tried. If none succeeds, probing
+// is abandoned for such URLs.
+func ProbeURL(input string, httpxclient *httpx.HTTPX) string {
+	for _, scheme := range HttpSchemes {
+		formedURL := fmt.Sprintf("%s://%s", scheme, input)
+		req, err := httpxclient.NewRequest(http.MethodHead, formedURL)
+		if err != nil {
+			continue
+		}
+		req.Header.Set("User-Agent", uarand.GetRandom())
+
+		if _, err = httpxclient.Do(req, httpx.UnsafeOptions{}); err != nil {
+			continue
+		}
+		return formedURL
+	}
+	return ""
+}


### PR DESCRIPTION
## Proposed changes
This PR adds an additional method to `SimpleInputProvider` to add a raw target with http probe and update the example code on how to use nuclei as a library. 

## Example
https://github.com/projectdiscovery/nuclei/blob/195c80a9ff8a34359342b768f421134d0842edd9/v2/examples/simple.go#L94

## Checklist
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)