### PR TITLE
fix duplicated result event in cli & SDK

### DIFF
--- a/v2/internal/runner/runner.go
+++ b/v2/internal/runner/runner.go
@@ -310,6 +310,15 @@ func New(options *types.Options) (*Runner, error) {
 	if httpclient != nil {
 		opts.HTTPClient = httpclient
 	}
+	if opts.HTTPClient == nil {
+		httpOpts := retryablehttp.DefaultOptionsSingle
+		httpOpts.Timeout = 20 * time.Second // for stability reasons
+		if options.Timeout > 20 {
+			httpOpts.Timeout = time.Duration(options.Timeout) * time.Second
+		}
+		// in testing it was found most of times when interactsh failed, it was due to failure in registering /polling requests
+		opts.HTTPClient = retryablehttp.NewClient(retryablehttp.DefaultOptionsSingle)
+	}
 	interactshClient, err := interactsh.New(opts)
 	if err != nil {
 		gologger.Error().Msgf("Could not create interactsh client: %s", err)

--- a/v2/pkg/output/output.go
+++ b/v2/pkg/output/output.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/pkg/errors"
@@ -76,6 +77,9 @@ type InternalWrappedEvent struct {
 	Results         []*ResultEvent
 	OperatorsResult *operators.Result
 	UsesInteractsh  bool
+	// Only applicable if interactsh is used
+	// This is used to avoid duplicate successful interactsh events
+	InteractshMatched atomic.Bool
 }
 
 func (iwe *InternalWrappedEvent) HasOperatorResult() bool {

--- a/v2/pkg/protocols/common/executer/executer.go
+++ b/v2/pkg/protocols/common/executer/executer.go
@@ -77,7 +77,7 @@ func (e *Executer) Execute(input *contextargs.Context) (bool, error) {
 			if err := e.options.Output.WriteFailure(event.InternalEvent); err != nil {
 				gologger.Warning().Msgf("Could not write failure event to output: %s\n", err)
 			}
-			results.CompareAndSwap(false, true)
+			results.Store(true)
 		}
 	}
 
@@ -109,9 +109,9 @@ func (e *Executer) Execute(input *contextargs.Context) (bool, error) {
 			} else {
 				if !(event.UsesInteractsh && event.InteractshMatched.Load()) && writer.WriteResult(event, e.options.Output, e.options.Progress, e.options.IssuesClient) {
 					if event.UsesInteractsh {
-						event.InteractshMatched.CompareAndSwap(false, true)
+						results.Store(true)
 					}
-					results.CompareAndSwap(false, true)
+					results.Store(true)
 				} else {
 					lastMatcherEvent = event
 				}
@@ -171,7 +171,7 @@ func (e *Executer) ExecuteWithResults(input *contextargs.Context, callback proto
 			if event.OperatorsResult == nil {
 				return
 			}
-			results.CompareAndSwap(false, true)
+			results.Store(true)
 			callback(event)
 		})
 		if err != nil {

--- a/v2/pkg/protocols/common/interactsh/interactsh.go
+++ b/v2/pkg/protocols/common/interactsh/interactsh.go
@@ -179,7 +179,9 @@ func (c *Client) processInteractionForRequest(interaction *server.Interaction, d
 		c.debugPrintInteraction(interaction, data.Event.OperatorsResult)
 	}
 
-	if writer.WriteResult(data.Event, c.options.Output, c.options.Progress, c.options.IssuesClient) {
+	// if event is not already matched, write it to output
+	if !data.Event.InteractshMatched.Load() && writer.WriteResult(data.Event, c.options.Output, c.options.Progress, c.options.IssuesClient) {
+		data.Event.InteractshMatched.Store(true)
 		c.matched.Store(true)
 		if requestShouldStopAtFirstMatch(data) || c.options.StopAtFirstMatch {
 			_ = c.matchedTemplates.SetWithExpire(hash(data.Event.InternalEvent), true, defaultInteractionDuration)

--- a/v2/pkg/protocols/common/interactsh/interactsh.go
+++ b/v2/pkg/protocols/common/interactsh/interactsh.go
@@ -100,6 +100,10 @@ func (c *Client) poll() error {
 
 	err = interactsh.StartPolling(c.pollDuration, func(interaction *server.Interaction) {
 		request, err := c.requests.Get(interaction.UniqueID)
+		// for more context in github actions
+		if strings.EqualFold(os.Getenv("GITHUB_ACTIONS"), "true") && c.options.Debug {
+			gologger.DefaultLogger.Print().Msgf("[Interactsh]: got interaction of %v for request %v and error %v", interaction, request, err)
+		}
 		if errors.Is(err, gcache.KeyNotFoundError) || request == nil {
 			// If we don't have any request for this ID, add it to temporary
 			// lru cache, so we can correlate when we get an add request.
@@ -155,6 +159,11 @@ func (c *Client) processInteractionForRequest(interaction *server.Interaction, d
 	data.Event.Unlock()
 
 	result, matched := data.Operators.Execute(data.Event.InternalEvent, data.MatchFunc, data.ExtractFunc, c.options.Debug || c.options.DebugRequest || c.options.DebugResponse)
+
+	// for more context in github actions
+	if strings.EqualFold(os.Getenv("GITHUB_ACTIONS"), "true") && c.options.Debug {
+		gologger.DefaultLogger.Print().Msgf("[Interactsh]: got result %v and status %v after processing interaction", result, matched)
+	}
 
 	// if we don't match, return
 	if !matched || result == nil {


### PR DESCRIPTION
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->

- for context refer https://github.com/projectdiscovery/nuclei/issues/4041#issuecomment-1680542127
- proposed implementation adds a atomic bool (switch) to skip writing interactsh match event if it is already written to outputwriter (includes both SDK & cli )
- closes #4041 


## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)