### PR TITLE
fix missing results in flow template + feature: internal matchers using `internal: true`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ pkg/protocols/headless/engine/.cache
 /bindgen
 /jsdocgen
 /scrapefuncs
+/integration_tests/.cache/
+/integration_tests/.nuclei-config/
+/*.yaml

--- a/cmd/integration-test/flow.go
+++ b/cmd/integration-test/flow.go
@@ -67,7 +67,7 @@ func (t *iterateValuesFlow) Execute(filePath string) error {
 	if err != nil {
 		return err
 	}
-	return expectResultsCount(results, 1)
+	return expectResultsCount(results, 2)
 }
 
 type dnsNsProbe struct{}
@@ -77,7 +77,7 @@ func (t *dnsNsProbe) Execute(filePath string) error {
 	if err != nil {
 		return err
 	}
-	return expectResultsCount(results, 1)
+	return expectResultsCount(results, 2)
 }
 
 func getBase64(input string) string {

--- a/integration_tests/flow/conditional-flow-negative.yaml
+++ b/integration_tests/flow/conditional-flow-negative.yaml
@@ -15,6 +15,7 @@ dns:
       - type: word
         words:
           - "ghost.io"
+        internal: true
 
 http:
   - method: GET

--- a/integration_tests/flow/conditional-flow.yaml
+++ b/integration_tests/flow/conditional-flow.yaml
@@ -15,6 +15,7 @@ dns:
       - type: word
         words:
           - "ghost.io"
+        internal: true
 
 http:
   - method: GET

--- a/integration_tests/flow/dns-ns-probe.yaml
+++ b/integration_tests/flow/dns-ns-probe.yaml
@@ -22,6 +22,7 @@ dns:
       - type: word
         words:
           - "IN\tNS"
+        # internal: true
     extractors:
       - type: regex
         internal: true

--- a/integration_tests/flow/dns-ns-probe.yaml
+++ b/integration_tests/flow/dns-ns-probe.yaml
@@ -22,7 +22,7 @@ dns:
       - type: word
         words:
           - "IN\tNS"
-        # internal: true
+        internal: true
     extractors:
       - type: regex
         internal: true

--- a/integration_tests/flow/flow-hide-matcher.yaml
+++ b/integration_tests/flow/flow-hide-matcher.yaml
@@ -1,10 +1,10 @@
 id: flow-hide-matcher
 
 info:
-  name: Test HTTP Template
+  name: Test Flow Hide Matcher
   author: pdteam
   severity: info
-  description: In flow matcher output of previous step is hidden and only last event matcher output is shown
+  description: In Template any matcher can be marked as internal which hides it from the output.
 
 flow: http(1) && http(2)
 
@@ -17,6 +17,7 @@ http:
       - type: word
         words:
           - ok
+        internal: true
 
   - method: GET
     path:

--- a/integration_tests/flow/iterate-values-flow.yaml
+++ b/integration_tests/flow/iterate-values-flow.yaml
@@ -21,9 +21,9 @@ http:
     extractors:
       - type: regex
         name: emails
-        internal: true
         regex:
           - '[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}'
+        internal: true
 
   - method: GET
     path:
@@ -33,3 +33,9 @@ http:
       - type: word
         words:
           - "Welcome"
+    
+    extractors:
+      - type: dsl
+        name: email
+        dsl:
+          - email

--- a/pkg/operators/matchers/matchers.go
+++ b/pkg/operators/matchers/matchers.go
@@ -120,6 +120,14 @@ type Matcher struct {
 	//   - false
 	//   - true
 	MatchAll bool `yaml:"match-all,omitempty" json:"match-all,omitempty" jsonschema:"title=match all values,description=match all matcher values ignoring condition"`
+	// description: |
+	//  Internal when true hides the matcher from output. Default is false.
+	// It is meant to be used in multiprotocol / flow templates to create internal matcher condition without printing it in output.
+	// or other similar use cases.
+	// values:
+	//   - false
+	//   - true
+	Internal bool `yaml:"internal,omitempty" json:"internal,omitempty" jsonschema:"title=hide matcher from output,description=hide matcher from output"`
 
 	// cached data for the compiled matcher
 	condition     ConditionType // todo: this field should be the one used for overridden marshal ops

--- a/pkg/operators/matchers/validate.go
+++ b/pkg/operators/matchers/validate.go
@@ -11,7 +11,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-var commonExpectedFields = []string{"Type", "Condition", "Name", "MatchAll", "Negative"}
+var commonExpectedFields = []string{"Type", "Condition", "Name", "MatchAll", "Negative", "Internal"}
 
 // Validate perform initial validation on the matcher structure
 func (matcher *Matcher) Validate() error {

--- a/pkg/operators/operators.go
+++ b/pkg/operators/operators.go
@@ -90,6 +90,8 @@ type Result struct {
 
 	// Optional lineCounts for file protocol
 	LineCount string
+	// Operators is reference to operators that generated this result (Read-Only)
+	Operators *Operators
 }
 
 func (result *Result) HasMatch(name string) bool {
@@ -217,6 +219,7 @@ func (operators *Operators) Execute(data map[string]interface{}, match MatchFunc
 		Extracts:      make(map[string][]string),
 		DynamicValues: make(map[string][]string),
 		outputUnique:  make(map[string]struct{}),
+		Operators:     operators,
 	}
 
 	// state variable to check if all extractors are internal

--- a/pkg/operators/operators.go
+++ b/pkg/operators/operators.go
@@ -196,7 +196,11 @@ func (r *Result) Merge(result *Result) {
 		}
 	}
 	for k, v := range result.DynamicValues {
-		r.DynamicValues[k] = v
+		if _, ok := r.DynamicValues[k]; !ok {
+			r.DynamicValues[k] = v
+		} else {
+			r.DynamicValues[k] = sliceutil.Dedupe(append(r.DynamicValues[k], v...))
+		}
 	}
 	for k, v := range result.PayloadValues {
 		r.PayloadValues[k] = v

--- a/pkg/protocols/file/operators.go
+++ b/pkg/protocols/file/operators.go
@@ -48,6 +48,10 @@ func (request *Request) Extract(data map[string]interface{}, extractor *extracto
 		return extractor.ExtractRegex(itemStr)
 	case extractors.KValExtractor:
 		return extractor.ExtractKval(data)
+	case extractors.JSONExtractor:
+		return extractor.ExtractJSON(itemStr)
+	case extractors.XPathExtractor:
+		return extractor.ExtractXPath(itemStr)
 	case extractors.DSLExtractor:
 		return extractor.ExtractDSL(data)
 	}

--- a/pkg/scan/scan_context.go
+++ b/pkg/scan/scan_context.go
@@ -2,6 +2,7 @@ package scan
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/projectdiscovery/nuclei/v3/pkg/output"
@@ -10,45 +11,42 @@ import (
 
 type ScanContext struct {
 	context.Context
-	Input  *contextargs.Context
-	errors []error
-	events []*output.InternalWrappedEvent
+	// exported / configurable fields
+	Input *contextargs.Context
 
+	// callbacks or hooks
 	OnError  func(error)
 	OnResult func(e *output.InternalWrappedEvent)
+
+	// unexported state fields
+	errors   []error
+	warnings []string
+	events   []*output.InternalWrappedEvent
 }
 
+// NewScanContext creates a new scan context using input
 func NewScanContext(input *contextargs.Context) *ScanContext {
 	return &ScanContext{Input: input}
 }
 
+// GenerateResult returns final results slice from all events
 func (s *ScanContext) GenerateResult() []*output.ResultEvent {
 	return aggregateResults(s.events)
 }
 
-func aggregateResults(events []*output.InternalWrappedEvent) []*output.ResultEvent {
-	var results []*output.ResultEvent
-	for _, e := range events {
-		results = append(results, e.Results...)
-	}
-	return results
-}
-
-func joinErrors(errors []error) string {
-	var errorMessages []string
-	for _, e := range errors {
-		errorMessages = append(errorMessages, e.Error())
-	}
-	return strings.Join(errorMessages, "; ")
-}
-
+// LogEvent logs events to all events and triggeres any callbacks
 func (s *ScanContext) LogEvent(e *output.InternalWrappedEvent) {
+	if e == nil {
+		// do not log nil events
+		return
+	}
 	if s.OnResult != nil {
 		s.OnResult(e)
 	}
 	s.events = append(s.events, e)
 }
 
+// LogError logs error to all events and triggeres any callbacks
 func (s *ScanContext) LogError(err error) {
 	if err == nil {
 		return
@@ -67,4 +65,36 @@ func (s *ScanContext) LogError(err error) {
 	for _, e := range s.events {
 		e.InternalEvent["error"] = errorMessage
 	}
+}
+
+// LogWarning logs warning to all events
+func (s *ScanContext) LogWarning(format string, args ...any) {
+	val := fmt.Sprintf(format, args...)
+	s.warnings = append(s.warnings, val)
+
+	for _, e := range s.events {
+		if e.InternalEvent != nil {
+			e.InternalEvent["warning"] = strings.Join(s.warnings, "; ")
+		}
+	}
+}
+
+// aggregateResults aggregates results from multiple events
+func aggregateResults(events []*output.InternalWrappedEvent) []*output.ResultEvent {
+	var results []*output.ResultEvent
+	for _, e := range events {
+		results = append(results, e.Results...)
+	}
+	return results
+}
+
+// joinErrors joins multiple errors and returns a single error string
+func joinErrors(errors []error) string {
+	var errorMessages []string
+	for _, e := range errors {
+		if e != nil {
+			errorMessages = append(errorMessages, e.Error())
+		}
+	}
+	return strings.Join(errorMessages, "; ")
 }

--- a/pkg/tmplexec/exec.go
+++ b/pkg/tmplexec/exec.go
@@ -117,6 +117,22 @@ func (e *TemplateExecuter) Execute(ctx *scan.ScanContext) (bool, error) {
 			// something went wrong
 			return
 		}
+		// check for internal true matcher event
+		if event.HasOperatorResult() && event.OperatorsResult.Matched && event.OperatorsResult.Operators != nil {
+			// note all matchers should have internal:true if it is a combination then print it
+			allInternalMatchers := true
+			for _, matcher := range event.OperatorsResult.Operators.Matchers {
+				if allInternalMatchers && !matcher.Internal {
+					allInternalMatchers = false
+					break
+				}
+			}
+			if allInternalMatchers {
+				// this is a internal event and no meant to be printed
+				return
+			}
+		}
+
 		// If no results were found, and also interactsh is not being used
 		// in that case we can skip it, otherwise we've to show failure in
 		// case of matcher-status flag.

--- a/pkg/tmplexec/exec.go
+++ b/pkg/tmplexec/exec.go
@@ -141,6 +141,7 @@ func (e *TemplateExecuter) Execute(ctx *scan.ScanContext) (bool, error) {
 	if e.options.Flow != "" {
 		flowexec := flow.NewFlowExecutor(e.requests, ctx, e.options, results)
 		if err := flowexec.Compile(); err != nil {
+			ctx.LogError(err)
 			return false, err
 		}
 		err = flowexec.ExecuteWithResults(ctx)

--- a/pkg/tmplexec/exec.go
+++ b/pkg/tmplexec/exec.go
@@ -47,7 +47,7 @@ func NewTemplateExecuter(requests []protocols.Request, options *protocols.Execut
 		// we use a dummy input here because goal of flow executor at this point is to just check
 		// syntax and other things are correct before proceeding to actual execution
 		// during execution new instance of flow will be created as it is tightly coupled with lot of executor options
-		e.engine = flow.NewFlowExecutor(requests, contextargs.NewWithInput("dummy"), options, e.results)
+		e.engine = flow.NewFlowExecutor(requests, scan.NewScanContext(contextargs.NewWithInput("dummy")), options, e.results)
 	} else {
 		// Review:
 		// multiproto engine is only used if there is more than one protocol in template
@@ -139,7 +139,7 @@ func (e *TemplateExecuter) Execute(ctx *scan.ScanContext) (bool, error) {
 	// so in compile step earlier we compile it to validate javascript syntax and other things
 	// and while executing we create new instance of flow executor everytime
 	if e.options.Flow != "" {
-		flowexec := flow.NewFlowExecutor(e.requests, ctx.Input, e.options, results)
+		flowexec := flow.NewFlowExecutor(e.requests, ctx, e.options, results)
 		if err := flowexec.Compile(); err != nil {
 			return false, err
 		}

--- a/pkg/tmplexec/flow/flow_executor.go
+++ b/pkg/tmplexec/flow/flow_executor.go
@@ -182,7 +182,7 @@ func (f *FlowExecutor) ExecuteWithResults(ctx *scan.ScanContext) error {
 		return fmt.Errorf("output callback cannot be nil")
 	}
 	// pass flow and execute the js vm and handle errors
-	value, err := f.jsVM.RunProgram(f.program)
+	_, err := f.jsVM.RunProgram(f.program)
 	if err != nil {
 		ctx.LogError(err)
 		return errorutil.NewWithErr(err).Msgf("failed to execute flow\n%v\n", f.options.Flow)
@@ -193,11 +193,6 @@ func (f *FlowExecutor) ExecuteWithResults(ctx *scan.ScanContext) error {
 		return errorutil.NewWithErr(runtimeErr).Msgf("got following errors while executing flow")
 	}
 
-	if value.Export() != nil {
-		f.results.Store(value.ToBoolean())
-	} else {
-		f.results.Store(true)
-	}
 	return nil
 }
 

--- a/pkg/tmplexec/flow/flow_internal.go
+++ b/pkg/tmplexec/flow/flow_internal.go
@@ -81,7 +81,6 @@ func (f *FlowExecutor) requestExecutor(reqMap mapsutil.Map[string, protocols.Req
 func (f *FlowExecutor) protocolResultCallback(req protocols.Request, matcherStatus *atomic.Bool, opts *ProtoOptions) func(result *output.InternalWrappedEvent) {
 	return func(result *output.InternalWrappedEvent) {
 		if result != nil {
-			f.results.CompareAndSwap(false, true)
 			// Note: flow specific implicit behaviours should be handled here
 			// before logging the event
 			f.ctx.LogEvent(result)
@@ -89,6 +88,7 @@ func (f *FlowExecutor) protocolResultCallback(req protocols.Request, matcherStat
 			// add add it to template context
 			// this is a conflicting behaviour with iterate-all
 			if result.HasOperatorResult() {
+				f.results.CompareAndSwap(false, true)
 				// this is to handle case where there is any operator result (matcher or extractor)
 				matcherStatus.CompareAndSwap(false, result.OperatorsResult.Matched)
 				if !result.OperatorsResult.Matched && !hasMatchers(req.GetCompiledOperators()) {


### PR DESCRIPTION
### Proposed Changes

- refactor flow engine to use `scan.ScanContext`
- fix missing results/events in flow templates
- add feature to hide result/event in matchers using `internal: true`
- updated integration test to match new behaviour of flow & `internal: true`
- fix missing extractors in file protocol
- fix: dynamic values overwritten when merging results (file protocol)
- closes #4580 
- closes #4581 
- closes #4443 
- closes #4058 

>[!NOTE]
> Nuclei before this PR < 3.1.4 only printed/logged last event / final result when using flow with `matchers` but this implicit behaviour caused issue (see: #4581 ) . Hence this now needs to be done explicitly in much cleaner and controlled way by adding `internal: true` to matchers