### PR TITLE
code protocol: donot exit on non zero status code

### DIFF
--- a/pkg/protocols/code/code.go
+++ b/pkg/protocols/code/code.go
@@ -139,8 +139,8 @@ func (request *Request) ExecuteWithResults(input *contextargs.Context, dynamicVa
 		metaSrc.AddVariable(gozerotypes.Variable{Name: name, Value: v})
 	}
 	gOutput, err := request.gozero.Eval(context.Background(), request.src, metaSrc)
-	if err != nil {
-		return err
+	if err != nil && gOutput == nil {
+		return errorutil.NewWithErr(err).Msgf("[%s] Could not execute code on local machine %v", request.options.TemplateID, input.MetaInput.Input)
 	}
 	gologger.Verbose().Msgf("[%s] Executed code on local machine %v", request.options.TemplateID, input.MetaInput.Input)
 


### PR DESCRIPTION
### Proposed Changes

>when writing code protocol templates . some exploits may return non-zero status code but current logic stops executing template in case on non-zero exit code which should not be the case

- closes #4586 

### example template

```yaml
id: py-code-snippet

info:
  name: py-code-snippet
  author: pdteam
  severity: info
  tags: code
  description: |
    py-code-snippet

self-contained: true

code:
  - engine:
      - sh
      - bash
    source: |
      nuclei -exy
    
    matchers:
      - type: word
        words:
          - "not defined"

    extractors:
      - type: dsl
        dsl:
          - '"nuclei -exy :"+ response'
# digest: 4a0a00473045022100a834da82e4af5b144f86397c4595a84cdb82336572a3f62b5074e3d4bdf1d47502207555875e3149bfb32f731e0fac16015d586d3bcc8b0811a1d5294cdbf2d861af:73812c4e0e52692225979bd2d5f05a3c
```


### output

```console
$ ./nuclei -t a.yaml -code -v      

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.1.4-dev

		projectdiscovery.io

[VER] Started metrics server at localhost:9092
[INF] Current nuclei version: v3.1.4-dev (development)
[INF] Current nuclei-templates version: v9.7.2 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 61
[INF] Templates loaded for current scan: 1
[INF] Executing 1 signed templates from tarun
[VER] [py-code-snippet] Executed code on local machine 
[py-code-snippet] [code] [info]  [nuclei -exy :flag provided but not defined: -exy]
```