### PR TITLE
header fuzzing support in http templates

### DIFF
--- a/integration_tests/fuzz/fuzz-header-basic.yaml
+++ b/integration_tests/fuzz/fuzz-header-basic.yaml
@@ -1,0 +1,49 @@
+id: fuzz-header-basic
+
+info:
+  name: fuzz header basic
+  author: pdteam
+  severity: info
+  description: |
+    In this template we check for any reflection when fuzzing Origin header
+
+variables:
+  first: "{{rand_int(10000, 99999)}}"
+
+http:
+  - raw:
+      - |
+        GET /?x=aaa&y=bbb HTTP/1.1
+        Host: {{Hostname}}
+        Origin: https://example.com
+        X-Fuzz-Header: 1337
+        Cookie: z=aaa; bb=aaa
+        User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko)
+        Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8
+        Accept-Language: en-US,en;q=0.9
+        Connection: close
+
+    payloads:
+      reflection:
+        - "'\"><{{first}}"
+
+    fuzzing:
+      - part: headers
+        type: replace
+        mode: single
+        keys: ["Origin"]
+        fuzz:
+          - "{{reflection}}"
+
+    stop-at-first-match: true
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "{{reflection}}"
+
+      - type: word
+        part: header
+        words:
+          - "text/html"

--- a/integration_tests/fuzz/fuzz-header-multiple.yaml
+++ b/integration_tests/fuzz/fuzz-header-multiple.yaml
@@ -1,0 +1,41 @@
+id: fuzz-header-basic
+
+info:
+  name: fuzz header basic
+  author: pdteam
+  severity: info
+  description: |
+    In this template we check for any reflection when fuzzing headers
+
+http:
+  - raw:
+      - |
+        GET /?x=aaa&y=bbb HTTP/1.1
+        Host: {{Hostname}}
+        Origin: https://example.com
+        X-Forwared-For: 1337
+        Cookie: z=aaa; bb=aaa
+        User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko)
+        Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8
+        Accept-Language: en-US,en;q=0.9
+        Connection: close
+
+    payloads:
+      reflection:
+        - "secret.local"
+
+    fuzzing:
+      - part: headers
+        type: replace
+        mode: multiple
+        keys: ["Origin", "X-Forwared-For"]
+        fuzz:
+          - "{{reflection}}"
+
+    stop-at-first-match: true
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "admin"

--- a/integration_tests/fuzz/fuzz-header-multiple.yaml
+++ b/integration_tests/fuzz/fuzz-header-multiple.yaml
@@ -1,11 +1,11 @@
-id: fuzz-header-basic
+id: fuzz-header-multiple
 
 info:
-  name: fuzz header basic
+  name: fuzz header multiple
   author: pdteam
   severity: info
   description: |
-    In this template we check for any reflection when fuzzing headers
+    In this template we fuzz multiple headers with single payload
 
 http:
   - raw:

--- a/v2/cmd/integration-test/fuzz.go
+++ b/v2/cmd/integration-test/fuzz.go
@@ -17,6 +17,8 @@ var fuzzingTestCases = []TestCaseInfo{
 	{Path: "fuzz/fuzz-type.yaml", TestCase: &fuzzTypeOverride{}},
 	{Path: "fuzz/fuzz-query.yaml", TestCase: &httpFuzzQuery{}},
 	{Path: "fuzz/fuzz-headless.yaml", TestCase: &HeadlessFuzzingQuery{}},
+	{Path: "fuzz/fuzz-header-basic.yaml", TestCase: &FuzzHeaderBasic{}},
+	{Path: "fuzz/fuzz-header-multiple.yaml", TestCase: &FuzzHeaderMultiple{}},
 }
 
 type httpFuzzQuery struct{}
@@ -146,4 +148,53 @@ func (h *HeadlessFuzzingQuery) Execute(filePath string) error {
 		return err
 	}
 	return expectResultsCount(got, 2)
+}
+
+type FuzzHeaderBasic struct{}
+
+// Execute executes a test case and returns an error if occurred
+func (h *FuzzHeaderBasic) Execute(filePath string) error {
+	router := httprouter.New()
+	router.GET("/", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+		host := r.Header.Get("Origin")
+		// redirect to different domain
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, "<html><body><a href="+host+">Click Here</a></body></html>")
+	})
+	ts := httptest.NewTLSServer(router)
+	defer ts.Close()
+
+	got, err := testutils.RunNucleiTemplateAndGetResults(filePath, ts.URL, debug)
+	if err != nil {
+		return err
+	}
+	return expectResultsCount(got, 1)
+}
+
+type FuzzHeaderMultiple struct{}
+
+// Execute executes a test case and returns an error if occurred
+func (h *FuzzHeaderMultiple) Execute(filePath string) error {
+	router := httprouter.New()
+	router.GET("/", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+		host1 := r.Header.Get("Origin")
+		host2 := r.Header.Get("X-Forwared-For")
+
+		fmt.Printf("host1: %s, host2: %s\n", host1, host2)
+		if host1 == host2 && host2 == "secret.local" {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprintf(w, "welcome! to secret admin panel")
+			return
+		}
+		// redirect to different domain
+		w.WriteHeader(http.StatusForbidden)
+	})
+	ts := httptest.NewTLSServer(router)
+	defer ts.Close()
+
+	got, err := testutils.RunNucleiTemplateAndGetResults(filePath, ts.URL, debug)
+	if err != nil {
+		return err
+	}
+	return expectResultsCount(got, 1)
 }

--- a/v2/pkg/protocols/common/fuzz/execute.go
+++ b/v2/pkg/protocols/common/fuzz/execute.go
@@ -9,6 +9,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/contextargs"
 	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/generators"
 	"github.com/projectdiscovery/retryablehttp-go"
+	errorutil "github.com/projectdiscovery/utils/errors"
 )
 
 // ExecuteRuleInput is the input for rule Execute function
@@ -41,8 +42,11 @@ type GeneratedRequest struct {
 // Input is not thread safe and should not be shared between concurrent
 // goroutines.
 func (rule *Rule) Execute(input *ExecuteRuleInput) error {
+	if input.BaseRequest == nil {
+		return errorutil.NewWithTag("fuzz", "base request is nil for rule %v", rule)
+	}
 	if !rule.isExecutable(input.BaseRequest) {
-		return nil
+		return errorutil.NewWithTag("fuzz", "rule is not executable on %v", input.BaseRequest.URL.String())
 	}
 	baseValues := input.Values
 	if rule.generator == nil {

--- a/v2/pkg/protocols/common/fuzz/execute_test.go
+++ b/v2/pkg/protocols/common/fuzz/execute_test.go
@@ -1,22 +1,35 @@
 package fuzz
 
 import (
+	"github.com/projectdiscovery/retryablehttp-go"
+	urlutil "github.com/projectdiscovery/utils/url"
 	"testing"
 
-	"github.com/projectdiscovery/nuclei/v2/pkg/protocols/common/contextargs"
 	"github.com/stretchr/testify/require"
 )
+
+func buildRequestFromUrl(url string) (*retryablehttp.Request, error) {
+	parsed, err := urlutil.Parse(url)
+	if err != nil {
+		return nil, err
+	}
+	return retryablehttp.NewRequestFromURL("GET", parsed, nil)
+}
 
 func TestRuleIsExecutable(t *testing.T) {
 	rule := &Rule{Part: "query"}
 	err := rule.Compile(nil, nil)
 	require.NoError(t, err, "could not compile rule")
 
-	input := contextargs.NewWithInput("https://example.com/?url=localhost")
-	result := rule.isExecutable(input)
+	req, err := buildRequestFromUrl("https://example.com/?url=localhost")
+	require.NoError(t, err, "could not build request")
+
+	result := rule.isExecutable(req)
 	require.True(t, result, "could not get correct result")
 
-	input = contextargs.NewWithInput("https://example.com/")
-	result = rule.isExecutable(input)
+	req, err = buildRequestFromUrl("https://example.com/")
+	require.NoError(t, err, "could not build request")
+
+	result = rule.isExecutable(req)
 	require.False(t, result, "could not get correct result")
 }

--- a/v2/pkg/protocols/common/fuzz/execute_test.go
+++ b/v2/pkg/protocols/common/fuzz/execute_test.go
@@ -2,32 +2,23 @@ package fuzz
 
 import (
 	"github.com/projectdiscovery/retryablehttp-go"
-	urlutil "github.com/projectdiscovery/utils/url"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
-
-func buildRequestFromUrl(url string) (*retryablehttp.Request, error) {
-	parsed, err := urlutil.Parse(url)
-	if err != nil {
-		return nil, err
-	}
-	return retryablehttp.NewRequestFromURL("GET", parsed, nil)
-}
 
 func TestRuleIsExecutable(t *testing.T) {
 	rule := &Rule{Part: "query"}
 	err := rule.Compile(nil, nil)
 	require.NoError(t, err, "could not compile rule")
 
-	req, err := buildRequestFromUrl("https://example.com/?url=localhost")
+	req, err := retryablehttp.NewRequest("GET", "https://example.com/?url=localhost", nil)
 	require.NoError(t, err, "could not build request")
 
 	result := rule.isExecutable(req)
 	require.True(t, result, "could not get correct result")
 
-	req, err = buildRequestFromUrl("https://example.com/")
+	req, err = retryablehttp.NewRequest("GET", "https://example.com/", nil)
 	require.NoError(t, err, "could not build request")
 
 	result = rule.isExecutable(req)

--- a/v2/pkg/protocols/common/fuzz/fuzz.go
+++ b/v2/pkg/protocols/common/fuzz/fuzz.go
@@ -99,10 +99,12 @@ type partType int
 
 const (
 	queryPartType partType = iota + 1
+	headersPartType
 )
 
 var stringToPartType = map[string]partType{
-	"query": queryPartType,
+	"query":   queryPartType,
+	"headers": headersPartType,
 }
 
 // modeType is the mode of rule enum declaration

--- a/v2/pkg/protocols/headless/request.go
+++ b/v2/pkg/protocols/headless/request.go
@@ -2,10 +2,11 @@ package headless
 
 import (
 	"fmt"
-	"github.com/projectdiscovery/retryablehttp-go"
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/projectdiscovery/retryablehttp-go"
 
 	"github.com/pkg/errors"
 	"golang.org/x/exp/maps"

--- a/v2/pkg/protocols/headless/request.go
+++ b/v2/pkg/protocols/headless/request.go
@@ -2,6 +2,7 @@ package headless
 
 import (
 	"fmt"
+	"github.com/projectdiscovery/retryablehttp-go"
 	"net/url"
 	"strings"
 	"time"
@@ -211,12 +212,16 @@ func (request *Request) executeFuzzingRule(input *contextargs.Context, payloads 
 	if _, err := urlutil.Parse(input.MetaInput.Input); err != nil {
 		return errors.Wrap(err, "could not parse url")
 	}
+	baseRequest, err := retryablehttp.NewRequest("GET", input.MetaInput.Input, nil)
+	if err != nil {
+		return errors.Wrap(err, "could not create base request")
+	}
 	for _, rule := range request.Fuzzing {
 		err := rule.Execute(&fuzz.ExecuteRuleInput{
 			Input:       input,
 			Callback:    fuzzRequestCallback,
 			Values:      payloads,
-			BaseRequest: nil,
+			BaseRequest: baseRequest,
 		})
 		if err == types.ErrNoMoreRequests {
 			return nil

--- a/v2/pkg/protocols/http/request.go
+++ b/v2/pkg/protocols/http/request.go
@@ -229,8 +229,12 @@ func (request *Request) executeTurboHTTP(input *contextargs.Context, dynamicValu
 
 // executeFuzzingRule executes fuzzing request for a URL
 func (request *Request) executeFuzzingRule(input *contextargs.Context, previous output.InternalEvent, callback protocols.OutputEventCallback) error {
-	if _, err := urlutil.Parse(input.MetaInput.Input); err != nil {
-		return errors.Wrap(err, "could not parse url")
+	// If request is self-contained we don't need to parse any input.
+	if !request.SelfContained {
+		// If it's not self-contained we parse user provided input
+		if _, err := urlutil.Parse(input.MetaInput.Input); err != nil {
+			return errors.Wrap(err, "could not parse url")
+		}
 	}
 	fuzzRequestCallback := func(gr fuzz.GeneratedRequest) bool {
 		hasInteractMatchers := interactsh.HasMatchers(request.CompiledOperators)

--- a/v2/pkg/protocols/http/request.go
+++ b/v2/pkg/protocols/http/request.go
@@ -277,6 +277,7 @@ func (request *Request) executeFuzzingRule(input *contextargs.Context, previous 
 			if request.options.HostErrorsCache != nil {
 				request.options.HostErrorsCache.MarkFailed(input.MetaInput.Input, requestErr)
 			}
+			gologger.Verbose().Msgf("[%s] Error occurred in request: %s\n", request.options.TemplateID, requestErr)
 		}
 		request.options.Progress.IncrementRequests()
 


### PR DESCRIPTION
#4113  Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->

Hi, I add new fuzzing part - `headersPartType`. It can be used to fuzz headers. Because user specify url as input I change argument type of `rule.isExecutable()` to access headers and body params in future. Can you please check that I move in right direction and if all is fine I will implement body parameters fuzzing

