### PR TITLE
mysql: ignore warning log + misc updates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -68,7 +68,7 @@ require (
 	github.com/go-git/go-git/v5 v5.11.0
 	github.com/go-ldap/ldap/v3 v3.4.5
 	github.com/go-pg/pg v8.0.7+incompatible
-	github.com/go-sql-driver/mysql v1.6.0
+	github.com/go-sql-driver/mysql v1.7.1
 	github.com/h2non/filetype v1.1.3
 	github.com/labstack/echo/v4 v4.10.2
 	github.com/lib/pq v1.10.1

--- a/go.sum
+++ b/go.sum
@@ -379,8 +379,8 @@ github.com/go-rod/rod v0.114.0/go.mod h1:aiedSEFg5DwG/fnNbUOTPMTTWX3MRj6vIs/a684
 github.com/go-sourcemap/sourcemap v2.1.3+incompatible h1:W1iEw64niKVGogNgBN3ePyLFfuisuzeidWPMPWmECqU=
 github.com/go-sourcemap/sourcemap v2.1.3+incompatible/go.mod h1:F8jJfvm2KbVjc5NqelyYJmf/v5J0dwNLS2mL4sNA1Jg=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
-github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
-github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
+github.com/go-sql-driver/mysql v1.7.1 h1:lUIinVbN1DY0xBg0eMOzmmtGoHwWBbvnWubQUrtU8EI=
+github.com/go-sql-driver/mysql v1.7.1/go.mod h1:OXbVy3sEdcQ2Doequ6Z5BW6fXNQTmx+9S1MCJN5yJMI=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572/go.mod h1:9Pwr4B2jHnOSGXyyzV8ROjYa2ojvAY6HCGYYfMoC3Ls=

--- a/pkg/protocols/common/protocolstate/state.go
+++ b/pkg/protocols/common/protocolstate/state.go
@@ -1,10 +1,12 @@
 package protocolstate
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/url"
 
+	"github.com/go-sql-driver/mysql"
 	"github.com/pkg/errors"
 	"golang.org/x/net/proxy"
 
@@ -133,6 +135,12 @@ func Init(options *types.Options) error {
 		return errors.Wrap(err, "could not create dialer")
 	}
 	Dialer = dialer
+
+	// override dialer in mysql
+	mysql.RegisterDialContext("tcp", func(ctx context.Context, addr string) (net.Conn, error) {
+		return Dialer.Dial(ctx, "tcp", addr)
+	})
+
 	return nil
 }
 


### PR DESCRIPTION
### Proposed Changes

- ignore invalid connection error `[mysql] 2024/01/30 14:28:51 packets.go:37: unexpected EOF`
- added new method to specify custom dsn `.ConnectWithDSN()` to connect with advanced options like ssl , oldpasswords mode etc
- donot reuse connections
- use fastdialer internally


```console
$  uncover -q 'port:3306 && MySQL: country:"IN"' -l 500 | ./nuclei -t ./a.yaml -vv -stats

  __  ______  _________ _   _____  _____
 / / / / __ \/ ___/ __ \ | / / _ \/ ___/
/ /_/ / / / / /__/ /_/ / |/ /  __/ /    
\__,_/_/ /_/\___/\____/|___/\___/_/

		projectdiscovery.io


                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.1.7

		projectdiscovery.io

[INF] Current uncover version v1.0.7 (latest)
[INF] Supplied input was automatically deduplicated (600 removed).
[INF] Current nuclei version: v3.1.7 (latest)
[INF] Current nuclei-templates version: v9.7.5 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 106
[INF] Templates loaded for current scan: 1
[WRN] Executing 1 unsigned templates. Use with caution.
[INF] Targets loaded for current scan: 600
[mysql-default-logins] MySQL - Default Logins (@dhiyaneshdk,@pussycat0x,@ritikchaddha) [high]
[0:00:05] | Templates: 1 | Hosts: 600 | RPS: 37 | Matched: 0 | Errors: 0 | Requests: 188/1200 (15%)
[mysql-default-logins] [javascript] [high]  xx.yy.zz.ww:3306 [passwords="root",usernames="root"]
[0:00:10] | Templates: 1 | Hosts: 600 | RPS: 30 | Matched: 2 | Errors: 0 | Requests: 308/1200 (25%)
[mysql-default-logins] [javascript] [high] xx.yy.zz.ww:3306 [passwords="root",usernames="root"]
[mysql-default-logins] [javascript] [high]  xx.yy.zz.ww:3306 [passwords="root",usernames="root"]
[0:00:15] | Templates: 1 | Hosts: 600 | RPS: 30 | Matched: 6 | Errors: 0 | Requests: 455/1200 (37%)
[0:00:20] | Templates: 1 | Hosts: 600 | RPS: 27 | Matched: 6 | Errors: 0 | Requests: 555/1200 (46%)
[0:00:25] | Templates: 1 | Hosts: 600 | RPS: 22 | Matched: 6 | Errors: 0 | Requests: 558/1200 (46%)
[0:00:27] | Templates: 1 | Hosts: 600 | RPS: 20 | Matched: 6 | Errors: 0 | Requests: 558/1200 (46%)
```