### PR TITLE
implement GetKerberoastableUsers in ldap module

### DIFF
--- a/pkg/js/libs/ldap/ldap.go
+++ b/pkg/js/libs/ldap/ldap.go
@@ -203,3 +203,91 @@ func getBaseNamingContext(opts *ldapSessionOptions, conn *ldap.Conn) (string, er
 	opts.baseDN = defaultNamingContext
 	return opts.baseDN, nil
 }
+
+// KerberoastableUser contains the important fields of the Active Directory
+// kerberoastable user
+type KerberoastableUser struct {
+	SAMAccountName       string
+	ServicePrincipalName string
+}
+
+// GetKerberoastableUsers collects all "person" users that have an SPN
+// associated with them. The LDAP filter is built with the same logic as
+// "GetUserSPNs.py", the well-known impacket example by Forta.
+// https://github.com/fortra/impacket/blob/master/examples/GetUserSPNs.py#L297
+//
+// Returns a list of KerberoastableUser, if an error occurs, returns an empty
+// slice and the raised error
+func (c *LdapClient) GetKerberoastableUsers(domain, controller string, username, password string) ([]KerberoastableUser, error) {
+	opts := &ldapSessionOptions{
+		domain:           domain,
+		domainController: controller,
+		username:         username,
+		password:         password,
+	}
+
+	if !protocolstate.IsHostAllowed(domain) {
+		// host is not valid according to network policy
+		return nil, protocolstate.ErrHostDenied.Msgf(domain)
+	}
+
+	conn, err := c.newLdapSession(opts)
+	if err != nil {
+		return nil, err
+	}
+	defer c.close(conn)
+
+	domainParts := strings.Split(domain, ".")
+	if username == "" {
+		err = conn.UnauthenticatedBind("")
+	} else {
+		err = conn.Bind(
+			fmt.Sprintf("%v\\%v", domainParts[0], username),
+			password,
+		)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	var baseDN strings.Builder
+	for i, part := range domainParts {
+		baseDN.WriteString("DC=")
+		baseDN.WriteString(part)
+		if i != len(domainParts)-1 {
+			baseDN.WriteString(",")
+		}
+	}
+
+	sr := ldap.NewSearchRequest(
+		baseDN.String(),
+		ldap.ScopeWholeSubtree,
+		ldap.NeverDerefAliases,
+		0, 0, false,
+		// (&(is_user)         (!(account_is_disabled))                         (has_SPN))
+		"(&(objectCategory=person)(!(userAccountControl:1.2.840.113556.1.4.803:=2))(servicePrincipalName=*))",
+		[]string{
+			"SAMAccountName",
+			"ServicePrincipalName",
+		},
+		nil,
+	)
+
+	res, err := conn.Search(sr)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(res.Entries) == 0 {
+		return nil, fmt.Errorf("no kerberoastable user found")
+	}
+
+	var ku []KerberoastableUser
+	for _, usr := range res.Entries {
+		ku = append(ku, KerberoastableUser{
+			SAMAccountName:       usr.GetAttributeValue("sAMAccountName"),
+			ServicePrincipalName: usr.GetAttributeValue("servicePrincipalName"),
+		})
+	}
+	return ku, nil
+}

--- a/pkg/js/libs/ldap/ldap.go
+++ b/pkg/js/libs/ldap/ldap.go
@@ -209,6 +209,10 @@ func getBaseNamingContext(opts *ldapSessionOptions, conn *ldap.Conn) (string, er
 type KerberoastableUser struct {
 	SAMAccountName       string
 	ServicePrincipalName string
+	PWDLastSet           string
+	MemberOf             string
+	UserAccountControl   string
+	LastLogon            string
 }
 
 // GetKerberoastableUsers collects all "person" users that have an SPN
@@ -269,6 +273,10 @@ func (c *LdapClient) GetKerberoastableUsers(domain, controller string, username,
 		[]string{
 			"SAMAccountName",
 			"ServicePrincipalName",
+			"pwdLastSet",
+			"MemberOf",
+			"userAccountControl",
+			"lastLogon",
 		},
 		nil,
 	)
@@ -287,6 +295,10 @@ func (c *LdapClient) GetKerberoastableUsers(domain, controller string, username,
 		ku = append(ku, KerberoastableUser{
 			SAMAccountName:       usr.GetAttributeValue("sAMAccountName"),
 			ServicePrincipalName: usr.GetAttributeValue("servicePrincipalName"),
+			PWDLastSet:           usr.GetAttributeValue("pwdLastSet"),
+			MemberOf:             usr.GetAttributeValue("MemberOf"),
+			UserAccountControl:   usr.GetAttributeValue("userAccountControl"),
+			LastLogon:            usr.GetAttributeValue("lastLogon"),
 		})
 	}
 	return ku, nil


### PR DESCRIPTION
## Proposed changes

Closes #4419 

With this change, a new method is exposed in the ldap module of the Javascript Protocol: `GetKerberoastableUsers()`. This method will return a slice of `KerberoastableUser`, containing important properties about the user in the context of Active Directory:

```go
type KerberoastableUser struct {
	SAMAccountName       string
	ServicePrincipalName string
	PWDLastSet           string
	MemberOf             string
	UserAccountControl   string
	LastLogon            string
}
```

The filter used to make the LDAP query is almost the same as the one used in the [Impacket](https://github.com/fortra/impacket/) example script `GetUserSPNs.py`, more precisely here:

https://github.com/fortra/impacket/blob/4b56c18a10663a62e36dfd872bcebd30aa24fb91/examples/GetUserSPNs.py#L297-L314

To test the correct implementation of this feature I set up an Active Directory (Domain: LAB.LOCAL) environment with 3 users: `victim`, `roastme` and `pdtest2`:

```cmd
net user victim Trust_Me_Br0 /add /domain
net user roastme 123.qwe /add /domain
net user pdtest2 !Qazxsw2 /add /domain
```

And assigned 1 SPN to `roastme` and 1 SPN to `pdtest2`:

```cmd
setspn -a DC01/ldap LAB\roastme
setspn -a DC01/cifs LAB\pdtest2
```

Then, I used this template:

```yaml
id: ldap-list-kerberoastable-users-test

info:
  name: test
  author: 5amu
  severity: info

javascript:
  - args:
      DomainController: "{{Host}}"
    code: |
      ldap = require("nuclei/ldap");
      client = ldap.LdapClient();
      users = client.GetKerberoastableUsers(template.Domain, DomainController, template.Username, template.Password);
      to_json(users);
    extractors:
      - type: json
        json:
          - '.[]'

```

And executed nuclei like this:

```bash
go run cmd/nuclei/main.go -u 192.168.56.10 -var Username=victim -var Password=Trust_Me_Br0 -var Domain=LAB.LOCAL -t test.yaml
```

![image](https://github.com/projectdiscovery/nuclei/assets/39925709/114700b3-340c-4fe3-b0ba-7e8401b697d2)

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)