### PR TITLE
introduce scan context

### DIFF
--- a/pkg/core/executors.go
+++ b/pkg/core/executors.go
@@ -5,7 +5,6 @@ import (
 	"sync/atomic"
 
 	"github.com/projectdiscovery/gologger"
-	"github.com/projectdiscovery/nuclei/v3/pkg/output"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/contextargs"
 	"github.com/projectdiscovery/nuclei/v3/pkg/templates"
 	"github.com/projectdiscovery/nuclei/v3/pkg/templates/types"
@@ -24,11 +23,12 @@ func (e *Engine) executeAllSelfContained(alltemplates []*templates.Template, res
 			var err error
 			var match bool
 			if e.Callback != nil {
-				err = template.Executer.ExecuteWithResults(contextargs.New(), func(event *output.InternalWrappedEvent) {
-					for _, result := range event.Results {
+				if results, err := template.Executer.ExecuteWithResults(contextargs.New()); err != nil {
+					for _, result := range results {
 						e.Callback(result)
 					}
-				})
+				}
+
 				match = true
 			} else {
 				match, err = template.Executer.Execute(contextargs.New())
@@ -118,11 +118,11 @@ func (e *Engine) executeTemplateWithTargets(template *templates.Template, target
 				ctxArgs := contextargs.New()
 				ctxArgs.MetaInput = value
 				if e.Callback != nil {
-					err = template.Executer.ExecuteWithResults(ctxArgs, func(event *output.InternalWrappedEvent) {
-						for _, result := range event.Results {
+					if results, err := template.Executer.ExecuteWithResults(ctxArgs); err != nil {
+						for _, result := range results {
 							e.Callback(result)
 						}
-					})
+					}
 					match = true
 				} else {
 					match, err = template.Executer.Execute(ctxArgs)
@@ -173,11 +173,11 @@ func (e *Engine) executeTemplatesOnTarget(alltemplates []*templates.Template, ta
 				ctxArgs := contextargs.New()
 				ctxArgs.MetaInput = value
 				if e.Callback != nil {
-					err = template.Executer.ExecuteWithResults(ctxArgs, func(event *output.InternalWrappedEvent) {
-						for _, result := range event.Results {
+					if results, err := template.Executer.ExecuteWithResults(ctxArgs); err != nil {
+						for _, result := range results {
 							e.Callback(result)
 						}
-					})
+					}
 					match = true
 				} else {
 					match, err = template.Executer.Execute(ctxArgs)

--- a/pkg/core/executors.go
+++ b/pkg/core/executors.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/contextargs"
+	"github.com/projectdiscovery/nuclei/v3/pkg/scan"
 	"github.com/projectdiscovery/nuclei/v3/pkg/templates"
 	"github.com/projectdiscovery/nuclei/v3/pkg/templates/types"
 	generalTypes "github.com/projectdiscovery/nuclei/v3/pkg/types"
@@ -22,8 +23,9 @@ func (e *Engine) executeAllSelfContained(alltemplates []*templates.Template, res
 			defer sg.Done()
 			var err error
 			var match bool
+			ctx := scan.NewScanContext(contextargs.New())
 			if e.Callback != nil {
-				if results, err := template.Executer.ExecuteWithResults(contextargs.New()); err != nil {
+				if results, err := template.Executer.ExecuteWithResults(ctx); err != nil {
 					for _, result := range results {
 						e.Callback(result)
 					}
@@ -31,7 +33,7 @@ func (e *Engine) executeAllSelfContained(alltemplates []*templates.Template, res
 
 				match = true
 			} else {
-				match, err = template.Executer.Execute(contextargs.New())
+				match, err = template.Executer.Execute(ctx)
 			}
 			if err != nil {
 				gologger.Warning().Msgf("[%s] Could not execute step: %s\n", e.executerOpts.Colorizer.BrightBlue(template.ID), err)
@@ -111,21 +113,22 @@ func (e *Engine) executeTemplateWithTargets(template *templates.Template, target
 
 			var match bool
 			var err error
+			ctxArgs := contextargs.New()
+			ctxArgs.MetaInput = value
+			ctx := scan.NewScanContext(ctxArgs)
 			switch template.Type() {
 			case types.WorkflowProtocol:
-				match = e.executeWorkflow(value, template.CompiledWorkflow)
+				match = e.executeWorkflow(ctx, template.CompiledWorkflow)
 			default:
-				ctxArgs := contextargs.New()
-				ctxArgs.MetaInput = value
 				if e.Callback != nil {
-					if results, err := template.Executer.ExecuteWithResults(ctxArgs); err != nil {
+					if results, err := template.Executer.ExecuteWithResults(ctx); err != nil {
 						for _, result := range results {
 							e.Callback(result)
 						}
 					}
 					match = true
 				} else {
-					match, err = template.Executer.Execute(ctxArgs)
+					match, err = template.Executer.Execute(ctx)
 				}
 			}
 			if err != nil {
@@ -166,21 +169,22 @@ func (e *Engine) executeTemplatesOnTarget(alltemplates []*templates.Template, ta
 
 			var match bool
 			var err error
+			ctxArgs := contextargs.New()
+			ctxArgs.MetaInput = value
+			ctx := scan.NewScanContext(ctxArgs)
 			switch template.Type() {
 			case types.WorkflowProtocol:
-				match = e.executeWorkflow(value, template.CompiledWorkflow)
+				match = e.executeWorkflow(ctx, template.CompiledWorkflow)
 			default:
-				ctxArgs := contextargs.New()
-				ctxArgs.MetaInput = value
 				if e.Callback != nil {
-					if results, err := template.Executer.ExecuteWithResults(ctxArgs); err != nil {
+					if results, err := template.Executer.ExecuteWithResults(ctx); err != nil {
 						for _, result := range results {
 							e.Callback(result)
 						}
 					}
 					match = true
 				} else {
-					match, err = template.Executer.Execute(ctxArgs)
+					match, err = template.Executer.Execute(ctx)
 				}
 			}
 			if err != nil {
@@ -221,7 +225,8 @@ func (e *ChildExecuter) Execute(template *templates.Template, value *contextargs
 
 		ctxArgs := contextargs.New()
 		ctxArgs.MetaInput = value
-		match, err := template.Executer.Execute(ctxArgs)
+		ctx := scan.NewScanContext(ctxArgs)
+		match, err := template.Executer.Execute(ctx)
 		if err != nil {
 			gologger.Warning().Msgf("[%s] Could not execute step: %s\n", e.e.executerOpts.Colorizer.BrightBlue(template.ID), err)
 		}

--- a/pkg/core/workflow_execute.go
+++ b/pkg/core/workflow_execute.go
@@ -1,26 +1,29 @@
 package core
 
 import (
+	"fmt"
 	"net/http/cookiejar"
 	"sync/atomic"
 
 	"github.com/remeh/sizedwaitgroup"
 
 	"github.com/projectdiscovery/gologger"
+	"github.com/projectdiscovery/nuclei/v3/pkg/output"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/contextargs"
+	"github.com/projectdiscovery/nuclei/v3/pkg/scan"
 	"github.com/projectdiscovery/nuclei/v3/pkg/workflows"
 )
 
 const workflowStepExecutionError = "[%s] Could not execute workflow step: %s\n"
 
 // executeWorkflow runs a workflow on an input and returns true or false
-func (e *Engine) executeWorkflow(input *contextargs.MetaInput, w *workflows.Workflow) bool {
+func (e *Engine) executeWorkflow(ctx *scan.ScanContext, w *workflows.Workflow) bool {
 	results := &atomic.Bool{}
 
 	// at this point we should be at the start root execution of a workflow tree, hence we create global shared instances
 	workflowCookieJar, _ := cookiejar.New(nil)
 	ctxArgs := contextargs.New()
-	ctxArgs.MetaInput = input
+	ctxArgs.MetaInput = ctx.Input.MetaInput
 	ctxArgs.CookieJar = workflowCookieJar
 
 	// we can know the nesting level only at runtime, so the best we can do here is increase template threads by one unit in case it's equal to 1 to allow
@@ -37,7 +40,7 @@ func (e *Engine) executeWorkflow(input *contextargs.MetaInput, w *workflows.Work
 		func(template *workflows.WorkflowTemplate) {
 			defer swg.Done()
 
-			if err := e.runWorkflowStep(template, ctxArgs, results, &swg, w); err != nil {
+			if err := e.runWorkflowStep(template, ctx, results, &swg, w); err != nil {
 				gologger.Warning().Msgf(workflowStepExecutionError, template.Template, err)
 			}
 		}(template)
@@ -48,7 +51,7 @@ func (e *Engine) executeWorkflow(input *contextargs.MetaInput, w *workflows.Work
 
 // runWorkflowStep runs a workflow step for the workflow. It executes the workflow
 // in a recursive manner running all subtemplates and matchers.
-func (e *Engine) runWorkflowStep(template *workflows.WorkflowTemplate, input *contextargs.Context, results *atomic.Bool, swg *sizedwaitgroup.SizedWaitGroup, w *workflows.Workflow) error {
+func (e *Engine) runWorkflowStep(template *workflows.WorkflowTemplate, ctx *scan.ScanContext, results *atomic.Bool, swg *sizedwaitgroup.SizedWaitGroup, w *workflows.Workflow) error {
 	var firstMatched bool
 	var err error
 	var mainErr error
@@ -59,43 +62,44 @@ func (e *Engine) runWorkflowStep(template *workflows.WorkflowTemplate, input *co
 
 			// Don't print results with subtemplates, only print results on template.
 			if len(template.Subtemplates) > 0 {
-				// err = executer.Executer.ExecuteWithResults(input, func(result *output.InternalWrappedEvent) {
-				// 	if result.OperatorsResult == nil {
-				// 		return
-				// 	}
-				// 	if len(result.Results) > 0 {
-				// 		firstMatched = true
-				// 	}
+				ctx.OnResult = func(result *output.InternalWrappedEvent) {
+					if result.OperatorsResult == nil {
+						return
+					}
+					if len(result.Results) > 0 {
+						firstMatched = true
+					}
 
-				// 	if result.OperatorsResult != nil && result.OperatorsResult.Extracts != nil {
-				// 		for k, v := range result.OperatorsResult.Extracts {
-				// 			// normalize items:
-				// 			switch len(v) {
-				// 			case 0, 1:
-				// 				// - key:[item] => key: item
-				// 				input.Set(k, v[0])
-				// 			default:
-				// 				// - key:[item_0, ..., item_n] => key0:item_0, keyn:item_n
-				// 				for vIdx, vVal := range v {
-				// 					normalizedKIdx := fmt.Sprintf("%s%d", k, vIdx)
-				// 					input.Set(normalizedKIdx, vVal)
-				// 				}
-				// 				// also add the original name with full slice
-				// 				input.Set(k, v)
-				// 			}
-				// 		}
-				// 	}
-				// })
+					if result.OperatorsResult != nil && result.OperatorsResult.Extracts != nil {
+						for k, v := range result.OperatorsResult.Extracts {
+							// normalize items:
+							switch len(v) {
+							case 0, 1:
+								// - key:[item] => key: item
+								ctx.Input.Set(k, v[0])
+							default:
+								// - key:[item_0, ..., item_n] => key0:item_0, keyn:item_n
+								for vIdx, vVal := range v {
+									normalizedKIdx := fmt.Sprintf("%s%d", k, vIdx)
+									ctx.Input.Set(normalizedKIdx, vVal)
+								}
+								// also add the original name with full slice
+								ctx.Input.Set(k, v)
+							}
+						}
+					}
+				}
+				_, err = executer.Executer.ExecuteWithResults(ctx)
 			} else {
 				var matched bool
-				matched, err = executer.Executer.Execute(input)
+				matched, err = executer.Executer.Execute(ctx)
 				if matched {
 					firstMatched = true
 				}
 			}
 			if err != nil {
 				if w.Options.HostErrorsCache != nil {
-					w.Options.HostErrorsCache.MarkFailed(input.MetaInput.ID(), err)
+					w.Options.HostErrorsCache.MarkFailed(ctx.Input.MetaInput.ID(), err)
 				}
 				if len(template.Executers) == 1 {
 					mainErr = err
@@ -113,35 +117,36 @@ func (e *Engine) runWorkflowStep(template *workflows.WorkflowTemplate, input *co
 		for _, executer := range template.Executers {
 			executer.Options.Progress.AddToTotal(int64(executer.Executer.Requests()))
 
-			// err := executer.Executer.ExecuteWithResults(input, func(event *output.InternalWrappedEvent) {
-			// 	if event.OperatorsResult == nil {
-			// 		return
-			// 	}
+			ctx.OnResult = func(event *output.InternalWrappedEvent) {
+				if event.OperatorsResult == nil {
+					return
+				}
 
-			// 	if event.OperatorsResult.Extracts != nil {
-			// 		for k, v := range event.OperatorsResult.Extracts {
-			// 			input.Set(k, v)
-			// 		}
-			// 	}
+				if event.OperatorsResult.Extracts != nil {
+					for k, v := range event.OperatorsResult.Extracts {
+						ctx.Input.Set(k, v)
+					}
+				}
 
-			// 	for _, matcher := range template.Matchers {
-			// 		if !matcher.Match(event.OperatorsResult) {
-			// 			continue
-			// 		}
+				for _, matcher := range template.Matchers {
+					if !matcher.Match(event.OperatorsResult) {
+						continue
+					}
 
-			// 		for _, subtemplate := range matcher.Subtemplates {
-			// 			swg.Add()
+					for _, subtemplate := range matcher.Subtemplates {
+						swg.Add()
 
-			// 			go func(subtemplate *workflows.WorkflowTemplate) {
-			// 				defer swg.Done()
+						go func(subtemplate *workflows.WorkflowTemplate) {
+							defer swg.Done()
 
-			// 				if err := e.runWorkflowStep(subtemplate, input, results, swg, w); err != nil {
-			// 					gologger.Warning().Msgf(workflowStepExecutionError, subtemplate.Template, err)
-			// 				}
-			// 			}(subtemplate)
-			// 		}
-			// 	}
-			// })
+							if err := e.runWorkflowStep(subtemplate, ctx, results, swg, w); err != nil {
+								gologger.Warning().Msgf(workflowStepExecutionError, subtemplate.Template, err)
+							}
+						}(subtemplate)
+					}
+				}
+			}
+			_, err := executer.Executer.ExecuteWithResults(ctx)
 			if err != nil {
 				if len(template.Executers) == 1 {
 					mainErr = err
@@ -158,7 +163,7 @@ func (e *Engine) runWorkflowStep(template *workflows.WorkflowTemplate, input *co
 			swg.Add()
 
 			go func(template *workflows.WorkflowTemplate) {
-				if err := e.runWorkflowStep(template, input, results, swg, w); err != nil {
+				if err := e.runWorkflowStep(template, ctx, results, swg, w); err != nil {
 					gologger.Warning().Msgf(workflowStepExecutionError, template.Template, err)
 				}
 				swg.Done()

--- a/pkg/core/workflow_execute_test.go
+++ b/pkg/core/workflow_execute_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/progress"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/contextargs"
+	"github.com/projectdiscovery/nuclei/v3/pkg/scan"
 	"github.com/projectdiscovery/nuclei/v3/pkg/types"
 	"github.com/projectdiscovery/nuclei/v3/pkg/workflows"
 	"github.com/stretchr/testify/require"
@@ -186,12 +187,13 @@ func (m *mockExecuter) Execute(input *contextargs.Context) (bool, error) {
 }
 
 // ExecuteWithResults executes the protocol requests and returns results instead of writing them.
-func (m *mockExecuter) ExecuteWithResults(input *contextargs.Context, callback protocols.OutputEventCallback) error {
+func (m *mockExecuter) ExecuteWithResults(input *contextargs.Context) ([]*output.ResultEvent, error) {
+	scanCtx := scan.NewScanContext(input)
 	if m.executeHook != nil {
 		m.executeHook(input.MetaInput)
 	}
 	for _, output := range m.outputs {
-		callback(output)
+		scanCtx.LogEvent(output)
 	}
-	return nil
+	return scanCtx.GenerateResult(), nil
 }

--- a/pkg/core/workflow_execute_test.go
+++ b/pkg/core/workflow_execute_test.go
@@ -25,7 +25,9 @@ func TestWorkflowsSimple(t *testing.T) {
 	}}
 
 	engine := &Engine{}
-	matched := engine.executeWorkflow(&contextargs.MetaInput{Input: "https://test.com"}, workflow)
+	input := contextargs.NewWithInput("https://test.com")
+	ctx := scan.NewScanContext(input)
+	matched := engine.executeWorkflow(ctx, workflow)
 	require.True(t, matched, "could not get correct match value")
 }
 
@@ -47,7 +49,9 @@ func TestWorkflowsSimpleMultiple(t *testing.T) {
 	}}
 
 	engine := &Engine{}
-	matched := engine.executeWorkflow(&contextargs.MetaInput{Input: "https://test.com"}, workflow)
+	input := contextargs.NewWithInput("https://test.com")
+	ctx := scan.NewScanContext(input)
+	matched := engine.executeWorkflow(ctx, workflow)
 	require.True(t, matched, "could not get correct match value")
 
 	require.Equal(t, "https://test.com", firstInput, "could not get correct first input")
@@ -73,7 +77,9 @@ func TestWorkflowsSubtemplates(t *testing.T) {
 	}}
 
 	engine := &Engine{}
-	matched := engine.executeWorkflow(&contextargs.MetaInput{Input: "https://test.com"}, workflow)
+	input := contextargs.NewWithInput("https://test.com")
+	ctx := scan.NewScanContext(input)
+	matched := engine.executeWorkflow(ctx, workflow)
 	require.True(t, matched, "could not get correct match value")
 
 	require.Equal(t, "https://test.com", firstInput, "could not get correct first input")
@@ -97,7 +103,9 @@ func TestWorkflowsSubtemplatesNoMatch(t *testing.T) {
 	}}
 
 	engine := &Engine{}
-	matched := engine.executeWorkflow(&contextargs.MetaInput{Input: "https://test.com"}, workflow)
+	input := contextargs.NewWithInput("https://test.com")
+	ctx := scan.NewScanContext(input)
+	matched := engine.executeWorkflow(ctx, workflow)
 	require.False(t, matched, "could not get correct match value")
 
 	require.Equal(t, "https://test.com", firstInput, "could not get correct first input")
@@ -126,7 +134,9 @@ func TestWorkflowsSubtemplatesWithMatcher(t *testing.T) {
 	}}
 
 	engine := &Engine{}
-	matched := engine.executeWorkflow(&contextargs.MetaInput{Input: "https://test.com"}, workflow)
+	input := contextargs.NewWithInput("https://test.com")
+	ctx := scan.NewScanContext(input)
+	matched := engine.executeWorkflow(ctx, workflow)
 	require.True(t, matched, "could not get correct match value")
 
 	require.Equal(t, "https://test.com", firstInput, "could not get correct first input")
@@ -155,7 +165,9 @@ func TestWorkflowsSubtemplatesWithMatcherNoMatch(t *testing.T) {
 	}}
 
 	engine := &Engine{}
-	matched := engine.executeWorkflow(&contextargs.MetaInput{Input: "https://test.com"}, workflow)
+	input := contextargs.NewWithInput("https://test.com")
+	ctx := scan.NewScanContext(input)
+	matched := engine.executeWorkflow(ctx, workflow)
 	require.False(t, matched, "could not get correct match value")
 
 	require.Equal(t, "https://test.com", firstInput, "could not get correct first input")
@@ -179,21 +191,20 @@ func (m *mockExecuter) Requests() int {
 }
 
 // Execute executes the protocol group and  returns true or false if results were found.
-func (m *mockExecuter) Execute(input *contextargs.Context) (bool, error) {
+func (m *mockExecuter) Execute(ctx *scan.ScanContext) (bool, error) {
 	if m.executeHook != nil {
-		m.executeHook(input.MetaInput)
+		m.executeHook(ctx.Input.MetaInput)
 	}
 	return m.result, nil
 }
 
 // ExecuteWithResults executes the protocol requests and returns results instead of writing them.
-func (m *mockExecuter) ExecuteWithResults(input *contextargs.Context) ([]*output.ResultEvent, error) {
-	scanCtx := scan.NewScanContext(input)
+func (m *mockExecuter) ExecuteWithResults(ctx *scan.ScanContext) ([]*output.ResultEvent, error) {
 	if m.executeHook != nil {
-		m.executeHook(input.MetaInput)
+		m.executeHook(ctx.Input.MetaInput)
 	}
 	for _, output := range m.outputs {
-		scanCtx.LogEvent(output)
+		ctx.LogEvent(output)
 	}
-	return scanCtx.GenerateResult(), nil
+	return ctx.GenerateResult(), nil
 }

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -157,6 +157,7 @@ type ResultEvent struct {
 	Lines []int `json:"matched-line,omitempty"`
 
 	FileToIndexPosition map[string]int `json:"-"`
+	Error               string         `json:"error,omitempty"`
 }
 
 // NewStandardWriter creates a new output writer based on user configurations

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -354,6 +354,7 @@ func (w *StandardWriter) WriteFailure(wrappedEvent *InternalWrappedEvent) error 
 		Timestamp:     time.Now(),
 		//FIXME: this is workaround to encode the template when no results were found
 		TemplateEncoded: w.encodeTemplate(types.ToString(event["template-path"])),
+		Error:           types.ToString(event["error"]),
 	}
 	return w.Write(data)
 }

--- a/pkg/protocols/code/code.go
+++ b/pkg/protocols/code/code.go
@@ -255,6 +255,7 @@ func (request *Request) MakeResultEventItem(wrapped *output.InternalWrappedEvent
 		Timestamp:        time.Now(),
 		MatcherStatus:    true,
 		TemplateEncoded:  request.options.EncodeTemplate(),
+		Error:            types.ToString(wrapped.InternalEvent["error"]),
 	}
 	return data
 }

--- a/pkg/protocols/dns/operators.go
+++ b/pkg/protocols/dns/operators.go
@@ -123,6 +123,7 @@ func (request *Request) MakeResultEventItem(wrapped *output.InternalWrappedEvent
 		Request:          types.ToString(wrapped.InternalEvent["request"]),
 		Response:         types.ToString(wrapped.InternalEvent["raw"]),
 		TemplateEncoded:  request.options.EncodeTemplate(),
+		Error:            types.ToString(wrapped.InternalEvent["error"]),
 	}
 	return data
 }

--- a/pkg/protocols/file/operators.go
+++ b/pkg/protocols/file/operators.go
@@ -108,6 +108,7 @@ func (request *Request) MakeResultEventItem(wrapped *output.InternalWrappedEvent
 		Response:         types.ToString(wrapped.InternalEvent["raw"]),
 		Timestamp:        time.Now(),
 		TemplateEncoded:  request.options.EncodeTemplate(),
+		Error:            types.ToString(wrapped.InternalEvent["error"]),
 	}
 	return data
 }

--- a/pkg/protocols/headless/operators.go
+++ b/pkg/protocols/headless/operators.go
@@ -139,6 +139,7 @@ func (request *Request) MakeResultEventItem(wrapped *output.InternalWrappedEvent
 		Request:          types.ToString(wrapped.InternalEvent["request"]),
 		Response:         types.ToString(wrapped.InternalEvent["data"]),
 		TemplateEncoded:  request.options.EncodeTemplate(),
+		Error:            types.ToString(wrapped.InternalEvent["error"]),
 	}
 	return data
 }

--- a/pkg/protocols/http/operators.go
+++ b/pkg/protocols/http/operators.go
@@ -165,6 +165,7 @@ func (request *Request) MakeResultEventItem(wrapped *output.InternalWrappedEvent
 		Response:         request.truncateResponse(wrapped.InternalEvent["response"]),
 		CURLCommand:      types.ToString(wrapped.InternalEvent["curl-command"]),
 		TemplateEncoded:  request.options.EncodeTemplate(),
+		Error:            types.ToString(wrapped.InternalEvent["error"]),
 	}
 	return data
 }

--- a/pkg/protocols/javascript/js.go
+++ b/pkg/protocols/javascript/js.go
@@ -635,6 +635,7 @@ func (request *Request) MakeResultEventItem(wrapped *output.InternalWrappedEvent
 		Response:         types.ToString(wrapped.InternalEvent["response"]),
 		IP:               types.ToString(wrapped.InternalEvent["ip"]),
 		TemplateEncoded:  request.options.EncodeTemplate(),
+		Error:            types.ToString(wrapped.InternalEvent["error"]),
 	}
 	return data
 }

--- a/pkg/protocols/network/operators.go
+++ b/pkg/protocols/network/operators.go
@@ -109,6 +109,7 @@ func (request *Request) MakeResultEventItem(wrapped *output.InternalWrappedEvent
 		Request:          types.ToString(wrapped.InternalEvent["request"]),
 		Response:         types.ToString(wrapped.InternalEvent["data"]),
 		TemplateEncoded:  request.options.EncodeTemplate(),
+		Error:            types.ToString(wrapped.InternalEvent["error"]),
 	}
 	return data
 }

--- a/pkg/protocols/offlinehttp/operators.go
+++ b/pkg/protocols/offlinehttp/operators.go
@@ -152,6 +152,7 @@ func (request *Request) MakeResultEventItem(wrapped *output.InternalWrappedEvent
 		Request:          types.ToString(wrapped.InternalEvent["request"]),
 		Response:         types.ToString(wrapped.InternalEvent["raw"]),
 		TemplateEncoded:  request.options.EncodeTemplate(),
+		Error:            types.ToString(wrapped.InternalEvent["error"]),
 	}
 	return data
 }

--- a/pkg/protocols/protocols.go
+++ b/pkg/protocols/protocols.go
@@ -27,6 +27,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/variables"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/headless/engine"
 	"github.com/projectdiscovery/nuclei/v3/pkg/reporting"
+	"github.com/projectdiscovery/nuclei/v3/pkg/scan"
 	templateTypes "github.com/projectdiscovery/nuclei/v3/pkg/templates/types"
 	"github.com/projectdiscovery/nuclei/v3/pkg/types"
 )
@@ -40,9 +41,9 @@ type Executer interface {
 	// Requests returns the total number of requests the rule will perform
 	Requests() int
 	// Execute executes the protocol group and returns true or false if results were found.
-	Execute(input *contextargs.Context) (bool, error)
+	Execute(ctx *scan.ScanContext) (bool, error)
 	// ExecuteWithResults executes the protocol requests and returns results instead of writing them.
-	ExecuteWithResults(input *contextargs.Context) ([]*output.ResultEvent, error)
+	ExecuteWithResults(ctx *scan.ScanContext) ([]*output.ResultEvent, error)
 }
 
 // ExecutorOptions contains the configuration options for executer clients

--- a/pkg/protocols/protocols.go
+++ b/pkg/protocols/protocols.go
@@ -42,7 +42,7 @@ type Executer interface {
 	// Execute executes the protocol group and returns true or false if results were found.
 	Execute(input *contextargs.Context) (bool, error)
 	// ExecuteWithResults executes the protocol requests and returns results instead of writing them.
-	ExecuteWithResults(input *contextargs.Context, callback OutputEventCallback) error
+	ExecuteWithResults(input *contextargs.Context) ([]*output.ResultEvent, error)
 }
 
 // ExecutorOptions contains the configuration options for executer clients

--- a/pkg/protocols/ssl/ssl.go
+++ b/pkg/protocols/ssl/ssl.go
@@ -376,6 +376,7 @@ func (request *Request) MakeResultEventItem(wrapped *output.InternalWrappedEvent
 		MatcherStatus:    true,
 		IP:               types.ToString(wrapped.InternalEvent["ip"]),
 		TemplateEncoded:  request.options.EncodeTemplate(),
+		Error:            types.ToString(wrapped.InternalEvent["error"]),
 	}
 	return data
 }

--- a/pkg/protocols/websocket/websocket.go
+++ b/pkg/protocols/websocket/websocket.go
@@ -410,6 +410,7 @@ func (request *Request) MakeResultEventItem(wrapped *output.InternalWrappedEvent
 		Request:          types.ToString(wrapped.InternalEvent["request"]),
 		Response:         types.ToString(wrapped.InternalEvent["response"]),
 		TemplateEncoded:  request.options.EncodeTemplate(),
+		Error:            types.ToString(wrapped.InternalEvent["error"]),
 	}
 	return data
 }

--- a/pkg/protocols/whois/whois.go
+++ b/pkg/protocols/whois/whois.go
@@ -186,6 +186,7 @@ func (request *Request) MakeResultEventItem(wrapped *output.InternalWrappedEvent
 		Request:          types.ToString(wrapped.InternalEvent["request"]),
 		Response:         types.ToString(wrapped.InternalEvent["response"]),
 		TemplateEncoded:  request.options.EncodeTemplate(),
+		Error:            types.ToString(wrapped.InternalEvent["error"]),
 	}
 	return data
 }

--- a/pkg/scan/scan_context.go
+++ b/pkg/scan/scan_context.go
@@ -49,7 +49,7 @@ func (s *ScanContext) LogEvent(e *output.InternalWrappedEvent) {
 	s.events = append(s.events, e)
 }
 
-func (s *ScanContext) LogError(err error) error {
+func (s *ScanContext) LogError(err error) {
 	if s.OnError != nil {
 		s.OnError(err)
 	}
@@ -63,6 +63,4 @@ func (s *ScanContext) LogError(err error) error {
 	for _, e := range s.events {
 		e.InternalEvent["error"] = errorMessage
 	}
-
-	return err
 }

--- a/pkg/scan/scan_context.go
+++ b/pkg/scan/scan_context.go
@@ -1,0 +1,52 @@
+package scan
+
+import (
+	"context"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/model"
+	"github.com/projectdiscovery/nuclei/v3/pkg/output"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/contextargs"
+)
+
+type ScanContext struct {
+	context.Context
+	ScanId string // MD5 (templateID+target+ip)
+	// existing Input/target related info
+	Input *contextargs.Context
+	// templateInfo
+	Info model.Info
+	// Globally shared args aka template Context
+	TemplateMap map[string]interface{}
+	// stats tracker like req count etc
+	// Stats *Stats
+
+	errors  []error
+	results []*output.ResultEvent
+
+	OnError  func(error)
+	OnResult func(e *output.InternalWrappedEvent)
+}
+
+func NewScanContext(input *contextargs.Context) *ScanContext {
+	return &ScanContext{Input: input}
+}
+
+func (s *ScanContext) GenerateResult() []*output.ResultEvent {
+	// ...
+	return s.results
+}
+
+func (s *ScanContext) LogEvent(e *output.InternalWrappedEvent) {
+	if s.OnResult != nil {
+		s.OnResult(e)
+	}
+	s.results = append(s.results, e.Results...)
+}
+
+func (s *ScanContext) LogError(err error) error {
+	if s.OnError != nil {
+		s.OnError(err)
+	}
+	s.errors = append(s.errors, err)
+	return err
+}

--- a/pkg/scan/scan_context.go
+++ b/pkg/scan/scan_context.go
@@ -23,12 +23,7 @@ func NewScanContext(input *contextargs.Context) *ScanContext {
 }
 
 func (s *ScanContext) GenerateResult() []*output.ResultEvent {
-	errorMessage := joinErrors(s.errors)
-	results := aggregateResults(s.events)
-	for _, result := range results {
-		result.Error = errorMessage
-	}
-	return results
+	return aggregateResults(s.events)
 }
 
 func aggregateResults(events []*output.InternalWrappedEvent) []*output.ResultEvent {
@@ -59,5 +54,15 @@ func (s *ScanContext) LogError(err error) error {
 		s.OnError(err)
 	}
 	s.errors = append(s.errors, err)
+
+	errorMessage := joinErrors(s.errors)
+	results := aggregateResults(s.events)
+	for _, result := range results {
+		result.Error = errorMessage
+	}
+	for _, e := range s.events {
+		e.InternalEvent["error"] = errorMessage
+	}
+
 	return err
 }

--- a/pkg/scan/scan_context.go
+++ b/pkg/scan/scan_context.go
@@ -50,6 +50,10 @@ func (s *ScanContext) LogEvent(e *output.InternalWrappedEvent) {
 }
 
 func (s *ScanContext) LogError(err error) {
+	if err == nil {
+		return
+	}
+
 	if s.OnError != nil {
 		s.OnError(err)
 	}

--- a/pkg/templates/cluster.go
+++ b/pkg/templates/cluster.go
@@ -10,7 +10,6 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/operators"
 	"github.com/projectdiscovery/nuclei/v3/pkg/output"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols"
-	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/contextargs"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/helpers/writer"
 	"github.com/projectdiscovery/nuclei/v3/pkg/scan"
 	"github.com/projectdiscovery/nuclei/v3/pkg/templates/types"
@@ -241,12 +240,12 @@ func (e *ClusterExecuter) Requests() int {
 }
 
 // Execute executes the protocol group and returns true or false if results were found.
-func (e *ClusterExecuter) Execute(input *contextargs.Context) (bool, error) {
+func (e *ClusterExecuter) Execute(ctx *scan.ScanContext) (bool, error) {
 	var results bool
 
-	inputItem := input.Clone()
-	if e.options.InputHelper != nil && input.MetaInput.Input != "" {
-		if inputItem.MetaInput.Input = e.options.InputHelper.Transform(input.MetaInput.Input, e.templateType); input.MetaInput.Input == "" {
+	inputItem := ctx.Input.Clone()
+	if e.options.InputHelper != nil && ctx.Input.MetaInput.Input != "" {
+		if inputItem.MetaInput.Input = e.options.InputHelper.Transform(ctx.Input.MetaInput.Input, e.templateType); ctx.Input.MetaInput.Input == "" {
 			return false, nil
 		}
 	}
@@ -275,19 +274,19 @@ func (e *ClusterExecuter) Execute(input *contextargs.Context) (bool, error) {
 		}
 	})
 	if err != nil && e.options.HostErrorsCache != nil {
-		e.options.HostErrorsCache.MarkFailed(input.MetaInput.Input, err)
+		e.options.HostErrorsCache.MarkFailed(ctx.Input.MetaInput.Input, err)
 	}
 	return results, err
 }
 
 // ExecuteWithResults executes the protocol requests and returns results instead of writing them.
-func (e *ClusterExecuter) ExecuteWithResults(input *contextargs.Context) ([]*output.ResultEvent, error) {
-	scanCtx := scan.NewScanContext(input)
+func (e *ClusterExecuter) ExecuteWithResults(ctx *scan.ScanContext) ([]*output.ResultEvent, error) {
+	scanCtx := scan.NewScanContext(ctx.Input)
 	dynamicValues := make(map[string]interface{})
 
-	inputItem := input.Clone()
-	if e.options.InputHelper != nil && input.MetaInput.Input != "" {
-		if inputItem.MetaInput.Input = e.options.InputHelper.Transform(input.MetaInput.Input, e.templateType); input.MetaInput.Input == "" {
+	inputItem := ctx.Input.Clone()
+	if e.options.InputHelper != nil && ctx.Input.MetaInput.Input != "" {
+		if inputItem.MetaInput.Input = e.options.InputHelper.Transform(ctx.Input.MetaInput.Input, e.templateType); ctx.Input.MetaInput.Input == "" {
 			return nil, nil
 		}
 	}
@@ -305,7 +304,7 @@ func (e *ClusterExecuter) ExecuteWithResults(input *contextargs.Context) ([]*out
 		}
 	})
 	if err != nil && e.options.HostErrorsCache != nil {
-		e.options.HostErrorsCache.MarkFailed(input.MetaInput.Input, err)
+		e.options.HostErrorsCache.MarkFailed(ctx.Input.MetaInput.Input, err)
 	}
 	return scanCtx.GenerateResult(), err
 }

--- a/pkg/templates/cluster.go
+++ b/pkg/templates/cluster.go
@@ -303,6 +303,10 @@ func (e *ClusterExecuter) ExecuteWithResults(ctx *scan.ScanContext) ([]*output.R
 			}
 		}
 	})
+	if err != nil {
+		ctx.LogError(err)
+	}
+
 	if err != nil && e.options.HostErrorsCache != nil {
 		e.options.HostErrorsCache.MarkFailed(ctx.Input.MetaInput.Input, err)
 	}

--- a/pkg/templates/cluster.go
+++ b/pkg/templates/cluster.go
@@ -300,7 +300,6 @@ func (e *ClusterExecuter) ExecuteWithResults(input *contextargs.Context) ([]*out
 				event.InternalEvent["template-path"] = operator.templatePath
 				event.InternalEvent["template-info"] = operator.templateInfo
 				event.Results = e.requests.MakeResultEvent(event)
-				// callback(event)
 				scanCtx.LogEvent(event)
 			}
 		}

--- a/pkg/testutils/testutils.go
+++ b/pkg/testutils/testutils.go
@@ -180,6 +180,7 @@ func (m *MockOutputWriter) WriteFailure(wrappedEvent *output.InternalWrappedEven
 		Timestamp:     time.Now(),
 		//FIXME: this is workaround to encode the template when no results were found
 		TemplateEncoded: m.encodeTemplate(types.ToString(event["template-path"])),
+		Error:           types.ToString(event["error"]),
 	}
 	return m.Write(data)
 }

--- a/pkg/tmplexec/exec.go
+++ b/pkg/tmplexec/exec.go
@@ -156,10 +156,7 @@ func (e *TemplateExecuter) Execute(ctx *scan.ScanContext) (bool, error) {
 
 // ExecuteWithResults executes the protocol requests and returns results instead of writing them.
 func (e *TemplateExecuter) ExecuteWithResults(ctx *scan.ScanContext) ([]*output.ResultEvent, error) {
-	// scanCtx := scan.NewScanContext(input)
 	err := e.engine.ExecuteWithResults(ctx)
-	if err != nil && !e.options.Options.MatcherStatus {
-		return nil, err
-	}
+	ctx.LogError(err)
 	return ctx.GenerateResult(), err
 }

--- a/pkg/tmplexec/flow/flow_executor.go
+++ b/pkg/tmplexec/flow/flow_executor.go
@@ -184,10 +184,12 @@ func (f *FlowExecutor) ExecuteWithResults(ctx *scan.ScanContext) error {
 	// pass flow and execute the js vm and handle errors
 	value, err := f.jsVM.RunProgram(f.program)
 	if err != nil {
+		ctx.LogError(err)
 		return errorutil.NewWithErr(err).Msgf("failed to execute flow\n%v\n", f.options.Flow)
 	}
 	runtimeErr := f.GetRuntimeErrors()
 	if runtimeErr != nil {
+		ctx.LogError(runtimeErr)
 		return errorutil.NewWithErr(runtimeErr).Msgf("got following errors while executing flow")
 	}
 	// this is where final result is generated/created

--- a/pkg/tmplexec/flow/flow_executor.go
+++ b/pkg/tmplexec/flow/flow_executor.go
@@ -14,6 +14,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/contextargs"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/generators"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
+	"github.com/projectdiscovery/nuclei/v3/pkg/scan"
 	templateTypes "github.com/projectdiscovery/nuclei/v3/pkg/templates/types"
 
 	"github.com/projectdiscovery/nuclei/v3/pkg/types"
@@ -161,15 +162,15 @@ func (f *FlowExecutor) Compile() error {
 }
 
 // ExecuteWithResults executes the flow and returns results
-func (f *FlowExecutor) ExecuteWithResults(input *contextargs.Context, callback protocols.OutputEventCallback) error {
+func (f *FlowExecutor) ExecuteWithResults(ctx *scan.ScanContext) error {
 	defer func() {
 		if e := recover(); e != nil {
-			gologger.Error().Label(f.options.TemplateID).Msgf("panic occurred while executing target %v with flow: %v", input.MetaInput.Input, e)
+			gologger.Error().Label(f.options.TemplateID).Msgf("panic occurred while executing target %v with flow: %v", ctx.Input.MetaInput.Input, e)
 			panic(e)
 		}
 	}()
 
-	f.input = input
+	f.input = ctx.Input
 	// -----Load all types of variables-----
 	// add all input args to template context
 	if f.input != nil && f.input.HasArgs() {
@@ -177,7 +178,7 @@ func (f *FlowExecutor) ExecuteWithResults(input *contextargs.Context, callback p
 			f.options.GetTemplateCtx(f.input.MetaInput).Set(key, value)
 		})
 	}
-	if callback == nil {
+	if ctx.OnResult == nil {
 		return fmt.Errorf("output callback cannot be nil")
 	}
 	// pass flow and execute the js vm and handle errors
@@ -190,7 +191,8 @@ func (f *FlowExecutor) ExecuteWithResults(input *contextargs.Context, callback p
 		return errorutil.NewWithErr(runtimeErr).Msgf("got following errors while executing flow")
 	}
 	// this is where final result is generated/created
-	callback(f.lastEvent)
+	// callback(f.lastEvent)
+	ctx.LogEvent(f.lastEvent)
 	if value.Export() != nil {
 		f.results.Store(value.ToBoolean())
 	} else {

--- a/pkg/tmplexec/flow/flow_executor.go
+++ b/pkg/tmplexec/flow/flow_executor.go
@@ -191,7 +191,6 @@ func (f *FlowExecutor) ExecuteWithResults(ctx *scan.ScanContext) error {
 		return errorutil.NewWithErr(runtimeErr).Msgf("got following errors while executing flow")
 	}
 	// this is where final result is generated/created
-	// callback(f.lastEvent)
 	ctx.LogEvent(f.lastEvent)
 	if value.Export() != nil {
 		f.results.Store(value.ToBoolean())

--- a/pkg/tmplexec/flow/flow_executor_test.go
+++ b/pkg/tmplexec/flow/flow_executor_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/progress"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/contextargs"
+	"github.com/projectdiscovery/nuclei/v3/pkg/scan"
 	"github.com/projectdiscovery/nuclei/v3/pkg/templates"
 	"github.com/projectdiscovery/nuclei/v3/pkg/testutils"
 	"github.com/projectdiscovery/ratelimit"
@@ -54,7 +55,8 @@ func TestFlowTemplateWithIndex(t *testing.T) {
 	require.Nil(t, err, "could not compile template")
 
 	input := contextargs.NewWithInput("hackerone.com")
-	gotresults, err := Template.Executer.Execute(input)
+	ctx := scan.NewScanContext(input)
+	gotresults, err := Template.Executer.Execute(ctx)
 	require.Nil(t, err, "could not execute template")
 	require.True(t, gotresults)
 }
@@ -72,7 +74,8 @@ func TestFlowTemplateWithID(t *testing.T) {
 	require.Nil(t, err, "could not compile template")
 
 	target := contextargs.NewWithInput("hackerone.com")
-	gotresults, err := Template.Executer.Execute(target)
+	ctx := scan.NewScanContext(target)
+	gotresults, err := Template.Executer.Execute(ctx)
 	require.Nil(t, err, "could not execute template")
 	require.True(t, gotresults)
 }
@@ -93,7 +96,8 @@ func TestFlowWithProtoPrefix(t *testing.T) {
 	require.Nil(t, err, "could not compile template")
 
 	input := contextargs.NewWithInput("hackerone.com")
-	gotresults, err := Template.Executer.Execute(input)
+	ctx := scan.NewScanContext(input)
+	gotresults, err := Template.Executer.Execute(ctx)
 	require.Nil(t, err, "could not execute template")
 	require.True(t, gotresults)
 }
@@ -112,8 +116,9 @@ func TestFlowWithConditionNegative(t *testing.T) {
 	require.Nil(t, err, "could not compile template")
 
 	input := contextargs.NewWithInput("scanme.sh")
+	ctx := scan.NewScanContext(input)
 	// expect no results and verify thant dns request is executed and http is not
-	gotresults, err := Template.Executer.Execute(input)
+	gotresults, err := Template.Executer.Execute(ctx)
 	require.Nil(t, err, "could not execute template")
 	require.False(t, gotresults)
 }
@@ -132,8 +137,9 @@ func TestFlowWithConditionPositive(t *testing.T) {
 	require.Nil(t, err, "could not compile template")
 
 	input := contextargs.NewWithInput("blog.projectdiscovery.io")
+	ctx := scan.NewScanContext(input)
 	// positive match . expect results also verify that both dns() and http() were executed
-	gotresults, err := Template.Executer.Execute(input)
+	gotresults, err := Template.Executer.Execute(ctx)
 	require.Nil(t, err, "could not execute template")
 	require.True(t, gotresults)
 }
@@ -151,8 +157,10 @@ func TestFlowWithNoMatchers(t *testing.T) {
 	err = Template.Executer.Compile()
 	require.Nil(t, err, "could not compile template")
 
+	input := contextargs.NewWithInput("blog.projectdiscovery.io")
+	ctx := scan.NewScanContext(input)
 	// positive match . expect results also verify that both dns() and http() were executed
-	gotresults, err := Template.Executer.Execute(contextargs.NewWithInput("blog.projectdiscovery.io"))
+	gotresults, err := Template.Executer.Execute(ctx)
 	require.Nil(t, err, "could not execute template")
 	require.True(t, gotresults)
 
@@ -165,8 +173,10 @@ func TestFlowWithNoMatchers(t *testing.T) {
 	err = Template.Executer.Compile()
 	require.Nil(t, err, "could not compile template")
 
+	anotherInput := contextargs.NewWithInput("blog.projectdiscovery.io")
+	anotherCtx := scan.NewScanContext(anotherInput)
 	// positive match . expect results also verify that both dns() and http() were executed
-	gotresults, err = Template.Executer.Execute(contextargs.NewWithInput("blog.projectdiscovery.io"))
+	gotresults, err = Template.Executer.Execute(anotherCtx)
 	require.Nil(t, err, "could not execute template")
 	require.True(t, gotresults)
 

--- a/pkg/tmplexec/generic/exec.go
+++ b/pkg/tmplexec/generic/exec.go
@@ -7,7 +7,7 @@ import (
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/nuclei/v3/pkg/output"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols"
-	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/contextargs"
+	"github.com/projectdiscovery/nuclei/v3/pkg/scan"
 )
 
 // generic engine as name suggests is a generic template
@@ -34,18 +34,18 @@ func (g *Generic) Compile() error {
 }
 
 // ExecuteWithResults executes the template and returns results
-func (g *Generic) ExecuteWithResults(input *contextargs.Context, callback protocols.OutputEventCallback) error {
+func (g *Generic) ExecuteWithResults(ctx *scan.ScanContext) error {
 	dynamicValues := make(map[string]interface{})
-	if input.HasArgs() {
-		input.ForEach(func(key string, value interface{}) {
+	if ctx.Input.HasArgs() {
+		ctx.Input.ForEach(func(key string, value interface{}) {
 			dynamicValues[key] = value
 		})
 	}
 	previous := make(map[string]interface{})
 
 	for _, req := range g.requests {
-		inputItem := input.Clone()
-		if g.options.InputHelper != nil && input.MetaInput.Input != "" {
+		inputItem := ctx.Input.Clone()
+		if g.options.InputHelper != nil && ctx.Input.MetaInput.Input != "" {
 			if inputItem.MetaInput.Input = g.options.InputHelper.Transform(inputItem.MetaInput.Input, req.Type()); inputItem.MetaInput.Input == "" {
 				return nil
 			}
@@ -72,13 +72,14 @@ func (g *Generic) ExecuteWithResults(input *contextargs.Context, callback protoc
 			}
 			// for ExecuteWithResults : this callback will execute user defined callback and some error handling
 			// for Execute : this callback will print the result to output
-			callback(event)
+			// callback(event)
+			ctx.LogEvent(event)
 		})
 		if err != nil {
 			if g.options.HostErrorsCache != nil {
-				g.options.HostErrorsCache.MarkFailed(input.MetaInput.ID(), err)
+				g.options.HostErrorsCache.MarkFailed(ctx.Input.MetaInput.ID(), err)
 			}
-			gologger.Warning().Msgf("[%s] Could not execute request for %s: %s\n", g.options.TemplateID, input.MetaInput.PrettyPrint(), err)
+			gologger.Warning().Msgf("[%s] Could not execute request for %s: %s\n", g.options.TemplateID, ctx.Input.MetaInput.PrettyPrint(), err)
 		}
 		// If a match was found and stop at first match is set, break out of the loop and return
 		if g.results.Load() && (g.options.StopAtFirstMatch || g.options.Options.StopAtFirstMatch) {

--- a/pkg/tmplexec/generic/exec.go
+++ b/pkg/tmplexec/generic/exec.go
@@ -72,7 +72,6 @@ func (g *Generic) ExecuteWithResults(ctx *scan.ScanContext) error {
 			}
 			// for ExecuteWithResults : this callback will execute user defined callback and some error handling
 			// for Execute : this callback will print the result to output
-			// callback(event)
 			ctx.LogEvent(event)
 		})
 		if err != nil {

--- a/pkg/tmplexec/generic/exec.go
+++ b/pkg/tmplexec/generic/exec.go
@@ -75,6 +75,7 @@ func (g *Generic) ExecuteWithResults(ctx *scan.ScanContext) error {
 			ctx.LogEvent(event)
 		})
 		if err != nil {
+			ctx.LogError(err)
 			if g.options.HostErrorsCache != nil {
 				g.options.HostErrorsCache.MarkFailed(ctx.Input.MetaInput.ID(), err)
 			}

--- a/pkg/tmplexec/interface.go
+++ b/pkg/tmplexec/interface.go
@@ -1,8 +1,7 @@
 package tmplexec
 
 import (
-	"github.com/projectdiscovery/nuclei/v3/pkg/protocols"
-	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/contextargs"
+	"github.com/projectdiscovery/nuclei/v3/pkg/scan"
 	"github.com/projectdiscovery/nuclei/v3/pkg/tmplexec/flow"
 	"github.com/projectdiscovery/nuclei/v3/pkg/tmplexec/generic"
 	"github.com/projectdiscovery/nuclei/v3/pkg/tmplexec/multiproto"
@@ -26,7 +25,7 @@ type TemplateEngine interface {
 	Compile() error
 
 	// ExecuteWithResults executes the template and returns results
-	ExecuteWithResults(input *contextargs.Context, callback protocols.OutputEventCallback) error
+	ExecuteWithResults(ctx *scan.ScanContext) error
 
 	// Name returns name of template engine
 	Name() string

--- a/pkg/tmplexec/multiproto/multi.go
+++ b/pkg/tmplexec/multiproto/multi.go
@@ -93,6 +93,7 @@ func (m *MultiProtocol) ExecuteWithResults(ctx *scan.ScanContext) error {
 		err := req.ExecuteWithResults(ctx.Input, output.InternalEvent(values), nil, multiProtoCallback)
 		// if error skip execution of next protocols
 		if err != nil {
+			ctx.LogError(err)
 			return err
 		}
 	}

--- a/pkg/tmplexec/multiproto/multi.go
+++ b/pkg/tmplexec/multiproto/multi.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/projectdiscovery/nuclei/v3/pkg/output"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols"
-	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/contextargs"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/generators"
+	"github.com/projectdiscovery/nuclei/v3/pkg/scan"
 )
 
 // Mutliprotocol is a template executer engine that executes multiple protocols
@@ -43,9 +43,9 @@ func (m *MultiProtocol) Compile() error {
 }
 
 // ExecuteWithResults executes the template and returns results
-func (m *MultiProtocol) ExecuteWithResults(input *contextargs.Context, callback protocols.OutputEventCallback) error {
+func (m *MultiProtocol) ExecuteWithResults(ctx *scan.ScanContext) error {
 	// put all readonly args into template context
-	m.options.GetTemplateCtx(input.MetaInput).Merge(m.readOnlyArgs)
+	m.options.GetTemplateCtx(ctx.Input.MetaInput).Merge(m.readOnlyArgs)
 	var finalProtoEvent *output.InternalWrappedEvent
 	// callback to process results from all protocols
 	multiProtoCallback := func(event *output.InternalWrappedEvent) {
@@ -59,7 +59,7 @@ func (m *MultiProtocol) ExecuteWithResults(input *contextargs.Context, callback 
 				// we either need to add support for iterate-all in other protocols or implement a different logic (specific to template context)
 				// currently if dynamic value array only contains one value we replace it with the value
 				if len(v) == 1 {
-					m.options.GetTemplateCtx(input.MetaInput).Set(k, v[0])
+					m.options.GetTemplateCtx(ctx.Input.MetaInput).Set(k, v[0])
 				} else {
 					// Note: if extracted value contains multiple values then they can be accessed by indexing
 					// ex: if values are dynamic = []string{"a","b","c"} then they are available as
@@ -67,9 +67,9 @@ func (m *MultiProtocol) ExecuteWithResults(input *contextargs.Context, callback 
 					// we intentionally omit first index for unknown situations (where no of extracted values are not known)
 					for i, val := range v {
 						if i == 0 {
-							m.options.GetTemplateCtx(input.MetaInput).Set(k, val)
+							m.options.GetTemplateCtx(ctx.Input.MetaInput).Set(k, val)
 						} else {
-							m.options.GetTemplateCtx(input.MetaInput).Set(k+strconv.Itoa(i), val)
+							m.options.GetTemplateCtx(ctx.Input.MetaInput).Set(k+strconv.Itoa(i), val)
 						}
 					}
 				}
@@ -77,8 +77,8 @@ func (m *MultiProtocol) ExecuteWithResults(input *contextargs.Context, callback 
 		}
 
 		// evaluate all variables after execution of each protocol
-		variableMap := m.options.Variables.Evaluate(m.options.GetTemplateCtx(input.MetaInput).GetAll())
-		m.options.GetTemplateCtx(input.MetaInput).Merge(variableMap) // merge all variables into template context
+		variableMap := m.options.Variables.Evaluate(m.options.GetTemplateCtx(ctx.Input.MetaInput).GetAll())
+		m.options.GetTemplateCtx(ctx.Input.MetaInput).Merge(variableMap) // merge all variables into template context
 	}
 
 	// template context: contains values extracted using `internal` extractor from previous protocols
@@ -89,8 +89,8 @@ func (m *MultiProtocol) ExecuteWithResults(input *contextargs.Context, callback 
 
 	// execute all protocols in the queue
 	for _, req := range m.requests {
-		values := m.options.GetTemplateCtx(input.MetaInput).GetAll()
-		err := req.ExecuteWithResults(input, output.InternalEvent(values), nil, multiProtoCallback)
+		values := m.options.GetTemplateCtx(ctx.Input.MetaInput).GetAll()
+		err := req.ExecuteWithResults(ctx.Input, output.InternalEvent(values), nil, multiProtoCallback)
 		// if error skip execution of next protocols
 		if err != nil {
 			return err
@@ -100,7 +100,8 @@ func (m *MultiProtocol) ExecuteWithResults(input *contextargs.Context, callback 
 	// currently the outer callback is only executed once (for the last protocol in queue)
 	// due to workflow logic at https://github.com/projectdiscovery/nuclei/blob/main/pkg/protocols/common/executer/executem.go#L150
 	// this causes addition of duplicated / unncessary variables with prefix template_id_all_variables
-	callback(finalProtoEvent)
+	// callback(finalProtoEvent)
+	ctx.LogEvent(finalProtoEvent)
 
 	return nil
 }

--- a/pkg/tmplexec/multiproto/multi.go
+++ b/pkg/tmplexec/multiproto/multi.go
@@ -100,7 +100,6 @@ func (m *MultiProtocol) ExecuteWithResults(ctx *scan.ScanContext) error {
 	// currently the outer callback is only executed once (for the last protocol in queue)
 	// due to workflow logic at https://github.com/projectdiscovery/nuclei/blob/main/pkg/protocols/common/executer/executem.go#L150
 	// this causes addition of duplicated / unncessary variables with prefix template_id_all_variables
-	// callback(finalProtoEvent)
 	ctx.LogEvent(finalProtoEvent)
 
 	return nil

--- a/pkg/tmplexec/multiproto/multi_test.go
+++ b/pkg/tmplexec/multiproto/multi_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/progress"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/contextargs"
+	"github.com/projectdiscovery/nuclei/v3/pkg/scan"
 	"github.com/projectdiscovery/nuclei/v3/pkg/templates"
 	"github.com/projectdiscovery/nuclei/v3/pkg/testutils"
 	"github.com/projectdiscovery/ratelimit"
@@ -52,7 +53,9 @@ func TestMultiProtoWithDynamicExtractor(t *testing.T) {
 	err = Template.Executer.Compile()
 	require.Nil(t, err, "could not compile template")
 
-	gotresults, err := Template.Executer.Execute(contextargs.NewWithInput("blog.projectdiscovery.io"))
+	input := contextargs.NewWithInput("blog.projectdiscovery.io")
+	ctx := scan.NewScanContext(input)
+	gotresults, err := Template.Executer.Execute(ctx)
 	require.Nil(t, err, "could not execute template")
 	require.True(t, gotresults)
 }
@@ -67,7 +70,9 @@ func TestMultiProtoWithProtoPrefix(t *testing.T) {
 	err = Template.Executer.Compile()
 	require.Nil(t, err, "could not compile template")
 
-	gotresults, err := Template.Executer.Execute(contextargs.NewWithInput("blog.projectdiscovery.io"))
+	input := contextargs.NewWithInput("blog.projectdiscovery.io")
+	ctx := scan.NewScanContext(input)
+	gotresults, err := Template.Executer.Execute(ctx)
 	require.Nil(t, err, "could not execute template")
 	require.True(t, gotresults)
 }


### PR DESCRIPTION
# Proposed changes (initial)

### Please describe your feature request:
When I use nuclei to run my test cases using `matcher-status` option that generates a result event for failed matchers, it doesn't include results when the host got errored out for multiple reasons, which nuclei failed to report.

nuclei have a separate option to track errored hosts with error information using `-elog` option, and unfortunately, it can not be mapped directly with the result itself.


### Describe the use case of this feature:
I'm running nuclei in my CI pipeline, nuclei reported multiple results upon 1st run; as a result of one vulnerability, I've taken down the vulnerable host, upon next nuclei run, nuclei failed to report the same vulnerabilities as it silently failed to run as host is not accessible.

Instead, nuclei can still generate failed match events and populate error information as it does when using with `-elog` option.

Here is example run with this support: 

<details>
<summary>1. Test Template</summary>

```yaml
id: failed_test

info:
  name: Test HTTP Template
  author: pdteam
  severity: info

http:
  - method: GET
    path:
      - "{{BaseURL}}"

    matchers:
      - type: word
        words:
          - "This is test matcher text"
```
</details>


<details>
<summary>2. Test Run</summary>

```console
echo https://googleaaaaaaaaa.com | nuclei -t test.yaml -matcher-status -jsonl

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.0.2

		projectdiscovery.io

[INF] Current nuclei version: v3.0.2 (latest)
[INF] Current nuclei-templates version: v9.6.7 (latest)
[INF] New templates added in latest release: 1
[INF] Templates loaded for current scan: 1
[WRN] Executing 1 unsigned templates. Use with caution.
[INF] Targets loaded for current scan: 1
```
</details>



<details>
<summary>3. Test Result</summary>


```diff
{
  "template-id": "failed_test",
  "template-path": "/Users/geekboy/Github/nuclei-templates/test.yaml",
  "info": {
    "name": "Test HTTP Template",
    "author": [
      "pdteam"
    ],
    "tags": null,
    "severity": "info"
  },
  "type": "http",
  "host": "https://gggggggggggle.com",
  "request": "GET / HTTP/1.1\r\nHost: gggggggggggle.com\r\nUser-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2866.71 Safari/537.36\r\nConnection: close\r\nAccept: */*\r\nAccept-Language: en\r\nAccept-Encoding: gzip\r\n\r\n",
-  "response": "XXXX",
  "timestamp": "2023-10-27T18:08:24.24882+05:30",
+  "error": "context deadline exceeded",
  "matcher-status": false
}
```
</details>

**Note:**
- This support needs to be reflected for SDK uses as well.


# Proposed changes 

## Refactor Nuclei to use `ScanCtx`

### Jargon

- **scan = 1 template x 1 target**

> when we say stateless in this context it means stateless for a scan
> 

## Background / Intro

- In Nuclei we have `TemplateExecuter` for executing a template on one or more than 1 targets (tmplexec package).

```go
func (e *TemplateExecuter) ExecuteWithResults(input *contextargs.Context, callback protocols.OutputEventCallback) error {
```

- This is function signature of method used to execute a scan ( scan == 1 target + 1 template )
- This is called N times in several goroutines when there is more than 1 target and Hence it is necessary that `TemplateExecuter` and all its field are stateless (in context of scan) . simply put a scan should not update/modify any data in TemplateExecuter or it will cause a race condition / panic

## Requirement / Issue

we are trying to return any error occured during execution of a scan in json response when `-ms` flag is used (ref: https://github.com/projectdiscovery/nuclei/issues/4299) .The solution for this is to add a field called `error` in `ResultEvent` .  But problem is that it doesn’t seem to be possible with current arch/design . since we generate `ResultEvent` in callbacks, looking at above function signature we can tell that error is returned seperately and we exit function on error ( at multiple places).

generating event in callback may not be good idea and we have so many nested callbacks in nuclei but unfortunately there is no simple / alternate solution to replace callbacks at least for now

### How does current error logging work (like elog etc) ??

TemplateExecuter/ Protocols etc have a field called `ExecuterOptions` which contains global (ideally) read-only resources that are shared across all protocols ex: browser instance , interactsh instance and lot more . we have `output.Writer` field in `ExecuterOptions` that is called to log errors to a io.Writer .

```go
// Request logs a request in the trace log
Request(templateID, url, requestType string, err error)
```

Since this is a global writer it is not possible to hijack error’s and pass it to `ResultEvent`

## `*contextargs.Context`

- this is input context . more specifically contains target and any arguments from workflows and is specific to scan
- In Nuclei v3 we introduced `templateContext` (a global map of variables per scan) for this we are hashing contextArgs and using that as key  . since `input *contextargs.Context` is scan specific . ( it is cloned at protocol level etc but more or less remains constant for a scan )
- This key is then used to read/modify/update variables by using a synchronized Map in `ExecuterOptions` . this ideally should not happen since we aim to keep `TemplateExecuter` stateless but this was only/easiest hack to use at that moment

# Proposed Solution

I think solution is not something entirely new but it just extends to existing implementation of `contextArgs.Context` and following a strict practice/guidelines while coding

The idea remains the same i.e keeping `TemplateExecuter` and `Protocols.Request` stateless and move all update/modify related data (like variables/templateContext)  to `ScanContext` . The idea is to treat it the same way as we  use `context.Context` in golang . 

ScanContext is wrapper around `input *contextargs.Context` and will include all stateful data related to a scan

```go
type ScanContext struct {
	// embed context.Context
	context.Context
	// scanID
	scanID string // MD5 (templateID+target+ip)
	// existing input/target related info
	input *contextargs.Context
	// templateInfo
	Info model.Info
	// Globally shared args aka template Context
	TemplateMap map[string]interface{}
  // stats tracker like req count etc
	Stats *Stats 

	// hooks / callbacks
	OnError func(error)

	OnResult func(e *InternalWrappedEvent)

	// other fields to be added here
}

func (s *ScanContext) GenerateResult() *output.ResultEvent

func (s *ScanContext) LogError(err error) error {}
// other required fields
```

so any function invocations in `ExecuteWithResults` function should follow the almost same new function signature as shown below

```go
func (x *Type) XyzMethod(ctx *ScanContext,......) ... {
```

### Example

- this is example execute method that protocols implement

```go
// Example Execute method of a protocol like ssl , http
func Execute(ScanCtx context.Context) error {
  generatedHttpRequest, err := generator.Make(...)
	if err != nil {
		return ScanCtx.LogError(err)
	}
	return nil
}
```

- After change we will do following in tmplexec package

### current implementation

```go
// ExecuteWithResults executes the protocol requests and returns results instead of writing them.
func (e *TemplateExecuter) ExecuteWithResults(input *contextargs.Context, callback protocols.OutputEventCallback) error {
	userCallback := func(event *output.InternalWrappedEvent) {
		if event != nil {
			callback(event)
		}
	}
	return e.engine.ExecuteWithResults(input, userCallback)
}
```

### new Implementation

```go
// ExecuteWithResults executes the protocol requests and returns results instead of writing them.
func (e *TemplateExecuter) ExecuteWithResults(input *contextargs.Context) (*ResultEvent, error) {
	// create scanCtx using input 
  scanCtx := NewScanCtx(input)
	// execute template / engine
	err := e.engine.ExecuteWithResults(scanctx)
	if err != nil && !e.options.MatcherStatus {
			return nil, err
	}
	return scanCtx.GenerateResult(),err
}
```

> when we use LogError method it will save given error in `ScanContext` struct and will be used when generating result .
> 

With this we can include much more than just a error in `ResultEvent` since GenerateResult is a method of `ScanContext` and it has all scan related data . we can include everything that will be required in clean way . Others things that can be included in `ResultEvent` are

- **All Template Context Variables**
- **Stats like total request sent / failed etc**
- **Analytics related data like Time taken for a scan**
- **All existing stuff like template Metadata etc**
- **Request / Response Logs ( in all protocols)**
- Other Future requirements related to scan

### Conclusion

- we are abstracting callbacks from function invocations . and later on we can slowly refactor / remove callbacks with any better solutions



## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)