### PR TITLE
added support & unit-tests for more fuzzing parts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -199,6 +199,7 @@ require (
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect
 	github.com/tidwall/rtred v0.1.2 // indirect
+	github.com/tidwall/sjson v1.2.5 // indirect
 	github.com/tidwall/tinyqueue v0.1.1 // indirect
 	github.com/tim-ywliu/nested-logrus-formatter v1.3.2 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -986,6 +986,7 @@ github.com/tidwall/btree v1.7.0/go.mod h1:twD9XRA5jj9VUQGELzDO4HPQTNJsoWWfYEL+EU
 github.com/tidwall/buntdb v1.3.0 h1:gdhWO+/YwoB2qZMeAU9JcWWsHSYU3OvcieYgFRS0zwA=
 github.com/tidwall/buntdb v1.3.0/go.mod h1:lZZrZUWzlyDJKlLQ6DKAy53LnG7m5kHyrEHvvcDmBpU=
 github.com/tidwall/gjson v1.12.1/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/gjson v1.17.0 h1:/Jocvlh98kcTfpN2+JzGQWQcqrPQwDrVEMApx/M5ZwM=
 github.com/tidwall/gjson v1.17.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/grect v0.1.4 h1:dA3oIgNgWdSspFzn1kS4S/RDpZFLrIxAZOdJKjYapOg=
@@ -999,6 +1000,8 @@ github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
 github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/tidwall/rtred v0.1.2 h1:exmoQtOLvDoO8ud++6LwVsAMTu0KPzLTUrMln8u1yu8=
 github.com/tidwall/rtred v0.1.2/go.mod h1:hd69WNXQ5RP9vHd7dqekAz+RIdtfBogmglkZSRxCHFQ=
+github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
+github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
 github.com/tidwall/tinyqueue v0.1.1 h1:SpNEvEggbpyN5DIReaJ2/1ndroY8iyEGxPYxoSaymYE=
 github.com/tidwall/tinyqueue v0.1.1/go.mod h1:O/QNHwrnjqr6IHItYrzoHAKYhBkLI67Q096fQP5zMYw=
 github.com/tim-ywliu/nested-logrus-formatter v1.3.2 h1:jugNJ2/CNCI79SxOJCOhwUHeN3O7/7/bj+ZRGOFlCSw=

--- a/pkg/protocols/common/fuzz/fuzz.go
+++ b/pkg/protocols/common/fuzz/fuzz.go
@@ -100,11 +100,15 @@ type partType int
 const (
 	queryPartType partType = iota + 1
 	headersPartType
+	bodyPartType
+	allPartType
 )
 
 var stringToPartType = map[string]partType{
 	"query":   queryPartType,
 	"headers": headersPartType,
+	"body":    bodyPartType,
+	"all":     allPartType,
 }
 
 // modeType is the mode of rule enum declaration

--- a/pkg/protocols/common/fuzz/parts_test.go
+++ b/pkg/protocols/common/fuzz/parts_test.go
@@ -1,8 +1,12 @@
 package fuzz
 
 import (
+	"bytes"
 	"github.com/projectdiscovery/retryablehttp-go"
+	"io"
 	"net/http"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols"
@@ -74,10 +78,12 @@ func TestExecuteHeadersPartRule(t *testing.T) {
 	})
 }
 func TestExecuteQueryPartRule(t *testing.T) {
-	URL := "http://localhost:8080/?url=localhost&mode=multiple&file=passwdfile"
 	options := &protocols.ExecutorOptions{
 		Interactsh: &interactsh.Client{},
 	}
+	URL := "http://localhost:8080/?url=localhost&mode=multiple&file=passwdfile"
+	req, err := retryablehttp.NewRequest("GET", URL, nil)
+	require.NoError(t, err, "can't build request")
 	t.Run("single", func(t *testing.T) {
 		rule := &Rule{
 			ruleType: postfixRuleType,
@@ -86,9 +92,9 @@ func TestExecuteQueryPartRule(t *testing.T) {
 			options:  options,
 		}
 		var generatedURL []string
-		input := contextargs.NewWithInput(URL)
 		err := rule.executeQueryPartRule(&ExecuteRuleInput{
-			Input: input,
+			Input:       contextargs.New(),
+			BaseRequest: req,
 			Callback: func(gr GeneratedRequest) bool {
 				generatedURL = append(generatedURL, gr.Request.URL.String())
 				return true
@@ -109,9 +115,9 @@ func TestExecuteQueryPartRule(t *testing.T) {
 			options:  options,
 		}
 		var generatedURL string
-		input := contextargs.NewWithInput(URL)
 		err := rule.executeQueryPartRule(&ExecuteRuleInput{
-			Input: input,
+			Input:       contextargs.New(),
+			BaseRequest: req,
 			Callback: func(gr GeneratedRequest) bool {
 				generatedURL = gr.Request.URL.String()
 				return true
@@ -141,4 +147,496 @@ func TestExecuteReplaceRule(t *testing.T) {
 		returned := rule.executeReplaceRule(nil, test.value, test.replacement)
 		require.Equal(t, test.expected, returned, "could not get correct value")
 	}
+}
+
+func TestExecuteBodyPartRule(t *testing.T) {
+	options := &protocols.ExecutorOptions{
+		Interactsh: &interactsh.Client{},
+	}
+	req, err := retryablehttp.NewRequest("POST", "http://localhost:8080/", nil)
+	require.NoError(t, err, "can't build request")
+
+	// Test for form encoded body single-mode
+	t.Run("form-encoded-body-single", func(t *testing.T) {
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		body := "key1=value1&key2=value2"
+		req.Header.Set("Content-Length", strconv.Itoa(len(body)))
+		req.Body = io.NopCloser(strings.NewReader(body))
+
+		rule := &Rule{
+			ruleType: postfixRuleType,
+			partType: bodyPartType,
+			modeType: singleModeType,
+			options:  options,
+		}
+		var generatedBodies []string
+		err := rule.executeBodyPartRule(&ExecuteRuleInput{
+			Input:       contextargs.New(),
+			BaseRequest: req,
+			Callback: func(gr GeneratedRequest) bool {
+				bodyBytes, _ := io.ReadAll(gr.Request.Body)
+				_ = gr.Request.Body.Close()
+				req.Body = io.NopCloser(bytes.NewBuffer(bodyBytes)) // reset the "read-once" type body for future read
+				generatedBodies = append(generatedBodies, string(bodyBytes))
+				return true
+			},
+		}, "1337")
+		require.NoError(t, err, "could not execute body part rule for form-encoded")
+
+		expectedBodies := []string{
+			"key1=value11337&key2=value2", // Fuzzed key1
+			"key1=value1&key2=value21337", // Fuzzed key2
+		}
+		require.ElementsMatch(t, expectedBodies, generatedBodies, "bodies did not match expected fuzzed bodies")
+	})
+
+	// Test for form encoded body multiple-mode
+	t.Run("form-encoded-body-multiple", func(t *testing.T) {
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		body := "key1=value1&key2=value2"
+		req.Header.Set("Content-Length", strconv.Itoa(len(body)))
+		req.Body = io.NopCloser(strings.NewReader(body))
+
+		rule := &Rule{
+			ruleType: postfixRuleType,
+			partType: bodyPartType,
+			modeType: multipleModeType,
+			options:  options,
+		}
+		var generatedBodies []string
+		err := rule.executeBodyPartRule(&ExecuteRuleInput{
+			Input:       contextargs.New(),
+			BaseRequest: req,
+			Callback: func(gr GeneratedRequest) bool {
+				bodyBytes, _ := io.ReadAll(gr.Request.Body)
+				_ = gr.Request.Body.Close()
+				req.Body = io.NopCloser(bytes.NewBuffer(bodyBytes)) // reset the "read-once" type body for future read
+				generatedBodies = append(generatedBodies, string(bodyBytes))
+				return true
+			},
+		}, "1337")
+		require.NoError(t, err, "could not execute body part rule for form-encoded")
+
+		expectedBodies := []string{
+			"key1=value11337&key2=value21337", // Fuzzed key1 & key2
+		}
+		require.ElementsMatch(t, expectedBodies, generatedBodies, "bodies did not match expected fuzzed bodies")
+	})
+
+	// Test for json body single-mode
+	t.Run("json-body-single", func(t *testing.T) {
+		req.Header.Set("Content-Type", "application/json")
+		body := "{\"key1\":\"def\",\"key2\":true,\"key3\":[1,\"2\"],\"key4\":{\"key5\":\"aaa\",\"key6\":{\"key7\":[\"bbb\", \"ccc\"]}}}"
+		req.Header.Set("Content-Length", strconv.Itoa(len(body)))
+		req.Body = io.NopCloser(strings.NewReader(body))
+
+		rule := &Rule{
+			ruleType: postfixRuleType,
+			partType: bodyPartType,
+			modeType: singleModeType,
+			options:  options,
+		}
+		var generatedBodies []string
+		err := rule.executeBodyPartRule(&ExecuteRuleInput{
+			Input:       contextargs.New(),
+			BaseRequest: req,
+			Callback: func(gr GeneratedRequest) bool {
+				bodyBytes, _ := io.ReadAll(gr.Request.Body)
+				_ = gr.Request.Body.Close()
+				req.Body = io.NopCloser(bytes.NewBuffer(bodyBytes)) // reset the "read-once" type body for future read
+				generatedBodies = append(generatedBodies, string(bodyBytes))
+				return true
+			},
+		}, "1337")
+		require.NoError(t, err, "could not execute body part rule for json body")
+
+		expectedBodies := []string{
+			"{\"key1\":\"def1337\",\"key2\":true,\"key3\":[1,\"2\"],\"key4\":{\"key5\":\"aaa\",\"key6\":{\"key7\":[\"bbb\",\"ccc\"]}}}", // Fuzzed key1
+			"{\"key1\":\"def\",\"key2\":true,\"key3\":[1,\"21337\"],\"key4\":{\"key5\":\"aaa\",\"key6\":{\"key7\":[\"bbb\",\"ccc\"]}}}", // Fuzzed key3[0]
+			"{\"key1\":\"def\",\"key2\":true,\"key3\":[1,\"2\"],\"key4\":{\"key5\":\"aaa1337\",\"key6\":{\"key7\":[\"bbb\",\"ccc\"]}}}", // Fuzzed key4.key5
+			"{\"key1\":\"def\",\"key2\":true,\"key3\":[1,\"2\"],\"key4\":{\"key5\":\"aaa\",\"key6\":{\"key7\":[\"bbb1337\",\"ccc\"]}}}", // Fuzzed key6.key7[0]
+			"{\"key1\":\"def\",\"key2\":true,\"key3\":[1,\"2\"],\"key4\":{\"key5\":\"aaa\",\"key6\":{\"key7\":[\"bbb\",\"ccc1337\"]}}}", // Fuzzed key6.key7[1]
+		}
+		require.ElementsMatch(t, expectedBodies, generatedBodies, "bodies did not match expected fuzzed bodies")
+	})
+
+	// Test for json body single-mode
+	t.Run("json-body-multiple", func(t *testing.T) {
+		req.Header.Set("Content-Type", "application/json")
+		body := "{\"key1\":\"def\",\"key2\":true,\"key3\":[1,\"2\"],\"key4\":{\"key5\":\"aaa\",\"key6\":{\"key7\":[\"bbb\", \"ccc\"]}}}"
+		req.Header.Set("Content-Length", strconv.Itoa(len(body)))
+		req.Body = io.NopCloser(strings.NewReader(body))
+
+		rule := &Rule{
+			ruleType: postfixRuleType,
+			partType: bodyPartType,
+			modeType: multipleModeType,
+			options:  options,
+		}
+		var generatedBodies []string
+		err := rule.executeBodyPartRule(&ExecuteRuleInput{
+			Input:       contextargs.New(),
+			BaseRequest: req,
+			Callback: func(gr GeneratedRequest) bool {
+				bodyBytes, _ := io.ReadAll(gr.Request.Body)
+				_ = gr.Request.Body.Close()
+				req.Body = io.NopCloser(bytes.NewBuffer(bodyBytes)) // reset the "read-once" type body for future read
+				generatedBodies = append(generatedBodies, string(bodyBytes))
+				return true
+			},
+		}, "1337")
+		require.NoError(t, err, "could not execute body part rule for json body")
+
+		expectedBodies := []string{
+			// Fuzzed key1, key3[0], key4.key5, key6.key7[0] & key6.key7[1] together
+			"{\"key1\":\"def1337\",\"key2\":true,\"key3\":[1,\"21337\"],\"key4\":{\"key5\":\"aaa1337\",\"key6\":{\"key7\":[\"bbb1337\",\"ccc1337\"]}}}",
+		}
+		require.ElementsMatch(t, expectedBodies, generatedBodies, "bodies did not match expected fuzzed bodies")
+	})
+
+	// Test for graphql request with referenced variables (content-type: application/json) single-mode
+	t.Run("graphql-body-single", func(t *testing.T) {
+		req.URL.Path = "/graphql"
+		req.Header.Set("Content-Type", "application/json")
+		body := "{\"query\":\"mutation SetMessage($msg: String!, $name: String!) { setMessage(message: $msg, name: $name) }\",\"variables\":{\"msg\":\"Hello, GraphQL!\",\"name\":\"Nikoo\"}}"
+		req.Header.Set("Content-Length", strconv.Itoa(len(body)))
+		req.Body = io.NopCloser(strings.NewReader(body))
+
+		rule := &Rule{
+			ruleType: postfixRuleType,
+			partType: bodyPartType,
+			modeType: singleModeType,
+			options:  options,
+		}
+		var generatedBodies []string
+		err := rule.executeBodyPartRule(&ExecuteRuleInput{
+			Input:       contextargs.New(),
+			BaseRequest: req,
+			Callback: func(gr GeneratedRequest) bool {
+				bodyBytes, _ := io.ReadAll(gr.Request.Body)
+				_ = gr.Request.Body.Close()
+				req.Body = io.NopCloser(bytes.NewBuffer(bodyBytes)) // reset the "read-once" type body for future read
+				generatedBodies = append(generatedBodies, string(bodyBytes))
+				return true
+			},
+		}, "1337")
+		require.NoError(t, err, "could not execute body part rule for graphql body")
+
+		expectedBodies := []string{
+			"{\"query\":\"mutation SetMessage($msg: String!, $name: String!) { setMessage(message: $msg, name: $name) }\",\"variables\":{\"msg\":\"Hello, GraphQL!1337\",\"name\":\"Nikoo\"}}",
+			"{\"query\":\"mutation SetMessage($msg: String!, $name: String!) { setMessage(message: $msg, name: $name) }\",\"variables\":{\"msg\":\"Hello, GraphQL!\",\"name\":\"Nikoo1337\"}}",
+		}
+		require.ElementsMatch(t, expectedBodies, generatedBodies, "bodies did not match expected fuzzed bodies")
+	})
+
+	// Test for graphql request with referenced variables (content-type: application/json) multiple-mode
+	t.Run("graphql-body-multiple", func(t *testing.T) {
+		req.URL.Path = "/graphql"
+		req.Header.Set("Content-Type", "application/json")
+		body := "{\"query\":\"mutation SetMessage($msg: String!, $name: String!) { setMessage(message: $msg, name: $name) }\",\"variables\":{\"msg\":\"Hello, GraphQL!\",\"name\":\"Nikoo\"}}"
+		req.Header.Set("Content-Length", strconv.Itoa(len(body)))
+		req.Body = io.NopCloser(strings.NewReader(body))
+
+		rule := &Rule{
+			ruleType: postfixRuleType,
+			partType: bodyPartType,
+			modeType: multipleModeType,
+			options:  options,
+		}
+		var generatedBodies []string
+		err := rule.executeBodyPartRule(&ExecuteRuleInput{
+			Input:       contextargs.New(),
+			BaseRequest: req,
+			Callback: func(gr GeneratedRequest) bool {
+				bodyBytes, _ := io.ReadAll(gr.Request.Body)
+				_ = gr.Request.Body.Close()
+				req.Body = io.NopCloser(bytes.NewBuffer(bodyBytes)) // reset the "read-once" type body for future read
+				generatedBodies = append(generatedBodies, string(bodyBytes))
+				return true
+			},
+		}, "1337")
+		require.NoError(t, err, "could not execute body part rule for graphql body")
+
+		expectedBodies := []string{
+			"{\"query\":\"mutation SetMessage($msg: String!, $name: String!) { setMessage(message: $msg, name: $name) }\",\"variables\":{\"msg\":\"Hello, GraphQL!1337\",\"name\":\"Nikoo1337\"}}",
+		}
+		require.ElementsMatch(t, expectedBodies, generatedBodies, "bodies did not match expected fuzzed bodies")
+	})
+
+	// Test for graphql request with referenced variables (content-type: application/json) multiple-mode
+	t.Run("negative-graphql-body-multiple", func(t *testing.T) {
+		req.URL.Path = "/notgraphql"
+		req.Header.Set("Content-Type", "application/json")
+		body := "{\"query\":\"mutation SetMessage($msg: String!, $name: String!) { setMessage(message: $msg, name: $name) }\",\"variables\":{\"msg\":\"Hello, GraphQL!\",\"name\":\"Nikoo\"}}"
+		req.Header.Set("Content-Length", strconv.Itoa(len(body)))
+		req.Body = io.NopCloser(strings.NewReader(body))
+
+		rule := &Rule{
+			ruleType: postfixRuleType,
+			partType: bodyPartType,
+			modeType: multipleModeType,
+			options:  options,
+		}
+		var generatedBodies []string
+		err := rule.executeBodyPartRule(&ExecuteRuleInput{
+			Input:       contextargs.New(),
+			BaseRequest: req,
+			Callback: func(gr GeneratedRequest) bool {
+				bodyBytes, _ := io.ReadAll(gr.Request.Body)
+				_ = gr.Request.Body.Close()
+				req.Body = io.NopCloser(bytes.NewBuffer(bodyBytes)) // reset the "read-once" type body for future read
+				generatedBodies = append(generatedBodies, string(bodyBytes))
+				return true
+			},
+		}, "1337")
+		require.NoError(t, err, "could not execute body part rule for not graphql request")
+
+		expectedBodies := []string{
+			"{\"query\":\"mutation SetMessage($msg: String!, $name: String!) { setMessage(message: $msg, name: $name) }1337\",\"variables\":{\"msg\":\"Hello, GraphQL!1337\",\"name\":\"Nikoo1337\"}}",
+		}
+		require.ElementsMatch(t, expectedBodies, generatedBodies, "bodies did not match expected fuzzed bodies")
+
+		unwantedBodies := []string{
+			"{\"query\":\"mutation SetMessage($msg: String!, $name: String!) { setMessage(message: $msg, name: $name) }\",\"variables\":{\"msg\":\"Hello, GraphQL!1337\",\"name\":\"Nikoo1337\"}}",
+		}
+		for _, generatedBody := range generatedBodies {
+			for _, unwantedBody := range unwantedBodies {
+				require.NotEqual(t, unwantedBody, generatedBody, "generated body matches an unwanted body")
+			}
+		}
+
+	})
+
+}
+
+func TestExecuteAllPartsRule(t *testing.T) {
+	options := &protocols.ExecutorOptions{
+		Interactsh: &interactsh.Client{},
+	}
+
+	// Test for all parts with form encoded body in multiple-mode
+	t.Run("all-parts-form-encoded-body-multiple", func(t *testing.T) {
+		req, err := retryablehttp.NewRequest("POST", "http://localhost:8080/?url=localhost&mode=multiple&file=passwdfile", nil)
+		require.NoError(t, err, "can't build request")
+		req.Header.Set("X-Custom-Foo", "foo")
+		req.Header.Set("X-Custom-Bar", "bar")
+
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		body := "key1=value1&key2=value2"
+		req.Header.Set("Content-Length", strconv.Itoa(len(body)))
+		req.Body = io.NopCloser(strings.NewReader(body))
+
+		rule := &Rule{
+			ruleType: postfixRuleType,
+			partType: allPartType,
+			modeType: multipleModeType,
+			options:  options,
+		}
+
+		var generatedURLs []string
+		var generatedHeaders []http.Header
+		var generatedBodies []string
+
+		err = rule.executeAllPartRule(&ExecuteRuleInput{
+			Input:       contextargs.New(),
+			BaseRequest: req,
+			Callback: func(gr GeneratedRequest) bool {
+				bodyBytes, _ := io.ReadAll(gr.Request.Body)
+				_ = gr.Request.Body.Close()
+				req.Body = io.NopCloser(bytes.NewBuffer(bodyBytes)) // set the body again for future read
+				generatedURLs = append(generatedURLs, gr.Request.URL.String())
+
+				generatedHeaders = append(generatedHeaders, gr.Request.Header.Clone())
+				generatedBodies = append(generatedBodies, string(bodyBytes))
+				return true
+			},
+		}, "1337")
+		require.NoError(t, err, "could not execute all part rule for form-encoded")
+
+		expectedURLs := []string{
+			"http://localhost:8080/?url=localhost1337&mode=multiple1337&file=passwdfile1337", // Fuzzed url
+			"http://localhost:8080/?url=localhost1337&mode=multiple1337&file=passwdfile1337", // Fuzzed mode
+			"http://localhost:8080/?url=localhost1337&mode=multiple1337&file=passwdfile1337", // Fuzzed file
+		}
+		expectedHeaders := []http.Header{
+			{
+				"X-Custom-Foo":   {"foo"},
+				"X-Custom-Bar":   {"bar"},
+				"Content-Type":   {"application/x-www-form-urlencoded"},
+				"Content-Length": {"23"},
+			},
+			{
+				"X-Custom-Foo":   {"foo"},
+				"X-Custom-Bar":   {"bar"},
+				"Content-Type":   {"application/x-www-form-urlencoded"},
+				"Content-Length": {"31"},
+			},
+			{
+				"X-Custom-Foo":   {"foo1337"},
+				"X-Custom-Bar":   {"bar1337"},
+				"Content-Type":   {"application/x-www-form-urlencoded1337"},
+				"Content-Length": {"231337"},
+			},
+		}
+		expectedBodies := []string{
+			"key1=value1&key2=value2",
+			"key1=value1&key2=value2",
+			"key1=value11337&key2=value21337",
+		}
+		require.ElementsMatch(t, expectedURLs, generatedURLs, "URL did not match expected fuzzed bodies")
+		require.ElementsMatch(t, expectedHeaders, generatedHeaders, "headers did not match expected fuzzed bodies")
+		require.ElementsMatch(t, expectedBodies, generatedBodies, "bodies did not match expected fuzzed bodies")
+	})
+
+	// Test for all parts with json body in multiple-mode
+	t.Run("all-parts-json-body-multiple", func(t *testing.T) {
+		req, err := retryablehttp.NewRequest("POST", "http://localhost:8080/?url=localhost&mode=multiple&file=passwdfile", nil)
+		require.NoError(t, err, "can't build request")
+		req.Header.Set("X-Custom-Foo", "foo")
+		req.Header.Set("X-Custom-Bar", "bar")
+		req.Header.Set("Content-Type", "application/json")
+
+		body := "{\"key1\":\"def\",\"key2\":true,\"key3\":[1,\"2\"],\"key4\":{\"key5\":\"aaa\",\"key6\":{\"key7\":[\"bbb\", \"ccc\"]}}}"
+		req.Header.Set("Content-Length", strconv.Itoa(len(body)))
+		req.Body = io.NopCloser(strings.NewReader(body))
+
+		rule := &Rule{
+			ruleType: postfixRuleType,
+			partType: allPartType,
+			modeType: multipleModeType,
+			options:  options,
+		}
+
+		var generatedURLs []string
+		var generatedHeaders []http.Header
+		var generatedBodies []string
+
+		err = rule.executeAllPartRule(&ExecuteRuleInput{
+			Input:       contextargs.New(),
+			BaseRequest: req,
+			Callback: func(gr GeneratedRequest) bool {
+				bodyBytes, _ := io.ReadAll(gr.Request.Body)
+				_ = gr.Request.Body.Close()
+				req.Body = io.NopCloser(bytes.NewBuffer(bodyBytes)) // reset the "read-once" type body for future read
+
+				generatedURLs = append(generatedURLs, gr.Request.URL.String())
+				generatedHeaders = append(generatedHeaders, gr.Request.Header.Clone())
+				generatedBodies = append(generatedBodies, string(bodyBytes))
+				return true
+			},
+		}, "1337")
+		require.NoError(t, err, "could not execute body part rule for json body")
+
+		expectedURLs := []string{
+			"http://localhost:8080/?url=localhost1337&mode=multiple1337&file=passwdfile1337", // Fuzzed url
+			"http://localhost:8080/?url=localhost1337&mode=multiple1337&file=passwdfile1337", // Fuzzed mode
+			"http://localhost:8080/?url=localhost1337&mode=multiple1337&file=passwdfile1337", // Fuzzed file
+		}
+		expectedHeaders := []http.Header{
+			{
+				"X-Custom-Foo":   {"foo"},
+				"X-Custom-Bar":   {"bar"},
+				"Content-Type":   {"application/json"},
+				"Content-Length": {"94"},
+			},
+			{
+				"X-Custom-Foo":   {"foo"},
+				"X-Custom-Bar":   {"bar"},
+				"Content-Type":   {"application/json"},
+				"Content-Length": {"113"},
+			},
+			{
+				"X-Custom-Foo":   {"foo1337"},
+				"X-Custom-Bar":   {"bar1337"},
+				"Content-Type":   {"application/json1337"},
+				"Content-Length": {"941337"},
+			},
+		}
+
+		expectedBodies := []string{
+			"{\"key1\":\"def\",\"key2\":true,\"key3\":[1,\"2\"],\"key4\":{\"key5\":\"aaa\",\"key6\":{\"key7\":[\"bbb\", \"ccc\"]}}}",
+			"{\"key1\":\"def\",\"key2\":true,\"key3\":[1,\"2\"],\"key4\":{\"key5\":\"aaa\",\"key6\":{\"key7\":[\"bbb\", \"ccc\"]}}}",
+			"{\"key1\":\"def1337\",\"key2\":true,\"key3\":[1,\"21337\"],\"key4\":{\"key5\":\"aaa1337\",\"key6\":{\"key7\":[\"bbb1337\",\"ccc1337\"]}}}",
+		}
+
+		require.ElementsMatch(t, expectedURLs, generatedURLs, "URL did not match expected fuzzed bodies")
+		require.ElementsMatch(t, expectedHeaders, generatedHeaders, "headers did not match expected fuzzed bodies")
+		require.ElementsMatch(t, expectedBodies, generatedBodies, "bodies did not match expected fuzzed bodies")
+	})
+
+	// Test for all parts with graphql request body with referenced variables (content-type: application/json) in multiple-mode
+	t.Run("all-parts-graphql-body-multiple", func(t *testing.T) {
+		req, err := retryablehttp.NewRequest("POST", "http://localhost:8080/graphql?url=localhost&mode=multiple&file=passwdfile", nil)
+		require.NoError(t, err, "can't build request")
+		req.Header.Set("X-Custom-Foo", "foo")
+		req.Header.Set("X-Custom-Bar", "bar")
+		req.Header.Set("Content-Type", "application/json")
+		body := "{\"query\":\"mutation SetMessage($msg: String!, $name: String!) { setMessage(message: $msg, name: $name) }\",\"variables\":{\"msg\":\"Hello, GraphQL!\",\"name\":\"Nikoo\"}}"
+		req.Header.Set("Content-Length", strconv.Itoa(len(body)))
+		req.Body = io.NopCloser(strings.NewReader(body))
+
+		rule := &Rule{
+			ruleType: postfixRuleType,
+			partType: allPartType,
+			modeType: multipleModeType,
+			options:  options,
+		}
+
+		var generatedURLs []string
+		var generatedHeaders []http.Header
+		var generatedBodies []string
+
+		err = rule.executeAllPartRule(&ExecuteRuleInput{
+			Input:       contextargs.New(),
+			BaseRequest: req,
+			Callback: func(gr GeneratedRequest) bool {
+				bodyBytes, _ := io.ReadAll(gr.Request.Body)
+				_ = gr.Request.Body.Close()
+				req.Body = io.NopCloser(bytes.NewBuffer(bodyBytes)) // reset the "read-once" type body for future read
+
+				generatedURLs = append(generatedURLs, gr.Request.URL.String())
+				generatedHeaders = append(generatedHeaders, gr.Request.Header.Clone())
+				generatedBodies = append(generatedBodies, string(bodyBytes))
+				return true
+			},
+		}, "1337")
+		require.NoError(t, err, "could not execute body part rule for graphql body")
+
+		expectedURLs := []string{
+			"http://localhost:8080/graphql?url=localhost1337&mode=multiple1337&file=passwdfile1337", // Fuzzed url
+			"http://localhost:8080/graphql?url=localhost1337&mode=multiple1337&file=passwdfile1337", // Fuzzed mode
+			"http://localhost:8080/graphql?url=localhost1337&mode=multiple1337&file=passwdfile1337", // Fuzzed file
+		}
+		expectedHeaders := []http.Header{
+			{
+				"X-Custom-Foo":   {"foo1337"},
+				"X-Custom-Bar":   {"bar1337"},
+				"Content-Type":   {"application/json1337"},
+				"Content-Length": {"1581337"},
+			},
+			{
+				"X-Custom-Foo":   {"foo"},
+				"X-Custom-Bar":   {"bar"},
+				"Content-Type":   {"application/json"},
+				"Content-Length": {"158"},
+			},
+			{
+				"X-Custom-Foo":   {"foo"},
+				"X-Custom-Bar":   {"bar"},
+				"Content-Type":   {"application/json"},
+				"Content-Length": {"166"},
+			},
+		}
+
+		expectedBodies := []string{
+			"{\"query\":\"mutation SetMessage($msg: String!, $name: String!) { setMessage(message: $msg, name: $name) }\",\"variables\":{\"msg\":\"Hello, GraphQL!\",\"name\":\"Nikoo\"}}",
+			"{\"query\":\"mutation SetMessage($msg: String!, $name: String!) { setMessage(message: $msg, name: $name) }\",\"variables\":{\"msg\":\"Hello, GraphQL!\",\"name\":\"Nikoo\"}}",
+			"{\"query\":\"mutation SetMessage($msg: String!, $name: String!) { setMessage(message: $msg, name: $name) }\",\"variables\":{\"msg\":\"Hello, GraphQL!1337\",\"name\":\"Nikoo1337\"}}",
+		}
+
+		require.ElementsMatch(t, expectedURLs, generatedURLs, "URL did not match expected fuzzed bodies")
+		require.ElementsMatch(t, expectedHeaders, generatedHeaders, "headers did not match expected fuzzed bodies")
+		require.ElementsMatch(t, expectedBodies, generatedBodies, "bodies did not match expected fuzzed bodies")
+	})
+
 }


### PR DESCRIPTION
## Proposed changes

I have added support for specifying more parts in the fuzzing templates. This is in reference to Issue https://github.com/projectdiscovery/nuclei/issues/4113

This PR includes code changes and unit-tests related to:
```yaml
http:
  - raw: ...
    ...
    fuzzing:
      - part: body
     ...
...
```
and
 
```yaml
http:
  - raw: ...
    ...
    fuzzing:
      - part: all
     ...
...
```

Behavior Explanation
---
* When `http[].fuzzing[].part` in the specified template is set to `body`, appropriate request body fuzzing shall be applied depending on whether`Content-Type: application/x-www-form-urlencoded` or `Content-Type: application/json` or `/graphql` over `Content-Type: application/json`. 

* When `http[].fuzzing[].part` in the specified template is set to `all`, fuzzing behavior shall occur as per expectation when `part: query` and `part: headers` along with request body fuzzing (as described above) in the order: Query Parameters then Header Values finally Body.

URL Encoded bodies
---

Supported
> In the following example, all the repeating characters indicate that they shall be fuzzed, leaving other values intact
```yaml
...
http:
  - raw:
      - |
        POST /?x=abc&y=def HTTP/1.1
        Host: {{Hostname}}
        Origin: http://example.com
        X-Forwared-For: 1337
        Content-Type: application/x-www-form-urlencoded
        Cookie: z=pqr; bb=pqr
        User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko)
        Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8
        Accept-Language: en-US,en;q=0.9
        Connection: close

        key1=ddd&key2=aaa&key3=ccc
...
```

JSON bodies
---
All nested values (Arrays & Objects nested within Arrays & Objects) of type `string` are considered for fuzzing (either at parallelly or sequentially depending on the existing `single` or `multiple` mode) and all other types such as boolean, numbers etc. are ignored.

Supported 
> In the following example, all the repeating characters indicate that they shall be fuzzed, leaving other values intact
```yaml
http:
  - raw:
      - |
        POST /?x=abc&y=def HTTP/1.1
        Host: {{Hostname}}
        Origin: http://example.com
        X-Forwared-For: 1337
        Content-Type: application/json
        Cookie: z=pqr; bb=pqr
        User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko)
        Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8
        Accept-Language: en-US,en;q=0.9
        Connection: close

        {"key1":"ddd","key2":true,"key3":[1,"222"],"key4":{"key5":"aaa","key6":{"key7":["bbb", "ccc"]}}} 
```

GraphQL bodies
---
Requests with `Content-Type: application/graphql` is not supported in this PR. Only requests with path `/graphql`,  `Content-Type: application/json` and request body having referenced variables i.e. `.variables` are supported in this PR.

Supported
> In the following example, all the repeating characters indicate that they shall be fuzzed, leaving other values intact
```yaml
http:
  - raw:
      - |
        POST /graphql/ HTTP/1.1
        Host: {{Hostname}}
        Content-Type: application/json
        Content-Length: 149

        {
          "query": "mutation SetMessage($msg: String!, $name: String!) { setMessage(message: $msg, name: $name) }",
          "variables": {
              "msg": "aaa",
              "name": "bbb"
          }
        }
```

Not-yet supported
```yaml
http:
  - raw:
      - |
        POST /graphql/ HTTP/1.1
        Host: {{Hostname}}
        Content-Type: application/json
        Content-Length: 149

        { "query": "mutation { setMessage(message: \"Hey\", name: \"Nikoo\") }" }
```



## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)