### PR TITLE
feat: reuse Github issues instead of creating a new one every time for the same finding

### DIFF
--- a/v2/cmd/nuclei/issue-tracker-config.yaml
+++ b/v2/cmd/nuclei/issue-tracker-config.yaml
@@ -17,6 +17,8 @@
 #  project-name: test-project
 #  # issue-label is the label of the created issue type
 #  issue-label: bug
+#  # duplicate-issue-check flag to enable duplicate tracking issue check.
+#  duplicate-issue-check: false
 #
 # GitLab contains configuration options for gitlab issue tracker
 #gitlab:


### PR DESCRIPTION
## Proposed changes

Currently the issue reporter on github creates a new issue every time a finding is encountered. This commit changes this behavior and instead keeps one issue per all encounters of a particular finding, where finding is considered a unique title.

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (tested manually as the reporter lacks a test suite)
- [x] I have added necessary documentation (if appropriate)