### PR TITLE
Add endpoint var

### DIFF
--- a/docs/template-example/network.mdx
+++ b/docs/template-example/network.mdx
@@ -16,7 +16,7 @@ info:
 
 tcp:
   - host: 
-      - "{{Hostname}}"
+      - "{{Endpoint}}"
     inputs:
       - data: "PING\r\n"
     read-size: 4
@@ -41,7 +41,7 @@ info:
 
 tcp:
   - host: 
-      - "tls://{{Hostname}}"
+      - "tls://{{Endpoint}}"
     inputs:
       - data: "PING\r\n"
     read-size: 4
@@ -66,7 +66,7 @@ info:
 
 tcp:
   - host: 
-      - "{{Hostname}}"
+      - "{{Endpoint}}"
     inputs:
       - data: "50494e47"
         type: hex
@@ -98,7 +98,7 @@ tcp:
   - inputs:
       - data: "{{hex_decode('3a000000a741000000000000d40700000000000061646d696e2e24636d640000000000ffffffff130000001069736d6173746572000100000000')}}"
     host:
-      - "{{Hostname}}"
+      - "{{Endpoint}}"
     read-size: 2048
     matchers:
       - type: word
@@ -131,7 +131,7 @@ tcp:
         read: 1024
       - data: "site cpto /var/www/html/{{randstr}}\r\n"
     host:
-      - "{{Hostname}}"
+      - "{{Endpoint}}"
     read-size: 1024
     matchers:
       - type: word

--- a/docs/template-guide/network.mdx
+++ b/docs/template-guide/network.mdx
@@ -66,20 +66,20 @@ Multiple steps can be chained together in sequence to do network reading / writi
 
 The next part of the requests is the **host** to connect to. Dynamic variables can be placed in the path to modify its value on runtime. Variables start with `{{` and end with `}}` and are case-sensitive.
 
-1. **Hostname** - variable is replaced by the hostname provided on command line.
+1. **Endpoint** - variable is replaced by the IP/domain and port combination provided on command line.
 
 An example name value:
 
 ```yaml
 host: 
-  - "{{Hostname}}"
+  - "{{Endpoint}}"
 ```
 
-Nuclei can also do TLS connection to the target server. Just add `tls://` as prefix before the **Hostname** and you're good to go.
+Nuclei can also do TLS connection to the target server. Just add `tls://` as prefix before the **Endpoint** and you're good to go.
 
 ```yaml
 host:
-  - "tls://{{Hostname}}"
+  - "tls://{{Endpoint}}"
 ```
 
 If a port is specified in the host, the user supplied port is ignored and the template port takes precedence.
@@ -91,8 +91,8 @@ Starting from Nuclei v2.9.15, a new field called `port` has been introduced in n
 Previously, if you wanted to write a network template for an exploit targeting SSH, you would have to specify both the hostname and the port in the host field, like this:
 ```yaml
 host:
-  - "{{Hostname}}"
-  - "{{Host}}:22"
+  - "{{Endpoint}}"
+  - "{{Endpoint}}:22"
 ```
 
 In the above example, two network requests are sent: one to the port specified in the input/target, and another to the default SSH port (22).
@@ -117,7 +117,7 @@ To address these issues while maintaining the existing functionality, network te
 
 ```yaml
 host:
-  - "{{Hostname}}"
+  - "{{Endpoint}}"
 port: 22
 ```
 In this new design, the functionality to run templates on non-standard ports will still exist, except for the default reserved ports (`80`, `443`, `8080`, `8443`, `8081`, `53`). Additionally, the list of default reserved ports can be customized by adding a new field called exclude-ports:
@@ -154,7 +154,7 @@ tcp:
   - inputs:
       - data: "{{hex_decode('3a000000a741000000000000d40700000000000061646d696e2e24636d640000000000ffffffff130000001069736d6173746572000100000000')}}"
     host:
-      - "{{Hostname}}"
+      - "{{Endpoint}}"
     port: 27017
     read-size: 2048
     matchers:

--- a/pkg/protocols/utils/variables.go
+++ b/pkg/protocols/utils/variables.go
@@ -22,6 +22,7 @@ func init() {
 		RootURL:  "RootURL",
 		Hostname: "Hostname",
 		Host:     "Host",
+		Endpoint: "Endpoint",
 		Port:     "Port",
 		Path:     "Path",
 		File:     "File",
@@ -42,6 +43,7 @@ const (
 	RootURL
 	Hostname
 	Host
+	Endpoint
 	Port
 	Path
 	File
@@ -158,6 +160,8 @@ func generateVariables(inputURL *urlutil.URL, removeTrailingSlash bool) map[stri
 			knownVariables[v] = parsed.Host
 		case Host:
 			knownVariables[v] = parsed.Hostname()
+		case Endpoint:
+			knownVariables[v] = endpoint(parsed.Hostname(), port)
 		case Port:
 			knownVariables[v] = port
 		case Path:
@@ -171,4 +175,11 @@ func generateVariables(inputURL *urlutil.URL, removeTrailingSlash bool) map[stri
 		}
 	}
 	return generators.MergeMaps(knownVariables, GenerateDNSVariables(parsed.Hostname()))
+}
+
+func endpoint(hostname, port string) string {
+	if port != "" {
+		return fmt.Sprintf("%s:%s", hostname, port)
+	}
+	return hostname
 }

--- a/pkg/protocols/utils/variables.go
+++ b/pkg/protocols/utils/variables.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"fmt"
+	"net"
 	"path"
 	"strings"
 
@@ -179,7 +180,7 @@ func generateVariables(inputURL *urlutil.URL, removeTrailingSlash bool) map[stri
 
 func endpoint(hostname, port string) string {
 	if port != "" {
-		return fmt.Sprintf("%s:%s", hostname, port)
+		return net.JoinHostPort(hostname, port)
 	}
 	return hostname
 }


### PR DESCRIPTION
## Proposal
Define a simple `IpPort` variable (or similar name) that points to the actual `ip|domain:port` without ambiguity and "deprecate" or disincentive `Hostname` and `Host` usage, unless necessary. Closes #3954.

```console
$ cat test.txt 
192.168.5.1:443
192.168.1.1

$ cat test.yaml 
id: test

info:
  name: test
  author: test
  severity: info
  tags: test

tcp:
    - host:
      - "{{Endpoint}}"
      port: 443
      matchers:
        - type: dsl
          dsl:
            - "jarm(Hostname) == 'xxxxxx'"


$ cat test.txt | go run . -t test.yaml -verbose

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.0.1

                projectdiscovery.io

[INF] Current nuclei version: v3.0.1 (latest)
[INF] Current nuclei-templates version: v9.6.7 (latest)
[INF] New templates added in latest release: 1
[INF] Templates loaded for current scan: 1
[WRN] Executing 1 unsigned templates. Use with caution.
[INF] Targets loaded for current scan: 2
[VER] Sent TCP request to 192.168.1.1:443
[WRN] [test] Could not make network request for (192.168.5.1:443) : could not connect to server: [:RUNTIME] ztls fallback failed <- dial tcp 192.168.5.1:443: i/o timeout
[INF] No results found. Better luck next time!
```

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)