### PR TITLE
fix fuzzing self-contained input requirement

### DIFF
--- a/pkg/protocols/http/request.go
+++ b/pkg/protocols/http/request.go
@@ -303,6 +303,7 @@ func (request *Request) executeFuzzingRule(input *contextargs.Context, previous 
 		if err != nil {
 			continue
 		}
+		input.MetaInput = &contextargs.MetaInput{Input: generated.URL()}
 		for _, rule := range request.Fuzzing {
 			err = rule.Execute(&fuzz.ExecuteRuleInput{
 				Input:       input,


### PR DESCRIPTION
## Proposed changes
Closes #4509

```console
$ cat test.yaml
id: fuzzing-temp
info:
  name: Fuzzing Template
  author: custom
  severity: low

self-contained: true

http:
  - method: GET
    path:
      - "https://example.com/?param_name=123"
      
    payloads:
      payload_set1:
        - "1"
        - "2"
    attack: clusterbomb
    fuzzing:
      - part: query
        type: replace
        mode: single
        keys:
          - "param_name"
        fuzz:
          - "{{payload_set1}}"
    matchers:
      - type: status
        status:
          - 200

$ go run . -t ./test.yaml

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.1.4-dev

                projectdiscovery.io

[INF] Current nuclei version: v3.1.4-dev (development)
[INF] Current nuclei-templates version: v9.7.2 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 61
[INF] Templates loaded for current scan: 1
[WRN] Executing 1 unsigned templates. Use with caution.
[fuzzing-temp] [http] [low] https://example.com/?param_name=1
[fuzzing-temp] [http] [low] https://example.com/?param_name=2
```


## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)