### PR TITLE
Add '-Vf' parameter, allows specifying the file for multiple variables (#2347)

### DIFF
--- a/v2/cmd/integration-test/template-path.go
+++ b/v2/cmd/integration-test/template-path.go
@@ -20,7 +20,7 @@ var templatesPathTestCases = []TestCaseInfo{
 	//relative path
 	{Path: "dns/dns-saas-service-detection.yaml", TestCase: &relativePathTemplateTest{}},
 	//absolute path
-	{Path: fmt.Sprintf("%v/dns/cname-fingerprint.yaml", getTemplatePath()), TestCase: &absolutePathTemplateTest{}},
+	{Path: fmt.Sprintf("%v/dns/dns-saas-service-detection.yaml", getTemplatePath()), TestCase: &absolutePathTemplateTest{}},
 }
 
 type cwdTemplateTest struct{}

--- a/v2/cmd/integration-test/template-path.go
+++ b/v2/cmd/integration-test/template-path.go
@@ -18,7 +18,7 @@ var templatesPathTestCases = []TestCaseInfo{
 	//cwd
 	{Path: "./dns/cname-fingerprint.yaml", TestCase: &cwdTemplateTest{}},
 	//relative path
-	{Path: "dns/cname-fingerprint.yaml", TestCase: &relativePathTemplateTest{}},
+	{Path: "dns/dns-saas-service-detection.yaml", TestCase: &relativePathTemplateTest{}},
 	//absolute path
 	{Path: fmt.Sprintf("%v/dns/cname-fingerprint.yaml", getTemplatePath()), TestCase: &absolutePathTemplateTest{}},
 }

--- a/v2/cmd/nuclei/main.go
+++ b/v2/cmd/nuclei/main.go
@@ -191,6 +191,7 @@ on extensive configurability, massive extensibility and ease of use.`)
 		flagSet.StringVarP(&options.ReportingConfig, "report-config", "rc", "", "nuclei reporting module configuration file"), // TODO merge into the config file or rename to issue-tracking
 		flagSet.StringSliceVarP(&options.CustomHeaders, "header", "H", nil, "custom header/cookie to include in all http request in header:value format (cli, file)", goflags.FileStringSliceOptions),
 		flagSet.RuntimeMapVarP(&options.Vars, "var", "V", nil, "custom vars in key=value format"),
+		flagSet.StringVarP(&options.VarsFile, "var-file", "Vf", "", "custom vars in file (equal-sign-separated)"),
 		flagSet.StringVarP(&options.ResolversFile, "resolvers", "r", "", "file containing resolver list for nuclei"),
 		flagSet.BoolVarP(&options.SystemResolvers, "system-resolvers", "sr", false, "use system DNS resolving as error fallback"),
 		flagSet.BoolVarP(&options.DisableClustering, "disable-clustering", "dc", false, "disable clustering of requests"),

--- a/v2/pkg/protocols/common/generators/options.go
+++ b/v2/pkg/protocols/common/generators/options.go
@@ -1,8 +1,36 @@
 package generators
 
 import (
+	"os"
+	"bufio"
+	"strings"
 	"github.com/projectdiscovery/nuclei/v2/pkg/types"
 )
+
+func ReadVarsFromFile(path string) (map[string]interface{}, error) {
+	file, err := os.OpenFile(path, os.O_RDONLY, 0)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	m := make(map[string]interface{})
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		parts := strings.SplitN(scanner.Text(), "=", 2)
+		if len(parts) == 2 {
+			key := strings.TrimSpace(parts[0])
+			value := strings.TrimSpace(parts[1])
+			m[key] = value
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return m, nil
+}
 
 // BuildPayloadFromOptions returns a map with the payloads provided via CLI
 func BuildPayloadFromOptions(options *types.Options) map[string]interface{} {
@@ -15,6 +43,14 @@ func BuildPayloadFromOptions(options *types.Options) map[string]interface{} {
 	// merge with env vars
 	if options.EnvironmentVariables {
 		m = MergeMaps(EnvVars(), m)
+	}
+
+	// merge with vars from a file
+	if options.VarsFile != "" {
+		vars, err := ReadVarsFromFile(options.VarsFile)
+		if err == nil {
+			m = MergeMaps(vars)
+		}
 	}
 	return m
 }

--- a/v2/pkg/protocols/common/generators/options_test.go
+++ b/v2/pkg/protocols/common/generators/options_test.go
@@ -1,0 +1,43 @@
+package generators
+
+import (
+	"os"
+	"testing"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadVarsFromFile(t *testing.T) {
+	content := `var1=value1
+var2=value2
+var3=value3
+var1=value11
+var4=value4=
+var5
+var6 = value6`
+	tmp, err := os.CreateTemp("", "vars.*.txt")
+
+	if err != nil {
+		t.Fatalf("Create a file failed: %v", err)
+	}
+	defer tmp.Close()
+	defer os.Remove(tmp.Name())
+
+	if _, err := tmp.WriteString(content); err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+
+	vars, err := ReadVarsFromFile(tmp.Name())
+
+	if err != nil {
+		t.Fatalf("Read failed: %v", err)
+	}
+
+	got := map[string]interface{}{
+		"var1": "value11", // Override
+		"var2": "value2",
+		"var3": "value3",
+		"var4": "value4=",
+		"var6": "value6",
+	}
+	require.Equal(t, vars, got, "vars not equal")
+}

--- a/v2/pkg/protocols/common/generators/options_test.go
+++ b/v2/pkg/protocols/common/generators/options_test.go
@@ -10,6 +10,7 @@ func TestReadVarsFromFile(t *testing.T) {
 	content := `var1=value1
 var2=value2
 var3=value3
+
 var1=value11
 var4=value4=
 var5

--- a/v2/pkg/types/types.go
+++ b/v2/pkg/types/types.go
@@ -42,6 +42,8 @@ type Options struct {
 	CustomHeaders goflags.StringSlice
 	// Vars is the list of custom global vars
 	Vars goflags.RuntimeMap
+	// VarsFile is a file containing key=value
+	VarsFile string
 	// Severities filters templates based on their severity and only run the matching ones.
 	Severities severity.Severities
 	// ExcludeSeverities specifies severities to exclude


### PR DESCRIPTION
Add '-Vf' parameter, allows specifying the file for multiple variables #2347 

* Example:

stackoverflow.yaml:

```yaml
id: stackoverflow

info:
  name: StackOverflow User Name Information - Detect
  author: lu4nx
  severity: info

self-contained: true
http:
  - method: GET
    path:
      - "https://stackoverflow.com/{{var1}}/filter?search={{user}}"

    matchers-condition: and
    matchers:
      - type: word
        part: body
        words:
          - "{{match-text}}"
        negative: true

      - type: status
        status:
          - 200
```

vars.txt:

```
user=lu4nx
var1=users
match-text=<p>No users matched your search.</p>
```

```
$ ./nuclei -t /tmp/stackoverflow.yaml -duc -Vf /tmp/vars.txt                  

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v2.9.10

		projectdiscovery.io

[INF] Current nuclei version: v2.9.10 (outdated)
[INF] Current nuclei-templates version: v9.5.8 (outdated)
[INF] New templates added in latest release: 113
[INF] Templates loaded for current scan: 1
[stackoverflow] [http] [info] https://stackoverflow.com/users/filter?search=lu4nx
```


