### PR TITLE
Support for multiple `status-not` values in Jira report configuration

### DIFF
--- a/cmd/nuclei/issue-tracker-config.yaml
+++ b/cmd/nuclei/issue-tracker-config.yaml
@@ -55,15 +55,19 @@
 #  # User custom fields for Jira Cloud instead
 #  severity-as-label: true
 #  # Whatever your final status is that you want to use as a closed ticket - Closed, Done, Remediated, etc
-#  # When checking for duplicates, the JQL query will filter out status's that match this.
+#  # You can have more than 1 closed ticket status. For example if you can have:
+#  # status-not:
+#  #   - Done
+#  #   - Won't Fix
+#  # When checking for duplicates, the JQL query will filter out statuses that match this.
 #  # If it finds a match _and_ the ticket does have this status, a new one will be created.
 # status-not: Closed
 #  # Customfield supports name, id and freeform. name and id are to be used when the custom field is a dropdown.
 #  # freeform can be used if the custom field is just a text entry
-#  # Variables can be used to pull various pieces of data from the finding itself. 
+#  # Variables can be used to pull various pieces of data from the finding itself.
 #  # Supported variables: $CVSSMetrics, $CVEID, $CWEID, $Host, $Severity, $CVSSScore, $Name
 # custom-fields:
-#  customfield_00001: 
+#  customfield_00001:
 #    name: "Nuclei"
 #  customfield_00002:
 #    freeform: $CVSSMetrics

--- a/pkg/reporting/trackers/jira/jira_test.go
+++ b/pkg/reporting/trackers/jira/jira_test.go
@@ -2,6 +2,7 @@ package jira
 
 import (
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
 	"strings"
 	"testing"
 )
@@ -34,4 +35,25 @@ func TestTableCreation(t *testing.T) {
 | d | e |
 `
 	assert.Equal(t, expected, table)
+}
+
+func TestStatusNotCustomUnmarshal(t *testing.T) {
+	type Data struct {
+		StatusNot StringArrayCoerced `yaml:"status-not" json:"status_not"`
+	}
+
+	scenarios := [][]byte{
+		[]byte("status-not: Testing"),
+		[]byte(`status-not:
+        - Testing`),
+		[]byte(`status-not:
+        - Testing
+        - Testing`),
+	}
+
+	for _, scenario := range scenarios {
+		data := Data{}
+		assert.Nil(t, yaml.Unmarshal(scenario, &data))
+		assert.Equal(t, "Testing", data.StatusNot[0])
+	}
 }


### PR DESCRIPTION
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->
- Add custom YAML unmarshal to 'coerce' values into an array of strings
- Example:
```
status-not: Done
# Is the same as
status-not:
  - Done
```
- This allows us to define more than one status
- JQL query is also modified to support this new feature. Uses the `NOT IN` keyword vs. the previous `status !=` expression

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)