### PR TITLE
extractors as dynamic vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ vendor
 dist
 integration_tests/nuclei
 integration_tests/integration-test
+integration_tests/.cache
 cmd/nuclei/main
 cmd/nuclei/nuclei
 cmd/integration-test/nuclei

--- a/pkg/operators/operators.go
+++ b/pkg/operators/operators.go
@@ -225,13 +225,13 @@ func (operators *Operators) Execute(data map[string]interface{}, match MatchFunc
 		for match := range extract(data, extractor) {
 			extractorResults = append(extractorResults, match)
 
-			if extractor.Internal {
-				if data, ok := result.DynamicValues[extractor.Name]; !ok {
-					result.DynamicValues[extractor.Name] = []string{match}
-				} else {
-					result.DynamicValues[extractor.Name] = append(data, match)
-				}
+			if data, ok := result.DynamicValues[extractor.Name]; !ok {
+				result.DynamicValues[extractor.Name] = []string{match}
 			} else {
+				result.DynamicValues[extractor.Name] = append(data, match)
+			}
+
+			if !extractor.Internal {
 				if _, ok := result.outputUnique[match]; !ok {
 					result.OutputExtracts = append(result.OutputExtracts, match)
 					result.outputUnique[match] = struct{}{}
@@ -288,9 +288,6 @@ func (operators *Operators) Execute(data map[string]interface{}, match MatchFunc
 
 	result.Matched = matches
 	result.Extracted = len(result.OutputExtracts) > 0
-	if len(result.DynamicValues) > 0 {
-		return result, true
-	}
 
 	// Don't print if we have matchers, and they have not matched, regardless of extractor
 	if len(operators.Matchers) > 0 && !matches {
@@ -301,6 +298,11 @@ func (operators *Operators) Execute(data map[string]interface{}, match MatchFunc
 	if len(result.Extracts) > 0 || len(result.OutputExtracts) > 0 || matches {
 		return result, true
 	}
+
+	if len(result.DynamicValues) > 0 {
+		return result, true
+	}
+
 	return nil, false
 }
 

--- a/pkg/operators/operators.go
+++ b/pkg/operators/operators.go
@@ -241,24 +241,24 @@ func (operators *Operators) Execute(data map[string]interface{}, match MatchFunc
 		if len(extractorResults) > 0 && !extractor.Internal && extractor.Name != "" {
 			result.Extracts[extractor.Name] = extractorResults
 		}
-	}
 
-	// expose dynamic values to same request matchers
-	if len(result.DynamicValues) > 0 {
-		dataDynamicValues := make(map[string]interface{})
-		for dynName, dynValues := range result.DynamicValues {
-			if len(dynValues) > 1 {
-				for dynIndex, dynValue := range dynValues {
-					dynKeyName := fmt.Sprintf("%s%d", dynName, dynIndex)
-					dataDynamicValues[dynKeyName] = dynValue
+		// expose dynamic values to same request extractors/matchers
+		if len(result.DynamicValues) > 0 {
+			dataDynamicValues := make(map[string]interface{})
+			for dynName, dynValues := range result.DynamicValues {
+				if len(dynValues) > 1 {
+					for dynIndex, dynValue := range dynValues {
+						dynKeyName := fmt.Sprintf("%s%d", dynName, dynIndex)
+						dataDynamicValues[dynKeyName] = dynValue
+					}
+					dataDynamicValues[dynName] = dynValues
+				} else {
+					dataDynamicValues[dynName] = dynValues[0]
 				}
-				dataDynamicValues[dynName] = dynValues
-			} else {
-				dataDynamicValues[dynName] = dynValues[0]
-			}
 
+			}
+			data = generators.MergeMaps(data, dataDynamicValues)
 		}
-		data = generators.MergeMaps(data, dataDynamicValues)
 	}
 
 	for matcherIndex, matcher := range operators.Matchers {

--- a/pkg/operators/operators.go
+++ b/pkg/operators/operators.go
@@ -289,6 +289,10 @@ func (operators *Operators) Execute(data map[string]interface{}, match MatchFunc
 	result.Matched = matches
 	result.Extracted = len(result.OutputExtracts) > 0
 
+	if len(result.DynamicValues) > 0 {
+		return result, true
+	}
+
 	// Don't print if we have matchers, and they have not matched, regardless of extractor
 	if len(operators.Matchers) > 0 && !matches {
 		return nil, false
@@ -296,10 +300,6 @@ func (operators *Operators) Execute(data map[string]interface{}, match MatchFunc
 	// Write a final string of output if matcher type is
 	// AND or if we have extractors for the mechanism too.
 	if len(result.Extracts) > 0 || len(result.OutputExtracts) > 0 || matches {
-		return result, true
-	}
-
-	if len(result.DynamicValues) > 0 {
 		return result, true
 	}
 

--- a/pkg/protocols/protocols.go
+++ b/pkg/protocols/protocols.go
@@ -215,10 +215,6 @@ type Request interface {
 type OutputEventCallback func(result *output.InternalWrappedEvent)
 
 func MakeDefaultResultEvent(request Request, wrapped *output.InternalWrappedEvent) []*output.ResultEvent {
-	if len(wrapped.OperatorsResult.DynamicValues) > 0 && !wrapped.OperatorsResult.Matched {
-		return nil
-	}
-
 	results := make([]*output.ResultEvent, 0, len(wrapped.OperatorsResult.Matches)+1)
 
 	// If we have multiple matchers with names, write each of them separately.

--- a/pkg/protocols/protocols.go
+++ b/pkg/protocols/protocols.go
@@ -224,16 +224,14 @@ func MakeDefaultResultEvent(request Request, wrapped *output.InternalWrappedEven
 			data.MatcherName = matcherNames
 			results = append(results, data)
 		}
-	} else if len(wrapped.OperatorsResult.Extracts) > 0 {
+	}
+	if len(wrapped.OperatorsResult.Extracts) > 0 {
 		for k, v := range wrapped.OperatorsResult.Extracts {
 			data := request.MakeResultEventItem(wrapped)
 			data.ExtractorName = k
 			data.ExtractedResults = v
 			results = append(results, data)
 		}
-	} else {
-		data := request.MakeResultEventItem(wrapped)
-		results = append(results, data)
 	}
 	return results
 }


### PR DESCRIPTION
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->

without `internal: true`
```console
$ cat test.yaml
id: basic-raw-example
info:
  name: Test RAW Template
  author: pdteam
  severity: info

requests:
  - raw:
      - |
        GET / HTTP/1.1
        Host: {{Hostname}}

      - |
        GET /test HTTP/1.1
        Host: {{Hostname}}
        Test: {{server}}

    extractors:
      - type: kval
        name: server
        kval:
          - "server"

$ go run . -t ./test.yaml -u https://geonet.shodan.io/

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.1.0

                projectdiscovery.io

[WRN] Found 1 templates loaded with deprecated protocol syntax, update before v3 for continued support.
[INF] Current nuclei version: v3.1.0 (latest)
[INF] Current nuclei-templates version: v9.7.1 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 0
[INF] Templates loaded for current scan: 1
[WRN] Executing 1 unsigned templates. Use with caution.
[INF] Targets loaded for current scan: 1
[basic-raw-example:server] [http] [info] https://geonet.shodan.io/ [cloudflare]
[basic-raw-example:server] [http] [info] https://geonet.shodan.io/test [cloudflare]
```

with `internal: true`
```console
$ cat test.yaml
id: basic-raw-example
info:
  name: Test RAW Template
  author: pdteam
  severity: info

requests:
  - raw:
      - |
        GET / HTTP/1.1
        Host: {{Hostname}}

      - |
        GET /test HTTP/1.1
        Host: {{Hostname}}
        Test: {{server}}

    extractors:
      - type: kval
        internal: true
        name: server
        kval:
          - "server"

$ go run . -t ./test.yaml -u https://geonet.shodan.io/
                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.1.0
                [projectdiscovery.io](http://projectdiscovery.io/)
[WRN] Found 1 templates loaded with deprecated protocol syntax, update before v3 for continued support.
[INF] Current nuclei version: v3.1.0 (latest)
[INF] Current nuclei-templates version: v9.7.1 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 0
[INF] Templates loaded for current scan: 1
[WRN] Executing 1 unsigned templates. Use with caution.
[INF] Targets loaded for current scan: 1
[basic-raw-example] [http] [info] https://geonet.shodan.io/
[basic-raw-example] [http] [info] https://geonet.shodan.io/test
```



Closes #1222.
Based on #1364.
## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)