### PR TITLE
Check matcher status for cluster template execution

### DIFF
--- a/v2/pkg/templates/cluster.go
+++ b/v2/pkg/templates/cluster.go
@@ -249,7 +249,7 @@ func (e *ClusterExecuter) Execute(input *contextargs.Context) (bool, error) {
 			event.InternalEvent["template-path"] = operator.templatePath
 			event.InternalEvent["template-info"] = operator.templateInfo
 
-			if result == nil && !matched {
+			if result == nil && !matched && e.options.Options.MatcherStatus {
 				if err := e.options.Output.WriteFailure(event); err != nil {
 					gologger.Warning().Msgf("Could not write failure event to output: %s\n", err)
 				}


### PR DESCRIPTION
closes https://github.com/projectdiscovery/nuclei/issues/4130

we are checking the matcherStatus for normal execution before failure
https://github.com/projectdiscovery/nuclei/blob/daeded0935187d459bb7f4e9224ce8b71ea2fb55/v2/pkg/protocols/common/executer/executer.go#L78

but not checking when clustered template execution, so updated it