### PR TITLE
pass exclude list to layer 4 fast dialer

### DIFF
--- a/pkg/core/inputs/hybrid/hmap_test.go
+++ b/pkg/core/inputs/hybrid/hmap_test.go
@@ -12,10 +12,11 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/contextargs"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
 	"github.com/projectdiscovery/nuclei/v3/pkg/types"
+	"github.com/projectdiscovery/nuclei/v3/pkg/utils/expand"
 	"github.com/stretchr/testify/require"
 )
 
-func Test_expandCIDRInputValue(t *testing.T) {
+func Test_expandCIDR(t *testing.T) {
 	tests := []struct {
 		cidr     string
 		expected []string
@@ -33,7 +34,7 @@ func Test_expandCIDRInputValue(t *testing.T) {
 		require.Nil(t, err, "could not create temporary input file")
 		input := &Input{hostMap: hm}
 
-		ips := input.expandCIDRInputValue(tt.cidr)
+		ips := expand.CIDR(tt.cidr)
 		input.addTargets(ips)
 		// scan
 		got := []string{}
@@ -170,7 +171,7 @@ func Test_expandASNInputValue(t *testing.T) {
 		require.Nil(t, err, "could not create temporary input file")
 		input := &Input{hostMap: hm}
 		// get the IP addresses for ASN number
-		ips := input.expandASNInputValue(tt.asn)
+		ips := expand.ASN(tt.asn)
 		input.addTargets(ips)
 		// scan the hmap
 		got := []string{}

--- a/pkg/protocols/common/protocolstate/state.go
+++ b/pkg/protocols/common/protocolstate/state.go
@@ -9,8 +9,10 @@ import (
 	"golang.org/x/net/proxy"
 
 	"github.com/projectdiscovery/fastdialer/fastdialer"
+	"github.com/projectdiscovery/mapcidr/asn"
 	"github.com/projectdiscovery/networkpolicy"
 	"github.com/projectdiscovery/nuclei/v3/pkg/types"
+	"github.com/projectdiscovery/nuclei/v3/pkg/utils/expand"
 )
 
 // Dialer is a shared fastdialer instance for host DNS resolution
@@ -102,6 +104,15 @@ func Init(options *types.Options) error {
 	if options.RestrictLocalNetworkAccess {
 		opts.Deny = append(networkpolicy.DefaultIPv4DenylistRanges, networkpolicy.DefaultIPv6DenylistRanges...)
 	}
+	for _, excludeTarget := range options.ExcludeTargets {
+		switch {
+		case asn.IsASN(excludeTarget):
+			opts.Deny = append(opts.Deny, expand.ASN(excludeTarget)...)
+		default:
+			opts.Deny = append(opts.Deny, excludeTarget)
+		}
+	}
+
 	opts.WithDialerHistory = true
 	opts.SNIName = options.SNI
 

--- a/pkg/utils/expand/expand.go
+++ b/pkg/utils/expand/expand.go
@@ -1,0 +1,26 @@
+package expand
+
+import (
+	"github.com/projectdiscovery/mapcidr"
+	"github.com/projectdiscovery/mapcidr/asn"
+)
+
+// Expands CIDR to IPs
+func CIDR(value string) []string {
+	var ips []string
+	ipsCh, _ := mapcidr.IPAddressesAsStream(value)
+	for ip := range ipsCh {
+		ips = append(ips, ip)
+	}
+	return ips
+}
+
+// Expand ASN to IPs
+func ASN(value string) []string {
+	var ips []string
+	cidrs, _ := asn.GetCIDRsForASNNum(value)
+	for _, cidr := range cidrs {
+		ips = append(ips, CIDR(cidr.String())...)
+	}
+	return ips
+}


### PR DESCRIPTION
## Proposed changes
Propagate exclusion list to fastdialer

## Checklist
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Example
```console
$ cat /etc/hosts
192.168.10.1 bingo.bongo

$ go run . -id tech-detect -u http://bingo.bongo/ -eh 192.168.10.0/24 -v
...
[WRN] [tech-detect] Could not execute request for http://bingo.bongo/: GET http://bingo.bongo/ giving up after 2 attempts: Get "http://bingo.bongo/": denied address found for host
[INF] No results found. Better luck next time!
```
<img width="1439" alt="Screenshot 2024-01-05 at 12 24 11" src="https://github.com/projectdiscovery/nuclei/assets/13421144/28ebc3cc-eb95-4c2a-a5d5-c66607c104f6">
