### PR TITLE
add timeout

### DIFF
--- a/pkg/js/generated/js/libssh/ssh.js
+++ b/pkg/js/generated/js/libssh/ssh.js
@@ -1,4 +1,4 @@
-/** @module ssh */
+/**@module ssh */
 
 /**
  * @typedef {object} HandshakeLog
@@ -13,14 +13,14 @@ const HandshakeLog = {};
 class SSHClient {
     /**
     @method
-    @description Close closes the SSH connection and destroys the client. Returns the success state and error. If error is not nil, state will be false.
+    @description Close closes the SSH connection and destroys the client
     @returns {boolean} - The success state of the operation.
     @throws {error} - The error encountered during the operation.
     @example
     let m = require('nuclei/ssh');
     let c = m.SSHClient();
     let state = c.Connect('localhost', 22, 'user', 'password');
-    c.Close();
+    let result = c.Close();
     */
     Close() {
         // implemented in go
@@ -28,13 +28,13 @@ class SSHClient {
 
     /**
     @method
-    @description Connect tries to connect to provided host and port with provided username and password with ssh. Returns state of connection and error. If error is not nil, state will be false.
+    @description Connect tries to connect to provided host and port with provided username and password with ssh.
     @param {string} host - The host to connect to.
     @param {number} port - The port to connect to.
     @param {string} username - The username for the connection.
     @param {string} password - The password for the connection.
-    @returns {boolean} - The state of the connection.
-    @throws {error} - The error encountered during the connection.
+    @returns {boolean} - The success state of the operation.
+    @throws {error} - The error encountered during the operation.
     @example
     let m = require('nuclei/ssh');
     let c = m.SSHClient();
@@ -46,11 +46,11 @@ class SSHClient {
 
     /**
     @method
-    @description ConnectSSHInfoMode tries to connect to provided host and port with provided host and port. Returns HandshakeLog and error. If error is not nil, state will be false.
+    @description ConnectSSHInfoMode tries to connect to provided host and port with provided host and port
     @param {string} host - The host to connect to.
     @param {number} port - The port to connect to.
     @returns {HandshakeLog} - The HandshakeLog object containing information about the ssh connection.
-    @throws {error} - The error encountered during the connection.
+    @throws {error} - The error encountered during the operation.
     @example
     let m = require('nuclei/ssh');
     let c = m.SSHClient();
@@ -62,17 +62,17 @@ class SSHClient {
 
     /**
     @method
-    @description ConnectWithKey tries to connect to provided host and port with provided username and private_key. Returns state of connection and error. If error is not nil, state will be false.
+    @description ConnectWithKey tries to connect to provided host and port with provided username and private_key.
     @param {string} host - The host to connect to.
     @param {number} port - The port to connect to.
     @param {string} username - The username for the connection.
     @param {string} key - The private key for the connection.
-    @returns {boolean} - The state of the connection.
-    @throws {error} - The error encountered during the connection.
+    @returns {boolean} - The success state of the operation.
+    @throws {error} - The error encountered during the operation.
     @example
     let m = require('nuclei/ssh');
     let c = m.SSHClient();
-    let result = c.ConnectWithKey('localhost', 22, 'user', 'private_key');
+    let result = c.ConnectWithKey('localhost', 22, 'user', 'key');
     */
     ConnectWithKey(host, port, username, key) {
         // implemented in go
@@ -80,16 +80,29 @@ class SSHClient {
 
     /**
     @method
-    @description Run tries to open a new SSH session, then tries to execute the provided command in said session. Returns string and error. If error is not nil, state will be false. The string contains the command output.
+    @description Run tries to open a new SSH session, then tries to execute the provided command in said session
     @param {string} cmd - The command to execute.
     @returns {string} - The output of the command.
-    @throws {error} - The error encountered during the execution of the command.
+    @throws {error} - The error encountered during the operation.
     @example
     let m = require('nuclei/ssh');
     let c = m.SSHClient();
     let result = c.Run('ls');
     */
     Run(cmd) {
+        // implemented in go
+    };
+
+    /**
+    @method
+    @description SetTimeout sets the timeout for the SSH connection in seconds
+    @param {number} sec - The number of seconds for the timeout.
+    @example
+    let m = require('nuclei/ssh');
+    let c = m.SSHClient();
+    c.SetTimeout(30);
+    */
+    SetTimeout(sec) {
         // implemented in go
     };
 };

--- a/pkg/js/libs/ssh/ssh.go
+++ b/pkg/js/libs/ssh/ssh.go
@@ -133,6 +133,8 @@ func connect(host string, port int, user, password, privateKey string) (*ssh.Cli
 	conf := &ssh.ClientConfig{
 		User: user,
 		Auth: []ssh.AuthMethod{},
+		// FIXME: This should be configurable
+		Timeout: 10 * time.Second,
 	}
 	if len(password) > 0 {
 		conf.Auth = append(conf.Auth, ssh.Password(password))

--- a/pkg/js/libs/ssh/ssh.go
+++ b/pkg/js/libs/ssh/ssh.go
@@ -1,7 +1,6 @@
 package ssh
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -16,6 +15,12 @@ import (
 // Internally client uses github.com/zmap/zgrab2/lib/ssh driver.
 type SSHClient struct {
 	Connection *ssh.Client
+	timeout    time.Duration
+}
+
+// SetTimeout sets the timeout for the SSH connection in seconds
+func (c *SSHClient) SetTimeout(sec int) {
+	c.timeout = time.Duration(sec) * time.Second
 }
 
 // Connect tries to connect to provided host and port
@@ -24,7 +29,12 @@ type SSHClient struct {
 // Returns state of connection and error. If error is not nil,
 // state will be false
 func (c *SSHClient) Connect(host string, port int, username, password string) (bool, error) {
-	conn, err := connect(host, port, username, password, "")
+	conn, err := connect(&connectOptions{
+		Host:     host,
+		Port:     port,
+		User:     username,
+		Password: password,
+	})
 	if err != nil {
 		return false, err
 	}
@@ -39,7 +49,13 @@ func (c *SSHClient) Connect(host string, port int, username, password string) (b
 // Returns state of connection and error. If error is not nil,
 // state will be false
 func (c *SSHClient) ConnectWithKey(host string, port int, username, key string) (bool, error) {
-	conn, err := connect(host, port, username, "", key)
+	conn, err := connect(&connectOptions{
+		Host:       host,
+		Port:       port,
+		User:       username,
+		PrivateKey: key,
+	})
+
 	if err != nil {
 		return false, err
 	}
@@ -57,7 +73,10 @@ func (c *SSHClient) ConnectWithKey(host string, port int, username, key string) 
 // HandshakeLog is a struct that contains information about the
 // ssh connection
 func (c *SSHClient) ConnectSSHInfoMode(host string, port int) (*ssh.HandshakeLog, error) {
-	return connectSSHInfoMode(host, port)
+	return connectSSHInfoMode(&connectOptions{
+		Host: host,
+		Port: port,
+	})
 }
 
 // Run tries to open a new SSH session, then tries to execute
@@ -96,11 +115,38 @@ func (c *SSHClient) Close() (bool, error) {
 	return true, nil
 }
 
-func connectSSHInfoMode(host string, port int) (*ssh.HandshakeLog, error) {
-	if !protocolstate.IsHostAllowed(host) {
-		// host is not valid according to network policy
-		return nil, protocolstate.ErrHostDenied.Msgf(host)
+// unexported functions
+type connectOptions struct {
+	Host       string
+	Port       int
+	User       string
+	Password   string
+	PrivateKey string
+	Timeout    time.Duration // default 10s
+}
+
+func (c *connectOptions) validate() error {
+	if c.Host == "" {
+		return errorutil.New("host is required")
 	}
+	if c.Port <= 0 {
+		return errorutil.New("port is required")
+	}
+	if !protocolstate.IsHostAllowed(c.Host) {
+		// host is not valid according to network policy
+		return protocolstate.ErrHostDenied.Msgf(c.Host)
+	}
+	if c.Timeout == 0 {
+		c.Timeout = 10 * time.Second
+	}
+	return nil
+}
+
+func connectSSHInfoMode(opts *connectOptions) (*ssh.HandshakeLog, error) {
+	if err := opts.validate(); err != nil {
+		return nil, err
+	}
+
 	data := new(ssh.HandshakeLog)
 
 	sshConfig := ssh.MakeSSHConfig()
@@ -111,7 +157,7 @@ func connectSSHInfoMode(host string, port int) (*ssh.HandshakeLog, error) {
 		data.Banner = strings.TrimSpace(banner)
 		return nil
 	}
-	rhost := fmt.Sprintf("%s:%d", host, port)
+	rhost := fmt.Sprintf("%s:%d", opts.Host, opts.Port)
 	client, err := ssh.Dial("tcp", rhost, sshConfig)
 	if err != nil {
 		return nil, err
@@ -121,33 +167,28 @@ func connectSSHInfoMode(host string, port int) (*ssh.HandshakeLog, error) {
 	return data, nil
 }
 
-func connect(host string, port int, user, password, privateKey string) (*ssh.Client, error) {
-	if !protocolstate.IsHostAllowed(host) {
-		// host is not valid according to network policy
-		return nil, protocolstate.ErrHostDenied.Msgf(host)
-	}
-	if host == "" || port <= 0 {
-		return nil, errors.New("invalid host or port")
+func connect(opts *connectOptions) (*ssh.Client, error) {
+	if err := opts.validate(); err != nil {
+		return nil, err
 	}
 
 	conf := &ssh.ClientConfig{
-		User: user,
-		Auth: []ssh.AuthMethod{},
-		// FIXME: This should be configurable
-		Timeout: 10 * time.Second,
+		User:    opts.User,
+		Auth:    []ssh.AuthMethod{},
+		Timeout: opts.Timeout,
 	}
-	if len(password) > 0 {
-		conf.Auth = append(conf.Auth, ssh.Password(password))
+	if len(opts.Password) > 0 {
+		conf.Auth = append(conf.Auth, ssh.Password(opts.Password))
 	}
-	if len(privateKey) > 0 {
-		signer, err := ssh.ParsePrivateKey([]byte(privateKey))
+	if len(opts.PrivateKey) > 0 {
+		signer, err := ssh.ParsePrivateKey([]byte(opts.PrivateKey))
 		if err != nil {
 			return nil, err
 		}
 		conf.Auth = append(conf.Auth, ssh.PublicKeys(signer))
 	}
 
-	client, err := ssh.Dial("tcp", fmt.Sprintf("%s:%d", host, port), conf)
+	client, err := ssh.Dial("tcp", fmt.Sprintf("%s:%d", opts.Host, opts.Port), conf)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Proposed changes

before
```console
$ go run . -u http://106.75.35.102:8013 -id CVE-2023-34039 -stats -v

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.1.0

                projectdiscovery.io

[VER] Started metrics server at localhost:9092
[WRN] Excluded 3 template[s] with known weak matchers / tags excluded from default run using .nuclei-ignore
[INF] Current nuclei version: v3.1.0 (latest)
[INF] Current nuclei-templates version: v9.7.1 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 0
[INF] Templates loaded for current scan: 1
[INF] Executing 1 signed templates from projectdiscovery/nuclei-templates
[INF] Targets loaded for current scan: 1
[0:00:05] | Templates: 1 | Hosts: 1 | RPS: 0 | Matched: 0 | Errors: 0 | Requests: 0/23 (0%)
[0:00:10] | Templates: 1 | Hosts: 1 | RPS: 0 | Matched: 0 | Errors: 0 | Requests: 0/23 (0%)
[0:00:15] | Templates: 1 | Hosts: 1 | RPS: 0 | Matched: 0 | Errors: 0 | Requests: 0/23 (0%)
[0:00:20] | Templates: 1 | Hosts: 1 | RPS: 0 | Matched: 0 | Errors: 0 | Requests: 0/23 (0%)
[0:00:25] | Templates: 1 | Hosts: 1 | RPS: 0 | Matched: 0 | Errors: 0 | Requests: 0/23 (0%)
[0:00:30] | Templates: 1 | Hosts: 1 | RPS: 0 | Matched: 0 | Errors: 0 | Requests: 0/23 (0%)
[0:00:35] | Templates: 1 | Hosts: 1 | RPS: 0 | Matched: 0 | Errors: 0 | Requests: 0/23 (0%)
[0:00:40] | Templates: 1 | Hosts: 1 | RPS: 0 | Matched: 0 | Errors: 0 | Requests: 0/23 (0%)
[0:00:45] | Templates: 1 | Hosts: 1 | RPS: 0 | Matched: 0 | Errors: 0 | Requests: 0/23 (0%)
[0:00:50] | Templates: 1 | Hosts: 1 | RPS: 0 | Matched: 0 | Errors: 0 | Requests: 0/23 (0%)
[0:00:55] | Templates: 1 | Hosts: 1 | RPS: 0 | Matched: 0 | Errors: 0 | Requests: 0/23 (0%)
[0:01:00] | Templates: 1 | Hosts: 1 | RPS: 0 | Matched: 0 | Errors: 0 | Requests: 0/23 (0%)
[0:01:05] | Templates: 1 | Hosts: 1 | RPS: 0 | Matched: 0 | Errors: 0 | Requests: 0/23 (0%)
[0:01:10] | Templates: 1 | Hosts: 1 | RPS: 0 | Matched: 0 | Errors: 0 | Requests: 0/23 (0%)
[0:01:15] | Templates: 1 | Hosts: 1 | RPS: 0 | Matched: 0 | Errors: 0 | Requests: 0/23 (0%)
[0:01:20] | Templates: 1 | Hosts: 1 | RPS: 0 | Matched: 0 | Errors: 0 | Requests: 0/23 (0%)
[0:01:25] | Templates: 1 | Hosts: 1 | RPS: 0 | Matched: 0 | Errors: 0 | Requests: 0/23 (0%)
[0:01:30] | Templates: 1 | Hosts: 1 | RPS: 0 | Matched: 0 | Errors: 0 | Requests: 0/23 (0%)
[0:01:35] | Templates: 1 | Hosts: 1 | RPS: 0 | Matched: 0 | Errors: 0 | Requests: 0/23 (0%)
[0:01:40] | Templates: 1 | Hosts: 1 | RPS: 0 | Matched: 0 | Errors: 0 | Requests: 0/23 (0%)
[0:01:45] | Templates: 1 | Hosts: 1 | RPS: 0 | Matched: 0 | Errors: 0 | Requests: 0/23 (0%)
[0:01:50] | Templates: 1 | Hosts: 1 | RPS: 0 | Matched: 0 | Errors: 0 | Requests: 0/23 (0%)
[0:01:55] | Templates: 1 | Hosts: 1 | RPS: 0 | Matched: 0 | Errors: 0 | Requests: 0/23 (0%)
[0:02:00] | Templates: 1 | Hosts: 1 | RPS: 0 | Matched: 0 | Errors: 0 | Requests: 0/23 (0%)
…
[0:07:10] | Templates: 1 | Hosts: 1 | RPS: 0 | Matched: 0 | Errors: 0 | Requests: 0/23 (0%)
[0:07:15] | Templates: 1 | Hosts: 1 | RPS: 0 | Matched: 0 | Errors: 0 | Requests: 0/23 (0%)
[0:07:20] | Templates: 1 | Hosts: 1 | RPS: 0 | Matched: 0 | Errors: 0 | Requests: 0/23 (0%)
[0:07:25] | Templates: 1 | Hosts: 1 | RPS: 0 | Matched: 0 | Errors: 0 | Requests: 0/23 (0%)
[0:07:30] | Templates: 1 | Hosts: 1 | RPS: 0 | Matched: 0 | Errors: 0 | Requests: 0/23 (0%)
[0:07:35] | Templates: 1 | Hosts: 1 | RPS: 0 | Matched: 0 | Errors: 0 | Requests: 0/23 (0%)
[0:07:40] | Templates: 1 | Hosts: 1 | RPS: 0 | Matched: 0 | Errors: 0 | Requests: 0/23 (0%)
[0:07:45] | Templates: 1 | Hosts: 1 | RPS: 0 | Matched: 0 | Errors: 0 | Requests: 0/23 (0%)
[0:07:50] | Templates: 1 | Hosts: 1 | RPS: 0 | Matched: 0 | Errors: 0 | Requests: 0/23 (0%)
[0:07:55] | Templates: 1 | Hosts: 1 | RPS: 0 | Matched: 0 | Errors: 0 | Requests: 0/23 (0%)
[0:08:00] | Templates: 1 | Hosts: 1 | RPS: 0 | Matched: 0 | Errors: 0 | Requests: 0/23 (0%)
[0:08:05] | Templates: 1 | Hosts: 1 | RPS: 0 | Matched: 0 | Errors: 0 | Requests: 0/23 (0%)
[0:08:10] | Templates: 1 | Hosts: 1 | RPS: 0 | Matched: 0 | Errors: 0 | Requests: 0/23 (0%)
[0:08:15] | Templates: 1 | Hosts: 1 | RPS: 0 | Matched: 0 | Errors: 0 | Requests: 0/23 (0%)
[0:08:20] | Templates: 1 | Hosts: 1 | RPS: 0 | Matched: 0 | Errors: 0 | Requests: 0/23 (0%)
[0:08:25] | Templates: 1 | Hosts: 1 | RPS: 0 | Matched: 0 | Errors: 0 | Requests: 0/23 (0%)
[0:08:30] | Templates: 1 | Hosts: 1 | RPS: 0 | Matched: 0 | Errors: 0 | Requests: 0/23 (0%)
[0:08:35] | Templates: 1 | Hosts: 1 | RPS: 0 | Matched: 0 | Errors: 0 | Requests: 0/23 (0%)
….
```

after

```console
$ go run . -u http://106.75.35.102:8013 -id CVE-2023-34039 -stats -v

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.1.0

                projectdiscovery.io

[VER] Started metrics server at localhost:9092
[WRN] Excluded 3 template[s] with known weak matchers / tags excluded from default run using .nuclei-ignore
[INF] Current nuclei version: v3.1.0 (latest)
[INF] Current nuclei-templates version: v9.7.1 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 0
[INF] Templates loaded for current scan: 1
[INF] Executing 1 signed templates from projectdiscovery/nuclei-templates
[INF] Targets loaded for current scan: 1
[0:00:05] | Templates: 1 | Hosts: 1 | RPS: 0 | Matched: 0 | Errors: 0 | Requests: 0/23 (0%)
[0:00:10] | Templates: 1 | Hosts: 1 | RPS: 0 | Matched: 0 | Errors: 0 | Requests: 0/23 (0%)
[VER] [CVE-2023-34039] Sent Javascript request to 106.75.35.102:8013
[VER] [CVE-2023-34039] Sent Javascript request to 106.75.35.102:8013
[VER] [CVE-2023-34039] Sent Javascript request to 106.75.35.102:8013
[VER] [CVE-2023-34039] Sent Javascript request to 106.75.35.102:8013
[VER] [CVE-2023-34039] Sent Javascript request to 106.75.35.102:8013
[VER] [CVE-2023-34039] Sent Javascript request to 106.75.35.102:8013
[VER] [CVE-2023-34039] Sent Javascript request to 106.75.35.102:8013
[VER] [CVE-2023-34039] Sent Javascript request to 106.75.35.102:8013
[VER] [CVE-2023-34039] Sent Javascript request to 106.75.35.102:8013
[VER] [CVE-2023-34039] Sent Javascript request to 106.75.35.102:8013
[0:00:15] | Templates: 1 | Hosts: 1 | RPS: 0 | Matched: 0 | Errors: 0 | Requests: 10/23 (43%)
[0:00:20] | Templates: 1 | Hosts: 1 | RPS: 0 | Matched: 0 | Errors: 0 | Requests: 10/23 (43%)
[VER] [CVE-2023-34039] Sent Javascript request to 106.75.35.102:8013
[VER] [CVE-2023-34039] Sent Javascript request to 106.75.35.102:8013
[VER] [CVE-2023-34039] Sent Javascript request to 106.75.35.102:8013
[VER] [CVE-2023-34039] Sent Javascript request to 106.75.35.102:8013
[VER] [CVE-2023-34039] Sent Javascript request to 106.75.35.102:8013
[VER] [CVE-2023-34039] Sent Javascript request to 106.75.35.102:8013
[VER] [CVE-2023-34039] Sent Javascript request to 106.75.35.102:8013
[VER] [CVE-2023-34039] Sent Javascript request to 106.75.35.102:8013
[VER] [CVE-2023-34039] Sent Javascript request to 106.75.35.102:8013
[VER] [CVE-2023-34039] Sent Javascript request to 106.75.35.102:8013
[0:00:25] | Templates: 1 | Hosts: 1 | RPS: 0 | Matched: 0 | Errors: 0 | Requests: 20/23 (86%)
[0:00:30] | Templates: 1 | Hosts: 1 | RPS: 0 | Matched: 0 | Errors: 0 | Requests: 20/23 (86%)
[VER] [CVE-2023-34039] Sent Javascript request to 106.75.35.102:8013
[VER] [CVE-2023-34039] Sent Javascript request to 106.75.35.102:8013
[0:00:31] | Templates: 1 | Hosts: 1 | RPS: 0 | Matched: 0 | Errors: 0 | Requests: 22/23 (95%)
[INF] No results found. Better luck next time!
```


## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)