### PR TITLE
one-to-one corresponding requests and responses

### DIFF
--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -110,6 +110,11 @@ func (iwe *InternalWrappedEvent) SetOperatorResult(operatorResult *operators.Res
 	iwe.OperatorsResult = operatorResult
 }
 
+type RequestResponsePair struct {
+	Request string
+	Response string
+}
+
 // ResultEvent is a wrapped result event for a single nuclei output.
 type ResultEvent struct {
 	// Template is the relative filename for the template
@@ -149,6 +154,8 @@ type ResultEvent struct {
 	Request string `json:"request,omitempty"`
 	// Response is the optional, dumped response for the match.
 	Response string `json:"response,omitempty"`
+	// Packet is the optional, dumped requests and responses for the match. The request and response are one-to-one.
+	Packet map[int]RequestResponsePair `json:"packet,omitempty"`
 	// Metadata contains any optional metadata for the event
 	Metadata map[string]interface{} `json:"meta,omitempty"`
 	// IP is the IP address for the found result event.

--- a/pkg/protocols/http/operators.go
+++ b/pkg/protocols/http/operators.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"fmt"
 	"net/http"
 	"strings"
 	"time"
@@ -157,6 +158,24 @@ func (request *Request) MakeResultEventItem(wrapped *output.InternalWrappedEvent
 	if types.ToString(wrapped.InternalEvent["path"]) != "" {
 		fields.Path = types.ToString(wrapped.InternalEvent["path"])
 	}
+	Packet := make(map[int]output.RequestResponsePair)
+	index := 1
+	for true{
+		d := output.RequestResponsePair{}
+		reqT,reqOK := wrapped.InternalEvent[fmt.Sprintf("request_%v",index)]
+		rspT,rspOK := wrapped.InternalEvent[fmt.Sprintf("response_%v",index)]
+		if !reqOK && !rspOK{
+			break
+		}
+		if reqOK{
+			d.Request = types.ToString(reqT)
+		}
+		if rspOK{
+			d.Response = types.ToString(rspT)
+		}
+		Packet[index] = d
+		index++
+	}
 	data := &output.ResultEvent{
 		TemplateID:       types.ToString(wrapped.InternalEvent["template-id"]),
 		TemplatePath:     types.ToString(wrapped.InternalEvent["template-path"]),
@@ -178,6 +197,7 @@ func (request *Request) MakeResultEventItem(wrapped *output.InternalWrappedEvent
 		CURLCommand:      types.ToString(wrapped.InternalEvent["curl-command"]),
 		TemplateEncoded:  request.options.EncodeTemplate(),
 		Error:            types.ToString(wrapped.InternalEvent["error"]),
+		Packet: 		  Packet,
 	}
 	return data
 }


### PR DESCRIPTION
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->

When looking at the out.ResultEvent structure of nuclei, I found that this structure does not correctly express multiple requests and responses and one-to-one correspondence. This will cause nuclei to output only the last matching response in the case of using a multi-request template, and it is very inconvenient to get the first few packets after scanning. I have improved this problem so that nuclei can correctly output all one-to-one matching request and response packages.
![图片](https://github.com/projectdiscovery/nuclei/assets/100852628/82dd837a-821b-443d-82d1-beaa94699dc4)

test.yaml
```
id: test

info:
  name: test
  author: SleepingBag945
  severity: critical


http:
  - raw:
    - |
      GET / HTTP/1.1
      Host: {{Hostname}}
    - |
      GET /1/ HTTP/1.1
      Host: {{Hostname}}

    matchers:
      - type: dsl
        condition: and
        dsl:
          - 'status_code_1==200'
          - status_code_2==404
```
target:
python3 -m http.server
http://127.0.0.1:8000

```
./nuclei -t test.yaml -u http://127.0.0.1:8000 -j -duc

[INF] Current nuclei version: v3.1.5 (outdated)
[INF] Current nuclei-templates version: v9.7.2 (outdated)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 46
[INF] Templates loaded for current scan: 1
[WRN] Executing 1 unsigned templates. Use with caution.
[INF] Targets loaded for current scan: 1
{"template-id":"test","template-path":"/Users/coco/Desktop/nuclei_workflow/test.yaml","template-encoded":"aWQ6IHRlc3QNCg0KaW5mbzoNCiAgbmFtZTogdGVzdA0KICBhdXRob3I6IFNsZWVwaW5nQmFnOTQ1DQogIHNldmVyaXR5OiBjcml0aWNhbA0KDQoNCmh0dHA6DQogIC0gcmF3Og0KICAgIC0gfA0KICAgICAgR0VUIC8gSFRUUC8xLjENCiAgICAgIEhvc3Q6IHt7SG9zdG5hbWV9fQ0KICAgIC0gfA0KICAgICAgR0VUIC8xLyBIVFRQLzEuMQ0KICAgICAgSG9zdDoge3tIb3N0bmFtZX19DQoNCiAgICBtYXRjaGVyczoNCiAgICAgIC0gdHlwZTogZHNsDQogICAgICAgIGNvbmRpdGlvbjogYW5kDQogICAgICAgIGRzbDoNCiAgICAgICAgICAtICdzdGF0dXNfY29kZV8xPT0yMDAnDQogICAgICAgICAgLSBzdGF0dXNfY29kZV8yPT00MDQ=","info":{"name":"test","author":["sleepingbag945"],"tags":null,"severity":"critical"},"type":"http","host":"127.0.0.1:8000","port":"8000","scheme":"http","url":"http://127.0.0.1:8000","matched-at":"http://127.0.0.1:8000/1/","request":"GET /1/ HTTP/1.1\r\nHost: 127.0.0.1:8000\r\nUser-Agent: Mozilla/5.0 (X11; Ubuntu; Linux i686 on x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2820.59 Safari/537.36\r\nConnection: close\r\nAccept-Encoding: gzip\r\n\r\n","response":"HTTP/1.0 404 File not found\r\nContent-Length: 335\r\nConnection: close\r\nContent-Type: text/html;charset=utf-8\r\nDate: Mon, 15 Jan 2024 03:03:56 GMT\r\nServer: SimpleHTTP/0.6 Python/3.11.1\r\n\r\n\u003c!DOCTYPE HTML\u003e\n\u003chtml lang=\"en\"\u003e\n    \u003chead\u003e\n        \u003cmeta charset=\"utf-8\"\u003e\n        \u003ctitle\u003eError response\u003c/title\u003e\n    \u003c/head\u003e\n    \u003cbody\u003e\n        \u003ch1\u003eError response\u003c/h1\u003e\n        \u003cp\u003eError code: 404\u003c/p\u003e\n        \u003cp\u003eMessage: File not found.\u003c/p\u003e\n        \u003cp\u003eError code explanation: 404 - Nothing matches the given URI.\u003c/p\u003e\n    \u003c/body\u003e\n\u003c/html\u003e\n","packet":{"1":{"Request":"GET / HTTP/1.1\r\nHost: 127.0.0.1:8000\r\nUser-Agent: Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1866.237 Safari/537.36\r\nConnection: close\r\nAccept-Encoding: gzip\r\n\r\n","Response":"HTTP/1.0 200 OK\r\nConnection: close\r\nContent-Length: 324\r\nContent-Type: text/html; charset=utf-8\r\nDate: Mon, 15 Jan 2024 03:03:56 GMT\r\nServer: SimpleHTTP/0.6 Python/3.11.1\r\n\r\n\u003c!DOCTYPE HTML\u003e\n\u003chtml lang=\"en\"\u003e\n\u003chead\u003e\n\u003cmeta charset=\"utf-8\"\u003e\n\u003ctitle\u003eDirectory listing for /\u003c/title\u003e\n\u003c/head\u003e\n\u003cbody\u003e\n\u003ch1\u003eDirectory listing for /\u003c/h1\u003e\n\u003chr\u003e\n\u003cul\u003e\n\u003cli\u003e\u003ca href=\".DS_Store\"\u003e.DS_Store\u003c/a\u003e\u003c/li\u003e\n\u003cli\u003e\u003ca href=\"config.zip\"\u003econfig.zip\u003c/a\u003e\u003c/li\u003e\n\u003cli\u003e\u003ca href=\"dddd_linux64\"\u003edddd_linux64\u003c/a\u003e\u003c/li\u003e\n\u003c/ul\u003e\n\u003chr\u003e\n\u003c/body\u003e\n\u003c/html\u003e\n"},"2":{"Request":"GET /1/ HTTP/1.1\r\nHost: 127.0.0.1:8000\r\nUser-Agent: Mozilla/5.0 (X11; Ubuntu; Linux i686 on x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2820.59 Safari/537.36\r\nConnection: close\r\nAccept-Encoding: gzip\r\n\r\n","Response":"HTTP/1.0 404 File not found\r\nContent-Length: 335\r\nConnection: close\r\nContent-Type: text/html;charset=utf-8\r\nDate: Mon, 15 Jan 2024 03:03:56 GMT\r\nServer: SimpleHTTP/0.6 Python/3.11.1\r\n\r\n\u003c!DOCTYPE HTML\u003e\n\u003chtml lang=\"en\"\u003e\n    \u003chead\u003e\n        \u003cmeta charset=\"utf-8\"\u003e\n        \u003ctitle\u003eError response\u003c/title\u003e\n    \u003c/head\u003e\n    \u003cbody\u003e\n        \u003ch1\u003eError response\u003c/h1\u003e\n        \u003cp\u003eError code: 404\u003c/p\u003e\n        \u003cp\u003eMessage: File not found.\u003c/p\u003e\n        \u003cp\u003eError code explanation: 404 - Nothing matches the given URI.\u003c/p\u003e\n    \u003c/body\u003e\n\u003c/html\u003e\n"}},"ip":"127.0.0.1","timestamp":"2024-01-15T04:03:56.091429+01:00","curl-command":"curl -X 'GET' -d '' -H 'Host: 127.0.0.1:8000' -H 'User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux i686 on x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2820.59 Safari/537.36' 'http://127.0.0.1:8000/1/'","matcher-status":true}
```


## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)