### PR TITLE
update template url

### DIFF
--- a/v2/pkg/output/output.go
+++ b/v2/pkg/output/output.go
@@ -215,7 +215,7 @@ func NewStandardWriter(options *types.Options) (*StandardWriter, error) {
 func (w *StandardWriter) Write(event *ResultEvent) error {
 	// Enrich the result event with extra metadata on the template-path and url.
 	if event.TemplatePath != "" {
-		event.Template, event.TemplateURL = utils.TemplatePathURL(types.ToString(event.TemplatePath))
+		event.Template, event.TemplateURL = utils.TemplatePathURL(types.ToString(event.TemplatePath), types.ToString(event.TemplateID))
 	}
 	event.Timestamp = time.Now()
 
@@ -327,7 +327,7 @@ func (w *StandardWriter) WriteFailure(wrappedEvent *InternalWrappedEvent) error 
 	// if no results were found, manually create a failure event
 	event := wrappedEvent.InternalEvent
 
-	templatePath, templateURL := utils.TemplatePathURL(types.ToString(event["template-path"]))
+	templatePath, templateURL := utils.TemplatePathURL(types.ToString(event["template-path"]), types.ToString(event["template-id"]))
 	var templateInfo model.Info
 	if event["template-info"] != nil {
 		templateInfo = event["template-info"].(model.Info)

--- a/v2/pkg/testutils/testutils.go
+++ b/v2/pkg/testutils/testutils.go
@@ -141,7 +141,7 @@ func (m *MockOutputWriter) WriteFailure(wrappedEvent *output.InternalWrappedEven
 	if m.WriteCallback != nil {
 		// create event
 		event := wrappedEvent.InternalEvent
-		templatePath, templateURL := utils.TemplatePathURL(types.ToString(event["template-path"]))
+		templatePath, templateURL := utils.TemplatePathURL(types.ToString(event["template-path"]), types.ToString(event["template-id"]))
 		var templateInfo model.Info
 		if ti, ok := event["template-info"].(model.Info); ok {
 			templateInfo = ti

--- a/v2/pkg/utils/template_path.go
+++ b/v2/pkg/utils/template_path.go
@@ -8,11 +8,11 @@ import (
 
 const (
 	// TemplatesRepoURL is the URL for files in nuclei-templates repository
-	TemplatesRepoURL = "https://github.com/projectdiscovery/nuclei-templates/blob/main/"
+	TemplatesRepoURL = "https://templates.nuclei.sh/public/"
 )
 
 // TemplatePathURL returns the Path and URL for the provided template
-func TemplatePathURL(fullPath string) (string, string) {
+func TemplatePathURL(fullPath, templateId string) (string, string) {
 	var templateDirectory string
 	configData := config.DefaultConfig
 	if configData.TemplatesDirectory != "" && strings.HasPrefix(fullPath, configData.TemplatesDirectory) {
@@ -22,6 +22,6 @@ func TemplatePathURL(fullPath string) (string, string) {
 	}
 
 	finalPath := strings.TrimPrefix(strings.TrimPrefix(fullPath, templateDirectory), "/")
-	templateURL := TemplatesRepoURL + finalPath
+	templateURL := TemplatesRepoURL + templateId
 	return finalPath, templateURL
 }


### PR DESCRIPTION
### Proposal:
```diff
- "template-url": "https://github.com/projectdiscovery/nuclei-templates/blob/main/http/technologies/tech-detect.yaml",
+ "template-url": "https://templates.nuclei.sh/public/tech-detect",
```
`https://templates.nuclei.sh/public/` is static, and `tech-detect` is a unique public template id.

```console
$ go run main.go -u scanme.sh -jsonl | jq .

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v2.9.13

                projectdiscovery.io

[INF] Current nuclei version: v2.9.13 (latest)
[INF] Current nuclei-templates version: v9.6.2 (latest)
[INF] New templates added in latest release: 61
[INF] Templates loaded for current scan: 6721
[INF] Targets loaded for current scan: 1
[INF] Running httpx on input host
[INF] Found 1 URL from httpx
[INF] Templates clustered: 1192 (Reduced 1132 Requests)
[INF] Using Interactsh Server: oast.online
{
  "template": "ssl/mismatched-ssl-certificate.yaml",
  "template-url": "https://templates.nuclei.sh/public/mismatched-ssl-certificate",
  "template-id": "mismatched-ssl-certificate",
  "template-path": "/home/vscode/nuclei-templates/ssl/mismatched-ssl-certificate.yaml",
  "info": {
    "name": "Mismatched SSL Certificate",
    "author": [
      "pdteam"
    ],
    "tags": [
      "ssl",
      "mismatched",
      "tls"
    ],
    "description": "Mismatched certificates occur when there is inconsistency between the common name to which the certificate was issued and the domain name in the URL. This issue impacts the trust value of the affected website.\n",
    "reference": [
      "https://www.invicti.com/web-vulnerability-scanner/vulnerabilities/ssl-certificate-name-hostname-mismatch/"
    ],
    "severity": "low",
    "metadata": {
      "max-request": 1
    }
  },
  "type": "ssl",
  "host": "scanme.sh",
  "matched-at": "scanme.sh:443",
  "extracted-results": [
    "CN: scanme"
  ],
  "ip": "128.199.158.128",
  "timestamp": "2023-09-01T11:57:27.879278667Z",
  "matcher-status": true
}
{
  "template": "ssl/self-signed-ssl.yaml",
  "template-url": "https://templates.nuclei.sh/public/self-signed-ssl",
  "template-id": "self-signed-ssl",
  "template-path": "/home/vscode/nuclei-templates/ssl/self-signed-ssl.yaml",
  "info": {
    "name": "Self Signed SSL Certificate",
    "author": [
      "righettod",
      "pdteam"
    ],
    "tags": [
      "ssl"
    ],
    "description": "self-signed certificates are public key certificates that are not issued by a certificate authority. These self-signed\ncertificates are easy to make and do not cost money. However, they do not provide any trust value.\n",
    "reference": [
      "https://www.rapid7.com/db/vulnerabilities/ssl-self-signed-certificate/"
    ],
    "severity": "low",
    "metadata": {
      "max-request": 1
    },
    "remediation": "Purchase or generate a proper SSL certificate for this service.\n"
  },
  "type": "ssl",
  "host": "scanme.sh",
  "matched-at": "scanme.sh:443",
  "ip": "128.199.158.128",
  "timestamp": "2023-09-01T11:57:27.881173042Z",
  "matcher-status": true
}
{
  "template": "ssl/detect-ssl-issuer.yaml",
  "template-url": "https://templates.nuclei.sh/public/ssl-issuer",
  "template-id": "ssl-issuer",
  "template-path": "/home/vscode/nuclei-templates/ssl/detect-ssl-issuer.yaml",
  "info": {
    "name": "Detect SSL Certificate Issuer",
    "author": [
      "lingtren"
    ],
    "tags": [
      "ssl"
    ],
    "description": "Extract the issuer's organization from the target's certificate. Issuers are entities which sign and distribute certificates.\n",
    "severity": "info",
    "metadata": {
      "max-request": 1
    }
  },
  "type": "ssl",
  "host": "scanme.sh",
  "matched-at": "scanme.sh:443",
  "extracted-results": [
    "pd"
  ],
  "ip": "128.199.158.128",
  "timestamp": "2023-09-01T11:57:27.881423959Z",
  "matcher-status": true
}
^C[INF] CTRL+C pressed: Exiting
[INF] Creating resume file: /home/vscode/.config/nuclei/resume-cjot30a1n4a1ig8u6k1g.cfg
exit status 1
```

Closes #4108.