### PR TITLE
Introduce template encoded field

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,8 +157,9 @@ OUTPUT:
    -silent                       display findings only
    -nc, -no-color                disable output content coloring (ANSI escape codes)
    -j, -jsonl                    write output in JSONL(ines) format
-   -irr, -include-rr             include request/response pairs in the JSON, JSONL, and Markdown outputs (for findings only) [DEPRECATED use -omit-raw] (default true)
+   -irr, -include-rr -omit-raw   include request/response pairs in the JSON, JSONL, and Markdown outputs (for findings only) [DEPRECATED use -omit-raw] (default true)
    -or, -omit-raw                omit request/response pairs in the JSON, JSONL, and Markdown outputs (for findings only)
+   -ot, -omit-template           omit encoded template in the JSON, JSONL output
    -nm, -no-meta                 disable printing result metadata in cli output
    -ts, -timestamp               enables printing timestamp in cli output
    -rdb, -report-db string       nuclei reporting database (always use this to persist report data)

--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -222,6 +222,7 @@ on extensive configurability, massive extensibility and ease of use.`)
 		flagSet.BoolVarP(&options.JSONL, "jsonl", "j", false, "write output in JSONL(ines) format"),
 		flagSet.BoolVarP(&options.JSONRequests, "include-rr", "irr", true, "include request/response pairs in the JSON, JSONL, and Markdown outputs (for findings only) [DEPRECATED use `-omit-raw`]"),
 		flagSet.BoolVarP(&options.OmitRawRequests, "omit-raw", "or", false, "omit request/response pairs in the JSON, JSONL, and Markdown outputs (for findings only)"),
+		flagSet.BoolVarP(&options.OmitTemplate, "omit-template", "ot", false, "omit encoded template in the JSON, JSONL output"),
 		flagSet.BoolVarP(&options.NoMeta, "no-meta", "nm", false, "disable printing result metadata in cli output"),
 		flagSet.BoolVarP(&options.Timestamp, "timestamp", "ts", false, "enables printing timestamp in cli output"),
 		flagSet.StringVarP(&options.ReportingDB, "report-db", "rdb", "", "nuclei reporting database (always use this to persist report data)"),

--- a/docs/getting-started/install.mdx
+++ b/docs/getting-started/install.mdx
@@ -9,7 +9,7 @@ title: 'Install'
     go install -v github.com/projectdiscovery/nuclei/v3/cmd/nuclei@latest
     ```
 
-    <Note>Nuclei require latest **GO** version to install successfully.</Note>
+    <Note>Nuclei requires latest **GO** version to install successfully.</Note>
 
   </Tab>
   <Tab title="Brew">

--- a/docs/template-guide/flow.mdx
+++ b/docs/template-guide/flow.mdx
@@ -34,9 +34,9 @@ http:
       - "{{BaseURL}}/wp-login.php"
 
     matchers:
-        - type: word
-            words:
-            - "WordPress"
+      - type: word
+        words:
+          - "WordPress"
 
   - method: POST
     path:

--- a/go.mod
+++ b/go.mod
@@ -77,7 +77,7 @@ require (
 	github.com/mholt/archiver v3.1.1+incompatible
 	github.com/ory/dockertest/v3 v3.10.0
 	github.com/praetorian-inc/fingerprintx v1.1.9
-	github.com/projectdiscovery/dsl v0.0.26
+	github.com/projectdiscovery/dsl v0.0.27
 	github.com/projectdiscovery/fasttemplate v0.0.2
 	github.com/projectdiscovery/goflags v0.1.25
 	github.com/projectdiscovery/gologger v1.1.11

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/pkg/errors v0.9.1
 	github.com/projectdiscovery/clistats v0.0.19
-	github.com/projectdiscovery/fastdialer v0.0.40
+	github.com/projectdiscovery/fastdialer v0.0.41
 	github.com/projectdiscovery/hmap v0.0.22
 	github.com/projectdiscovery/interactsh v1.1.7
 	github.com/projectdiscovery/rawhttp v0.1.23

--- a/go.sum
+++ b/go.sum
@@ -791,8 +791,8 @@ github.com/projectdiscovery/cdncheck v1.0.9 h1:BS15gzj9gb5AVSKqTDzPamfSgStu7nJQO
 github.com/projectdiscovery/cdncheck v1.0.9/go.mod h1:18SSl1w7rMj53CGeRIZTbDoa286a6xZIxGbaiEo4Fxs=
 github.com/projectdiscovery/clistats v0.0.19 h1:SA/qRHbmS9VEbVEPzX/ka01hZDYATL9ZjAnDatybhLw=
 github.com/projectdiscovery/clistats v0.0.19/go.mod h1:NQDAW/O7cK9xBIgk46kJjwGRkjSg5JkB8E4DvuxXr+c=
-github.com/projectdiscovery/dsl v0.0.26 h1:zSirh38+KIaBtak2Vi8LVpN5Aj1ZuwpARnQ69Ja5fSs=
-github.com/projectdiscovery/dsl v0.0.26/go.mod h1:XCsu0FtORqnjRElNTYrewzTw4LPlBtPu/j4T2Hel2UU=
+github.com/projectdiscovery/dsl v0.0.27 h1:7JosPkZi7l6wHn4ojxjZRqFIh58d5z2V/ZSDfvBEXDI=
+github.com/projectdiscovery/dsl v0.0.27/go.mod h1:jYku7Nu5FvlidS0+QNmh2I/UMvemf37bkWMKEU+SZ00=
 github.com/projectdiscovery/fastdialer v0.0.41 h1:OawlFknmOBYw73HsZV0RABTr4ksg3Gu63xamfqdlHaM=
 github.com/projectdiscovery/fastdialer v0.0.41/go.mod h1:hS5IrkkLN49ZY6dB8Vao6TxufebkE/Ml76Z6MRsl4fc=
 github.com/projectdiscovery/fasttemplate v0.0.2 h1:h2cISk5xDhlJEinlBQS6RRx0vOlOirB2y3Yu4PJzpiA=

--- a/go.sum
+++ b/go.sum
@@ -793,8 +793,8 @@ github.com/projectdiscovery/clistats v0.0.19 h1:SA/qRHbmS9VEbVEPzX/ka01hZDYATL9Z
 github.com/projectdiscovery/clistats v0.0.19/go.mod h1:NQDAW/O7cK9xBIgk46kJjwGRkjSg5JkB8E4DvuxXr+c=
 github.com/projectdiscovery/dsl v0.0.26 h1:zSirh38+KIaBtak2Vi8LVpN5Aj1ZuwpARnQ69Ja5fSs=
 github.com/projectdiscovery/dsl v0.0.26/go.mod h1:XCsu0FtORqnjRElNTYrewzTw4LPlBtPu/j4T2Hel2UU=
-github.com/projectdiscovery/fastdialer v0.0.40 h1:gXKJv32xyXDpNXM1zzaY7IGYfsZPPOp1V8CDjgKrNX0=
-github.com/projectdiscovery/fastdialer v0.0.40/go.mod h1:51m88QxZiJ06Df6WCFeauY9EjfbalLFKeqvDmXovwTI=
+github.com/projectdiscovery/fastdialer v0.0.41 h1:OawlFknmOBYw73HsZV0RABTr4ksg3Gu63xamfqdlHaM=
+github.com/projectdiscovery/fastdialer v0.0.41/go.mod h1:hS5IrkkLN49ZY6dB8Vao6TxufebkE/Ml76Z6MRsl4fc=
 github.com/projectdiscovery/fasttemplate v0.0.2 h1:h2cISk5xDhlJEinlBQS6RRx0vOlOirB2y3Yu4PJzpiA=
 github.com/projectdiscovery/fasttemplate v0.0.2/go.mod h1:XYWWVMxnItd+r0GbjA1GCsUopMw1/XusuQxdyAIHMCw=
 github.com/projectdiscovery/freeport v0.0.5 h1:jnd3Oqsl4S8n0KuFkE5Hm8WGDP24ITBvmyw5pFTHS8Q=

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -252,6 +252,8 @@ type Options struct {
 	JSONRequests bool
 	// OmitRawRequests omits requests/responses for matches in JSON output
 	OmitRawRequests bool
+	// OmitTemplate omits encoded template from JSON output
+	OmitTemplate bool
 	// JSONExport is the file to export JSON output format to
 	JSONExport string
 	// JSONLExport is the file to export JSONL output format to

--- a/pkg/utils/template_path.go
+++ b/pkg/utils/template_path.go
@@ -13,15 +13,11 @@ const (
 
 // TemplatePathURL returns the Path and URL for the provided template
 func TemplatePathURL(fullPath, templateId string) (string, string) {
-	var templateDirectory string
-	configData := config.DefaultConfig
-	if configData.TemplatesDirectory != "" && strings.HasPrefix(fullPath, configData.TemplatesDirectory) {
-		templateDirectory = configData.TemplatesDirectory
-	} else {
+	if IsCustomTemplate(fullPath) {
 		return "", ""
 	}
 
-	finalPath := strings.TrimPrefix(strings.TrimPrefix(fullPath, templateDirectory), "/")
+	relativePath := strings.TrimPrefix(strings.TrimPrefix(fullPath, config.DefaultConfig.TemplatesDirectory), "/")
 	templateURL := TemplatesRepoURL + templateId
-	return finalPath, templateURL
+	return relativePath, templateURL
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -78,3 +78,8 @@ func StringSliceContains(slice []string, item string) bool {
 	}
 	return false
 }
+
+// IsCustomTemplate checks if the template is a custom template
+func IsCustomTemplate(templatePath string) bool {
+	return !strings.HasPrefix(templatePath, config.DefaultConfig.TemplatesDirectory)
+}


### PR DESCRIPTION
## Proposed changes
```console
$ cat test.yaml 
id: basic-example

info:
  name: Test HTTP Template
  author: pdteam
  severity: info

http:
  - method: GET
    path:
      - "{{BaseURL}}"
    matchers:
      - type: word
        words:
          - "This is test matcher text"
        negative: true

$ go run . -u scanme.sh -t test.yaml -silent -j | jq
{
  "template-id": "basic-example",
  "template-path": "/workspaces/nuclei/cmd/nuclei/test.yaml",
  "template-encoded": "aWQ6IGJhc2ljLWV4YW1wbGUKCmluZm86CiAgbmFtZTogVGVzdCBIVFRQIFRlbXBsYXRlCiAgYXV0aG9yOiBwZHRlYW0KICBzZXZlcml0eTogaW5mbwoKaHR0cDoKICAtIG1ldGhvZDogR0VUCiAgICBwYXRoOgogICAgICAtICJ7e0Jhc2VVUkx9fSIKICAgIG1hdGNoZXJzOgogICAgICAtIHR5cGU6IHdvcmQKICAgICAgICB3b3JkczoKICAgICAgICAgIC0gIlRoaXMgaXMgdGVzdCBtYXRjaGVyIHRleHQiCiAgICAgICAgbmVnYXRpdmU6IHRydWUKICAgICAgICA=",
  "info": {
    "name": "Test HTTP Template",
    "author": [
      "pdteam"
    ],
    "tags": null,
    "severity": "info"
  },
  "type": "http",
  "host": "https://scanme.sh",
  "matched-at": "https://scanme.sh",
  "request": "GET / HTTP/1.1\r\nHost: scanme.sh\r\nUser-Agent: Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.2117.157 Safari/537.36\r\nConnection: close\r\nAccept: */*\r\nAccept-Language: en\r\nAccept-Encoding: gzip\r\n\r\n",
  "response": "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 2\r\nContent-Type: text/plain; charset=utf-8\r\nDate: Mon, 30 Oct 2023 13:36:43 GMT\r\n\r\nok",
  "ip": "128.199.158.128",
  "timestamp": "2023-10-30T13:36:43.731371096Z",
  "curl-command": "curl -X 'GET' -H 'Accept: */*' -H 'Accept-Language: en' -H 'User-Agent: Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.2117.157 Safari/537.36' 'https://scanme.sh'",
  "matcher-status": true
}
```
This PR also adds `-ot, -omit-template  omit encoded template in the JSON, JSONL output` flag and 1MB max template file size for encoding.

Closes #4218.


## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)