### PR TITLE
Implement automatic execution based on the 'detect' template when usi…

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/automaticscan2"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
@@ -40,7 +41,6 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/progress"
 	"github.com/projectdiscovery/nuclei/v3/pkg/projectfile"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols"
-	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/automaticscan"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/contextargs"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/hosterrorscache"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/interactsh"
@@ -533,7 +533,7 @@ func (r *Runner) isInputNonHTTP() bool {
 func (r *Runner) executeSmartWorkflowInput(executorOpts protocols.ExecutorOptions, store *loader.Store, engine *core.Engine) (*atomic.Bool, error) {
 	r.progress.Init(r.hmapInputProvider.Count(), 0, 0)
 
-	service, err := automaticscan.New(automaticscan.Options{
+	service, err := automaticscan2.New(automaticscan2.Options{
 		ExecuterOpts: executorOpts,
 		Store:        store,
 		Engine:       engine,

--- a/pkg/protocols/common/automaticscan2/automaticscan.go
+++ b/pkg/protocols/common/automaticscan2/automaticscan.go
@@ -1,0 +1,164 @@
+package automaticscan2
+
+import (
+	"github.com/projectdiscovery/nuclei/v3/pkg/scan"
+	"strings"
+	"sync"
+
+	"github.com/pkg/errors"
+	"github.com/projectdiscovery/gologger"
+	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/config"
+	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/loader"
+	"github.com/projectdiscovery/nuclei/v3/pkg/core"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/contextargs"
+	"github.com/projectdiscovery/nuclei/v3/pkg/templates"
+	"github.com/projectdiscovery/nuclei/v3/pkg/templates/types"
+	sliceutil "github.com/projectdiscovery/utils/slice"
+)
+
+// Service is a service for automatic scan execution
+type Service struct {
+	opts          protocols.ExecutorOptions
+	store         *loader.Store
+	engine        *core.Engine
+	target        core.InputProvider
+	childExecuter *core.ChildExecuter
+	techTemplates []*templates.Template
+
+	results      bool
+	allTemplates []string
+}
+
+// Options contains configuration options for automatic scan service
+type Options struct {
+	ExecuterOpts protocols.ExecutorOptions
+	Store        *loader.Store
+	Engine       *core.Engine
+	Target       core.InputProvider
+}
+
+// New takes options and returns a new automatic scan service
+func New(opts Options) (*Service, error) {
+	config := config.DefaultConfig
+	defaultTemplatesDirectories := []string{config.TemplatesDirectory}
+
+	// adding custom template path if available
+	if len(opts.ExecuterOpts.Options.Templates) > 0 {
+		defaultTemplatesDirectories = append(defaultTemplatesDirectories, opts.ExecuterOpts.Options.Templates...)
+	}
+	// Collect path for default directories we want to look for templates in
+	var allTemplates []string
+	for _, directory := range defaultTemplatesDirectories {
+		templates, err := opts.ExecuterOpts.Catalog.GetTemplatePath(directory)
+		if err != nil {
+			return nil, errors.Wrap(err, "could not get templates in directory")
+		}
+		allTemplates = append(allTemplates, templates...)
+	}
+	tagTemplates := opts.Store.LoadTemplatesWithTags(allTemplates, []string{"tech"})
+	if len(tagTemplates) == 0 {
+		return nil, errors.New("could not find any templates with tech tag")
+	}
+	gologger.Info().Msgf("Loaded %d templates from the tech tag.\n", len(tagTemplates))
+
+	childExecuter := opts.Engine.ChildExecuter()
+
+	return &Service{
+		opts:          opts.ExecuterOpts,
+		store:         opts.Store,
+		engine:        opts.Engine,
+		target:        opts.Target,
+		allTemplates:  allTemplates,
+		childExecuter: childExecuter,
+		techTemplates: tagTemplates,
+	}, nil
+}
+
+// Close closes the service
+func (s *Service) Close() bool {
+	results := s.childExecuter.Close()
+	if results.Load() {
+		s.results = true
+	}
+	return s.results
+}
+
+// Execute performs the execution of automatic scan on provided input
+func (s *Service) Execute() {
+	// Iterate through each target making http request and identifying fingerprints
+	inputPool := s.engine.WorkPool().InputPool(types.HTTPProtocol)
+
+	s.target.Scan(func(value *contextargs.MetaInput) bool {
+		inputPool.WaitGroup.Add()
+
+		go func(input *contextargs.MetaInput) {
+			defer inputPool.WaitGroup.Done()
+			s.processInputPair(input)
+		}(value)
+		return true
+	})
+	inputPool.WaitGroup.Wait()
+}
+
+// processInputPair Retrieve the tags of the website from the tech template and then execute the corresponding template based on the tags.
+func (s *Service) processInputPair(input *contextargs.MetaInput) {
+	ctxArgs := contextargs.New()
+	ctxArgs.MetaInput = input
+	ctx := scan.NewScanContext(ctxArgs)
+	inputPool := s.engine.WorkPool().InputPool(types.HTTPProtocol)
+
+	successTags := make([]string, 0)
+	var mu sync.Mutex
+	for _, t := range s.techTemplates {
+		inputPool.WaitGroup.Add()
+		tags := t.Info.Tags.ToSlice()
+		func(template *templates.Template, tags []string) {
+			defer inputPool.WaitGroup.Done()
+			ok, err := template.Executer.Execute(ctx)
+			if err != nil {
+				gologger.Error().Msgf("error executing template: %s with error: %s\n", template.Info.Name, err)
+				return
+			}
+			if ok {
+				mu.Lock()
+				successTags = append(successTags, tags...)
+				mu.Unlock()
+			}
+		}(t, tags)
+	}
+	inputPool.WaitGroup.Wait()
+
+	// Add tags as addition to -as for comprehensive scans. Ref: nuclei/issues/3348
+	successTags = append(successTags, s.opts.Options.Tags...)
+	uniqueTags := sliceutil.Dedupe(successTags)
+	if len(uniqueTags) == 0 {
+		return
+	}
+	var tags []string
+	// delete tech tag
+	for _, tag := range uniqueTags {
+		if tag == "tech" || tag == "waf" || tag == "favicon" {
+			continue
+		}
+		tags = append(tags, tag)
+	}
+
+	templatesList := s.store.LoadTemplatesWithTags(s.allTemplates, tags)
+	gologger.Info().Msgf("Executing tags (%v) for host %s (%d templates)", strings.Join(tags, ","), input.Input, len(templatesList))
+	for _, t := range templatesList {
+		inputPool.WaitGroup.Add()
+		s.opts.Progress.AddToTotal(int64(t.Executer.Requests()))
+		if s.opts.Options.VerboseVerbose {
+			gologger.Print().Msgf("%s\n", templates.TemplateLogMessage(t.ID,
+				t.Info.Name,
+				t.Info.Authors.ToSlice(),
+				t.Info.SeverityHolder.Severity))
+		}
+		go func(t *templates.Template) {
+			defer inputPool.WaitGroup.Done()
+			s.childExecuter.Execute(t, input)
+		}(t)
+	}
+	inputPool.WaitGroup.Wait()
+}

--- a/pkg/protocols/common/automaticscan2/automaticscan_test.go
+++ b/pkg/protocols/common/automaticscan2/automaticscan_test.go
@@ -1,0 +1,1 @@
+package automaticscan2

--- a/pkg/protocols/common/automaticscan2/doc.go
+++ b/pkg/protocols/common/automaticscan2/doc.go
@@ -1,0 +1,9 @@
+// The function is a package called "automaticscan2." It is used to implement automated template execution based on fingerprint results.
+//
+// First, it performs fingerprint detection using the "tech" tag.
+// It extracts all the tags and executes the corresponding templates based on the tags.
+//
+// Finally, it removes some commonly unrelated tag names.
+//
+// The logic is simple and can be further improved to increase execution coverage.
+package automaticscan2


### PR DESCRIPTION
I have implemented the functionality mentioned in issue #4520 (https://github.com/projectdiscovery/nuclei/issues/4520). The original technology detection relied on Wappalyzer, but it proved to be insufficient in terms of accuracy and coverage. To address this, I have devised an approach that involves filtering out fingerprint detection templates based on the tags provided by 'detect'. Subsequently, these filtered templates are executed, and the resulting tags are merged. Finally, the templates associated with these merged tags are executed to obtain the desired results. This enhancement significantly improves the accuracy and coverage of technology detection in Nuclei.

Currently, everything is tag-based. In the future, it would be beneficial to improve the templates in the nuelci-templates repository by adding metadata to indicate the associated product. It is important to establish a standardized mapping of IDs from technology templates to other vulnerability templates. This enhancement will significantly enhance the capabilities of Nuclei. 



Environment：
```
docker pull medicean/vulapps:t_tomcat_1
docker run -d -p 8080:8080 medicean/vulapps:t_tomcat_1
nuclei update
nuclei -target http://192.168.32.40:8080 -as
```
```
                     __     _

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.1.4-dev

                projectdiscovery.io

[WRN] Found 12 template[s] loaded with deprecated paths, update before v3 for continued support.
[WRN] Found 1 templates with runtime error (use -validate flag for further examination)
[INF] Current nuclei version: v3.1.4-dev (development)
[INF] Current nuclei-templates version: v9.7.2 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 61
[INF] Templates loaded for current scan: 7380
[INF] Executing 7398 signed templates from projectdiscovery/nuclei-templates
[INF] Targets loaded for current scan: 1
[INF] Loaded 645 templates from the tech tag.
[apache-detect] [http] [info] http://192.168.32.40:8080 [Apache-Coyote/1.1]
[tomcat-detect:version] [http] [info] http://192.168.32.40:8080 [7.0.79]
[favicon-detect:apache-tomcat] [http] [info] http://192.168.32.40:8080/favicon.ico [path="images/"]
[waf-detect:ats] [http] [info] http://192.168.32.40:8080/
[waf-detect:apachegeneric] [http] [info] http://192.168.32.40:8080/
[INF] Executing tags (apache,tomcat,intrusive,misc) for host http://192.168.32.40:8080 (467 templates)
[CVE-2017-12617] [http] [high] http://192.168.32.40:8080/2aOCnb5sD7lAEEzFyJMEFa48Zl7.jsp
[CVE-2017-12615] [http] [high] http://192.168.32.40:8080/poc.jsp?cmd=cat+%2Fetc%2Fpasswd
[INF] Using Interactsh Server: oast.site
[CVE-2021-45428] [http] [critical] http://192.168.32.40:8080/2aOCnqPoj5xsa55cvmOuMWqWbYt.txt
[public-tomcat-manager] [http] [info] http://192.168.32.40:8080/manager/html
[tomcat-exposed-docs] [http] [info] http://192.168.32.40:8080/docs/
[insecure-firebase-database] [http] [high] http://192.168.32.40:8080/2aOCnMefNJjUtaHBqNCWFOTfHqt.json
[apache-detect] [http] [info] http://192.168.32.40:8080 [Apache-Coyote/1.1]
[tomcat-scripts] [http] [info] http://192.168.32.40:8080/examples/jsp/index.html
[put-method-enabled] [http] [high] http://192.168.32.40:8080/testing-put.txt
[tomcat-detect:version] [http] [info] http://192.168.32.40:8080 [7.0.79]
[tomcat-scripts] [http] [info] http://192.168.32.40:8080/examples/websocket/index.xhtml
[tomcat-manager-pathnormalization] [http] [info] http://192.168.32.40:8080/2aOCnfmKnWSTuvbqSRUo4Z0YDYD/..;/manager/html
[tomcat-scripts] [http] [info] http://192.168.32.40:8080/examples/servlets/servlet/SessionExample
[waf-detect:ats] [http] [info] http://192.168.32.40:8080/
[waf-detect:apachegeneric] [http] [info] http://192.168.32.40:8080/
```
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->


## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)