### PR TITLE
flow: flatten dynamic values array if len is 1

### DIFF
--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -134,6 +134,7 @@ func main() {
 	go func() {
 		for range c {
 			gologger.Info().Msgf("CTRL+C pressed: Exiting\n")
+			gologger.Info().Msgf("Attempting graceful shutdown...")
 			nucleiRunner.Close()
 			if options.ShouldSaveResume() {
 				gologger.Info().Msgf("Creating resume file: %s\n", resumeFileName)

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -328,7 +328,6 @@ func (r *Runner) runStandardEnumeration(executerOpts protocols.ExecutorOptions, 
 
 // Close releases all the resources and cleans up
 func (r *Runner) Close() {
-	gologger.Info().Msgf("Attempting graceful shutdown...")
 	if r.output != nil {
 		r.output.Close()
 	}

--- a/pkg/tmplexec/flow/flow_internal.go
+++ b/pkg/tmplexec/flow/flow_internal.go
@@ -98,7 +98,13 @@ func (f *FlowExecutor) protocolResultCallback(req protocols.Request, matcherStat
 				}
 				if len(result.OperatorsResult.DynamicValues) > 0 {
 					for k, v := range result.OperatorsResult.DynamicValues {
-						f.options.GetTemplateCtx(f.ctx.Input.MetaInput).Set(k, v)
+						// if length of v is 1 then remove slice and convert it to single value
+						if len(v) == 1 {
+							f.options.GetTemplateCtx(f.ctx.Input.MetaInput).Set(k, v[0])
+						} else {
+							// if not let user handle it in flow ex: `for(let val of template.extracted)`
+							f.options.GetTemplateCtx(f.ctx.Input.MetaInput).Set(k, v)
+						}
 					}
 				}
 			} else if !result.HasOperatorResult() && !hasOperators(req.GetCompiledOperators()) {


### PR DESCRIPTION
### Proposed Changes

- If only 1 value was extracted then flatten the array instead of keeping it as array . This was already implemented in multiprotocol and multi-request but was missing in `flow` templates
- attempt to save reporiting data (json exporters etc) when closing with `CTRL + C`
- closes #4547
- closes #4607 

### example template
```yaml
id: extracted_value

info:
  name: Extracted value does not work in flow
  author: pascal-sun
  severity: info

flow: http(1) && http(2)

http:
  - method: GET
    path:
      - "{{BaseURL}}"
      - "{{BaseURL}}/{{test}}"

    extractors: 
      - type: regex
        name: test
        group: 1
        regex:
          - 'This (domain) is for use in illustrative examples in documents.'
        internal: true

    matchers:
      - type: status
        internal: true
        status:
          - 200
 
  - method: GET
    path:
      - "https://example.org/{{test}}"
    matchers:
      - type: status
        status:
          - 404
```

### Nuclei Run
```console
$ ./nuclei -t a.yaml -u https://example.com

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.1.5

		projectdiscovery.io

[INF] Current nuclei version: v3.1.5 (latest)
[INF] Current nuclei-templates version: v9.7.2 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 61
[INF] Templates loaded for current scan: 1
[WRN] Executing 1 unsigned templates. Use with caution.
[INF] Targets loaded for current scan: 1
[extracted_value] [http] [info] https://example.org/domain
```