### PR TITLE
fix missing eq sign

### DIFF
--- a/pkg/protocols/http/raw/raw.go
+++ b/pkg/protocols/http/raw/raw.go
@@ -37,6 +37,7 @@ func Parse(request string, inputURL *urlutil.URL, unsafe, disablePathAutomerge b
 	// can be omitted but makes things clear
 	case rawrequest.Path == "":
 		if !disablePathAutomerge {
+			inputURL.Params.IncludeEquals = true
 			rawrequest.Path = inputURL.GetRelativePath()
 		}
 
@@ -47,6 +48,7 @@ func Parse(request string, inputURL *urlutil.URL, unsafe, disablePathAutomerge b
 			return nil, errorutil.NewWithErr(err).WithTag("raw").Msgf("failed to parse url %v from template", rawrequest.Path)
 		}
 		cloned := inputURL.Clone()
+		cloned.Params.IncludeEquals = true
 		if disablePathAutomerge {
 			cloned.Path = ""
 		}
@@ -59,6 +61,7 @@ func Parse(request string, inputURL *urlutil.URL, unsafe, disablePathAutomerge b
 	case unsafe:
 		prevPath := rawrequest.Path
 		cloned := inputURL.Clone()
+		cloned.Params.IncludeEquals = true
 		unsafeRelativePath := ""
 		if (cloned.Path == "" || cloned.Path == "/") && !strings.HasPrefix(prevPath, "/") {
 			// Edgecase if raw unsafe request is
@@ -90,6 +93,7 @@ func Parse(request string, inputURL *urlutil.URL, unsafe, disablePathAutomerge b
 
 	default:
 		cloned := inputURL.Clone()
+		cloned.Params.IncludeEquals = true
 		if disablePathAutomerge {
 			cloned.Path = ""
 		}
@@ -105,6 +109,7 @@ func Parse(request string, inputURL *urlutil.URL, unsafe, disablePathAutomerge b
 			rawrequest.Headers["Host"] = inputURL.Host
 		}
 		cloned := inputURL.Clone()
+		cloned.Params.IncludeEquals = true
 		cloned.Path = ""
 		_ = cloned.MergePath(rawrequest.Path, true)
 		rawrequest.FullURL = cloned.String()


### PR DESCRIPTION
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->

Closes #4512.

```console
$ cat test.yaml
id: CVE-2023-XXXXX
info:
  name: XXX
  author: foo
  severity: high
variables:
  path: '/lol.php?param1=foo&param2=&param3=bar'
http:
  - raw:
      - |
        GET /{{path}} HTTP/1.1
        Host: {{Hostname}}
        Connection: close

        # 
    unsafe: true
    req-condition: true

$ go run . -t ./test.yaml -u http://example.com --dreq

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.1.2

                projectdiscovery.io

[INF] Current nuclei version: v3.1.2 (latest)
[INF] Current nuclei-templates version: v9.7.1 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 0
[INF] Templates loaded for current scan: 1
[WRN] Executing 1 unsigned templates. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] [CVE-2023-XXXXX] Dumped HTTP request for http://example.com//lol.php?param1=foo&param2=&param3=bar

GET //lol.php?param1=foo&param2=&param3=bar HTTP/1.1
Host: example.com
Connection: close

# 
[INF] No results found. Better luck next time!
```
## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)