### PR TITLE
pdcp env fix: make PDCP_API_SERVER env optional

### DIFF
--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/projectdiscovery/utils/auth/pdcp"
 	_ "github.com/projectdiscovery/utils/pprof"
 
 	"github.com/projectdiscovery/goflags"
@@ -507,6 +508,7 @@ func printVersion() {
 	gologger.Info().Msgf("Nuclei Engine Version: %s", config.Version)
 	gologger.Info().Msgf("Nuclei Config Directory: %s", config.DefaultConfig.GetConfigDir())
 	gologger.Info().Msgf("Nuclei Cache Directory: %s", config.DefaultConfig.GetCacheDir()) // cache dir contains resume files
+	gologger.Info().Msgf("PDCP Directory: %s", pdcp.PDCPDir)
 	os.Exit(0)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -90,7 +90,7 @@ require (
 	github.com/projectdiscovery/sarif v0.0.1
 	github.com/projectdiscovery/tlsx v1.1.6-0.20231116215000-e842dc367a74
 	github.com/projectdiscovery/uncover v1.0.7
-	github.com/projectdiscovery/utils v0.0.75-0.20240122181331-b80b80760cc1
+	github.com/projectdiscovery/utils v0.0.75
 	github.com/projectdiscovery/wappalyzergo v0.0.109
 	github.com/redis/go-redis/v9 v9.1.0
 	github.com/ropnop/gokrb5/v8 v8.0.0-20201111231119-729746023c02

--- a/go.mod
+++ b/go.mod
@@ -90,7 +90,7 @@ require (
 	github.com/projectdiscovery/sarif v0.0.1
 	github.com/projectdiscovery/tlsx v1.1.6-0.20231116215000-e842dc367a74
 	github.com/projectdiscovery/uncover v1.0.7
-	github.com/projectdiscovery/utils v0.0.74-0.20240115220656-48fef326de18
+	github.com/projectdiscovery/utils v0.0.75-0.20240122181331-b80b80760cc1
 	github.com/projectdiscovery/wappalyzergo v0.0.109
 	github.com/redis/go-redis/v9 v9.1.0
 	github.com/ropnop/gokrb5/v8 v8.0.0-20201111231119-729746023c02

--- a/go.sum
+++ b/go.sum
@@ -849,8 +849,8 @@ github.com/projectdiscovery/tlsx v1.1.6-0.20231116215000-e842dc367a74 h1:G0gw+3z
 github.com/projectdiscovery/tlsx v1.1.6-0.20231116215000-e842dc367a74/go.mod h1:YH8el7/6pyZbNed1IibjzbGpeigiCVyvE28g5+LsPAw=
 github.com/projectdiscovery/uncover v1.0.7 h1:ut+2lTuvmftmveqF5RTjMWAgyLj8ltPQC7siFy9sj0A=
 github.com/projectdiscovery/uncover v1.0.7/go.mod h1:HFXgm1sRPuoN0D4oATljPIdmbo/EEh1wVuxQqo/dwFE=
-github.com/projectdiscovery/utils v0.0.75-0.20240122181331-b80b80760cc1 h1:FROuSy7/e1jxslD0etPG9gLLFXHq/WLiYxhXkkckNfA=
-github.com/projectdiscovery/utils v0.0.75-0.20240122181331-b80b80760cc1/go.mod h1:4MBUFfZ9Mm96PiWUj2zJ99sx2AVOpZkGukC6O16+p+o=
+github.com/projectdiscovery/utils v0.0.75 h1:VroGyPBTyFARP7HYa2lbmZvt40/bCaXu1q+NIhkKEmk=
+github.com/projectdiscovery/utils v0.0.75/go.mod h1:4MBUFfZ9Mm96PiWUj2zJ99sx2AVOpZkGukC6O16+p+o=
 github.com/projectdiscovery/wappalyzergo v0.0.109 h1:BERfwTRn1dvB1tbhyc5m67R8VkC9zbVuPsEq4VEm07k=
 github.com/projectdiscovery/wappalyzergo v0.0.109/go.mod h1:4Z3DKhi75zIPMuA+qSDDWxZvnhL4qTLmDx4dxNMu7MA=
 github.com/projectdiscovery/yamldoc-go v1.0.4 h1:eZoESapnMw6WAHiVgRwNqvbJEfNHEH148uthhFbG5jE=

--- a/go.sum
+++ b/go.sum
@@ -849,8 +849,8 @@ github.com/projectdiscovery/tlsx v1.1.6-0.20231116215000-e842dc367a74 h1:G0gw+3z
 github.com/projectdiscovery/tlsx v1.1.6-0.20231116215000-e842dc367a74/go.mod h1:YH8el7/6pyZbNed1IibjzbGpeigiCVyvE28g5+LsPAw=
 github.com/projectdiscovery/uncover v1.0.7 h1:ut+2lTuvmftmveqF5RTjMWAgyLj8ltPQC7siFy9sj0A=
 github.com/projectdiscovery/uncover v1.0.7/go.mod h1:HFXgm1sRPuoN0D4oATljPIdmbo/EEh1wVuxQqo/dwFE=
-github.com/projectdiscovery/utils v0.0.74-0.20240115220656-48fef326de18 h1:hQHfr0YlGGODVMQrN3c41itC477xdFDy/3hJbOfjPqY=
-github.com/projectdiscovery/utils v0.0.74-0.20240115220656-48fef326de18/go.mod h1:SEb3ZoGy1nxdnPNXAGhMZNhRcokRkoMEjC6l9H59t1s=
+github.com/projectdiscovery/utils v0.0.75-0.20240122181331-b80b80760cc1 h1:FROuSy7/e1jxslD0etPG9gLLFXHq/WLiYxhXkkckNfA=
+github.com/projectdiscovery/utils v0.0.75-0.20240122181331-b80b80760cc1/go.mod h1:4MBUFfZ9Mm96PiWUj2zJ99sx2AVOpZkGukC6O16+p+o=
 github.com/projectdiscovery/wappalyzergo v0.0.109 h1:BERfwTRn1dvB1tbhyc5m67R8VkC9zbVuPsEq4VEm07k=
 github.com/projectdiscovery/wappalyzergo v0.0.109/go.mod h1:4Z3DKhi75zIPMuA+qSDDWxZvnhL4qTLmDx4dxNMu7MA=
 github.com/projectdiscovery/yamldoc-go v1.0.4 h1:eZoESapnMw6WAHiVgRwNqvbJEfNHEH148uthhFbG5jE=


### PR DESCRIPTION
- bump utils
- add pdcp directory to -version
- PDCP_API_SERVER env was not marked as optional hence when setting api key from env . it was warning user that api key was not found
```console
$ export PDCP_API_KEY=30d50a66-safsdf-asfds-asdfa
$ nuclei -cloud-upload

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.1.6

		projectdiscovery.io

[INF] Current nuclei version: v3.1.6 (latest)
[INF] Current nuclei-templates version: v9.7.4 (latest)
[WRN] To view results on Cloud Dashboard, Configure API key from https://cloud.projectdiscovery.io
[INF] New templates added in latest release: 6
[INF] Templates loaded for current scan: 7432
[INF] Executing 7454 signed templates from projectdiscovery/nuclei-templates

```
this is now fixed by making PDCP_API_SERVER env as optional

```console
$ export PDCP_API_KEY=30d50a66-safsdf-asfds-asdfa
$ ./nuclei -cloud-upload

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.1.7-dev

		projectdiscovery.io

[INF] Current nuclei version: v3.1.7-dev (development)
[INF] Current nuclei-templates version: v9.7.4 (latest)
[INF] To view results on cloud dashboard, visit https://cloud.projectdiscovery.io/scans upon scan completion.
[INF] New templates added in latest release: 6
[INF] Templates loaded for current scan: 7432
[INF] Executing 7454 signed templates from projectdiscovery/nuclei-templates
```
- for more readability / ease we now print pdcp config directory with `-version flag`
```console
$ ./nuclei -version
[INF] Nuclei Engine Version: v3.1.7-dev
[INF] Nuclei Config Directory: /Users/tarun/Library/Application Support/nuclei
[INF] Nuclei Cache Directory: /Users/tarun/Library/Caches/nuclei
[INF] PDCP Directory: /Users/tarun/.pdcp
```