### PR TITLE
Add prompt to clarify parameter as template list instead of file

### DIFF
--- a/v2/pkg/catalog/config/template.go
+++ b/v2/pkg/catalog/config/template.go
@@ -48,7 +48,11 @@ func IsTemplate(filename string) bool {
 	if stringsutil.ContainsAny(filename, knownConfigFiles...) {
 		return false
 	}
-	return stringsutil.EqualFoldAny(filepath.Ext(filename), GetSupportTemplateFileExtensions()...)
+	isTemplate := stringsutil.EqualFoldAny(filepath.Ext(filename), GetSupportTemplateFileExtensions()...)
+	if !isTemplate {
+		gologger.Info().Msgf("The '%s' is recognized as a template list. Template file's extension should be yaml or json.\n", filename)
+	}
+	return isTemplate
 }
 
 type template struct {


### PR DESCRIPTION
This commit adds a prompt to inform users when their input is interpreted as a list of templates, rather than a single template file. This addresses potential confusion where a user may unknowingly pass a parameter intended to be a single template file but is treated as a list. The added message specifies that the file extension should be either yaml or json to be recognized as a single template file.

## Proposed changes

Problem
Today is my first day using Nuclei. I ran into an issue when using a file with a .yml extension. The application threw an error (see screenshot). After spending considerable time debugging, I found out that Nuclei was treating my file as a list of templates rather than a single template file.
<img width="1192" alt="image" src="https://github.com/projectdiscovery/nuclei/assets/31102783/af9fcd68-6f4e-401c-ae0c-7db496200030">


Solution
To address this, I've modified the code to add an info message. The new message informs the user that the application interprets their input as a list of templates. It also specifies that in order to be recognized as a single template file, the file extension should be either .yaml or .json (see screenshot).
![image](https://github.com/projectdiscovery/nuclei/assets/31102783/8f6ac288-9b1f-450c-9177-273edd13dd5a)

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)