### PR TITLE
add support for multiple ports in network template

### DIFF
--- a/pkg/protocols/network/network.go
+++ b/pkg/protocols/network/network.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"strconv"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -11,6 +12,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/expressions"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/generators"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/network/networkclientpool"
+	errorutil "github.com/projectdiscovery/utils/errors"
 	fileutil "github.com/projectdiscovery/utils/file"
 )
 
@@ -73,6 +75,10 @@ type Request struct {
 	// description: |
 	//   SelfContained specifies if the request is self-contained.
 	SelfContained bool `yaml:"-" json:"-"`
+
+	// description: |
+	// ports is post processed list of ports to scan (obtained from Port)
+	ports []string `yaml:"-" json:"-"`
 
 	// Operators for the current request go here.
 	operators.Operators `yaml:",inline,omitempty"`
@@ -166,6 +172,23 @@ func (request *Request) Compile(options *protocols.ExecutorOptions) error {
 		}
 		if compiled, evalErr := expressions.Evaluate(input.Data, map[string]interface{}{}); evalErr == nil {
 			input.Data = compiled
+		}
+	}
+
+	// parse ports and validate
+	if request.Port != "" {
+		for _, port := range strings.Split(request.Port, ",") {
+			if port == "" {
+				continue
+			}
+			portInt, err := strconv.Atoi(port)
+			if err != nil {
+				return errorutil.NewWithErr(err).Msgf("could not parse port %v from '%s'", port, request.Port)
+			}
+			if portInt < 1 || portInt > 65535 {
+				return errorutil.NewWithErr(err).Msgf("port %v is not in valid range", portInt)
+			}
+			request.ports = append(request.ports, port)
 		}
 	}
 

--- a/pkg/protocols/network/network.go
+++ b/pkg/protocols/network/network.go
@@ -186,7 +186,7 @@ func (request *Request) Compile(options *protocols.ExecutorOptions) error {
 				return errorutil.NewWithErr(err).Msgf("could not parse port %v from '%s'", port, request.Port)
 			}
 			if portInt < 1 || portInt > 65535 {
-				return errorutil.NewWithErr(err).Msgf("port %v is not in valid range", portInt)
+				return errorutil.NewWithTag(request.TemplateID, "port %v is not in valid range", portInt)
 			}
 			request.ports = append(request.ports, port)
 		}

--- a/pkg/protocols/network/request.go
+++ b/pkg/protocols/network/request.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"go.uber.org/multierr"
 	"golang.org/x/exp/maps"
 
 	"github.com/projectdiscovery/gologger"
@@ -22,6 +23,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/helpers/eventcreator"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/helpers/responsehighlighter"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/interactsh"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/replacer"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/utils/vardump"
 	protocolutils "github.com/projectdiscovery/nuclei/v3/pkg/protocols/utils"
@@ -44,52 +46,101 @@ func (request *Request) Type() templateTypes.ProtocolType {
 	return templateTypes.NetworkProtocol
 }
 
+// getOpenPorts returns all open ports from list of ports provided in template
+// if only 1 port is provided, no need to check if port is open or not
+func (request *Request) getOpenPorts(target *contextargs.Context) ([]string, error) {
+	if len(request.ports) == 1 {
+		// no need to check if port is open or not
+		return request.ports, nil
+	}
+	errs := []error{}
+	// if more than 1 port is provided, check if port is open or not
+	openPorts := make([]string, 0)
+	for _, port := range request.ports {
+		cloned := target.Clone()
+		if err := cloned.UseNetworkPort(port, request.ExcludePorts); err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		addr, err := getAddress(cloned.MetaInput.Input)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		conn, err := protocolstate.Dialer.Dial(context.TODO(), "tcp", addr)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		_ = conn.Close()
+		openPorts = append(openPorts, port)
+	}
+	if len(openPorts) == 0 {
+		return nil, multierr.Combine(errs...)
+	}
+	return openPorts, nil
+}
+
 // ExecuteWithResults executes the protocol requests and returns results instead of writing them.
 func (request *Request) ExecuteWithResults(target *contextargs.Context, metadata, previous output.InternalEvent, callback protocols.OutputEventCallback) error {
 	var address string
 	var err error
 
-	input := target.Clone()
-	// use network port updates input with new port requested in template file
-	// and it is ignored if input port is not standard http(s) ports like 80,8080,8081 etc
-	// idea is to reduce redundant dials to http ports
-	if err := input.UseNetworkPort(request.Port, request.ExcludePorts); err != nil {
-		gologger.Debug().Msgf("Could not network port from constants: %s\n", err)
-	}
-
-	if request.SelfContained {
-		address = ""
-	} else {
-		address, err = getAddress(input.MetaInput.Input)
+	// get open ports from list of ports provided in template
+	ports, err := request.getOpenPorts(target)
+	if len(ports) == 0 {
+		return err
 	}
 	if err != nil {
-		request.options.Output.Request(request.options.TemplatePath, input.MetaInput.Input, request.Type().String(), err)
-		request.options.Progress.IncrementFailedRequestsBy(1)
-		return errors.Wrap(err, "could not get address from url")
+		// TODO: replace this after scan context is implemented
+		gologger.Verbose().Msgf("[%v] got errors while checking open ports: %s\n", request.options.TemplateID, err)
 	}
-	variables := protocolutils.GenerateVariables(address, false, nil)
-	// add template ctx variables to varMap
-	variables = generators.MergeMaps(variables, request.options.GetTemplateCtx(input.MetaInput).GetAll())
-	variablesMap := request.options.Variables.Evaluate(variables)
-	variables = generators.MergeMaps(variablesMap, variables, request.options.Constants)
 
 	visitedAddresses := make(mapsutil.Map[string, struct{}])
 
-	for _, kv := range request.addresses {
-		actualAddress := replacer.Replace(kv.address, variables)
+	for _, port := range ports {
 
-		if visitedAddresses.Has(actualAddress) && !request.options.Options.DisableClustering {
-			continue
+		input := target.Clone()
+		// use network port updates input with new port requested in template file
+		// and it is ignored if input port is not standard http(s) ports like 80,8080,8081 etc
+		// idea is to reduce redundant dials to http ports
+		if err := input.UseNetworkPort(port, request.ExcludePorts); err != nil {
+			gologger.Debug().Msgf("Could not network port from constants: %s\n", err)
 		}
-		visitedAddresses.Set(actualAddress, struct{}{})
 
-		if err := request.executeAddress(variables, actualAddress, address, input, kv.tls, previous, callback); err != nil {
-			outputEvent := request.responseToDSLMap("", "", "", address, "")
-			callback(&output.InternalWrappedEvent{InternalEvent: outputEvent})
-			gologger.Warning().Msgf("[%v] Could not make network request for (%s) : %s\n", request.options.TemplateID, actualAddress, err)
-			continue
+		if request.SelfContained {
+			address = ""
+		} else {
+			address, err = getAddress(input.MetaInput.Input)
+		}
+		if err != nil {
+			request.options.Output.Request(request.options.TemplatePath, input.MetaInput.Input, request.Type().String(), err)
+			request.options.Progress.IncrementFailedRequestsBy(1)
+			return errors.Wrap(err, "could not get address from url")
+		}
+		variables := protocolutils.GenerateVariables(address, false, nil)
+		// add template ctx variables to varMap
+		variables = generators.MergeMaps(variables, request.options.GetTemplateCtx(input.MetaInput).GetAll())
+		variablesMap := request.options.Variables.Evaluate(variables)
+		variables = generators.MergeMaps(variablesMap, variables, request.options.Constants)
+
+		for _, kv := range request.addresses {
+			actualAddress := replacer.Replace(kv.address, variables)
+
+			if visitedAddresses.Has(actualAddress) && !request.options.Options.DisableClustering {
+				continue
+			}
+			visitedAddresses.Set(actualAddress, struct{}{})
+
+			if err := request.executeAddress(variables, actualAddress, address, input, kv.tls, previous, callback); err != nil {
+				outputEvent := request.responseToDSLMap("", "", "", address, "")
+				callback(&output.InternalWrappedEvent{InternalEvent: outputEvent})
+				gologger.Warning().Msgf("[%v] Could not make network request for (%s) : %s\n", request.options.TemplateID, actualAddress, err)
+				continue
+			}
 		}
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Proposed Changes

- While writing network templates common use case is to check for multiple open ports
```
Example:
while default port of ssh service is 22 . it is also commonly configured to use port 2222
```
- this pr adds support for multiple comma seperated values in port field and does the following
   - if more than one port is specified it probes to check if those ports are open on that targets
   - template is then executed on those open ports (can be one or more )
 - this does not remove / change any existing functionality introduced in `port` field PR and only extends its support for multiple ports
 - closes #4400  