### PR TITLE
introduce `template-encoded` field

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,8 +157,9 @@ OUTPUT:
    -silent                       display findings only
    -nc, -no-color                disable output content coloring (ANSI escape codes)
    -j, -jsonl                    write output in JSONL(ines) format
-   -irr, -include-rr             include request/response pairs in the JSON, JSONL, and Markdown outputs (for findings only) [DEPRECATED use -omit-raw] (default true)
+   -irr, -include-rr -omit-raw   include request/response pairs in the JSON, JSONL, and Markdown outputs (for findings only) [DEPRECATED use -omit-raw] (default true)
    -or, -omit-raw                omit request/response pairs in the JSON, JSONL, and Markdown outputs (for findings only)
+   -ot, -omit-template           omit encoded template in the JSON, JSONL output
    -nm, -no-meta                 disable printing result metadata in cli output
    -ts, -timestamp               enables printing timestamp in cli output
    -rdb, -report-db string       nuclei reporting database (always use this to persist report data)

--- a/cmd/integration-test/library.go
+++ b/cmd/integration-test/library.go
@@ -75,18 +75,18 @@ func executeNucleiAsLibrary(templatePath, templateURL string) ([]string, error) 
 	}
 	defer reportingClient.Close()
 
-	outputWriter := testutils.NewMockOutputWriter()
-	var results []string
-	outputWriter.WriteCallback = func(event *output.ResultEvent) {
-		results = append(results, fmt.Sprintf("%v\n", event))
-	}
-
 	defaultOpts := types.DefaultOptions()
 	_ = protocolstate.Init(defaultOpts)
 	_ = protocolinit.Init(defaultOpts)
 
 	defaultOpts.Templates = goflags.StringSlice{templatePath}
 	defaultOpts.ExcludeTags = config.ReadIgnoreFile().Tags
+
+	outputWriter := testutils.NewMockOutputWriter(defaultOpts.OmitTemplate)
+	var results []string
+	outputWriter.WriteCallback = func(event *output.ResultEvent) {
+		results = append(results, fmt.Sprintf("%v\n", event))
+	}
 
 	interactOpts := interactsh.DefaultOptions(outputWriter, reportingClient, mockProgress)
 	interactClient, err := interactsh.New(interactOpts)

--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -222,6 +222,7 @@ on extensive configurability, massive extensibility and ease of use.`)
 		flagSet.BoolVarP(&options.JSONL, "jsonl", "j", false, "write output in JSONL(ines) format"),
 		flagSet.BoolVarP(&options.JSONRequests, "include-rr", "irr", true, "include request/response pairs in the JSON, JSONL, and Markdown outputs (for findings only) [DEPRECATED use `-omit-raw`]"),
 		flagSet.BoolVarP(&options.OmitRawRequests, "omit-raw", "or", false, "omit request/response pairs in the JSON, JSONL, and Markdown outputs (for findings only)"),
+		flagSet.BoolVarP(&options.OmitTemplate, "omit-template", "ot", false, "omit encoded template in the JSON, JSONL output"),
 		flagSet.BoolVarP(&options.NoMeta, "no-meta", "nm", false, "disable printing result metadata in cli output"),
 		flagSet.BoolVarP(&options.Timestamp, "timestamp", "ts", false, "enables printing timestamp in cli output"),
 		flagSet.StringVarP(&options.ReportingDB, "report-db", "rdb", "", "nuclei reporting database (always use this to persist report data)"),

--- a/lib/sdk_private.go
+++ b/lib/sdk_private.go
@@ -35,7 +35,7 @@ import (
 // applyRequiredDefaults to options
 func (e *NucleiEngine) applyRequiredDefaults() {
 	if e.customWriter == nil {
-		mockoutput := testutils.NewMockOutputWriter()
+		mockoutput := testutils.NewMockOutputWriter(e.opts.OmitTemplate)
 		mockoutput.WriteCallback = func(event *output.ResultEvent) {
 			if len(e.resultCallbacks) > 0 {
 				for _, callback := range e.resultCallbacks {

--- a/pkg/catalog/config/nucleiconfig.go
+++ b/pkg/catalog/config/nucleiconfig.go
@@ -51,6 +51,28 @@ type Config struct {
 	configDir      string `json:"-"` //  Nuclei Global Config Directory
 }
 
+// IsCustomTemplate determines whether a given template is custom-built or part of the official Nuclei templates.
+// It checks if the template's path matches any of the predefined custom template directories
+// (such as S3, GitHub, GitLab, and Azure directories). If the template resides in any of these directories,
+// it is considered custom. Additionally, if the template's path does not start with the main Nuclei TemplatesDirectory,
+// it is also considered custom. This function assumes that template paths are either absolute
+// or relative to the same base as the paths configured in DefaultConfig.
+func (c *Config) IsCustomTemplate(templatePath string) bool {
+	customDirs := []string{
+		c.CustomS3TemplatesDirectory,
+		c.CustomGitHubTemplatesDirectory,
+		c.CustomGitLabTemplatesDirectory,
+		c.CustomAzureTemplatesDirectory,
+	}
+
+	for _, dir := range customDirs {
+		if strings.HasPrefix(templatePath, dir) {
+			return true
+		}
+	}
+	return !strings.HasPrefix(templatePath, c.TemplatesDirectory)
+}
+
 // WriteVersionCheckData writes version check data to config file
 func (c *Config) WriteVersionCheckData(ignorehash, nucleiVersion, templatesVersion string) error {
 	updated := false

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -21,6 +21,7 @@ import (
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/interactsh/pkg/server"
 	"github.com/projectdiscovery/nuclei/v3/internal/colorizer"
+	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/config"
 	"github.com/projectdiscovery/nuclei/v3/pkg/model"
 	"github.com/projectdiscovery/nuclei/v3/pkg/model/types/severity"
 	"github.com/projectdiscovery/nuclei/v3/pkg/operators"
@@ -360,7 +361,7 @@ var maxTemplateFileSizeForEncoding = 1024 * 1024
 
 func (w *StandardWriter) encodeTemplate(templatePath string) string {
 	data, err := os.ReadFile(templatePath)
-	if err == nil && !w.omitTemplate && len(data) <= maxTemplateFileSizeForEncoding {
+	if err == nil && !w.omitTemplate && len(data) <= maxTemplateFileSizeForEncoding && config.DefaultConfig.IsCustomTemplate(templatePath) {
 		return base64.StdEncoding.EncodeToString(data)
 	}
 	return ""

--- a/pkg/protocols/code/code.go
+++ b/pkg/protocols/code/code.go
@@ -254,6 +254,7 @@ func (request *Request) MakeResultEventItem(wrapped *output.InternalWrappedEvent
 		ExtractedResults: wrapped.OperatorsResult.OutputExtracts,
 		Timestamp:        time.Now(),
 		MatcherStatus:    true,
+		TemplateEncoded:  request.options.EncodeTemplate(),
 	}
 	return data
 }

--- a/pkg/protocols/dns/operators.go
+++ b/pkg/protocols/dns/operators.go
@@ -122,6 +122,7 @@ func (request *Request) MakeResultEventItem(wrapped *output.InternalWrappedEvent
 		Timestamp:        time.Now(),
 		Request:          types.ToString(wrapped.InternalEvent["request"]),
 		Response:         types.ToString(wrapped.InternalEvent["raw"]),
+		TemplateEncoded:  request.options.EncodeTemplate(),
 	}
 	return data
 }

--- a/pkg/protocols/file/operators.go
+++ b/pkg/protocols/file/operators.go
@@ -107,6 +107,7 @@ func (request *Request) MakeResultEventItem(wrapped *output.InternalWrappedEvent
 		ExtractedResults: wrapped.OperatorsResult.OutputExtracts,
 		Response:         types.ToString(wrapped.InternalEvent["raw"]),
 		Timestamp:        time.Now(),
+		TemplateEncoded:  request.options.EncodeTemplate(),
 	}
 	return data
 }

--- a/pkg/protocols/headless/operators.go
+++ b/pkg/protocols/headless/operators.go
@@ -138,6 +138,7 @@ func (request *Request) MakeResultEventItem(wrapped *output.InternalWrappedEvent
 		IP:               types.ToString(wrapped.InternalEvent["ip"]),
 		Request:          types.ToString(wrapped.InternalEvent["request"]),
 		Response:         types.ToString(wrapped.InternalEvent["data"]),
+		TemplateEncoded:  request.options.EncodeTemplate(),
 	}
 	return data
 }

--- a/pkg/protocols/http/operators.go
+++ b/pkg/protocols/http/operators.go
@@ -164,6 +164,7 @@ func (request *Request) MakeResultEventItem(wrapped *output.InternalWrappedEvent
 		Request:          types.ToString(wrapped.InternalEvent["request"]),
 		Response:         request.truncateResponse(wrapped.InternalEvent["response"]),
 		CURLCommand:      types.ToString(wrapped.InternalEvent["curl-command"]),
+		TemplateEncoded:  request.options.EncodeTemplate(),
 	}
 	return data
 }

--- a/pkg/protocols/javascript/js.go
+++ b/pkg/protocols/javascript/js.go
@@ -634,6 +634,7 @@ func (request *Request) MakeResultEventItem(wrapped *output.InternalWrappedEvent
 		Request:          types.ToString(wrapped.InternalEvent["request"]),
 		Response:         types.ToString(wrapped.InternalEvent["response"]),
 		IP:               types.ToString(wrapped.InternalEvent["ip"]),
+		TemplateEncoded:  request.options.EncodeTemplate(),
 	}
 	return data
 }

--- a/pkg/protocols/javascript/js_test.go
+++ b/pkg/protocols/javascript/js_test.go
@@ -32,7 +32,7 @@ func setup() {
 	progressImpl, _ := progress.NewStatsTicker(0, false, false, false, 0)
 
 	executerOpts = protocols.ExecutorOptions{
-		Output:       testutils.NewMockOutputWriter(),
+		Output:       testutils.NewMockOutputWriter(options.OmitTemplate),
 		Options:      options,
 		Progress:     progressImpl,
 		ProjectFile:  nil,

--- a/pkg/protocols/network/operators.go
+++ b/pkg/protocols/network/operators.go
@@ -108,6 +108,7 @@ func (request *Request) MakeResultEventItem(wrapped *output.InternalWrappedEvent
 		IP:               types.ToString(wrapped.InternalEvent["ip"]),
 		Request:          types.ToString(wrapped.InternalEvent["request"]),
 		Response:         types.ToString(wrapped.InternalEvent["data"]),
+		TemplateEncoded:  request.options.EncodeTemplate(),
 	}
 	return data
 }

--- a/pkg/protocols/offlinehttp/operators.go
+++ b/pkg/protocols/offlinehttp/operators.go
@@ -151,6 +151,7 @@ func (request *Request) MakeResultEventItem(wrapped *output.InternalWrappedEvent
 		IP:               types.ToString(wrapped.InternalEvent["ip"]),
 		Request:          types.ToString(wrapped.InternalEvent["request"]),
 		Response:         types.ToString(wrapped.InternalEvent["raw"]),
+		TemplateEncoded:  request.options.EncodeTemplate(),
 	}
 	return data
 }

--- a/pkg/protocols/ssl/ssl.go
+++ b/pkg/protocols/ssl/ssl.go
@@ -375,6 +375,7 @@ func (request *Request) MakeResultEventItem(wrapped *output.InternalWrappedEvent
 		Timestamp:        time.Now(),
 		MatcherStatus:    true,
 		IP:               types.ToString(wrapped.InternalEvent["ip"]),
+		TemplateEncoded:  request.options.EncodeTemplate(),
 	}
 	return data
 }

--- a/pkg/protocols/websocket/websocket.go
+++ b/pkg/protocols/websocket/websocket.go
@@ -409,6 +409,7 @@ func (request *Request) MakeResultEventItem(wrapped *output.InternalWrappedEvent
 		IP:               types.ToString(wrapped.InternalEvent["ip"]),
 		Request:          types.ToString(wrapped.InternalEvent["request"]),
 		Response:         types.ToString(wrapped.InternalEvent["response"]),
+		TemplateEncoded:  request.options.EncodeTemplate(),
 	}
 	return data
 }

--- a/pkg/protocols/whois/whois.go
+++ b/pkg/protocols/whois/whois.go
@@ -185,6 +185,7 @@ func (request *Request) MakeResultEventItem(wrapped *output.InternalWrappedEvent
 		MatcherStatus:    true,
 		Request:          types.ToString(wrapped.InternalEvent["request"]),
 		Response:         types.ToString(wrapped.InternalEvent["response"]),
+		TemplateEncoded:  request.options.EncodeTemplate(),
 	}
 	return data
 }

--- a/pkg/templates/compile_test.go
+++ b/pkg/templates/compile_test.go
@@ -39,7 +39,7 @@ func setup() {
 	progressImpl, _ := progress.NewStatsTicker(0, false, false, false, 0)
 
 	executerOpts = protocols.ExecutorOptions{
-		Output:       testutils.NewMockOutputWriter(),
+		Output:       testutils.NewMockOutputWriter(options.OmitTemplate),
 		Options:      options,
 		Progress:     progressImpl,
 		ProjectFile:  nil,

--- a/pkg/testutils/testutils.go
+++ b/pkg/testutils/testutils.go
@@ -188,7 +188,7 @@ var maxTemplateFileSizeForEncoding = 1024 * 1024
 
 func (w *MockOutputWriter) encodeTemplate(templatePath string) string {
 	data, err := os.ReadFile(templatePath)
-	if err == nil && !w.omitTemplate && len(data) <= maxTemplateFileSizeForEncoding {
+	if err == nil && !w.omitTemplate && len(data) <= maxTemplateFileSizeForEncoding && config.DefaultConfig.IsCustomTemplate(templatePath) {
 		return base64.StdEncoding.EncodeToString(data)
 	}
 	return ""

--- a/pkg/testutils/testutils.go
+++ b/pkg/testutils/testutils.go
@@ -2,6 +2,8 @@ package testutils
 
 import (
 	"context"
+	"encoding/base64"
+	"os"
 	"time"
 
 	"github.com/projectdiscovery/ratelimit"
@@ -84,7 +86,7 @@ func NewMockExecuterOptions(options *types.Options, info *TemplateInfo) *protoco
 		TemplateID:   info.ID,
 		TemplateInfo: info.Info,
 		TemplatePath: info.Path,
-		Output:       NewMockOutputWriter(),
+		Output:       NewMockOutputWriter(options.OmitTemplate),
 		Options:      options,
 		Progress:     progressImpl,
 		ProjectFile:  nil,
@@ -106,14 +108,15 @@ func (n *NoopWriter) Write(data []byte, level levels.Level) {}
 // MockOutputWriter is a mocked output writer.
 type MockOutputWriter struct {
 	aurora          aurora.Aurora
+	omitTemplate    bool
 	RequestCallback func(templateID, url, requestType string, err error)
 	FailureCallback func(result *output.InternalEvent)
 	WriteCallback   func(o *output.ResultEvent)
 }
 
 // NewMockOutputWriter creates a new mock output writer
-func NewMockOutputWriter() *MockOutputWriter {
-	return &MockOutputWriter{aurora: aurora.NewAurora(false)}
+func NewMockOutputWriter(omomitTemplate bool) *MockOutputWriter {
+	return &MockOutputWriter{aurora: aurora.NewAurora(false), omitTemplate: omomitTemplate}
 }
 
 // Close closes the output writer interface
@@ -175,8 +178,20 @@ func (m *MockOutputWriter) WriteFailure(wrappedEvent *output.InternalWrappedEven
 		Response:      types.ToString(event["response"]),
 		MatcherStatus: false,
 		Timestamp:     time.Now(),
+		//FIXME: this is workaround to encode the template when no results were found
+		TemplateEncoded: m.encodeTemplate(types.ToString(event["template-path"])),
 	}
 	return m.Write(data)
+}
+
+var maxTemplateFileSizeForEncoding = 1024 * 1024
+
+func (w *MockOutputWriter) encodeTemplate(templatePath string) string {
+	data, err := os.ReadFile(templatePath)
+	if err == nil && !w.omitTemplate && len(data) <= maxTemplateFileSizeForEncoding {
+		return base64.StdEncoding.EncodeToString(data)
+	}
+	return ""
 }
 
 func (m *MockOutputWriter) WriteStoreDebugData(host, templateID, eventType string, data string) {}

--- a/pkg/tmplexec/flow/flow_executor_test.go
+++ b/pkg/tmplexec/flow/flow_executor_test.go
@@ -26,7 +26,7 @@ func setup() {
 	progressImpl, _ := progress.NewStatsTicker(0, false, false, false, 0)
 
 	executerOpts = protocols.ExecutorOptions{
-		Output:       testutils.NewMockOutputWriter(),
+		Output:       testutils.NewMockOutputWriter(options.OmitTemplate),
 		Options:      options,
 		Progress:     progressImpl,
 		ProjectFile:  nil,

--- a/pkg/tmplexec/multiproto/multi_test.go
+++ b/pkg/tmplexec/multiproto/multi_test.go
@@ -26,7 +26,7 @@ func setup() {
 	progressImpl, _ := progress.NewStatsTicker(0, false, false, false, 0)
 
 	executerOpts = protocols.ExecutorOptions{
-		Output:       testutils.NewMockOutputWriter(),
+		Output:       testutils.NewMockOutputWriter(options.OmitTemplate),
 		Options:      options,
 		Progress:     progressImpl,
 		ProjectFile:  nil,

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -252,6 +252,8 @@ type Options struct {
 	JSONRequests bool
 	// OmitRawRequests omits requests/responses for matches in JSON output
 	OmitRawRequests bool
+	// OmitTemplate omits encoded template from JSON output
+	OmitTemplate bool
 	// JSONExport is the file to export JSON output format to
 	JSONExport string
 	// JSONLExport is the file to export JSONL output format to

--- a/pkg/utils/template_path.go
+++ b/pkg/utils/template_path.go
@@ -13,15 +13,11 @@ const (
 
 // TemplatePathURL returns the Path and URL for the provided template
 func TemplatePathURL(fullPath, templateId string) (string, string) {
-	var templateDirectory string
-	configData := config.DefaultConfig
-	if configData.TemplatesDirectory != "" && strings.HasPrefix(fullPath, configData.TemplatesDirectory) {
-		templateDirectory = configData.TemplatesDirectory
-	} else {
+	if IsCustomTemplate(fullPath) {
 		return "", ""
 	}
 
-	finalPath := strings.TrimPrefix(strings.TrimPrefix(fullPath, templateDirectory), "/")
+	relativePath := strings.TrimPrefix(strings.TrimPrefix(fullPath, config.DefaultConfig.TemplatesDirectory), "/")
 	templateURL := TemplatesRepoURL + templateId
-	return finalPath, templateURL
+	return relativePath, templateURL
 }

--- a/pkg/utils/template_path.go
+++ b/pkg/utils/template_path.go
@@ -13,11 +13,15 @@ const (
 
 // TemplatePathURL returns the Path and URL for the provided template
 func TemplatePathURL(fullPath, templateId string) (string, string) {
-	if IsCustomTemplate(fullPath) {
+	var templateDirectory string
+	configData := config.DefaultConfig
+	if configData.TemplatesDirectory != "" && strings.HasPrefix(fullPath, configData.TemplatesDirectory) {
+		templateDirectory = configData.TemplatesDirectory
+	} else {
 		return "", ""
 	}
 
-	relativePath := strings.TrimPrefix(strings.TrimPrefix(fullPath, config.DefaultConfig.TemplatesDirectory), "/")
+	finalPath := strings.TrimPrefix(strings.TrimPrefix(fullPath, templateDirectory), "/")
 	templateURL := TemplatesRepoURL + templateId
-	return relativePath, templateURL
+	return finalPath, templateURL
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -78,8 +78,3 @@ func StringSliceContains(slice []string, item string) bool {
 	}
 	return false
 }
-
-// IsCustomTemplate checks if the template is a custom template
-func IsCustomTemplate(templatePath string) bool {
-	return !strings.HasPrefix(templatePath, config.DefaultConfig.TemplatesDirectory)
-}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -78,3 +78,8 @@ func StringSliceContains(slice []string, item string) bool {
 	}
 	return false
 }
+
+// IsCustomTemplate checks if the template is a custom template
+func IsCustomTemplate(templatePath string) bool {
+	return !strings.HasPrefix(templatePath, config.DefaultConfig.TemplatesDirectory)
+}


### PR DESCRIPTION
## Proposed changes
```console
$ cat test.yaml 
id: basic-example

info:
  name: Test HTTP Template
  author: pdteam
  severity: info

http:
  - method: GET
    path:
      - "{{BaseURL}}"
    matchers:
      - type: word
        words:
          - "This is test matcher text"
        negative: true

$ go run . -u scanme.sh -t test.yaml -silent -j | jq
{
  "template-id": "basic-example",
  "template-path": "/workspaces/nuclei/cmd/nuclei/test.yaml",
  "template-encoded": "aWQ6IGJhc2ljLWV4YW1wbGUKCmluZm86CiAgbmFtZTogVGVzdCBIVFRQIFRlbXBsYXRlCiAgYXV0aG9yOiBwZHRlYW0KICBzZXZlcml0eTogaW5mbwoKaHR0cDoKICAtIG1ldGhvZDogR0VUCiAgICBwYXRoOgogICAgICAtICJ7e0Jhc2VVUkx9fSIKICAgIG1hdGNoZXJzOgogICAgICAtIHR5cGU6IHdvcmQKICAgICAgICB3b3JkczoKICAgICAgICAgIC0gIlRoaXMgaXMgdGVzdCBtYXRjaGVyIHRleHQiCiAgICAgICAgbmVnYXRpdmU6IHRydWUKICAgICAgICA=",
  "info": {
    "name": "Test HTTP Template",
    "author": [
      "pdteam"
    ],
    "tags": null,
    "severity": "info"
  },
  "type": "http",
  "host": "https://scanme.sh",
  "matched-at": "https://scanme.sh",
  "request": "GET / HTTP/1.1\r\nHost: scanme.sh\r\nUser-Agent: Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.2117.157 Safari/537.36\r\nConnection: close\r\nAccept: */*\r\nAccept-Language: en\r\nAccept-Encoding: gzip\r\n\r\n",
  "response": "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 2\r\nContent-Type: text/plain; charset=utf-8\r\nDate: Mon, 30 Oct 2023 13:36:43 GMT\r\n\r\nok",
  "ip": "128.199.158.128",
  "timestamp": "2023-10-30T13:36:43.731371096Z",
  "curl-command": "curl -X 'GET' -H 'Accept: */*' -H 'Accept-Language: en' -H 'User-Agent: Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.2117.157 Safari/537.36' 'https://scanme.sh'",
  "matcher-status": true
}
```
This PR also adds `-ot, -omit-template  omit encoded template in the JSON, JSONL output` flag and 1MB max template file size for encoding.

Closes #4218.


## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)