### PR TITLE
Markdown Export Sorting 

### DIFF
--- a/v2/internal/runner/options.go
+++ b/v2/internal/runner/options.go
@@ -412,7 +412,7 @@ func readEnvInputVars(options *types.Options) {
 	options.MarkdownExportSortMode = strings.ToLower(os.Getenv("MARKDOWN_EXPORT_SORT_MODE"))
 	// If the user has not specified a valid sort mode, use the default
 	if options.MarkdownExportSortMode != "template" && options.MarkdownExportSortMode != "severity" && options.MarkdownExportSortMode != "host" {
-		options.MarkdownExportSortMode = "none"
+		options.MarkdownExportSortMode = ""
 	}
 }
 

--- a/v2/internal/runner/options.go
+++ b/v2/internal/runner/options.go
@@ -407,6 +407,13 @@ func readEnvInputVars(options *types.Options) {
 	options.GitLabTemplateDisableDownload = getBoolEnvValue("DISABLE_NUCLEI_TEMPLATES_GITLAB_DOWNLOAD")
 	options.AwsTemplateDisableDownload = getBoolEnvValue("DISABLE_NUCLEI_TEMPLATES_AWS_DOWNLOAD")
 	options.AzureTemplateDisableDownload = getBoolEnvValue("DISABLE_NUCLEI_TEMPLATES_AZURE_DOWNLOAD")
+
+	// Options to modify the behavior of exporters
+	options.MarkdownExportSortMode = strings.ToLower(os.Getenv("MARKDOWN_EXPORT_SORT_MODE"))
+	// If the user has not specified a valid sort mode, use the default
+	if options.MarkdownExportSortMode != "template" && options.MarkdownExportSortMode != "severity" && options.MarkdownExportSortMode != "host" {
+		options.MarkdownExportSortMode = "none"
+	}
 }
 
 func getBoolEnvValue(key string) bool {

--- a/v2/internal/runner/runner.go
+++ b/v2/internal/runner/runner.go
@@ -346,12 +346,14 @@ func createReportingOptions(options *types.Options) (*reporting.Options, error) 
 			reportingOptions.MarkdownExporter = &markdown.Options{
 				Directory:         options.MarkdownExportDirectory,
 				IncludeRawPayload: !options.OmitRawRequests,
+				SortMode:          options.MarkdownExportSortMode,
 			}
 		} else {
 			reportingOptions = &reporting.Options{}
 			reportingOptions.MarkdownExporter = &markdown.Options{
 				Directory:         options.MarkdownExportDirectory,
 				IncludeRawPayload: !options.OmitRawRequests,
+				SortMode:          options.MarkdownExportSortMode,
 			}
 		}
 	}

--- a/v2/pkg/reporting/exporters/markdown/markdown.go
+++ b/v2/pkg/reporting/exporters/markdown/markdown.go
@@ -2,6 +2,7 @@ package markdown
 
 import (
 	"bytes"
+	"github.com/projectdiscovery/gologger"
 	"os"
 	"path/filepath"
 	"strings"
@@ -25,6 +26,7 @@ type Options struct {
 	// Directory is the directory to export found results to
 	Directory         string `yaml:"directory"`
 	IncludeRawPayload bool   `yaml:"include-raw-payload"`
+	SortMode          string `yaml:"sort-mode"`
 }
 
 // New creates a new markdown exporter integration client based on options.
@@ -69,7 +71,36 @@ func (exporter *Exporter) Export(event *output.ResultEvent) error {
 	defer file.Close()
 
 	filename := createFileName(event)
-	host := util.CreateLink(event.Host, filename)
+
+	// If the sort mode is set to severity, host, or template, then we need to get a safe version of the name for a
+	// subdirectory to store the file in.
+	// This will allow us to sort the files into subdirectories based on the sort mode. The subdirectory will need to
+	// be created if it does not exist.
+	fileUrl := filename
+	subdirectory := ""
+	switch exporter.options.SortMode {
+	case "severity":
+		subdirectory = event.Info.SeverityHolder.Severity.String()
+	case "host":
+		subdirectory = event.Host
+	case "template":
+		subdirectory = event.TemplateID
+	}
+	if subdirectory != "" {
+		// Sanitize the subdirectory name to remove any characters that are not allowed in a directory name
+		subdirectory = sanitizeFilename(subdirectory)
+
+		// Prepend the subdirectory name to the filename for the fileUrl
+		fileUrl = filepath.Join(subdirectory, filename)
+
+		// Create the subdirectory if it does not exist
+		err = os.MkdirAll(filepath.Join(exporter.directory, subdirectory), 0755)
+		if err != nil {
+			gologger.Warning().Msgf("Could not create subdirectory for markdown report: %s", err)
+		}
+	}
+
+	host := util.CreateLink(event.Host, fileUrl)
 	finding := event.TemplateID + " " + event.MatcherName
 	severity := event.Info.SeverityHolder.Severity.String()
 
@@ -85,7 +116,7 @@ func (exporter *Exporter) Export(event *output.ResultEvent) error {
 	dataBuilder.WriteString(format.CreateReportDescription(event, util.MarkdownFormatter{}))
 	data := dataBuilder.Bytes()
 
-	return os.WriteFile(filepath.Join(exporter.directory, filename), data, 0644)
+	return os.WriteFile(filepath.Join(exporter.directory, subdirectory, filename), data, 0644)
 }
 
 func createFileName(event *output.ResultEvent) string {

--- a/v2/pkg/reporting/exporters/markdown/markdown.go
+++ b/v2/pkg/reporting/exporters/markdown/markdown.go
@@ -2,14 +2,16 @@ package markdown
 
 import (
 	"bytes"
-	"github.com/projectdiscovery/gologger"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/projectdiscovery/gologger"
+
 	"github.com/projectdiscovery/nuclei/v2/pkg/output"
 	"github.com/projectdiscovery/nuclei/v2/pkg/reporting/exporters/markdown/util"
 	"github.com/projectdiscovery/nuclei/v2/pkg/reporting/format"
+	fileutil "github.com/projectdiscovery/utils/file"
 	stringsutil "github.com/projectdiscovery/utils/strings"
 )
 
@@ -94,8 +96,7 @@ func (exporter *Exporter) Export(event *output.ResultEvent) error {
 		fileUrl = filepath.Join(subdirectory, filename)
 
 		// Create the subdirectory if it does not exist
-		err = os.MkdirAll(filepath.Join(exporter.directory, subdirectory), 0755)
-		if err != nil {
+		if err = fileutil.CreateFolders(filepath.Join(exporter.directory, subdirectory)); err != nil {
 			gologger.Warning().Msgf("Could not create subdirectory for markdown report: %s", err)
 		}
 	}

--- a/v2/pkg/types/types.go
+++ b/v2/pkg/types/types.go
@@ -93,6 +93,8 @@ type Options struct {
 	ReportingConfig string
 	// MarkdownExportDirectory is the directory to export reports in Markdown format
 	MarkdownExportDirectory string
+	// MarkdownExportSortMode is the method to sort the markdown reports (options: severity, template, host, none)
+	MarkdownExportSortMode string
 	// SarifExport is the file to export sarif output format to
 	SarifExport string
 	// CloudURL is the URL for the nuclei cloud endpoint


### PR DESCRIPTION
## Proposed changes
Addresses #3596 by adding support for a `MARKDOWN_EXPORT_SORT_MODE` environment variable when the `-me`/`-markdown-export` is present. This allows the following options:

- `template` sorts all markdown report files into a subdirectory based on the template ID
- `severity` sorts all markdown report files into a subdirectory based on the severity of the template
- `host` sorts all markdown report files into a subdirectory based on the hostname of the finding

Any other value keeps all markdown report files in the same root directory specified by the `-me`/`-markdown-export` flag.

In all cases, the `index.md` is at the root of the markdown export directory, and relative links are updated to include subdirectory paths if appropriate.

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)