### PR TITLE
fix logic bug in request[s] matcher condition

### DIFF
--- a/integration_tests/http/interactsh-requests-mc-and.yaml
+++ b/integration_tests/http/interactsh-requests-mc-and.yaml
@@ -1,0 +1,27 @@
+id: interactsh-requests-mc-and
+
+info:
+  name: interactsh multi request matcher condition
+  author: pdteam
+  severity: info
+
+requests:
+  - raw:
+      - |
+        GET /api/geoping/{{interactsh-url}} HTTP/1.1
+        Host: {{Hostname}}
+
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: interactsh_protocol  # Confirms the DNS Interaction
+        words:
+          - "dns"
+
+      - type: dsl
+        dsl:
+          - "status_code_2 == 200"

--- a/v2/cmd/integration-test/http.go
+++ b/v2/cmd/integration-test/http.go
@@ -1465,3 +1465,13 @@ func (h *httpDisablePathAutomerge) Execute(filePath string) error {
 	}
 	return expectResultsCount(got, 2)
 }
+
+type httpInteractshRequestsWithMCAnd struct{}
+
+func (h *httpInteractshRequestsWithMCAnd) Execute(filePath string) error {
+	got, err := testutils.RunNucleiTemplateAndGetResults(filePath, "honey.scanme.sh", debug)
+	if err != nil {
+		return err
+	}
+	return expectResultsCount(got, 1)
+}

--- a/v2/cmd/integration-test/interactsh.go
+++ b/v2/cmd/integration-test/interactsh.go
@@ -7,4 +7,5 @@ var interactshTestCases = []TestCaseInfo{
 	{Path: "http/interactsh.yaml", TestCase: &httpInteractshRequest{}, DisableOn: func() bool { return osutils.IsWindows() || osutils.IsOSX() }},
 	{Path: "http/interactsh-stop-at-first-match.yaml", TestCase: &httpInteractshStopAtFirstMatchRequest{}, DisableOn: func() bool { return osutils.IsWindows() || osutils.IsOSX() }},
 	{Path: "http/default-matcher-condition.yaml", TestCase: &httpDefaultMatcherCondition{}, DisableOn: func() bool { return osutils.IsWindows() || osutils.IsOSX() }},
+	{Path: "http/interactsh-requests-mc-and.yaml", TestCase: &httpInteractshRequestsWithMCAnd{}},
 }

--- a/v2/pkg/protocols/http/request.go
+++ b/v2/pkg/protocols/http/request.go
@@ -35,6 +35,7 @@ import (
 	templateTypes "github.com/projectdiscovery/nuclei/v2/pkg/templates/types"
 	"github.com/projectdiscovery/nuclei/v2/pkg/types"
 	"github.com/projectdiscovery/rawhttp"
+	sliceutil "github.com/projectdiscovery/utils/slice"
 	stringsutil "github.com/projectdiscovery/utils/strings"
 	urlutil "github.com/projectdiscovery/utils/url"
 )
@@ -342,6 +343,7 @@ func (request *Request) ExecuteWithResults(input *contextargs.Context, dynamicVa
 
 	var gotDynamicValues map[string][]string
 	var requestErr error
+
 	for {
 		// returns two values, error and skip, which skips the execution for the request instance.
 		executeFunc := func(data string, payloads, dynamicValue map[string]interface{}) (bool, error) {
@@ -375,7 +377,10 @@ func (request *Request) ExecuteWithResults(input *contextargs.Context, dynamicVa
 			}
 			var gotMatches bool
 			err = request.executeRequest(input, generatedHttpRequest, previous, hasInteractMatchers, func(event *output.InternalWrappedEvent) {
-				if hasInteractMarkers && hasInteractMatchers && request.options.Interactsh != nil {
+				// a special case where operators has interactsh matchers and multiple request are made
+				// ex: status_code_2 , interactsh_protocol (from 1st request) etc
+				needsRequestEvent := interactsh.HasMatchers(request.CompiledOperators) && request.NeedsRequestCondition()
+				if (hasInteractMarkers || needsRequestEvent) && request.options.Interactsh != nil {
 					requestData := &interactsh.RequestData{
 						MakeResultFunc: request.MakeResultEvent,
 						Event:          event,
@@ -383,7 +388,9 @@ func (request *Request) ExecuteWithResults(input *contextargs.Context, dynamicVa
 						MatchFunc:      request.Match,
 						ExtractFunc:    request.Extract,
 					}
-					request.options.Interactsh.RequestEvent(generatedHttpRequest.interactshURLs, requestData)
+					allOASTUrls := getInteractshURLsFromEvent(event.InternalEvent)
+					allOASTUrls = append(allOASTUrls, generatedHttpRequest.interactshURLs...)
+					request.options.Interactsh.RequestEvent(sliceutil.Dedupe(allOASTUrls), requestData)
 					gotMatches = request.options.Interactsh.AlreadyMatched(requestData)
 				}
 				// Add the extracts to the dynamic values if any.

--- a/v2/pkg/protocols/http/utils.go
+++ b/v2/pkg/protocols/http/utils.go
@@ -14,7 +14,9 @@ import (
 	"golang.org/x/text/transform"
 
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/generators"
+	"github.com/projectdiscovery/nuclei/v2/pkg/types"
 	"github.com/projectdiscovery/rawhttp"
+	mapsutil "github.com/projectdiscovery/utils/maps"
 	stringsutil "github.com/projectdiscovery/utils/strings"
 )
 
@@ -162,4 +164,17 @@ func decodeGBK(s []byte) ([]byte, error) {
 func isContentTypeGbk(contentType string) bool {
 	contentType = strings.ToLower(contentType)
 	return stringsutil.ContainsAny(contentType, "gbk", "gb2312", "gb18030")
+}
+
+// if template contains more than 1 request and matchers require requestcondition from
+// both requests , then we need to request for event from interactsh even if current request
+// doesnot use interactsh url in it
+func getInteractshURLsFromEvent(event map[string]interface{}) []string {
+	interactshUrls := map[string]struct{}{}
+	for k, v := range event {
+		if strings.HasPrefix(k, "interactsh-url") {
+			interactshUrls[types.ToString(v)] = struct{}{}
+		}
+	}
+	return mapsutil.GetKeys(interactshUrls)
 }


### PR DESCRIPTION
### Proposed Changes

- fix logic bug (variables required to evaluate were missing) when matcher condition / matchers are evaluated based on multiple requests (see template for more details) 
- adds integration test for this edgecase
- closes #2870 

### POC
```console
$  echo geonet.shodan.io | go run . -t ~/test-templates/interactsh-and-condition.yaml

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v2.9.11

		projectdiscovery.io

[WRN] Found 1 templates loaded with deprecated protocol syntax, update before v3 for continued support.
[INF] Current nuclei version: v2.9.11 (latest)
[INF] Current nuclei-templates version: v9.6.1 (latest)
[INF] New templates added in latest release: 198
[INF] Templates loaded for current scan: 1
[INF] Targets loaded for current scan: 1
[INF] Running httpx on input host
[INF] Found 1 URL from httpx
[INF] Using Interactsh Server: oast.pro
[test-interactsh] [http] [info] https://geonet.shodan.io/
```