### PR TITLE
Support wildcard matching for the `-template-id` parameter

### DIFF
--- a/v2/cmd/nuclei/main.go
+++ b/v2/cmd/nuclei/main.go
@@ -150,7 +150,7 @@ on extensive configurability, massive extensibility and ease of use.`)
 		flagSet.StringSliceVar(&options.Tags, "tags", nil, "templates to run based on tags (comma-separated, file)", goflags.FileNormalizedStringSliceOptions),
 		flagSet.StringSliceVarP(&options.ExcludeTags, "exclude-tags", "etags", nil, "templates to exclude based on tags (comma-separated, file)", goflags.FileNormalizedStringSliceOptions),
 		flagSet.StringSliceVarP(&options.IncludeTags, "include-tags", "itags", nil, "tags to be executed even if they are excluded either by default or configuration", goflags.FileNormalizedStringSliceOptions), // TODO show default deny list
-		flagSet.StringSliceVarP(&options.IncludeIds, "template-id", "id", nil, "templates to run based on template ids (comma-separated, file)", goflags.FileNormalizedStringSliceOptions),
+		flagSet.StringSliceVarP(&options.IncludeIds, "template-id", "id", nil, "templates to run based on template ids (comma-separated, file, allow-wildcard)", goflags.FileNormalizedStringSliceOptions),
 		flagSet.StringSliceVarP(&options.ExcludeIds, "exclude-id", "eid", nil, "templates to exclude based on template ids (comma-separated, file)", goflags.FileNormalizedStringSliceOptions),
 		flagSet.StringSliceVarP(&options.IncludeTemplates, "include-templates", "it", nil, "templates to be executed even if they are excluded either by default or configuration", goflags.FileCommaSeparatedStringSliceOptions),
 		flagSet.StringSliceVarP(&options.ExcludedTemplates, "exclude-templates", "et", nil, "template or template directory to exclude (comma-separated, file)", goflags.FileCommaSeparatedStringSliceOptions),

--- a/v2/pkg/catalog/loader/filter/tag_filter.go
+++ b/v2/pkg/catalog/loader/filter/tag_filter.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"path/filepath"
 
 	"github.com/Knetic/govaluate"
 	"github.com/projectdiscovery/gologger"
@@ -170,9 +171,19 @@ func isIdMatch(tagFilter *TagFilter, templateId string) bool {
 	if len(tagFilter.excludeIds) == 0 && len(tagFilter.allowedIds) == 0 {
 		return true
 	}
-	included := true
+	included := false
 	if len(tagFilter.allowedIds) > 0 {
-		_, included = tagFilter.allowedIds[templateId]
+		for id, _ := range tagFilter.allowedIds {
+			match, err := filepath.Match(id, templateId)
+			if err != nil {
+				continue
+			}
+
+			if match {
+				included = true
+				break
+			}
+		}
 	}
 
 	excluded := false

--- a/v2/pkg/catalog/loader/filter/tag_filter.go
+++ b/v2/pkg/catalog/loader/filter/tag_filter.go
@@ -173,7 +173,7 @@ func isIdMatch(tagFilter *TagFilter, templateId string) bool {
 	}
 	included := false
 	if len(tagFilter.allowedIds) > 0 {
-		for id, _ := range tagFilter.allowedIds {
+		for id := range tagFilter.allowedIds {
 			match, err := filepath.Match(id, templateId)
 			if err != nil {
 				continue

--- a/v2/pkg/catalog/loader/filter/tag_filter.go
+++ b/v2/pkg/catalog/loader/filter/tag_filter.go
@@ -171,18 +171,17 @@ func isIdMatch(tagFilter *TagFilter, templateId string) bool {
 	if len(tagFilter.excludeIds) == 0 && len(tagFilter.allowedIds) == 0 {
 		return true
 	}
-	included := false
-	if len(tagFilter.allowedIds) > 0 {
-		for id := range tagFilter.allowedIds {
-			match, err := filepath.Match(id, templateId)
-			if err != nil {
-				continue
-			}
 
-			if match {
-				included = true
-				break
-			}
+	included := len(tagFilter.allowedIds) == 0
+	for id := range tagFilter.allowedIds {
+		match, err := filepath.Match(id, templateId)
+		if err != nil {
+			continue
+		}
+
+		if match {
+			included = true
+			break
 		}
 	}
 


### PR DESCRIPTION
Hi, in order to specify plugins more efficiently and conveniently by template-id, I have added wildcard matching functionality to the `-template-id` parameter.

Example:

```
$ ./nuclei -duc -id '*fingerprint*,*waf*,metatag-cms' -u shellcodes.org 

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v2.9.6

		projectdiscovery.io

[WRN] Found 3150 templates loaded with deprecated protocol syntax, update before v2.9.5 for continued support.
[INF] Current nuclei version: v2.9.6 (outdated)
[INF] Current nuclei-templates version: v9.5.8 (latest)
[INF] New templates added in latest release: 113
[INF] Templates loaded for current scan: 12
[INF] Targets loaded for current scan: 1
[INF] Running httpx on input host
[INF] Found 1 URL from httpx
[INF] Templates clustered: 2 (Reduced 1 Requests)
[mx-fingerprint] [dns] [info] shellcodes.org [10 mxdomain.qq.com.]
[dns-waf-detect:cloudflare] [dns] [info] shellcodes.org
[waf-detect:cloudflare] [http] [info] https://shellcodes.org/
[waf-detect:nginxgeneric] [http] [info] https://shellcodes.org/
[metatag-cms] [http] [info] https://shellcodes.org [Org Mode]
[nameserver-fingerprint] [dns] [info] shellcodes.org [hank.ns.cloudflare.com.,isla.ns.cloudflare.com.]
```