### PR TITLE
remove duplicated outputwriter(interactsh) call

### DIFF
--- a/v2/pkg/catalog/config/constants.go
+++ b/v2/pkg/catalog/config/constants.go
@@ -17,7 +17,7 @@ const (
 	CLIConfigFileName               = "config.yaml"
 	ReportingConfigFilename         = "reporting-config.yaml"
 	// Version is the current version of nuclei
-	Version = `v2.9.10`
+	Version = `v2.9.11-dev`
 	// Directory Names of custom templates
 	CustomS3TemplatesDirName     = "s3"
 	CustomGitHubTemplatesDirName = "github"

--- a/v2/pkg/protocols/common/interactsh/interactsh.go
+++ b/v2/pkg/protocols/common/interactsh/interactsh.go
@@ -20,7 +20,6 @@ import (
 	"github.com/projectdiscovery/nuclei/v2/pkg/operators"
 	"github.com/projectdiscovery/nuclei/v2/pkg/output"
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/helpers/responsehighlighter"
-	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/helpers/writer"
 	errorutil "github.com/projectdiscovery/utils/errors"
 	stringsutil "github.com/projectdiscovery/utils/strings"
 )
@@ -179,11 +178,9 @@ func (c *Client) processInteractionForRequest(interaction *server.Interaction, d
 		c.debugPrintInteraction(interaction, data.Event.OperatorsResult)
 	}
 
-	if writer.WriteResult(data.Event, c.options.Output, c.options.Progress, c.options.IssuesClient) {
-		c.matched.Store(true)
-		if requestShouldStopAtFirstMatch(data) || c.options.StopAtFirstMatch {
-			_ = c.matchedTemplates.SetWithExpire(hash(data.Event.InternalEvent), true, defaultInteractionDuration)
-		}
+	c.matched.Store(true)
+	if requestShouldStopAtFirstMatch(data) || c.options.StopAtFirstMatch {
+		_ = c.matchedTemplates.SetWithExpire(hash(data.Event.InternalEvent), true, defaultInteractionDuration)
 	}
 
 	return true


### PR DESCRIPTION
## Proposed Changes

-  writer.WriteResult was called in interactsh package even though we usually manage result event in common/executor package which caused duplicated result on cli
- closes #4041 

### Before
```console
$ nuclei  -u http://target -t ~/test-templates/interactsh-matcher-dup.yaml 

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v2.9.10

		projectdiscovery.io

[INF] Current nuclei version: v2.9.10 (latest)
[INF] Current nuclei-templates version: v9.6.0 (latest)
[INF] New templates added in latest release: 33
[INF] Templates loaded for current scan: 1
[INF] Targets loaded for current scan: 1
[INF] Using Interactsh Server: oast.site
[CVE-2023-26067] [http] [high] http://target/cgi-bin/fax_change_faxtrace_settings
[CVE-2023-26067] [http] [high] http://target/cgi-bin/fax_change_faxtrace_settings
```

### After

```console
$  go run . -u http://target -t ~/test-templates/interactsh-matcher-dup.yaml 

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v2.9.11-dev

		projectdiscovery.io

[INF] Current nuclei version: v2.9.11-dev (development)
[INF] Current nuclei-templates version: v9.6.0 (latest)
[INF] New templates added in latest release: 33
[INF] Templates loaded for current scan: 1
[INF] Targets loaded for current scan: 1
[INF] Using Interactsh Server: oast.live
[CVE-2023-26067] [http] [high] http://target/cgi-bin/fax_change_faxtrace_settings
```