### PR TITLE
Adding default resp size to options

### DIFF
--- a/v2/pkg/types/types.go
+++ b/v2/pkg/types/types.go
@@ -421,6 +421,8 @@ func DefaultOptions() *Options {
 		Timeout:                 5,
 		Retries:                 1,
 		MaxHostError:            30,
+		ResponseReadSize:        10 * 1024 * 1024,
+		ResponseSaveSize:        1024 * 1024,
 	}
 }
 


### PR DESCRIPTION
## Proposed changes
Closes #3988 

## Checklist
- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Example
With the code snippet in the linked issue:
```console
$ cat test.go
...go
outputWriter := testutils.NewMockOutputWriter()
outputWriter.WriteCallback = func(event *output.ResultEvent) {
	fmt.Printf("\n\n\nGot Result: %+v\n", event.Response)
}
...
$ go run .
[INF] Using Interactsh Server: oast.site

Got Result: HTTP/1.1 200 OK
Connection: close
Content-Length: 2
Content-Type: text/plain; charset=utf-8
Date: Mon, 14 Aug 2023 09:14:05 GMT

ok
```