### PR TITLE
feat: allow cipher enumeration in SSL protocol

### DIFF
--- a/pkg/protocols/ssl/ssl.go
+++ b/pkg/protocols/ssl/ssl.go
@@ -76,6 +76,14 @@ type Request struct {
 	//   - "auto"
 	//	 - "openssl" # reverts to "auto" is openssl is not installed
 	ScanMode string `yaml:"scan_mode,omitempty" json:"scan_mode,omitempty" jsonschema:"title=Scan Mode,description=Scan Mode - auto if not specified.,enum=ctls,enum=ztls,enum=auto"`
+	// description: |
+	//   TLS Versions Enum - false if not specified
+	//   Enumerates supported TLS versions
+	TLSVersionsEnum bool `yaml:"tls_versions_enum,omitempty" json:"tls_versions_enum,omitempty" jsonschema:"title=Enumerate Versions,description=Enumerate Version - false if not specified"`
+	// description: |
+	//   TLS Ciphers Enum - false if not specified
+	//   Enumerates supported TLS ciphers
+	TLSCiphersEnum bool `yaml:"tls_ciphers_enum,omitempty" json:"tls_ciphers_enum,omitempty" jsonschema:"title=Enumerate Ciphers,description=Enumerate Ciphers - false if not specified"`
 
 	// cache any variables that may be needed for operation.
 	dialer  *fastdialer.Dialer
@@ -133,6 +141,8 @@ func (request *Request) Compile(options *protocols.ExecutorOptions) error {
 		ClientHello:       true,
 		ServerHello:       true,
 		DisplayDns:        true,
+		TlsVersionsEnum:   request.TLSVersionsEnum,
+		TlsCiphersEnum:    request.TLSCiphersEnum,
 	}
 
 	tlsxService, err := tlsx.New(tlsxOptions)


### PR DESCRIPTION
## Proposed changes

This allows enabling cipher and TLS version enumeration in SSL protocol; enabling templates to access ciphers_enum to perform checks on all supported ciphers.


## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)