### PR TITLE
add regex support for `-eh`

### DIFF
--- a/pkg/core/inputs/hybrid/hmap.go
+++ b/pkg/core/inputs/hybrid/hmap.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -437,7 +438,8 @@ func (i *Input) delItem(metaInput *contextargs.MetaInput) {
 			return err
 		}
 
-		if tmpUrl.Host == targetUrl.Host {
+		matched, _ := regexp.MatchString(metaInput.Input, tmpUrl.Host)
+		if tmpUrl.Host == targetUrl.Host || matched {
 			_ = i.hostMap.Del(tmpKey)
 			i.excludedHosts[tmpKey] = struct{}{}
 			i.excludedCount++


### PR DESCRIPTION
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->

```console
$ cat scan_list.txt 
1.1.1.1
status.example.com
docs.example.com
api.example.com
1.1.1.1/24
*.gov
admin*.gov

$ go run . -list scan_list.txt -eh example

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.1.0-dev

                projectdiscovery.io

[INF] Number of hosts excluded from input: 3
[INF] Supplied input was automatically deduplicated (1 removed).
[INF] Current nuclei version: v3.1.0-dev (development)
[INF] Current nuclei-templates version: v9.6.9 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 73
[INF] Templates loaded for current scan: 7278
[INF] Executing 5266 signed templates from projectdiscovery/nuclei-templates
[WRN] Executing 2027 unsigned templates. Use with caution.
[INF] Targets loaded for current scan: 258
[INF] Running httpx on input host
[INF] Found 255 URL from httpx
[INF] Templates clustered: 1253 (Reduced 314760 Requests)
[ptr-fingerprint] [dns] [info] 1.1.1.1.in-addr.arpa [one.one.one.one.]
[caa-fingerprint] [dns] [info] *.gov
[caa-fingerprint] [dns] [info] admin*.gov
[INF] Using Interactsh Server: oast.me
^C[INF] CTRL+C pressed: Exiting
[INF] Creating resume file: /home/vscode/.cache/nuclei/resume-cliqjsst08rodd1t1h00.cfg
[ERR] Couldn't create resume file: open /home/vscode/.cache/nuclei/resume-cliqjsst08rodd1t1h00.cfg: no such file or directory
exit status 1
```
Closes #4412.


## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)