### PR TITLE
Read-only filesystem fixes for when ~/.config is not writable

### DIFF
--- a/v2/pkg/catalog/config/nucleiconfig.go
+++ b/v2/pkg/catalog/config/nucleiconfig.go
@@ -291,7 +291,6 @@ func init() {
 	}
 	homeDir, _ := os.UserHomeDir()
 	DefaultConfig = &Config{
-		//homeDir:   folderutil.HomeDirOrDefault(""),
 		homeDir:   homeDir,
 		configDir: ConfigDir,
 	}
@@ -315,7 +314,6 @@ func getDefaultConfigDir() string {
 	// Review Needed:  Earlier a dependency was used to locate home dir
 	// i.e 	"github.com/mitchellh/go-homedir" not sure if it is needed
 	// Even if such case exists it should be abstracted via below function call in utils/folder
-	//homedir := folderutil.HomeDirOrDefault("")
 	// TBD: we should probably stick to specification and use config directories provided by distro
 	// instead of manually creating one since $HOME/.config/ is config directory of Linux desktops
 	// Ref: https://pkg.go.dev/os#UserConfigDir

--- a/v2/pkg/catalog/config/nucleiconfig.go
+++ b/v2/pkg/catalog/config/nucleiconfig.go
@@ -12,7 +12,6 @@ import (
 	"github.com/projectdiscovery/gologger"
 	errorutil "github.com/projectdiscovery/utils/errors"
 	fileutil "github.com/projectdiscovery/utils/file"
-	folderutil "github.com/projectdiscovery/utils/folder"
 )
 
 // DefaultConfig is the default nuclei configuration
@@ -290,8 +289,10 @@ func init() {
 			gologger.Error().Msgf("failed to create config directory at %v got: %s", ConfigDir, err)
 		}
 	}
+	homeDir, _ := os.UserHomeDir()
 	DefaultConfig = &Config{
-		homeDir:   folderutil.HomeDirOrDefault(""),
+		//homeDir:   folderutil.HomeDirOrDefault(""),
+		homeDir:   homeDir,
 		configDir: ConfigDir,
 	}
 	// try to read config from file
@@ -314,11 +315,12 @@ func getDefaultConfigDir() string {
 	// Review Needed:  Earlier a dependency was used to locate home dir
 	// i.e 	"github.com/mitchellh/go-homedir" not sure if it is needed
 	// Even if such case exists it should be abstracted via below function call in utils/folder
-	homedir := folderutil.HomeDirOrDefault("")
+	//homedir := folderutil.HomeDirOrDefault("")
 	// TBD: we should probably stick to specification and use config directories provided by distro
 	// instead of manually creating one since $HOME/.config/ is config directory of Linux desktops
 	// Ref: https://pkg.go.dev/os#UserConfigDir
 	// some distros like NixOS or others have totally different config directories this causes issues for us (since we are not using os.UserConfigDir)
+	homedir, _ := os.UserConfigDir()
 	userCfgDir := filepath.Join(homedir, ".config")
 	return filepath.Join(userCfgDir, "nuclei")
 }


### PR DESCRIPTION
## Proposed changes

When running nuclei in a lambda function, I ran into the issues described in https://github.com/projectdiscovery/nuclei/issues/3576. 

I've been using the changes locally for a few months with great success, but I understand that this might break existing installs so I am not sure if this is something that will even be considered.


I know there is a bit of testing and etc to sort out, but as I have not done any nuclei PRs out side of the templates project, I figured the best course of action was just to start a PR and get a dialog going.


## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)