### PR TITLE
misc improvements in js protocol execution

### DIFF
--- a/pkg/js/compiler/compiler.go
+++ b/pkg/js/compiler/compiler.go
@@ -157,7 +157,7 @@ func (c *Compiler) ExecuteWithOptions(code string, args *ExecuteArgs, opts *Exec
 	args.TemplateCtx = generators.MergeMaps(args.TemplateCtx, args.Args)
 	_ = runtime.Set("template", args.TemplateCtx)
 
-	if opts.Timeout == 0 || opts.Timeout > 180 {
+	if opts.Timeout <= 0 || opts.Timeout > 180 {
 		// some js scripts can take longer time so allow configuring timeout
 		// from template but keep it within sane limits (180s)
 		opts.Timeout = JsProtocolTimeout

--- a/pkg/js/compiler/init.go
+++ b/pkg/js/compiler/init.go
@@ -1,0 +1,20 @@
+package compiler
+
+import "github.com/projectdiscovery/nuclei/v3/pkg/types"
+
+// jsprotocolInit
+
+var (
+	// Per Execution Javascript timeout in seconds
+	JsProtocolTimeout = 10
+)
+
+// Init initializes the javascript protocol
+func Init(opts *types.Options) error {
+	if opts.Timeout < 10 {
+		// keep existing 10s timeout
+		return nil
+	}
+	JsProtocolTimeout = opts.Timeout
+	return nil
+}

--- a/pkg/js/libs/smb/smb.go
+++ b/pkg/js/libs/smb/smb.go
@@ -3,7 +3,6 @@ package smb
 import (
 	"context"
 	"fmt"
-	"net"
 	"time"
 
 	"github.com/hirochachacha/go-smb2"
@@ -24,26 +23,30 @@ type SMBClient struct{}
 // Returns handshake log and error. If error is not nil,
 // state will be false
 func (c *SMBClient) ConnectSMBInfoMode(host string, port int) (*smb.SMBLog, error) {
+	if !protocolstate.IsHostAllowed(host) {
+		// host is not valid according to network policy
+		return nil, protocolstate.ErrHostDenied.Msgf(host)
+	}
 	conn, err := protocolstate.Dialer.Dial(context.TODO(), "tcp", fmt.Sprintf("%s:%d", host, port))
 	if err != nil {
 		return nil, err
 	}
-	defer conn.Close()
+	// try to get SMBv2/v3 info
+	result, err := c.getSMBInfo(conn, true, false)
+	_ = conn.Close() // close regardless of error
+	if err == nil {
+		return result, nil
+	}
 
-	_ = conn.SetDeadline(time.Now().Add(10 * time.Second))
-	setupSession := true
-
-	result, err := smb.GetSMBLog(conn, setupSession, false, false)
+	// try to negotiate SMBv1
+	conn, err = protocolstate.Dialer.Dial(context.TODO(), "tcp", fmt.Sprintf("%s:%d", host, port))
 	if err != nil {
-		conn.Close()
-		conn, err = net.DialTimeout("tcp", fmt.Sprintf("%s:%d", host, port), 10*time.Second)
-		if err != nil {
-			return nil, err
-		}
-		result, err = smb.GetSMBLog(conn, setupSession, true, false)
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
+	}
+	defer conn.Close()
+	result, err = c.getSMBInfo(conn, true, true)
+	if err != nil {
+		return result, nil
 	}
 	return result, nil
 }
@@ -67,6 +70,10 @@ func (c *SMBClient) ListSMBv2Metadata(host string, port int) (*plugins.ServiceSM
 // Credentials cannot be blank. guest or anonymous credentials
 // can be used by providing empty password.
 func (c *SMBClient) ListShares(host string, port int, user, password string) ([]string, error) {
+	if !protocolstate.IsHostAllowed(host) {
+		// host is not valid according to network policy
+		return nil, protocolstate.ErrHostDenied.Msgf(host)
+	}
 	conn, err := protocolstate.Dialer.Dial(context.TODO(), "tcp", fmt.Sprintf("%s:%d", host, port))
 	if err != nil {
 		return nil, err

--- a/pkg/js/libs/smb/smb_private.go
+++ b/pkg/js/libs/smb/smb_private.go
@@ -9,7 +9,10 @@ import (
 	"github.com/praetorian-inc/fingerprintx/pkg/plugins"
 	"github.com/praetorian-inc/fingerprintx/pkg/plugins/services/smb"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
+	zgrabsmb "github.com/zmap/zgrab2/lib/smb/smb"
 )
+
+// ==== private helper functions/methods ====
 
 // collectSMBv2Metadata collects metadata for SMBv2 services.
 func collectSMBv2Metadata(host string, port int, timeout time.Duration) (*plugins.ServiceSMB, error) {
@@ -27,4 +30,16 @@ func collectSMBv2Metadata(host string, port int, timeout time.Duration) (*plugin
 		return nil, err
 	}
 	return metadata, nil
+}
+
+// getSMBInfo
+func (c *SMBClient) getSMBInfo(conn net.Conn, setupSession, v1 bool) (*zgrabsmb.SMBLog, error) {
+	_ = conn.SetDeadline(time.Now().Add(10 * time.Second))
+	defer conn.SetDeadline(time.Time{})
+
+	result, err := zgrabsmb.GetSMBLog(conn, setupSession, v1, false)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
 }

--- a/pkg/js/libs/smb/smb_private.go
+++ b/pkg/js/libs/smb/smb_private.go
@@ -35,7 +35,9 @@ func collectSMBv2Metadata(host string, port int, timeout time.Duration) (*plugin
 // getSMBInfo
 func (c *SMBClient) getSMBInfo(conn net.Conn, setupSession, v1 bool) (*zgrabsmb.SMBLog, error) {
 	_ = conn.SetDeadline(time.Now().Add(10 * time.Second))
-	defer conn.SetDeadline(time.Time{})
+	defer func() {
+		_ = conn.SetDeadline(time.Time{})
+	}()
 
 	result, err := zgrabsmb.GetSMBLog(conn, setupSession, v1, false)
 	if err != nil {

--- a/pkg/js/libs/smb/smbghost.go
+++ b/pkg/js/libs/smb/smbghost.go
@@ -20,6 +20,10 @@ const (
 // DetectSMBGhost tries to detect SMBGhost vulnerability
 // by using SMBv3 compression feature.
 func (c *SMBClient) DetectSMBGhost(host string, port int) (bool, error) {
+	if !protocolstate.IsHostAllowed(host) {
+		// host is not valid according to network policy
+		return false, protocolstate.ErrHostDenied.Msgf(host)
+	}
 	addr := net.JoinHostPort(host, strconv.Itoa(port))
 	conn, err := protocolstate.Dialer.Dial(context.TODO(), "tcp", addr)
 	if err != nil {

--- a/pkg/protocols/code/code.go
+++ b/pkg/protocols/code/code.go
@@ -1,6 +1,7 @@
 package code
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"regexp"
@@ -26,11 +27,13 @@ import (
 	protocolutils "github.com/projectdiscovery/nuclei/v3/pkg/protocols/utils"
 	templateTypes "github.com/projectdiscovery/nuclei/v3/pkg/templates/types"
 	"github.com/projectdiscovery/nuclei/v3/pkg/types"
+	contextutil "github.com/projectdiscovery/utils/context"
 	errorutil "github.com/projectdiscovery/utils/errors"
 )
 
 const (
-	pythonEnvRegex = `os\.getenv\(['"]([^'"]+)['"]\)`
+	pythonEnvRegex    = `os\.getenv\(['"]([^'"]+)['"]\)`
+	TimeoutMultiplier = 6 // timeout multiplier for code protocol
 )
 
 var (
@@ -121,12 +124,17 @@ func (request *Request) GetID() string {
 }
 
 // ExecuteWithResults executes the protocol requests and returns results instead of writing them.
-func (request *Request) ExecuteWithResults(input *contextargs.Context, dynamicValues, previous output.InternalEvent, callback protocols.OutputEventCallback) error {
+func (request *Request) ExecuteWithResults(input *contextargs.Context, dynamicValues, previous output.InternalEvent, callback protocols.OutputEventCallback) (err error) {
 	metaSrc, err := gozero.NewSourceWithString(input.MetaInput.Input, "")
 	if err != nil {
 		return err
 	}
 	defer func() {
+		// catch any panics just in case
+		if r := recover(); r != nil {
+			gologger.Error().Msgf("[%s] Panic occurred in code protocol: %s\n", request.options.TemplateID, r)
+			err = fmt.Errorf("panic occurred: %s", r)
+		}
 		if err := metaSrc.Cleanup(); err != nil {
 			gologger.Warning().Msgf("%s\n", err)
 		}
@@ -150,9 +158,24 @@ func (request *Request) ExecuteWithResults(input *contextargs.Context, dynamicVa
 		allvars[name] = v
 		metaSrc.AddVariable(gozerotypes.Variable{Name: name, Value: v})
 	}
-	gOutput, err := request.gozero.Eval(context.Background(), request.src, metaSrc)
-	if err != nil && gOutput == nil {
-		return errorutil.NewWithErr(err).Msgf("[%s] Could not execute code on local machine %v", request.options.TemplateID, input.MetaInput.Input)
+	timeout := TimeoutMultiplier * request.options.Options.Timeout
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
+	defer cancel()
+	// Note: we use contextutil despite the fact that gozero accepts context as argument
+	gOutput, err := contextutil.ExecFuncWithTwoReturns(ctx, func() (*gozerotypes.Result, error) {
+		return request.gozero.Eval(ctx, request.src, metaSrc)
+	})
+	if gOutput == nil {
+		// write error to stderr buff
+		var buff bytes.Buffer
+		if err != nil {
+			buff.WriteString(err.Error())
+		} else {
+			buff.WriteString("no output something went wrong")
+		}
+		gOutput = &gozerotypes.Result{
+			Stderr: buff,
+		}
 	}
 	gologger.Verbose().Msgf("[%s] Executed code on local machine %v", request.options.TemplateID, input.MetaInput.Input)
 

--- a/pkg/protocols/common/protocolinit/init.go
+++ b/pkg/protocols/common/protocolinit/init.go
@@ -3,6 +3,7 @@ package protocolinit
 import (
 	"github.com/corpix/uarand"
 
+	"github.com/projectdiscovery/nuclei/v3/pkg/js/compiler"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/dns/dnsclientpool"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/http/httpclientpool"
@@ -32,6 +33,9 @@ func Init(options *types.Options) error {
 		return err
 	}
 	if err := rdapclientpool.Init(options); err != nil {
+		return err
+	}
+	if err := compiler.Init(options); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
### Proposed Changes

- fix infinite hang on smbInfo ( retry with smbv1) (ref: https://github.com/projectdiscovery/aurora/issues/508)
- Global Javascript protocol script execution control using `-timeout` flag
- Custom timeout field in javascript protocol (allowed with sane limits 10 < timeout < 180s)
- default timeout of 6 * `-timeout` in code protocol
```console
$  ./nuclei -t a.yaml -v -svd -timeout 2 -code      

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.1.5

		projectdiscovery.io

[VER] Started metrics server at localhost:9092
[INF] Current nuclei version: v3.1.5 (latest)
[INF] Current nuclei-templates version: v9.7.3 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 46
[INF] Templates loaded for current scan: 1
[INF] Executing 1 signed templates from tarun
[VER] [py-code-snippet] Executed code on local machine 
[DBG] Code Protocol request variables: 
	1. Hostname => 
	2. Input => 

[DBG] Code Protocol response variables: 
	1. input => 
	2. interactsh-server => 
	3. response => 
	4. stderr => context deadline exceeded
	5. template-id => py-code-snippet
	6. template-info => {py-code-snippet pdteam c .... nil> {info} map[] <nil> }
	7. template-path => /Users/tarun/Codebase/nuclei/a.yaml
	8. type => code

[py-code-snippet:error] [code] [info]  ["context deadline exceeded"]

```