### PR TITLE
Omit Empty Fields

### DIFF
--- a/v2/pkg/model/model.go
+++ b/v2/pkg/model/model.go
@@ -47,7 +47,7 @@ type Info struct {
 	// examples:
 	//   - value: >
 	//       []string{"https://github.com/strapi/strapi", "https://github.com/getgrav/grav"}
-	Reference stringslice.RawStringSlice `json:"reference,omitempty" yaml:"reference,omitempty" jsonschema:"title=references for the template,description=Links relevant to the template"`
+	Reference *stringslice.RawStringSlice `json:"reference,omitempty" yaml:"reference,omitempty" jsonschema:"title=references for the template,description=Links relevant to the template"`
 	// description: |
 	//   Severity of the template.
 	SeverityHolder severity.Holder `json:"severity,omitempty" yaml:"severity,omitempty"`

--- a/v2/pkg/model/model.go
+++ b/v2/pkg/model/model.go
@@ -40,6 +40,15 @@ type Info struct {
 	//   - value: "\"Subversion ALM for the enterprise before 8.8.2 allows reflected XSS at multiple locations\""
 	Description string `json:"description,omitempty" yaml:"description,omitempty" jsonschema:"title=description of the template,description=In-depth explanation on what the template does,example=Bower is a package manager which stores package information in the bower.json file"`
 	// description: |
+	//   References for the template.
+	//
+	//   This should contain links relevant to the template.
+	//
+	// examples:
+	//   - value: >
+	//       []string{"https://github.com/strapi/strapi", "https://github.com/getgrav/grav"}
+	Reference stringslice.RawStringSlice `json:"reference,omitempty" yaml:"reference,omitempty" jsonschema:"title=references for the template,description=Links relevant to the template"`
+	// description: |
 	//   Severity of the template.
 	SeverityHolder severity.Holder `json:"severity,omitempty" yaml:"severity,omitempty"`
 	// description: |

--- a/v2/pkg/model/model.go
+++ b/v2/pkg/model/model.go
@@ -40,15 +40,6 @@ type Info struct {
 	//   - value: "\"Subversion ALM for the enterprise before 8.8.2 allows reflected XSS at multiple locations\""
 	Description string `json:"description,omitempty" yaml:"description,omitempty" jsonschema:"title=description of the template,description=In-depth explanation on what the template does,example=Bower is a package manager which stores package information in the bower.json file"`
 	// description: |
-	//   References for the template.
-	//
-	//   This should contain links relevant to the template.
-	//
-	// examples:
-	//   - value: >
-	//       []string{"https://github.com/strapi/strapi", "https://github.com/getgrav/grav"}
-	Reference stringslice.RawStringSlice `json:"reference,omitempty" yaml:"reference,omitempty" jsonschema:"title=references for the template,description=Links relevant to the template"`
-	// description: |
 	//   Severity of the template.
 	SeverityHolder severity.Holder `json:"severity,omitempty" yaml:"severity,omitempty"`
 	// description: |

--- a/v2/pkg/model/model_test.go
+++ b/v2/pkg/model/model_test.go
@@ -18,6 +18,7 @@ func TestInfoJsonMarshal(t *testing.T) {
 		Description:    "Test description",
 		SeverityHolder: severity.Holder{Severity: severity.High},
 		Tags:           stringslice.StringSlice{Value: []string{"cve", "misc"}},
+		Reference:      stringslice.NewRaw("Reference1"),
 		Metadata: map[string]interface{}{
 			"string_key": "string_value",
 			"array_key":  []string{"array_value1", "array_value2"},
@@ -30,7 +31,7 @@ func TestInfoJsonMarshal(t *testing.T) {
 	result, err := json.Marshal(&info)
 	assert.Nil(t, err)
 
-	expected := `{"name":"Test Template Name","author":["forgedhallpass","ice3man"],"tags":["cve","misc"],"description":"Test description","severity":"high","metadata":{"array_key":["array_value1","array_value2"],"map_key":{"key1":"val1"},"string_key":"string_value"}}`
+	expected := `{"name":"Test Template Name","author":["forgedhallpass","ice3man"],"tags":["cve","misc"],"description":"Test description","reference":"Reference1","severity":"high","metadata":{"array_key":["array_value1","array_value2"],"map_key":{"key1":"val1"},"string_key":"string_value"}}`
 	assert.Equal(t, expected, string(result))
 }
 
@@ -41,6 +42,7 @@ func TestInfoYamlMarshal(t *testing.T) {
 		Description:    "Test description",
 		SeverityHolder: severity.Holder{Severity: severity.High},
 		Tags:           stringslice.StringSlice{Value: []string{"cve", "misc"}},
+		Reference:      stringslice.NewRaw("Reference1"),
 		Metadata: map[string]interface{}{
 			"string_key": "string_value",
 			"array_key":  []string{"array_value1", "array_value2"},
@@ -61,6 +63,7 @@ tags:
 - cve
 - misc
 description: Test description
+reference: Reference1
 severity: high
 metadata:
   array_key:
@@ -96,6 +99,7 @@ func TestUnmarshal(t *testing.T) {
 		assert.Equal(t, info.Authors.ToSlice(), authors)
 		assert.Equal(t, info.Tags.ToSlice(), tags)
 		assert.Equal(t, info.SeverityHolder.Severity, severity.Critical)
+		assert.Equal(t, info.Reference.ToSlice(), references)
 		assert.Equal(t, info.Metadata, dynamicKeysMap)
 		return info
 	}

--- a/v2/pkg/model/model_test.go
+++ b/v2/pkg/model/model_test.go
@@ -18,7 +18,7 @@ func TestInfoJsonMarshal(t *testing.T) {
 		Description:    "Test description",
 		SeverityHolder: severity.Holder{Severity: severity.High},
 		Tags:           stringslice.StringSlice{Value: []string{"cve", "misc"}},
-		Reference:      stringslice.NewPointer("Reference1"),
+		Reference:      stringslice.NewRawStringSlice("Reference1"),
 		Metadata: map[string]interface{}{
 			"string_key": "string_value",
 			"array_key":  []string{"array_value1", "array_value2"},
@@ -42,7 +42,7 @@ func TestInfoYamlMarshal(t *testing.T) {
 		Description:    "Test description",
 		SeverityHolder: severity.Holder{Severity: severity.High},
 		Tags:           stringslice.StringSlice{Value: []string{"cve", "misc"}},
-		Reference:      stringslice.NewPointer("Reference1"),
+		Reference:      stringslice.NewRawStringSlice("Reference1"),
 		Metadata: map[string]interface{}{
 			"string_key": "string_value",
 			"array_key":  []string{"array_value1", "array_value2"},

--- a/v2/pkg/model/model_test.go
+++ b/v2/pkg/model/model_test.go
@@ -18,7 +18,6 @@ func TestInfoJsonMarshal(t *testing.T) {
 		Description:    "Test description",
 		SeverityHolder: severity.Holder{Severity: severity.High},
 		Tags:           stringslice.StringSlice{Value: []string{"cve", "misc"}},
-		Reference:      stringslice.NewRaw("Reference1"),
 		Metadata: map[string]interface{}{
 			"string_key": "string_value",
 			"array_key":  []string{"array_value1", "array_value2"},
@@ -31,7 +30,7 @@ func TestInfoJsonMarshal(t *testing.T) {
 	result, err := json.Marshal(&info)
 	assert.Nil(t, err)
 
-	expected := `{"name":"Test Template Name","author":["forgedhallpass","ice3man"],"tags":["cve","misc"],"description":"Test description","reference":"Reference1","severity":"high","metadata":{"array_key":["array_value1","array_value2"],"map_key":{"key1":"val1"},"string_key":"string_value"}}`
+	expected := `{"name":"Test Template Name","author":["forgedhallpass","ice3man"],"tags":["cve","misc"],"description":"Test description","severity":"high","metadata":{"array_key":["array_value1","array_value2"],"map_key":{"key1":"val1"},"string_key":"string_value"}}`
 	assert.Equal(t, expected, string(result))
 }
 
@@ -42,7 +41,6 @@ func TestInfoYamlMarshal(t *testing.T) {
 		Description:    "Test description",
 		SeverityHolder: severity.Holder{Severity: severity.High},
 		Tags:           stringslice.StringSlice{Value: []string{"cve", "misc"}},
-		Reference:      stringslice.NewRaw("Reference1"),
 		Metadata: map[string]interface{}{
 			"string_key": "string_value",
 			"array_key":  []string{"array_value1", "array_value2"},
@@ -63,7 +61,6 @@ tags:
 - cve
 - misc
 description: Test description
-reference: Reference1
 severity: high
 metadata:
   array_key:
@@ -99,7 +96,6 @@ func TestUnmarshal(t *testing.T) {
 		assert.Equal(t, info.Authors.ToSlice(), authors)
 		assert.Equal(t, info.Tags.ToSlice(), tags)
 		assert.Equal(t, info.SeverityHolder.Severity, severity.Critical)
-		assert.Equal(t, info.Reference.ToSlice(), references)
 		assert.Equal(t, info.Metadata, dynamicKeysMap)
 		return info
 	}

--- a/v2/pkg/model/model_test.go
+++ b/v2/pkg/model/model_test.go
@@ -18,7 +18,7 @@ func TestInfoJsonMarshal(t *testing.T) {
 		Description:    "Test description",
 		SeverityHolder: severity.Holder{Severity: severity.High},
 		Tags:           stringslice.StringSlice{Value: []string{"cve", "misc"}},
-		Reference:      stringslice.NewRaw("Reference1"),
+		Reference:      stringslice.NewPointer("Reference1"),
 		Metadata: map[string]interface{}{
 			"string_key": "string_value",
 			"array_key":  []string{"array_value1", "array_value2"},
@@ -42,7 +42,7 @@ func TestInfoYamlMarshal(t *testing.T) {
 		Description:    "Test description",
 		SeverityHolder: severity.Holder{Severity: severity.High},
 		Tags:           stringslice.StringSlice{Value: []string{"cve", "misc"}},
-		Reference:      stringslice.NewRaw("Reference1"),
+		Reference:      stringslice.NewPointer("Reference1"),
 		Metadata: map[string]interface{}{
 			"string_key": "string_value",
 			"array_key":  []string{"array_value1", "array_value2"},

--- a/v2/pkg/model/types/stringslice/stringslice_raw.go
+++ b/v2/pkg/model/types/stringslice/stringslice_raw.go
@@ -4,15 +4,10 @@ type RawStringSlice struct {
 	StringSlice
 }
 
-func NewRaw(value interface{}) RawStringSlice {
-	return RawStringSlice{StringSlice: StringSlice{Value: value}}
+func NewRawStringSlice(value interface{}) *RawStringSlice {
+	return &RawStringSlice{StringSlice: StringSlice{Value: value}}
 }
 
-func NewPointer(value interface{}) *RawStringSlice {
-	s := NewRaw(value)
-	return &s
-}
-
-func (rawStringSlice RawStringSlice) Normalize(value string) string {
+func (rawStringSlice *RawStringSlice) Normalize(value string) string {
 	return value
 }

--- a/v2/pkg/model/types/stringslice/stringslice_raw.go
+++ b/v2/pkg/model/types/stringslice/stringslice_raw.go
@@ -8,6 +8,11 @@ func NewRaw(value interface{}) RawStringSlice {
 	return RawStringSlice{StringSlice: StringSlice{Value: value}}
 }
 
+func NewPointer(value interface{}) *RawStringSlice {
+	s := NewRaw(value)
+	return &s
+}
+
 func (rawStringSlice RawStringSlice) Normalize(value string) string {
 	return value
 }

--- a/v2/pkg/output/output.go
+++ b/v2/pkg/output/output.go
@@ -142,9 +142,9 @@ type ResultEvent struct {
 	// Only applicable if the report is for HTTP.
 	CURLCommand string `json:"curl-command,omitempty"`
 	// MatcherStatus is the status of the match
-	MatcherStatus bool `json:"matcher-status"`
+	MatcherStatus bool `json:"matcher-status,omitempty"`
 	// Lines is the line count for the specified match
-	Lines []int `json:"matched-line"`
+	Lines []int `json:"matched-line,omitempty"`
 
 	FileToIndexPosition map[string]int `json:"-"`
 }

--- a/v2/pkg/output/output.go
+++ b/v2/pkg/output/output.go
@@ -142,7 +142,7 @@ type ResultEvent struct {
 	// Only applicable if the report is for HTTP.
 	CURLCommand string `json:"curl-command,omitempty"`
 	// MatcherStatus is the status of the match
-	MatcherStatus bool `json:"matcher-status,omitempty"`
+	MatcherStatus bool `json:"matcher-status"`
 	// Lines is the line count for the specified match
 	Lines []int `json:"matched-line,omitempty"`
 

--- a/v2/pkg/reporting/format/format_utils.go
+++ b/v2/pkg/reporting/format/format_utils.go
@@ -112,6 +112,19 @@ func CreateReportDescription(event *output.ResultEvent, formatter ResultFormatte
 		}
 	}
 
+	reference := event.Info.Reference
+	if !reference.IsEmpty() {
+		builder.WriteString("\nReferences: \n")
+
+		referenceSlice := reference.ToSlice()
+		for i, item := range referenceSlice {
+			builder.WriteString("- ")
+			builder.WriteString(item)
+			if len(referenceSlice)-1 != i {
+				builder.WriteString("\n")
+			}
+		}
+	}
 	builder.WriteString("\n")
 
 	if event.CURLCommand != "" {

--- a/v2/pkg/reporting/format/format_utils.go
+++ b/v2/pkg/reporting/format/format_utils.go
@@ -112,19 +112,6 @@ func CreateReportDescription(event *output.ResultEvent, formatter ResultFormatte
 		}
 	}
 
-	reference := event.Info.Reference
-	if !reference.IsEmpty() {
-		builder.WriteString("\nReferences: \n")
-
-		referenceSlice := reference.ToSlice()
-		for i, item := range referenceSlice {
-			builder.WriteString("- ")
-			builder.WriteString(item)
-			if len(referenceSlice)-1 != i {
-				builder.WriteString("\n")
-			}
-		}
-	}
 	builder.WriteString("\n")
 
 	if event.CURLCommand != "" {

--- a/v2/pkg/reporting/format/format_utils_test.go
+++ b/v2/pkg/reporting/format/format_utils_test.go
@@ -18,7 +18,7 @@ func TestToMarkdownTableString(t *testing.T) {
 		Description:    "Test description",
 		SeverityHolder: severity.Holder{Severity: severity.High},
 		Tags:           stringslice.StringSlice{Value: []string{"cve", "misc"}},
-		Reference:      stringslice.NewRaw("reference1"),
+		Reference:      stringslice.NewPointer("reference1"),
 		Metadata: map[string]interface{}{
 			"customDynamicKey1": "customDynamicValue1",
 			"customDynamicKey2": "customDynamicValue2",

--- a/v2/pkg/reporting/format/format_utils_test.go
+++ b/v2/pkg/reporting/format/format_utils_test.go
@@ -18,6 +18,7 @@ func TestToMarkdownTableString(t *testing.T) {
 		Description:    "Test description",
 		SeverityHolder: severity.Holder{Severity: severity.High},
 		Tags:           stringslice.StringSlice{Value: []string{"cve", "misc"}},
+		Reference:      stringslice.NewRaw("reference1"),
 		Metadata: map[string]interface{}{
 			"customDynamicKey1": "customDynamicValue1",
 			"customDynamicKey2": "customDynamicValue2",

--- a/v2/pkg/reporting/format/format_utils_test.go
+++ b/v2/pkg/reporting/format/format_utils_test.go
@@ -18,7 +18,6 @@ func TestToMarkdownTableString(t *testing.T) {
 		Description:    "Test description",
 		SeverityHolder: severity.Holder{Severity: severity.High},
 		Tags:           stringslice.StringSlice{Value: []string{"cve", "misc"}},
-		Reference:      stringslice.NewRaw("reference1"),
 		Metadata: map[string]interface{}{
 			"customDynamicKey1": "customDynamicValue1",
 			"customDynamicKey2": "customDynamicValue2",

--- a/v2/pkg/reporting/format/format_utils_test.go
+++ b/v2/pkg/reporting/format/format_utils_test.go
@@ -1,9 +1,10 @@
 package format
 
 import (
-	"github.com/stretchr/testify/assert"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/projectdiscovery/nuclei/v2/pkg/model"
 	"github.com/projectdiscovery/nuclei/v2/pkg/model/types/severity"
@@ -18,7 +19,7 @@ func TestToMarkdownTableString(t *testing.T) {
 		Description:    "Test description",
 		SeverityHolder: severity.Holder{Severity: severity.High},
 		Tags:           stringslice.StringSlice{Value: []string{"cve", "misc"}},
-		Reference:      stringslice.NewPointer("reference1"),
+		Reference:      stringslice.NewRawStringSlice("reference1"),
 		Metadata: map[string]interface{}{
 			"customDynamicKey1": "customDynamicValue1",
 			"customDynamicKey2": "customDynamicValue2",

--- a/v2/pkg/templates/templates_doc_examples.go
+++ b/v2/pkg/templates/templates_doc_examples.go
@@ -20,7 +20,7 @@ var (
 		Name:           "Argument Injection in Ruby Dragonfly",
 		Authors:        stringslice.StringSlice{Value: "0xspara"},
 		SeverityHolder: severity.Holder{Severity: severity.High},
-		Reference:      stringslice.NewRaw("https://zxsecurity.co.nz/research/argunment-injection-ruby-dragonfly/"),
+		Reference:      stringslice.NewPointer("https://zxsecurity.co.nz/research/argunment-injection-ruby-dragonfly/"),
 		Tags:           stringslice.StringSlice{Value: "cve,cve2021,rce,ruby"},
 	}
 	exampleNormalHTTPRequest = &http.Request{

--- a/v2/pkg/templates/templates_doc_examples.go
+++ b/v2/pkg/templates/templates_doc_examples.go
@@ -20,6 +20,7 @@ var (
 		Name:           "Argument Injection in Ruby Dragonfly",
 		Authors:        stringslice.StringSlice{Value: "0xspara"},
 		SeverityHolder: severity.Holder{Severity: severity.High},
+		Reference:      stringslice.NewRaw("https://zxsecurity.co.nz/research/argunment-injection-ruby-dragonfly/"),
 		Tags:           stringslice.StringSlice{Value: "cve,cve2021,rce,ruby"},
 	}
 	exampleNormalHTTPRequest = &http.Request{

--- a/v2/pkg/templates/templates_doc_examples.go
+++ b/v2/pkg/templates/templates_doc_examples.go
@@ -20,7 +20,7 @@ var (
 		Name:           "Argument Injection in Ruby Dragonfly",
 		Authors:        stringslice.StringSlice{Value: "0xspara"},
 		SeverityHolder: severity.Holder{Severity: severity.High},
-		Reference:      stringslice.NewPointer("https://zxsecurity.co.nz/research/argunment-injection-ruby-dragonfly/"),
+		Reference:      stringslice.NewRawStringSlice("https://zxsecurity.co.nz/research/argunment-injection-ruby-dragonfly/"),
 		Tags:           stringslice.StringSlice{Value: "cve,cve2021,rce,ruby"},
 	}
 	exampleNormalHTTPRequest = &http.Request{

--- a/v2/pkg/templates/templates_doc_examples.go
+++ b/v2/pkg/templates/templates_doc_examples.go
@@ -20,7 +20,6 @@ var (
 		Name:           "Argument Injection in Ruby Dragonfly",
 		Authors:        stringslice.StringSlice{Value: "0xspara"},
 		SeverityHolder: severity.Holder{Severity: severity.High},
-		Reference:      stringslice.NewRaw("https://zxsecurity.co.nz/research/argunment-injection-ruby-dragonfly/"),
 		Tags:           stringslice.StringSlice{Value: "cve,cve2021,rce,ruby"},
 	}
 	exampleNormalHTTPRequest = &http.Request{


### PR DESCRIPTION
## Proposed changes

Addresses #3892.

- Adds the `omitempty` property to the `Lines` property
- Switch the `reference` field to a pointer to a `RawStringSlice` since structs themselves (e.g. `RawStringSlice`) don't properly follow `omitempty` marshaling since they aren't nilable

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)