### PR TITLE
XPath matcher support

### DIFF
--- a/docs/template-guide/operators/matchers.mdx
+++ b/docs/template-guide/operators/matchers.mdx
@@ -8,7 +8,7 @@ Matchers allow different type of flexible comparisons on protocol responses. The
 
 ### Types
 
-Multiple matchers can be specified in a request. There are basically 6 types of matchers:
+Multiple matchers can be specified in a request. There are basically 7 types of matchers:
 
 | Matcher Type | Part Matched                |
 |--------------|-----------------------------|

--- a/docs/template-guide/operators/matchers.mdx
+++ b/docs/template-guide/operators/matchers.mdx
@@ -18,6 +18,7 @@ Multiple matchers can be specified in a request. There are basically 6 types of 
 | regex        | Part for a protocol         |
 | binary       | Part for a protocol         |
 | dsl          | Part for a protocol         |
+| xpath        | Part for a protocol         |
 
 To match status codes for responses, you can use the following syntax.
 
@@ -56,6 +57,16 @@ matchers:
 ```
 
 **Word** and **Regex** matchers can be further configured depending on the needs of the users.
+
+**XPath** matchers use XPath queries to match XML and HTML responses. If the XPath query returns any results, it's considered a match.
+
+```yaml
+matchers:
+  - type: xpath
+    part: body
+    xpath:
+      - "/html/head/title[contains(text(), 'Example Domain')]"
+```
 
 Complex matchers of type **dsl** allows building more elaborate expressions with helper functions. These function allow access to Protocol Response which contains variety of data based on each protocol. See protocol specific documentation to learn about different returned results.
 

--- a/v2/pkg/operators/matchers/match.go
+++ b/v2/pkg/operators/matchers/match.go
@@ -240,7 +240,6 @@ func (matcher *Matcher) MatchXPath(corpus string) bool {
 func (matcher *Matcher) MatchHTML(corpus string) bool {
 	doc, err := htmlquery.Parse(strings.NewReader(corpus))
 	if err != nil {
-		gologger.Warning().Msgf("Error in htmlquery.Parse(): %q", err.Error())
 		return false
 	}
 
@@ -249,7 +248,6 @@ func (matcher *Matcher) MatchHTML(corpus string) bool {
 	for _, k := range matcher.XPath {
 		nodes, err := htmlquery.QueryAll(doc, k)
 		if err != nil {
-			gologger.Warning().Msgf("Error while evaluating xpath matcher expression: %q", k)
 			continue
 		}
 
@@ -272,7 +270,6 @@ func (matcher *Matcher) MatchHTML(corpus string) bool {
 
 		matches = matches + len(nodes)
 	}
-
 	return matches > 0
 }
 
@@ -280,7 +277,6 @@ func (matcher *Matcher) MatchHTML(corpus string) bool {
 func (matcher *Matcher) MatchXML(corpus string) bool {
 	doc, err := xmlquery.Parse(strings.NewReader(corpus))
 	if err != nil {
-		gologger.Warning().Msgf("Error in xmlquery.Parse(): %q", err.Error())
 		return false
 	}
 
@@ -289,7 +285,6 @@ func (matcher *Matcher) MatchXML(corpus string) bool {
 	for _, k := range matcher.XPath {
 		nodes, err := xmlquery.QueryAll(doc, k)
 		if err != nil {
-			gologger.Warning().Msgf("Error while evaluating xpath matcher expression: %q", k)
 			continue
 		}
 
@@ -309,7 +304,6 @@ func (matcher *Matcher) MatchXML(corpus string) bool {
 		if matcher.condition == ORCondition && !matcher.MatchAll {
 			return true
 		}
-
 		matches = matches + len(nodes)
 	}
 

--- a/v2/pkg/operators/matchers/match.go
+++ b/v2/pkg/operators/matchers/match.go
@@ -253,7 +253,7 @@ func (matcher *Matcher) MatchHTML(corpus string) bool {
 			continue
 		}
 
-		// Continue if the word doesn't match
+		// Continue if the xpath doesn't return any nodes
 		if len(nodes) == 0 {
 			// If we are in an AND request and a match failed,
 			// return false as the AND condition fails on any single mismatch.
@@ -293,7 +293,7 @@ func (matcher *Matcher) MatchXML(corpus string) bool {
 			continue
 		}
 
-		// Continue if the word doesn't match
+		// Continue if the xpath doesn't return any nodes
 		if len(nodes) == 0 {
 			// If we are in an AND request and a match failed,
 			// return false as the AND condition fails on any single mismatch.

--- a/v2/pkg/operators/matchers/match.go
+++ b/v2/pkg/operators/matchers/match.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 
 	"github.com/Knetic/govaluate"
+	"github.com/antchfx/htmlquery"
+	"github.com/antchfx/xmlquery"
 
 	dslRepo "github.com/projectdiscovery/dsl"
 	"github.com/projectdiscovery/gologger"
@@ -224,6 +226,94 @@ func (matcher *Matcher) MatchDSL(data map[string]interface{}) bool {
 		}
 	}
 	return false
+}
+
+// MatchXPath matches on a generic map result
+func (matcher *Matcher) MatchXPath(corpus string) bool {
+	if strings.HasPrefix(corpus, "<?xml") {
+		return matcher.MatchXML(corpus)
+	}
+	return matcher.MatchHTML(corpus)
+}
+
+// MatchHTML matches items from HTML using XPath selectors
+func (matcher *Matcher) MatchHTML(corpus string) bool {
+	doc, err := htmlquery.Parse(strings.NewReader(corpus))
+	if err != nil {
+		gologger.Warning().Msgf("Error in htmlquery.Parse(): %q", err.Error())
+		return false
+	}
+
+	matches := 0
+
+	for _, k := range matcher.XPath {
+		nodes, err := htmlquery.QueryAll(doc, k)
+		if err != nil {
+			gologger.Warning().Msgf("Error while evaluating xpath matcher expression: %q", k)
+			continue
+		}
+
+		// Continue if the word doesn't match
+		if len(nodes) == 0 {
+			// If we are in an AND request and a match failed,
+			// return false as the AND condition fails on any single mismatch.
+			switch matcher.condition {
+			case ANDCondition:
+				return false
+			case ORCondition:
+				continue
+			}
+		}
+
+		// If the condition was an OR, return on the first match.
+		if matcher.condition == ORCondition && !matcher.MatchAll {
+			return true
+		}
+
+		matches = matches + len(nodes)
+	}
+
+	return matches > 0
+}
+
+// MatchXML matches items from XML using XPath selectors
+func (matcher *Matcher) MatchXML(corpus string) bool {
+	doc, err := xmlquery.Parse(strings.NewReader(corpus))
+	if err != nil {
+		gologger.Warning().Msgf("Error in xmlquery.Parse(): %q", err.Error())
+		return false
+	}
+
+	matches := 0
+
+	for _, k := range matcher.XPath {
+		nodes, err := xmlquery.QueryAll(doc, k)
+		if err != nil {
+			gologger.Warning().Msgf("Error while evaluating xpath matcher expression: %q", k)
+			continue
+		}
+
+		// Continue if the word doesn't match
+		if len(nodes) == 0 {
+			// If we are in an AND request and a match failed,
+			// return false as the AND condition fails on any single mismatch.
+			switch matcher.condition {
+			case ANDCondition:
+				return false
+			case ORCondition:
+				continue
+			}
+		}
+
+		// If the condition was an OR, return on the first match.
+		if matcher.condition == ORCondition && !matcher.MatchAll {
+			return true
+		}
+
+		matches = matches + len(nodes)
+	}
+
+	return matches > 0
 }
 
 // ignoreErr checks if the error is to be ignored or not

--- a/v2/pkg/operators/matchers/match_test.go
+++ b/v2/pkg/operators/matchers/match_test.go
@@ -157,9 +157,7 @@ func TestMatcher_MatchXPath_HTML(t *testing.T) {
 
 	// invalid xpath
 	m = &Matcher{Type: MatcherTypeHolder{MatcherType: XPathMatcher}, XPath: []string{"//a[@a==1]"}}
-	err = m.CompileMatchers()
-	require.Nil(t, err)
-
+	_ = m.CompileMatchers()
 	isMatched = m.MatchXPath(body)
 	require.False(t, isMatched, "Invalid xpath did not return false")
 }
@@ -203,9 +201,7 @@ func TestMatcher_MatchXPath_XML(t *testing.T) {
 
 	// invalid xpath
 	m = &Matcher{Type: MatcherTypeHolder{MatcherType: XPathMatcher}, XPath: []string{"//a[@a==1]"}}
-	err = m.CompileMatchers()
-	require.Nil(t, err)
-
+	_ = m.CompileMatchers()
 	isMatched = m.MatchXPath(body)
 	require.False(t, isMatched, "Invalid xpath did not return false")
 

--- a/v2/pkg/operators/matchers/match_test.go
+++ b/v2/pkg/operators/matchers/match_test.go
@@ -89,3 +89,128 @@ func TestMatcher_MatchDSL(t *testing.T) {
 		require.True(t, isMatched)
 	}
 }
+
+func TestMatcher_MatchXPath_HTML(t *testing.T) {
+	body := `<!doctype html>
+<html>
+<head>
+    <title>Example Domain</title>
+
+    <meta charset="utf-8" />
+    <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+</head>
+
+<body>
+<div>
+    <h1>Example Domain</h1>
+    <p>This domain is for use in illustrative examples in documents. You may use this
+    domain in literature without prior coordination or asking for permission.</p>
+    <p><a href="https://www.iana.org/domains/example">More information...</a></p>
+</div>
+</body>
+</html>
+`
+	body2 := `<!doctype html>
+<html>
+<head>
+    <title>Example Domain</title>
+</head>
+<body>
+<h1> It's test time! </h1>
+</body>
+</html>
+`
+
+	// single match
+	m := &Matcher{Type: MatcherTypeHolder{MatcherType: XPathMatcher}, XPath: []string{"/html/body/div/p[2]/a"}}
+	err := m.CompileMatchers()
+	require.Nil(t, err)
+
+	isMatched := m.MatchXPath(body)
+	require.True(t, isMatched, "Could not match valid XPath")
+
+	isMatched = m.MatchXPath("<h1>aaaaaaaaa")
+	require.False(t, isMatched, "Could match invalid XPath")
+
+	// OR match
+	m = &Matcher{Type: MatcherTypeHolder{MatcherType: XPathMatcher}, Condition: "or", XPath: []string{"/html/head/title[contains(text(), 'PATRICAAA')]", "/html/body/div/p[2]/a"}}
+	err = m.CompileMatchers()
+	require.Nil(t, err)
+
+	isMatched = m.MatchXPath(body)
+	require.True(t, isMatched, "Could not match valid multi-XPath with OR condition")
+
+	isMatched = m.MatchXPath(body2)
+	require.False(t, isMatched, "Could match invalid multi-XPath with OR condition")
+
+	// AND match
+	m = &Matcher{Type: MatcherTypeHolder{MatcherType: XPathMatcher}, Condition: "and", XPath: []string{"/html/head/title[contains(text(), 'Example Domain')]", "/html/body/div/p[2]/a"}}
+	err = m.CompileMatchers()
+	require.Nil(t, err)
+
+	isMatched = m.MatchXPath(body)
+	require.True(t, isMatched, "Could not match valid multi-XPath with AND condition")
+
+	isMatched = m.MatchXPath(body2)
+	require.False(t, isMatched, "Could match invalid multi-XPath with AND condition")
+
+	// invalid xpath
+	m = &Matcher{Type: MatcherTypeHolder{MatcherType: XPathMatcher}, XPath: []string{"//a[@a==1]"}}
+	err = m.CompileMatchers()
+	require.Nil(t, err)
+
+	isMatched = m.MatchXPath(body)
+	require.False(t, isMatched, "Invalid xpath did not return false")
+}
+
+func TestMatcher_MatchXPath_XML(t *testing.T) {
+	body := `<?xml version="1.0" encoding="utf-8"?><foo>bar</foo><wibble id="1" /><parent><child>baz</child></parent>`
+	body2 := `<?xml version="1.0" encoding="utf-8"?><test>bar</test><wibble2 id="1" /><roditelj><dijete>alo</dijete></roditelj>`
+
+	// single match
+	m := &Matcher{Type: MatcherTypeHolder{MatcherType: XPathMatcher}, XPath: []string{"//foo[contains(text(), 'bar')]"}}
+	err := m.CompileMatchers()
+	require.Nil(t, err)
+
+	isMatched := m.MatchXPath(body)
+	require.True(t, isMatched, "Could not match valid XPath")
+
+	isMatched = m.MatchXPath("<h1>aaaaaaaaa</h1>")
+	require.False(t, isMatched, "Could match invalid XPath")
+
+	// OR match
+	m = &Matcher{Type: MatcherTypeHolder{MatcherType: XPathMatcher}, Condition: "or", XPath: []string{"/foo[contains(text(), 'PATRICAAA')]", "/parent/child"}}
+	err = m.CompileMatchers()
+	require.Nil(t, err)
+
+	isMatched = m.MatchXPath(body)
+	require.True(t, isMatched, "Could not match valid multi-XPath with OR condition")
+
+	isMatched = m.MatchXPath(body2)
+	require.False(t, isMatched, "Could match invalid multi-XPath with OR condition")
+
+	// AND match
+	m = &Matcher{Type: MatcherTypeHolder{MatcherType: XPathMatcher}, Condition: "and", XPath: []string{"/foo[contains(text(), 'bar')]", "/parent/child"}}
+	err = m.CompileMatchers()
+	require.Nil(t, err)
+
+	isMatched = m.MatchXPath(body)
+	require.True(t, isMatched, "Could not match valid multi-XPath with AND condition")
+
+	isMatched = m.MatchXPath(body2)
+	require.False(t, isMatched, "Could match invalid multi-XPath with AND condition")
+
+	// invalid xpath
+	m = &Matcher{Type: MatcherTypeHolder{MatcherType: XPathMatcher}, XPath: []string{"//a[@a==1]"}}
+	err = m.CompileMatchers()
+	require.Nil(t, err)
+
+	isMatched = m.MatchXPath(body)
+	require.False(t, isMatched, "Invalid xpath did not return false")
+
+	// invalid xml
+	isMatched = m.MatchXPath("<h1> not right <q id=2/>notvalid")
+	require.False(t, isMatched, "Invalid xpath did not return false")
+
+}

--- a/v2/pkg/operators/matchers/match_test.go
+++ b/v2/pkg/operators/matchers/match_test.go
@@ -208,5 +208,4 @@ func TestMatcher_MatchXPath_XML(t *testing.T) {
 	// invalid xml
 	isMatched = m.MatchXPath("<h1> not right <q id=2/>notvalid")
 	require.False(t, isMatched, "Invalid xpath did not return false")
-
 }

--- a/v2/pkg/operators/matchers/matchers.go
+++ b/v2/pkg/operators/matchers/matchers.go
@@ -94,6 +94,16 @@ type Matcher struct {
 	//       []string{"!contains(tolower(all_headers), ''strict-transport-security'')"}
 	DSL []string `yaml:"dsl,omitempty" json:"dsl,omitempty" jsonschema:"title=dsl expressions to match in response,description=DSL are the dsl expressions that will be evaluated as part of nuclei matching rules"`
 	// description: |
+	//   XPath are the xpath queries expressions that will be evaluated against the response part.
+	// examples:
+	//   - name: XPath Matcher to check a title
+	//     value: >
+	//       []string{"/html/head/title[contains(text(), 'How to Find XPath')]"}
+	//   - name: XPath Matcher for finding links with target="_blank"
+	//     value: >
+	//       []string{"//a[@target="_blank"]"}
+	XPath []string `yaml:"xpath,omitempty" json:"xpath,omitempty" jsonschema:"title=xpath queries to match in response,description=xpath are the XPath queries that will be evaluated against the response part of nuclei matching rules"`
+	// description: |
 	//   Encoding specifies the encoding for the words field if any.
 	// values:
 	//   - "hex"

--- a/v2/pkg/operators/matchers/matchers_types.go
+++ b/v2/pkg/operators/matchers/matchers_types.go
@@ -25,6 +25,8 @@ const (
 	SizeMatcher
 	// name:dsl
 	DSLMatcher
+	// name:xpath
+	XPathMatcher
 	limit
 )
 
@@ -36,6 +38,7 @@ var MatcherTypes = map[MatcherType]string{
 	RegexMatcher:  "regex",
 	BinaryMatcher: "binary",
 	DSLMatcher:    "dsl",
+	XPathMatcher:  "xpath",
 }
 
 // GetType returns the type of the matcher

--- a/v2/pkg/operators/matchers/validate.go
+++ b/v2/pkg/operators/matchers/validate.go
@@ -38,6 +38,8 @@ func (matcher *Matcher) Validate() error {
 		expectedFields = append(commonExpectedFields, "Binary", "Part", "Encoding", "CaseInsensitive")
 	case RegexMatcher:
 		expectedFields = append(commonExpectedFields, "Regex", "Part", "Encoding", "CaseInsensitive")
+	case XPathMatcher:
+		expectedFields = append(commonExpectedFields, "XPath", "Part")
 	}
 	return checkFields(matcher, matcherMap, expectedFields...)
 }

--- a/v2/pkg/operators/matchers/validate.go
+++ b/v2/pkg/operators/matchers/validate.go
@@ -55,7 +55,6 @@ func (matcher *Matcher) Validate() error {
 			}
 		}
 	}
-
 	return nil
 }
 

--- a/v2/pkg/operators/matchers/validate.go
+++ b/v2/pkg/operators/matchers/validate.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/antchfx/xpath"
 	sliceutil "github.com/projectdiscovery/utils/slice"
 	"gopkg.in/yaml.v3"
 )
@@ -41,7 +42,21 @@ func (matcher *Matcher) Validate() error {
 	case XPathMatcher:
 		expectedFields = append(commonExpectedFields, "XPath", "Part")
 	}
-	return checkFields(matcher, matcherMap, expectedFields...)
+
+	if err = checkFields(matcher, matcherMap, expectedFields...); err != nil {
+		return err
+	}
+
+	// validate the XPath query
+	if matcher.matcherType == XPathMatcher {
+		for _, query := range matcher.XPath {
+			if _, err = xpath.Compile(query); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
 }
 
 func checkFields(m *Matcher, matcherMap map[string]interface{}, expectedFields ...string) error {

--- a/v2/pkg/operators/matchers/validate_test.go
+++ b/v2/pkg/operators/matchers/validate_test.go
@@ -25,4 +25,8 @@ func TestValidate(t *testing.T) {
 	err = m.Validate()
 	require.NotNil(t, err, "Invalid XPath template was correctly validated")
 
+	m = &Matcher{matcherType: XPathMatcher, XPath: []string{"//a[@a==1]"}}
+	err = m.Validate()
+	require.NotNil(t, err, "Invalid XPath query was correctly validated")
+
 }

--- a/v2/pkg/operators/matchers/validate_test.go
+++ b/v2/pkg/operators/matchers/validate_test.go
@@ -28,5 +28,4 @@ func TestValidate(t *testing.T) {
 	m = &Matcher{matcherType: XPathMatcher, XPath: []string{"//a[@a==1]"}}
 	err = m.Validate()
 	require.NotNil(t, err, "Invalid XPath query was correctly validated")
-
 }

--- a/v2/pkg/operators/matchers/validate_test.go
+++ b/v2/pkg/operators/matchers/validate_test.go
@@ -15,4 +15,14 @@ func TestValidate(t *testing.T) {
 	m = &Matcher{matcherType: DSLMatcher, Part: "test"}
 	err = m.Validate()
 	require.NotNil(t, err, "Invalid template was correctly validated")
+
+	m = &Matcher{matcherType: XPathMatcher, XPath: []string{"//q[@id=\"foo\"]"}}
+
+	err = m.Validate()
+	require.Nil(t, err, "Could not validate correct XPath template")
+
+	m = &Matcher{matcherType: XPathMatcher, Status: []int{123}}
+	err = m.Validate()
+	require.NotNil(t, err, "Invalid XPath template was correctly validated")
+
 }

--- a/v2/pkg/protocols/dns/operators.go
+++ b/v2/pkg/protocols/dns/operators.go
@@ -42,6 +42,8 @@ func (request *Request) Match(data map[string]interface{}, matcher *matchers.Mat
 		return matcher.ResultWithMatchedSnippet(matcher.MatchBinary(types.ToString(item)))
 	case matchers.DSLMatcher:
 		return matcher.Result(matcher.MatchDSL(data)), []string{}
+	case matchers.XPathMatcher:
+		return matcher.Result(matcher.MatchXPath(types.ToString(item))), []string{}
 	}
 	return false, []string{}
 }

--- a/v2/pkg/protocols/file/operators.go
+++ b/v2/pkg/protocols/file/operators.go
@@ -30,6 +30,8 @@ func (request *Request) Match(data map[string]interface{}, matcher *matchers.Mat
 		return matcher.ResultWithMatchedSnippet(matcher.MatchBinary(itemStr))
 	case matchers.DSLMatcher:
 		return matcher.Result(matcher.MatchDSL(data)), []string{}
+	case matchers.XPathMatcher:
+		return matcher.Result(matcher.MatchXPath(itemStr)), []string{}
 	}
 	return false, []string{}
 }

--- a/v2/pkg/protocols/headless/operators.go
+++ b/v2/pkg/protocols/headless/operators.go
@@ -37,6 +37,8 @@ func (request *Request) Match(data map[string]interface{}, matcher *matchers.Mat
 		return matcher.ResultWithMatchedSnippet(matcher.MatchBinary(itemStr))
 	case matchers.DSLMatcher:
 		return matcher.Result(matcher.MatchDSL(data)), []string{}
+	case matchers.XPathMatcher:
+		return matcher.Result(matcher.MatchXPath(itemStr)), []string{}
 	}
 	return false, []string{}
 }

--- a/v2/pkg/protocols/http/operators.go
+++ b/v2/pkg/protocols/http/operators.go
@@ -40,6 +40,8 @@ func (request *Request) Match(data map[string]interface{}, matcher *matchers.Mat
 		return matcher.ResultWithMatchedSnippet(matcher.MatchBinary(item))
 	case matchers.DSLMatcher:
 		return matcher.Result(matcher.MatchDSL(data)), []string{}
+	case matchers.XPathMatcher:
+		return matcher.Result(matcher.MatchXPath(item)), []string{}
 	}
 	return false, []string{}
 }

--- a/v2/pkg/protocols/network/operators.go
+++ b/v2/pkg/protocols/network/operators.go
@@ -30,6 +30,8 @@ func (request *Request) Match(data map[string]interface{}, matcher *matchers.Mat
 		return matcher.ResultWithMatchedSnippet(matcher.MatchBinary(itemStr))
 	case matchers.DSLMatcher:
 		return matcher.Result(matcher.MatchDSL(data)), []string{}
+	case matchers.XPathMatcher:
+		return matcher.Result(matcher.MatchXPath(itemStr)), []string{}
 	}
 	return false, []string{}
 }

--- a/v2/pkg/protocols/offlinehttp/operators.go
+++ b/v2/pkg/protocols/offlinehttp/operators.go
@@ -40,6 +40,8 @@ func (request *Request) Match(data map[string]interface{}, matcher *matchers.Mat
 		return matcher.ResultWithMatchedSnippet(matcher.MatchBinary(item))
 	case matchers.DSLMatcher:
 		return matcher.Result(matcher.MatchDSL(data)), []string{}
+	case matchers.XPathMatcher:
+		return matcher.Result(matcher.MatchXPath(item)), []string{}
 	}
 	return false, []string{}
 }

--- a/v2/pkg/protocols/protocols.go
+++ b/v2/pkg/protocols/protocols.go
@@ -176,6 +176,7 @@ func MakeDefaultExtractFunc(data map[string]interface{}, extractor *extractors.E
 		return extractor.ExtractXPath(itemStr)
 	case extractors.DSLExtractor:
 		return extractor.ExtractDSL(data)
+
 	}
 	return nil
 }
@@ -205,6 +206,8 @@ func MakeDefaultMatchFunc(data map[string]interface{}, matcher *matchers.Matcher
 		return matcher.ResultWithMatchedSnippet(matcher.MatchBinary(item))
 	case matchers.DSLMatcher:
 		return matcher.Result(matcher.MatchDSL(data)), nil
+	case matchers.XPathMatcher:
+		return matcher.Result(matcher.MatchXPath(item)), []string{}
 	}
 	return false, nil
 }

--- a/v2/pkg/protocols/protocols.go
+++ b/v2/pkg/protocols/protocols.go
@@ -176,7 +176,6 @@ func MakeDefaultExtractFunc(data map[string]interface{}, extractor *extractors.E
 		return extractor.ExtractXPath(itemStr)
 	case extractors.DSLExtractor:
 		return extractor.ExtractDSL(data)
-
 	}
 	return nil
 }


### PR DESCRIPTION
## Proposed changes

This pull request adds XPath matcher support. The same libraries as used by the extractor functionality are re-used here, so we have no new dependencies. Closes #4086

The following template and output shows the new XPath matcher support:

```
id: title-check

info:
  name: title-check
  author: test
  severity: critical

http:
  - raw:
      - |
        GET / HTTP/1.1
        Host: {{Hostname}}

    matchers:
      - type: xpath
        part: body
        xpath:
          - "/html/head/title[contains(text(), 'Example Domain')]"
```

```
:~$ nuclei -t xpath-test.yaml -u http://example.com

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v2.9.12

		projectdiscovery.io

[INF] Current nuclei version: v2.9.12 (latest)
[INF] Current nuclei-templates version: v9.6.2 (latest)
[INF] New templates added in latest release: 61
[INF] Templates loaded for current scan: 1
[INF] Targets loaded for current scan: 1
[title-check] [http] [critical] http://example.com/
```

The validation logic has been extended to return information about XPath syntax errors to end users, rather than just silently failing.

```
:~$ ./nuclei -t xpath-brokentest.yaml -validate

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v2.9.12

		projectdiscovery.io

[ERR] Error occurred parsing template /home/doi/xpath-brokentest.yaml: could not compile request: could not compile operators: could not compile matcher: /html/head/title[contains(text(), 'Example Domain'))] has an invalid token
[FTL] Could not validate templates: errors occurred during template validation
```
## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)