### PR TITLE
Improve error logging for unresolved variables

### DIFF
--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -350,6 +350,7 @@ on extensive configurability, massive extensibility and ease of use.`)
 		flagSet.BoolVarP(&options.EnablePprof, "enable-pprof", "ep", false, "enable pprof debugging server"),
 		flagSet.CallbackVarP(printTemplateVersion, "templates-version", "tv", "shows the version of the installed nuclei-templates"),
 		flagSet.BoolVarP(&options.HealthCheck, "health-check", "hc", false, "run diagnostic check up"),
+		flagSet.DynamicVarP(&options.ErrorLabels, "error-label", "elabel", []string{"UNV"}, "enable logging for specific error labels (comma-separated) (labels: UNV"),
 	)
 
 	flagSet.CreateGroup("update", "Update",

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -17,6 +17,7 @@ import (
 	"github.com/projectdiscovery/gologger/formatter"
 	"github.com/projectdiscovery/gologger/levels"
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/config"
+	elabel "github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/errors/label"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolinit"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/utils/vardump"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/headless/engine"
@@ -26,6 +27,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/reporting/exporters/markdown"
 	"github.com/projectdiscovery/nuclei/v3/pkg/reporting/exporters/sarif"
 	"github.com/projectdiscovery/nuclei/v3/pkg/types"
+	"github.com/projectdiscovery/nuclei/v3/pkg/utils/stats"
 	"github.com/projectdiscovery/nuclei/v3/pkg/utils/yaml"
 	fileutil "github.com/projectdiscovery/utils/file"
 	"github.com/projectdiscovery/utils/generic"
@@ -86,6 +88,8 @@ func ParseOptions(options *types.Options) {
 
 	// Load the resolvers if user asked for them
 	loadResolvers(options)
+
+	options.ErrorLabels = parseErrorLables(options.ErrorLabels)
 
 	err := protocolinit.Init(options)
 	if err != nil {
@@ -429,4 +433,22 @@ func readEnvInputVars(options *types.Options) {
 func getBoolEnvValue(key string) bool {
 	value := os.Getenv(key)
 	return strings.EqualFold(value, "true")
+}
+
+func parseErrorLables(errorLabels []string) []string {
+	// Make error label entries in stats
+	for _, v := range elabel.ErrorLableMap {
+		stats.NewEntry(v.Name, v.Description)
+	}
+	if len(errorLabels) == 0 {
+		return errorLabels
+	}
+	var errLabels []string
+	for _, label := range errorLabels {
+		label = strings.ToLower(label)
+		if v, ok := elabel.ErrorLableMap[label]; ok {
+			errLabels = append(errLabels, v.Name)
+		}
+	}
+	return errLabels
 }

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -17,6 +17,7 @@ import (
 	uncoverlib "github.com/projectdiscovery/uncover"
 	"github.com/projectdiscovery/utils/env"
 	permissionutil "github.com/projectdiscovery/utils/permission"
+	stringsutil "github.com/projectdiscovery/utils/strings"
 	updateutils "github.com/projectdiscovery/utils/update"
 
 	"github.com/logrusorgru/aurora"
@@ -40,6 +41,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/automaticscan"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/contextargs"
+	elabel "github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/errors/label"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/hosterrorscache"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/interactsh"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolinit"
@@ -492,6 +494,7 @@ func (r *Runner) RunEnumeration() error {
 		}
 	}
 	r.progress.Stop()
+	r.displayErrorInfo()
 
 	if executorOpts.InputHelper != nil {
 		_ = executorOpts.InputHelper.Close()
@@ -612,6 +615,17 @@ func (r *Runner) displayExecutionInfo(store *loader.Store) {
 	}
 	if r.hmapInputProvider.Count() > 0 {
 		gologger.Info().Msgf("Targets loaded for current scan: %d", r.hmapInputProvider.Count())
+	}
+}
+
+func (r *Runner) displayErrorInfo() {
+	if !r.options.Verbose {
+		return
+	}
+	errLables := r.options.ErrorLabels
+	// if error label is not provided, display the stats for specific labels
+	if !stringsutil.ContainsAny(elabel.UnresolvedVariablesErrorLabel, errLables...) {
+		stats.Display(elabel.UnresolvedVariablesErrorLabel)
 	}
 }
 

--- a/pkg/protocols/common/errors/label/error_label.go
+++ b/pkg/protocols/common/errors/label/error_label.go
@@ -1,0 +1,35 @@
+package label
+
+import (
+	"strings"
+)
+
+const (
+	UnresolvedVariablesErrorLabel = "unresolved-variables-error"
+)
+
+var (
+	ErrorLabels = []string{
+		UnresolvedVariablesErrorLabel,
+	}
+
+	ErrorLableMap = map[string]struct {
+		Name        string
+		Description string
+	}{
+		"unv": {
+			Name:        UnresolvedVariablesErrorLabel,
+			Description: "Failed %v requests due to unresolved variables. Use -elabel=UNV to enable unresolved variables logs.",
+		},
+	}
+)
+
+// Contains checks if the error string contains any of the provided labels, if yes returns matched label and true
+func Contains(errStr string, lables []string) (string, bool) {
+	for _, label := range lables {
+		if strings.Contains(errStr, label) {
+			return label, true
+		}
+	}
+	return "", false
+}

--- a/pkg/protocols/common/expressions/variables.go
+++ b/pkg/protocols/common/expressions/variables.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/Knetic/govaluate"
 	"github.com/projectdiscovery/nuclei/v3/pkg/operators/common/dsl"
+	elabel "github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/errors/label"
+	errorutil "github.com/projectdiscovery/utils/errors"
 )
 
 var (
@@ -38,7 +40,7 @@ func ContainsUnresolvedVariables(items ...string) error {
 			unresolvedVariables = append(unresolvedVariables, match[1])
 		}
 		if len(unresolvedVariables) > 0 {
-			return errors.New("unresolved variables found: " + strings.Join(unresolvedVariables, ","))
+			return errorutil.NewWithTag(elabel.UnresolvedVariablesErrorLabel, "unresolved variables found: "+strings.Join(unresolvedVariables, ","))
 		}
 	}
 

--- a/pkg/protocols/common/expressions/variables_test.go
+++ b/pkg/protocols/common/expressions/variables_test.go
@@ -1,9 +1,11 @@
 package expressions
 
 import (
-	"errors"
+	"fmt"
 	"testing"
 
+	elabel "github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/errors/label"
+	errorutil "github.com/projectdiscovery/utils/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -12,11 +14,11 @@ func TestUnresolvedVariablesCheck(t *testing.T) {
 		data string
 		err  error
 	}{
-		{"{{test}}", errors.New("unresolved variables found: test")},
-		{"{{test}}/{{another}}", errors.New("unresolved variables found: test,another")},
+		{"{{test}}", errorutil.NewWithTag(elabel.UnresolvedVariablesErrorLabel, "unresolved variables found: test")},
+		{"{{test}}/{{another}}", errorutil.NewWithTag(elabel.UnresolvedVariablesErrorLabel, "unresolved variables found: test,another")},
 		{"test", nil},
-		{"%7b%7btest%7d%7d", errors.New("unresolved variables found: test")},
-		{"%7B%7Bfirst%2Asecond%7D%7D", errors.New("unresolved variables found: first%2Asecond")},
+		{"%7b%7btest%7d%7d", errorutil.NewWithTag(elabel.UnresolvedVariablesErrorLabel, "unresolved variables found: test")},
+		{"%7B%7Bfirst%2Asecond%7D%7D", errorutil.NewWithTag(elabel.UnresolvedVariablesErrorLabel, fmt.Sprint("unresolved variables found: first%2Asecond"))},
 		{"{{7*7}}", nil},
 		{"{{'a'+'b'}}", nil},
 		{"{{'a'}}", nil},

--- a/pkg/protocols/common/expressions/variables_test.go
+++ b/pkg/protocols/common/expressions/variables_test.go
@@ -1,7 +1,7 @@
 package expressions
 
 import (
-	"fmt"
+	"errors"
 	"testing"
 
 	elabel "github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/errors/label"
@@ -18,7 +18,7 @@ func TestUnresolvedVariablesCheck(t *testing.T) {
 		{"{{test}}/{{another}}", errorutil.NewWithTag(elabel.UnresolvedVariablesErrorLabel, "unresolved variables found: test,another")},
 		{"test", nil},
 		{"%7b%7btest%7d%7d", errorutil.NewWithTag(elabel.UnresolvedVariablesErrorLabel, "unresolved variables found: test")},
-		{"%7B%7Bfirst%2Asecond%7D%7D", errorutil.NewWithTag(elabel.UnresolvedVariablesErrorLabel, fmt.Sprint("unresolved variables found: first%2Asecond"))},
+		{"%7B%7Bfirst%2Asecond%7D%7D", errorutil.NewWithTag(elabel.UnresolvedVariablesErrorLabel, errors.New("unresolved variables found: first%2Asecond").Error())},
 		{"{{7*7}}", nil},
 		{"{{'a'+'b'}}", nil},
 		{"{{'a'}}", nil},

--- a/pkg/protocols/http/request.go
+++ b/pkg/protocols/http/request.go
@@ -24,6 +24,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/output"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/contextargs"
+	elabel "github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/errors/label"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/expressions"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/fuzz"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/generators"
@@ -36,7 +37,9 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/http/signerpool"
 	templateTypes "github.com/projectdiscovery/nuclei/v3/pkg/templates/types"
 	"github.com/projectdiscovery/nuclei/v3/pkg/types"
+	"github.com/projectdiscovery/nuclei/v3/pkg/utils/stats"
 	"github.com/projectdiscovery/rawhttp"
+	errorutil "github.com/projectdiscovery/utils/errors"
 	"github.com/projectdiscovery/utils/reader"
 	sliceutil "github.com/projectdiscovery/utils/slice"
 	stringsutil "github.com/projectdiscovery/utils/strings"
@@ -368,6 +371,9 @@ func (request *Request) ExecuteWithResults(input *contextargs.Context, dynamicVa
 					return true, nil
 				}
 				request.options.Progress.IncrementFailedRequestsBy(int64(generator.Total()))
+				if lb, ok := elabel.Contains(err.Error(), elabel.ErrorLabels); ok {
+					stats.Increment(lb)
+				}
 				return true, err
 			}
 
@@ -462,7 +468,7 @@ func (request *Request) ExecuteWithResults(input *contextargs.Context, dynamicVa
 
 const drainReqSize = int64(8 * 1024)
 
-var errStopExecution = errors.New("stop execution due to unresolved variables")
+var errStopExecution = errorutil.NewWithTag(elabel.UnresolvedVariablesErrorLabel, "stop execution due to unresolved variables")
 
 // executeRequest executes the actual generated request and returns error if occurred
 func (request *Request) executeRequest(input *contextargs.Context, generatedRequest *generatedRequest, previousEvent output.InternalEvent, hasInteractMatchers bool, callback protocols.OutputEventCallback, requestCount int) error {
@@ -538,7 +544,10 @@ func (request *Request) executeRequest(input *contextargs.Context, generatedRequ
 			}
 		} else { // Check if are there any unresolved variables. If yes, skip unless overridden by user.
 			if varErr := expressions.ContainsUnresolvedVariables(dumpedRequestString); varErr != nil && !request.SkipVariablesCheck {
-				gologger.Warning().Msgf("[%s] Could not make http request for %s: %v\n", request.options.TemplateID, input.MetaInput.Input, varErr)
+				stats.Increment(elabel.UnresolvedVariablesErrorLabel)
+				if _, ok := elabel.Contains(varErr.Error(), request.options.Options.ErrorLabels); ok {
+					gologger.Warning().Msgf("[%s] Could not make http request for %s: %v\n", request.options.TemplateID, input.MetaInput.Input, varErr)
+				}
 				return errStopExecution
 			}
 		}

--- a/pkg/protocols/network/request.go
+++ b/pkg/protocols/network/request.go
@@ -18,6 +18,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/output"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/contextargs"
+	elabel "github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/errors/label"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/expressions"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/generators"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/helpers/eventcreator"
@@ -28,6 +29,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/utils/vardump"
 	protocolutils "github.com/projectdiscovery/nuclei/v3/pkg/protocols/utils"
 	templateTypes "github.com/projectdiscovery/nuclei/v3/pkg/templates/types"
+	"github.com/projectdiscovery/nuclei/v3/pkg/utils/stats"
 	errorutil "github.com/projectdiscovery/utils/errors"
 	mapsutil "github.com/projectdiscovery/utils/maps"
 	"github.com/projectdiscovery/utils/reader"
@@ -245,7 +247,11 @@ func (request *Request) executeRequestWithPayloads(variables map[string]interfac
 		reqBuilder.Write(finalData)
 
 		if err := expressions.ContainsUnresolvedVariables(string(finalData)); err != nil {
-			gologger.Warning().Msgf("[%s] Could not make network request for %s: %v\n", request.options.TemplateID, actualAddress, err)
+			request.options.Progress.IncrementFailedRequestsBy(1)
+			stats.Increment(elabel.UnresolvedVariablesErrorLabel)
+			if _, ok := elabel.Contains(err.Error(), request.options.Options.ErrorLabels); ok {
+				gologger.Warning().Msgf("[%s] Could not make network request for %s: %v\n", request.options.TemplateID, actualAddress, err)
+			}
 			return nil
 		}
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -96,6 +96,8 @@ type Options struct {
 	TraceLogFile string
 	// ErrorLogFile specifies a file to write with the errors of all requests
 	ErrorLogFile string
+	// ErrorLabels is the list of error labels to match and enable logging
+	ErrorLabels	[]string
 	// ReportingDB is the db for report storage as well as deduplication
 	ReportingDB string
 	// ReportingConfig is the config file for nuclei reporting module


### PR DESCRIPTION
## Proposed changes
- #3386 

### test
```console
✗ go run . -t ~/nuclei-templates/http/token-spray -v

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.1.0-dev

                projectdiscovery.io

[VER] Started metrics server at localhost:9092
[INF] Current nuclei version: v3.1.0-dev (development)
[INF] Current nuclei-templates version: v9.6.9 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 45
[INF] Templates loaded for current scan: 242
[INF] Executing 242 signed templates from projectdiscovery/nuclei-templates
[WRN] Failed 242 requests due to unresolved variables. Use -elabel=UNV to enable unresolved variables logs.
```
- to toggle
```
go run . -v -elabel=UNV
```

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)