### PR TITLE
add -code flag to run code proto templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ TEMPLATES:
    -nss, -no-strict-syntax                disable strict syntax check on templates
    -td, -template-display                 displays the templates content
    -tl                                    list all available templates
+   -sign                                  signs the templates with the private key defined in NUCLEI_SIGNATURE_PRIVATE_KEY env variable
+   -code                                  enable loading code protocol-based templates
 
 FILTERING:
    -a, -author string[]               templates to run based on authors (comma-separated, file)

--- a/README_CN.md
+++ b/README_CN.md
@@ -100,17 +100,19 @@ Nuclei是一款注重于可配置性、可扩展性和易用性的基于模板�
    -iv, -ip-version string[]             要扫描的主机名的IP版本（4,6）-（默认为4）
 
 模板：
-   -nt, -new-templates                   只扫描最新nuclei-templates版本中添加的模板
-   -ntv, -new-templates-version string[] 运行在特定nuclei-templates版本中添加的新模板
-   -as, -automatic-scan                  在web扫描中使用wappalyzer技术检测的指纹找包含对应tags的模板
-   -t, -templates string[]               指定需要扫描的模板文件或者模板目录（逗号分隔，文件）
-   -tu, -template-url string[]           从URL加载模板（逗号分隔，文件）
-   -w, -workflows string[]               指定需要扫描中的工作流文件或者工作流目录（逗号分隔，文件）
-   -wu, -workflow-url string[]           从URL加载工作流（逗号分隔，文件）
-   -validate                             验证模板
-   -nss, -no-strict-syntax               禁用对模板的严格语法检查
-   -td, -template-display                显示模板内容
-   -tl                                   列出所有可用的模板
+   -nt, -new-templates                    run only new templates added in latest nuclei-templates release
+   -ntv, -new-templates-version string[]  run new templates added in specific version
+   -as, -automatic-scan                   automatic web scan using wappalyzer technology detection to tags mapping
+   -t, -templates string[]                list of template or template directory to run (comma-separated, file)
+   -turl, -template-url string[]          template url or list containing template urls to run (comma-separated, file)
+   -w, -workflows string[]                list of workflow or workflow directory to run (comma-separated, file)
+   -wurl, -workflow-url string[]          workflow url or list containing workflow urls to run (comma-separated, file)
+   -validate                              validate the passed templates to nuclei
+   -nss, -no-strict-syntax                disable strict syntax check on templates
+   -td, -template-display                 displays the templates content
+   -tl                                    list all available templates
+   -sign                                  signs the templates with the private key defined in NUCLEI_SIGNATURE_PRIVATE_KEY env variable
+   -code                                  enable loading code protocol-based templates
 
 过滤：
    -a, -author string[]                  执行指定作者的模板（逗号分隔，文件）

--- a/README_ID.md
+++ b/README_ID.md
@@ -105,13 +105,15 @@ TEMPLATES:
    -ntv, -new-templates-version string[]  run new templates added in specific version
    -as, -automatic-scan                   automatic web scan using wappalyzer technology detection to tags mapping
    -t, -templates string[]                list of template or template directory to run (comma-separated, file)
-   -tu, -template-url string[]            list of template urls to run (comma-separated, file)
+   -turl, -template-url string[]          template url or list containing template urls to run (comma-separated, file)
    -w, -workflows string[]                list of workflow or workflow directory to run (comma-separated, file)
-   -wu, -workflow-url string[]            list of workflow urls to run (comma-separated, file)
+   -wurl, -workflow-url string[]          workflow url or list containing workflow urls to run (comma-separated, file)
    -validate                              validate the passed templates to nuclei
    -nss, -no-strict-syntax                disable strict syntax check on templates
    -td, -template-display                 displays the templates content
    -tl                                    list all available templates
+   -sign                                  signs the templates with the private key defined in NUCLEI_SIGNATURE_PRIVATE_KEY env variable
+   -code                                  enable loading code protocol-based templates
 
 FILTERING:
    -a, -author string[]               templates to run based on authors (comma-separated, file)

--- a/README_KR.md
+++ b/README_KR.md
@@ -98,15 +98,19 @@ TARGET:
    -resume string        resume.cfg를 사용한 스캔 재개(클러스터링이 비활성화됨)
 
 TEMPLATES:
-   -nt, -new-templates          nuclei-templates에 가장 최근에 추가된 새 템플릿만 실행
-   -as, -automatic-scan         태그 매핑에 대한 wappalyzer 기술 탐지를 사용한 자동 웹 스캔
-   -t, -templates string[]      실행할 템플릿 또는 템플릿 디렉터리 목록(쉼표로 구분된 파일)
-   -tu, -template-url string[]  실행할 템플릿 URL 목록(쉼표로 구분된 파일)
-   -w, -workflows string[]      실행할 워크플로 또는 워크플로 디렉터리 목록(쉼표로 구분된 파일)
-   -wu, -workflow-url string[]  실행할 워크플로 URL 목록(쉼표로 구분된 파일)
-   -validate                    nuclei로 전달된 템플릿 검증
-   -tl                          사용 가능한 모든 템플릿 목록
-   -td                          템플릿 내용 표시
+   -nt, -new-templates                    run only new templates added in latest nuclei-templates release
+   -ntv, -new-templates-version string[]  run new templates added in specific version
+   -as, -automatic-scan                   automatic web scan using wappalyzer technology detection to tags mapping
+   -t, -templates string[]                list of template or template directory to run (comma-separated, file)
+   -turl, -template-url string[]          template url or list containing template urls to run (comma-separated, file)
+   -w, -workflows string[]                list of workflow or workflow directory to run (comma-separated, file)
+   -wurl, -workflow-url string[]          workflow url or list containing workflow urls to run (comma-separated, file)
+   -validate                              validate the passed templates to nuclei
+   -nss, -no-strict-syntax                disable strict syntax check on templates
+   -td, -template-display                 displays the templates content
+   -tl                                    list all available templates
+   -sign                                  signs the templates with the private key defined in NUCLEI_SIGNATURE_PRIVATE_KEY env variable
+   -code                                  enable loading code protocol-based templates
 
 FILTERING:
    -a, -author string[]              작성자를 기준으로 실행할 템플릿(쉼표로 구분된 파일)

--- a/cmd/integration-test/code.go
+++ b/cmd/integration-test/code.go
@@ -87,7 +87,7 @@ type codeSnippet struct{}
 
 // Execute executes a test case and returns an error if occurred
 func (h *codeSnippet) Execute(filePath string) error {
-	results, err := testutils.RunNucleiArgsWithEnvAndGetResults(debug, getEnvValues(), "-t", filePath, "-u", "input")
+	results, err := testutils.RunNucleiArgsWithEnvAndGetResults(debug, getEnvValues(), "-t", filePath, "-u", "input", "-code")
 	if err != nil {
 		return err
 	}
@@ -98,7 +98,7 @@ type codeFile struct{}
 
 // Execute executes a test case and returns an error if occurred
 func (h *codeFile) Execute(filePath string) error {
-	results, err := testutils.RunNucleiArgsWithEnvAndGetResults(debug, getEnvValues(), "-t", filePath, "-u", "input")
+	results, err := testutils.RunNucleiArgsWithEnvAndGetResults(debug, getEnvValues(), "-t", filePath, "-u", "input", "-code")
 	if err != nil {
 		return err
 	}
@@ -109,7 +109,7 @@ type codeEnvVar struct{}
 
 // Execute executes a test case and returns an error if occurred
 func (h *codeEnvVar) Execute(filePath string) error {
-	results, err := testutils.RunNucleiArgsWithEnvAndGetResults(debug, getEnvValues(), "-t", filePath, "-u", "input", "-V", "baz=baz")
+	results, err := testutils.RunNucleiArgsWithEnvAndGetResults(debug, getEnvValues(), "-t", filePath, "-u", "input", "-V", "baz=baz", "-code")
 	if err != nil {
 		return err
 	}
@@ -120,7 +120,7 @@ type unsignedCode struct{}
 
 // Execute executes a test case and returns an error if occurred
 func (h *unsignedCode) Execute(filePath string) error {
-	results, err := testutils.RunNucleiArgsWithEnvAndGetResults(debug, getEnvValues(), "-t", filePath, "-u", "input")
+	results, err := testutils.RunNucleiArgsWithEnvAndGetResults(debug, getEnvValues(), "-t", filePath, "-u", "input", "-code")
 
 	// should error out
 	if err != nil {
@@ -135,7 +135,7 @@ type codePyNoSig struct{}
 
 // Execute executes a test case and returns an error if occurred
 func (h *codePyNoSig) Execute(filePath string) error {
-	results, err := testutils.RunNucleiArgsWithEnvAndGetResults(debug, getEnvValues(), "-t", filePath, "-u", "input")
+	results, err := testutils.RunNucleiArgsWithEnvAndGetResults(debug, getEnvValues(), "-t", filePath, "-u", "input", "-code")
 
 	// should error out
 	if err != nil {

--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -194,6 +194,7 @@ on extensive configurability, massive extensibility and ease of use.`)
 		flagSet.BoolVar(&options.TemplateList, "tl", false, "list all available templates"),
 		flagSet.StringSliceVarConfigOnly(&options.RemoteTemplateDomainList, "remote-template-domain", []string{"templates.nuclei.sh"}, "allowed domain list to load remote templates from"),
 		flagSet.BoolVar(&options.SignTemplates, "sign", false, "signs the templates with the private key defined in NUCLEI_SIGNATURE_PRIVATE_KEY env variable"),
+		flagSet.BoolVar(&options.EnableCodeTemplates, "code", false, "enable loading code protocol-based templates"),
 	)
 
 	flagSet.CreateGroup("filters", "Filtering",

--- a/cmd/tmc/main.go
+++ b/cmd/tmc/main.go
@@ -68,6 +68,7 @@ func init() {
 	defaultOpts := types.DefaultOptions()
 	// need to set headless to true for headless templates
 	defaultOpts.Headless = true
+	defaultOpts.EnableCodeTemplates = true
 	if err := protocolstate.Init(defaultOpts); err != nil {
 		gologger.Fatal().Msgf("Could not initialize protocol state: %s\n", err)
 	}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -671,6 +671,7 @@ func (r *Runner) displayExecutionInfo(store *loader.Store) {
 	if r.options.Verbose {
 		// only print these stats in verbose mode
 		stats.DisplayAsWarning(parsers.HeadlessFlagWarningStats)
+		stats.DisplayAsWarning(parsers.CodeFlagWarningStats)
 		stats.DisplayAsWarning(parsers.TemplatesExecutedStats)
 	}
 	stats.DisplayAsWarning(parsers.UnsignedWarning)

--- a/lib/config.go
+++ b/lib/config.go
@@ -319,3 +319,11 @@ func WithSandboxOptions(allowLocalFileAccess bool, restrictLocalNetworkAccess bo
 		return nil
 	}
 }
+
+// EnableCodeTemplates allows loading/executing code protocol templates
+func EnableCodeTemplates() NucleiSDKOptions {
+	return func(e *NucleiEngine) error {
+		e.opts.EnableCodeTemplates = true
+		return nil
+	}
+}

--- a/pkg/catalog/loader/loader.go
+++ b/pkg/catalog/loader/loader.go
@@ -403,6 +403,12 @@ func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) []*templ
 					if config.DefaultConfig.LogAllEvents {
 						gologger.Print().Msgf("[%v] Headless flag is required for headless template '%s'.\n", aurora.Yellow("WRN").String(), templatePath)
 					}
+				} else if len(parsed.RequestsCode) > 0 && !store.config.ExecutorOptions.Options.EnableCodeTemplates {
+					// donot include 'Code' protocol custom template in final list if code flag is not set
+					stats.Increment(parsers.CodeFlagWarningStats)
+					if config.DefaultConfig.LogAllEvents {
+						gologger.Print().Msgf("[%v] Code flag is required for code protocol template '%s'.\n", aurora.Yellow("WRN").String(), templatePath)
+					}
 				} else if len(parsed.RequestsCode) > 0 && !parsed.Verified && len(parsed.Workflows) == 0 {
 					// donot include unverified 'Code' protocol custom template in final list
 					stats.Increment(parsers.UnsignedWarning)

--- a/pkg/parsers/parser.go
+++ b/pkg/parsers/parser.go
@@ -145,6 +145,7 @@ const (
 	UnsignedWarning          = "unsigned-warnings"
 	HeadlessFlagWarningStats = "headless-flag-missing-warnings"
 	TemplatesExecutedStats   = "templates-executed"
+	CodeFlagWarningStats     = "code-flag-missing-warnings"
 )
 
 func init() {
@@ -154,8 +155,9 @@ func init() {
 	stats.NewEntry(SyntaxErrorStats, "Found %d templates with syntax error (use -validate flag for further examination)")
 	stats.NewEntry(RuntimeWarningsStats, "Found %d templates with runtime error (use -validate flag for further examination)")
 	stats.NewEntry(UnsignedWarning, "Found %d unsigned or tampered code template (carefully examine before using it & use -sign flag to sign them)")
-	stats.NewEntry(HeadlessFlagWarningStats, "Excluded %d headless templates (disabled as default), use -headless option to run headless templates.")
-	stats.NewEntry(TemplatesExecutedStats, "Excluded %d templates with known weak matchers / tags excluded from default run using .nuclei-ignore")
+	stats.NewEntry(HeadlessFlagWarningStats, "Excluded %d headless template[s] (disabled as default), use -headless option to run headless templates.")
+	stats.NewEntry(CodeFlagWarningStats, "Excluded %d code template[s] (disabled as default), use -code option to run code templates.")
+	stats.NewEntry(TemplatesExecutedStats, "Excluded %d template[s] with known weak matchers / tags excluded from default run using .nuclei-ignore")
 }
 
 // ParseTemplate parses a template and returns a *templates.Template structure

--- a/pkg/templates/compile.go
+++ b/pkg/templates/compile.go
@@ -176,7 +176,7 @@ func (template *Template) compileProtocolRequests(options *protocols.ExecutorOpt
 		if len(template.RequestsWHOIS) > 0 {
 			requests = append(requests, template.convertRequestToProtocolsRequest(template.RequestsWHOIS)...)
 		}
-		if len(template.RequestsCode) > 0 {
+		if len(template.RequestsCode) > 0 && options.Options.EnableCodeTemplates {
 			requests = append(requests, template.convertRequestToProtocolsRequest(template.RequestsCode)...)
 		}
 		if len(template.RequestsJavascript) > 0 {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -400,6 +400,8 @@ type Options struct {
 	CodeTemplateSignatureAlgorithm string
 	// SignTemplates enables signing of templates
 	SignTemplates bool
+	// EnableCodeTemplates enables code templates
+	EnableCodeTemplates bool
 }
 
 // ShouldLoadResume resume file


### PR DESCRIPTION
### Proposed Changes

- add `-code` flag to run code protocol template (disabled by default)
- closes https://github.com/projectdiscovery/nuclei/issues/4368

### without `-code` flag

```console
$ ./nuclei -u input -t ~/test-templates/code-example.yaml  -V "baz=baz" -v

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.0.3

		projectdiscovery.io

[url] got empty hostname for input skipping ip selection
[VER] Started metrics server at localhost:9092
[WRN] Excluded 1 code template[s] (disabled as default), use -code option to run code templates.
[INF] Current nuclei version: v3.0.3 (latest)
[INF] Current nuclei-templates version: v9.6.9 (latest)
[INF] Executing 1 signed templates from tarun
[INF] Targets loaded for current scan: 1
[INF] No results found. Better luck next time!
[FTL] Could not run nuclei: no templates provided for scan
```

### with `-code` flag

```console
$  ./nuclei -u input -t ~/test-templates/code-example.yaml  -V "baz=baz" -code

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.0.3

		projectdiscovery.io

[INF] Current nuclei version: v3.0.3 (latest)
[INF] Current nuclei-templates version: v9.6.9 (latest)
[INF] New templates added in latest release: 73
[INF] Templates loaded for current scan: 1
[INF] Executing 1 signed templates from tarun
[INF] Targets loaded for current scan: 1
[py-code-snippet] [code] [info] input
```