### PR TITLE
render nuclei-templates release

### DIFF
--- a/v2/cmd/nuclei/main.go
+++ b/v2/cmd/nuclei/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/gologger/levels"
 	"github.com/projectdiscovery/interactsh/pkg/client"
+	"github.com/projectdiscovery/nuclei/v2/internal/installer"
 	"github.com/projectdiscovery/nuclei/v2/internal/runner"
 	"github.com/projectdiscovery/nuclei/v2/pkg/catalog/config"
 	"github.com/projectdiscovery/nuclei/v2/pkg/model/types/severity"
@@ -339,6 +340,11 @@ on extensive configurability, massive extensibility and ease of use.`)
 	_ = flagSet.Parse()
 
 	gologger.DefaultLogger.SetTimestamp(options.Timestamp, levels.LevelDebug)
+
+	if options.Silent {
+		// hide release notes if silent mode is enabled
+		installer.HideReleaseNotes = true
+	}
 
 	if options.LeaveDefaultPorts {
 		http.LeaveDefaultPorts = true

--- a/v2/internal/installer/template.go
+++ b/v2/internal/installer/template.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/charmbracelet/glamour"
 	"github.com/olekukonko/tablewriter"
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/nuclei/v2/pkg/catalog/config"
@@ -29,6 +30,7 @@ const (
 var (
 	HideProgressBar        = true
 	HideUpdateChangesTable = false
+	HideReleaseNotes       = false
 )
 
 // TemplateUpdateResults contains the results of template update
@@ -105,6 +107,7 @@ func (t *TemplateManager) installTemplatesAt(dir string) error {
 	if err != nil {
 		return errorutil.NewWithErr(err).Msgf("failed to install templates at %s", dir)
 	}
+
 	// write templates to disk
 	if err := t.writeTemplatesToDisk(ghrd, dir); err != nil {
 		return errorutil.NewWithErr(err).Msgf("failed to write templates to disk at %s", dir)
@@ -311,6 +314,21 @@ func (t *TemplateManager) writeTemplatesToDisk(ghrd *updateutils.GHReleaseDownlo
 
 	if err = config.DefaultConfig.WriteTemplatesIndex(index); err != nil {
 		return errorutil.NewWithErr(err).Msgf("failed to write nuclei templates index")
+	}
+
+	if !HideReleaseNotes {
+		output := ghrd.Latest.GetBody()
+		// adjust colors for both dark / light terminal themes
+		r, err := glamour.NewTermRenderer(glamour.WithAutoStyle())
+		if err != nil {
+			gologger.Error().Msgf("markdown rendering not supported: %v", err)
+		}
+		if rendered, err := r.Render(output); err == nil {
+			output = rendered
+		} else {
+			gologger.Error().Msg(err.Error())
+		}
+		gologger.Print().Msgf("\n%v\n\n", output)
 	}
 
 	// after installation, create and write checksums to .checksum file


### PR DESCRIPTION
## Proposed Changes

- render nuclei templates release notes just like `nuclei -up`
- release notes are not visible when using `-silent` flag


![dummy](https://github.com/projectdiscovery/nuclei/assets/45962551/848bbc7c-d9e6-4250-94cc-fd23aeef0909)
