### PR TITLE
ignore example test in ci

### DIFF
--- a/lib/example_test.go
+++ b/lib/example_test.go
@@ -77,7 +77,7 @@ func ExampleThreadSafeNucleiEngine() {
 func TestMain(m *testing.M) {
 	// this file only contains testtables examples https://go.dev/blog/examples
 	// and actual functionality test are in sdk_test.go
-	if os.Getenv("GH_ACTION") != "" {
+	if os.Getenv("GH_ACTION") != "" || os.Getenv("CI") != "" {
 		// no need to run this test on github actions
 		return
 	}


### PR DESCRIPTION
- example test in go exist for **live demo** in documentation itself . and are not unit test we have seperate tests for functionality testing and more . 
- example test are failing in gh action . this PR disables that behaviour