### PR TITLE
output.ResultEvent add a Body field

### DIFF
--- a/v2/pkg/output/output.go
+++ b/v2/pkg/output/output.go
@@ -135,6 +135,8 @@ type ResultEvent struct {
 	Request string `json:"request,omitempty"`
 	// Response is the optional, dumped response for the match.
 	Response string `json:"response,omitempty"`
+	// Body is the optional, dumped response.body for the match.
+	Body string `json:"body,omitempty"`
 	// Metadata contains any optional metadata for the event
 	Metadata map[string]interface{} `json:"meta,omitempty"`
 	// IP is the IP address for the found result event.

--- a/v2/pkg/protocols/http/operators.go
+++ b/v2/pkg/protocols/http/operators.go
@@ -163,6 +163,7 @@ func (request *Request) MakeResultEventItem(wrapped *output.InternalWrappedEvent
 		IP:               types.ToString(wrapped.InternalEvent["ip"]),
 		Request:          types.ToString(wrapped.InternalEvent["request"]),
 		Response:         request.truncateResponse(wrapped.InternalEvent["response"]),
+		Body:             types.ToString(wrapped.InternalEvent["body"]),
 		CURLCommand:      types.ToString(wrapped.InternalEvent["curl-command"]),
 	}
 	return data


### PR DESCRIPTION
## Proposed changes

Sometimes, like Arbitrary File Read Vulnerability, we need to get a **Body** message


## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [X] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [X] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)