### PR TITLE
javascript: pooling and reuse with export functions + misc updates

### DIFF
--- a/cmd/integration-test/interactsh.go
+++ b/cmd/integration-test/interactsh.go
@@ -1,8 +1,10 @@
 package main
 
+import osutils "github.com/projectdiscovery/utils/os"
+
 // All Interactsh related testcases
 var interactshTestCases = []TestCaseInfo{
-	{Path: "protocols/http/interactsh.yaml", TestCase: &httpInteractshRequest{}, DisableOn: func() bool { return false }},
+	{Path: "protocols/http/interactsh.yaml", TestCase: &httpInteractshRequest{}, DisableOn: func() bool { return osutils.IsWindows() || osutils.IsOSX() }},
 	{Path: "protocols/http/interactsh-stop-at-first-match.yaml", TestCase: &httpInteractshStopAtFirstMatchRequest{}, DisableOn: func() bool { return true }}, // disable this test for now
 	{Path: "protocols/http/default-matcher-condition.yaml", TestCase: &httpDefaultMatcherCondition{}, DisableOn: func() bool { return true }},
 	{Path: "protocols/http/interactsh-requests-mc-and.yaml", TestCase: &httpInteractshRequestsWithMCAnd{}},

--- a/cmd/integration-test/interactsh.go
+++ b/cmd/integration-test/interactsh.go
@@ -3,7 +3,7 @@ package main
 // All Interactsh related testcases
 var interactshTestCases = []TestCaseInfo{
 	{Path: "protocols/http/interactsh.yaml", TestCase: &httpInteractshRequest{}, DisableOn: func() bool { return false }},
-	{Path: "protocols/http/interactsh-stop-at-first-match.yaml", TestCase: &httpInteractshStopAtFirstMatchRequest{}, DisableOn: func() bool { return false }}, // disable this test for now
-	{Path: "protocols/http/default-matcher-condition.yaml", TestCase: &httpDefaultMatcherCondition{}, DisableOn: func() bool { return false }},
+	{Path: "protocols/http/interactsh-stop-at-first-match.yaml", TestCase: &httpInteractshStopAtFirstMatchRequest{}, DisableOn: func() bool { return true }}, // disable this test for now
+	{Path: "protocols/http/default-matcher-condition.yaml", TestCase: &httpDefaultMatcherCondition{}, DisableOn: func() bool { return true }},
 	{Path: "protocols/http/interactsh-requests-mc-and.yaml", TestCase: &httpInteractshRequestsWithMCAnd{}},
 }

--- a/pkg/js/compiler/compiler.go
+++ b/pkg/js/compiler/compiler.go
@@ -114,13 +114,18 @@ func (c *Compiler) ExecuteWithOptions(program *goja.Program, args *ExecuteArgs, 
 				err = fmt.Errorf("panic: %v", r)
 			}
 		}()
-		return executeProgram(program, args, opts)
+		return ExecuteProgram(program, args, opts)
 	})
 	if err != nil {
 		return nil, err
 	}
-	res := ExecuteResult(opts.exports)
-	opts.exports = nil
+	var res ExecuteResult
+	if opts.exports != nil {
+		res = ExecuteResult(opts.exports)
+		opts.exports = nil
+	} else {
+		res = NewExecuteResult()
+	}
 	res["response"] = results.Export()
 	res["success"] = results.ToBoolean()
 	return res, nil

--- a/pkg/js/compiler/compiler.go
+++ b/pkg/js/compiler/compiler.go
@@ -67,7 +67,7 @@ func (e ExecuteResult) GetSuccess() bool {
 
 // Execute executes a script with the default options.
 func (c *Compiler) Execute(code string, args *ExecuteArgs) (ExecuteResult, error) {
-	p, err := goja.Compile("", code, false)
+	p, err := WrapScriptNCompile(code, false)
 	if err != nil {
 		return nil, err
 	}
@@ -114,4 +114,14 @@ func (c *Compiler) ExecuteWithOptions(program *goja.Program, args *ExecuteArgs, 
 		return nil, err
 	}
 	return ExecuteResult{"response": results.Export(), "success": results.ToBoolean()}, nil
+}
+
+// Wraps a script in a function and compiles it.
+func WrapScriptNCompile(script string, strict bool) (*goja.Program, error) {
+	val := fmt.Sprintf(`
+		(function() {
+			%s
+		})()
+	`, script)
+	return goja.Compile("", val, strict)
 }

--- a/pkg/js/compiler/compiler.go
+++ b/pkg/js/compiler/compiler.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/generators"
 	contextutil "github.com/projectdiscovery/utils/context"
+	stringsutil "github.com/projectdiscovery/utils/strings"
 )
 
 // Compiler provides a runtime to execute goja runtime
@@ -33,6 +34,11 @@ type ExecuteOptions struct {
 
 	/// Timeout for this script execution
 	Timeout int
+	// Source is original source of the script
+	Source *string
+
+	// Manually exported objects
+	exports map[string]interface{}
 }
 
 // ExecuteArgs is the arguments to pass to the script.
@@ -113,11 +119,19 @@ func (c *Compiler) ExecuteWithOptions(program *goja.Program, args *ExecuteArgs, 
 	if err != nil {
 		return nil, err
 	}
-	return ExecuteResult{"response": results.Export(), "success": results.ToBoolean()}, nil
+	res := ExecuteResult(opts.exports)
+	opts.exports = nil
+	res["response"] = results.Export()
+	res["success"] = results.ToBoolean()
+	return res, nil
 }
 
 // Wraps a script in a function and compiles it.
 func WrapScriptNCompile(script string, strict bool) (*goja.Program, error) {
+	if !stringsutil.ContainsAny(script, exportAsToken, exportToken) {
+		// this will not be run in a pooled runtime
+		return goja.Compile("", script, strict)
+	}
 	val := fmt.Sprintf(`
 		(function() {
 			%s

--- a/pkg/js/compiler/init.go
+++ b/pkg/js/compiler/init.go
@@ -6,8 +6,9 @@ import "github.com/projectdiscovery/nuclei/v3/pkg/types"
 
 var (
 	// Per Execution Javascript timeout in seconds
-	JsProtocolTimeout = 10
-	JsVmConcurrency   = 500
+	JsProtocolTimeout       = 10
+	PoolingJsVmConcurrency  = 100
+	NonPoolingVMConcurrency = 20
 )
 
 // Init initializes the javascript protocol
@@ -21,6 +22,7 @@ func Init(opts *types.Options) error {
 		opts.JsConcurrency = 100
 	}
 	JsProtocolTimeout = opts.Timeout
-	JsVmConcurrency = opts.JsConcurrency
+	PoolingJsVmConcurrency = opts.JsConcurrency
+	PoolingJsVmConcurrency -= NonPoolingVMConcurrency
 	return nil
 }

--- a/pkg/js/compiler/non-pool.go
+++ b/pkg/js/compiler/non-pool.go
@@ -1,0 +1,23 @@
+package compiler
+
+import (
+	"sync"
+
+	"github.com/dop251/goja"
+	"github.com/remeh/sizedwaitgroup"
+)
+
+var (
+	ephemeraljsc    = sizedwaitgroup.New(NonPoolingVMConcurrency)
+	lazyFixedSgInit = sync.OnceFunc(func() {
+		ephemeraljsc = sizedwaitgroup.New(NonPoolingVMConcurrency)
+	})
+)
+
+func executeWithoutPooling(p *goja.Program, args *ExecuteArgs, opts *ExecuteOptions) (result goja.Value, err error) {
+	lazyFixedSgInit()
+	ephemeraljsc.Add()
+	defer ephemeraljsc.Done()
+	runtime := createNewRuntime()
+	return executeWithRuntime(runtime, p, args, opts)
+}

--- a/pkg/js/libs/mysql/mysql.go
+++ b/pkg/js/libs/mysql/mysql.go
@@ -160,11 +160,10 @@ func (c *MySQLClient) ExecuteQueryWithOpts(opts DSNOptions, query string) (*util
 
 // ExecuteQuery connects to Mysql database using given credentials and database name.
 // and executes a query on the db.
-func (c *MySQLClient) ExecuteQuery(host string, port int, username, password, dbName, query string) (*utils.SQLResult, error) {
+func (c *MySQLClient) ExecuteQuery(host string, port int, username, password, query string) (*utils.SQLResult, error) {
 	return c.ExecuteQueryWithOpts(DSNOptions{
 		Host:     host,
 		Port:     port,
-		DbName:   dbName,
 		Protocol: "tcp",
 		Username: username,
 		Password: password,

--- a/pkg/js/libs/mysql/mysql.go
+++ b/pkg/js/libs/mysql/mysql.go
@@ -57,7 +57,7 @@ func (c *MySQLClient) Connect(host string, port int, username, password string) 
 		// host is not valid according to network policy
 		return false, protocolstate.ErrHostDenied.Msgf(host)
 	}
-	dsn, err := BuildDSN(DSNOptions{
+	dsn, err := BuildDSN(MySQLOptions{
 		Host:     host,
 		Port:     port,
 		DbName:   "INFORMATION_SCHEMA",
@@ -124,7 +124,7 @@ func (c *MySQLClient) ConnectWithDSN(dsn string) (bool, error) {
 	return connectWithDSN(dsn)
 }
 
-func (c *MySQLClient) ExecuteQueryWithOpts(opts DSNOptions, query string) (*utils.SQLResult, error) {
+func (c *MySQLClient) ExecuteQueryWithOpts(opts MySQLOptions, query string) (*utils.SQLResult, error) {
 	if !protocolstate.IsHostAllowed(opts.Host) {
 		// host is not valid according to network policy
 		return nil, protocolstate.ErrHostDenied.Msgf(opts.Host)
@@ -158,15 +158,28 @@ func (c *MySQLClient) ExecuteQueryWithOpts(opts DSNOptions, query string) (*util
 	return data, nil
 }
 
-// ExecuteQuery connects to Mysql database using given credentials and database name.
+// ExecuteQuery connects to Mysql database using given credentials
 // and executes a query on the db.
 func (c *MySQLClient) ExecuteQuery(host string, port int, username, password, query string) (*utils.SQLResult, error) {
-	return c.ExecuteQueryWithOpts(DSNOptions{
+	return c.ExecuteQueryWithOpts(MySQLOptions{
 		Host:     host,
 		Port:     port,
 		Protocol: "tcp",
 		Username: username,
 		Password: password,
+	}, query)
+}
+
+// ExecuteQuery connects to Mysql database using given credentials
+// and executes a query on the db.
+func (c *MySQLClient) ExecuteQueryOnDB(host string, port int, username, password, dbname, query string) (*utils.SQLResult, error) {
+	return c.ExecuteQueryWithOpts(MySQLOptions{
+		Host:     host,
+		Port:     port,
+		Protocol: "tcp",
+		Username: username,
+		Password: password,
+		DbName:   dbname,
 	}, query)
 }
 

--- a/pkg/js/libs/mysql/mysql.go
+++ b/pkg/js/libs/mysql/mysql.go
@@ -7,13 +7,12 @@ import (
 	"io"
 	"log"
 	"net"
-	"net/url"
 	"time"
 
 	"github.com/go-sql-driver/mysql"
 	"github.com/praetorian-inc/fingerprintx/pkg/plugins"
 	mysqlplugin "github.com/praetorian-inc/fingerprintx/pkg/plugins/services/mysql"
-	utils "github.com/projectdiscovery/nuclei/v3/pkg/js/utils"
+	"github.com/projectdiscovery/nuclei/v3/pkg/js/utils"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
 )
 
@@ -21,16 +20,6 @@ import (
 //
 // Internally client uses go-sql-driver/mysql driver.
 type MySQLClient struct{}
-
-// Connect connects to MySQL database using given credentials.
-//
-// If connection is successful, it returns true.
-// If connection is unsuccessful, it returns false and error.
-//
-// The connection is closed after the function returns.
-func (c *MySQLClient) Connect(host string, port int, username, password string) (bool, error) {
-	return connect(host, port, username, password, "INFORMATION_SCHEMA")
-}
 
 // IsMySQL checks if the given host is running MySQL database.
 //
@@ -58,83 +47,96 @@ func (c *MySQLClient) IsMySQL(host string, port int) (bool, error) {
 	return true, nil
 }
 
-// ConnectWithDB connects to MySQL database using given credentials and database name.
+// Connect connects to MySQL database using given credentials.
 //
 // If connection is successful, it returns true.
 // If connection is unsuccessful, it returns false and error.
-//
 // The connection is closed after the function returns.
-func (c *MySQLClient) ConnectWithDB(host string, port int, username, password, dbName string) (bool, error) {
-	return connect(host, port, username, password, dbName)
+func (c *MySQLClient) Connect(host string, port int, username, password string) (bool, error) {
+	if !protocolstate.IsHostAllowed(host) {
+		// host is not valid according to network policy
+		return false, protocolstate.ErrHostDenied.Msgf(host)
+	}
+	dsn, err := BuildDSN(DSNOptions{
+		Host:     host,
+		Port:     port,
+		DbName:   "INFORMATION_SCHEMA",
+		Protocol: "tcp",
+		Username: username,
+		Password: password,
+	})
+	if err != nil {
+		return false, err
+	}
+	return connectWithDSN(dsn)
+}
+
+type MySQLInfo struct {
+	Host      string               `json:"host,omitempty"`
+	IP        string               `json:"ip"`
+	Port      int                  `json:"port"`
+	Protocol  string               `json:"protocol"`
+	TLS       bool                 `json:"tls"`
+	Transport string               `json:"transport"`
+	Version   string               `json:"version,omitempty"`
+	Debug     plugins.ServiceMySQL `json:"debug,omitempty"`
+	Raw       string               `json:"metadata"`
+}
+
+// returns MySQLInfo when fingerpint is successful
+func (c *MySQLClient) FingerprintMySQL(host string, port int) (MySQLInfo, error) {
+	info := MySQLInfo{}
+	if !protocolstate.IsHostAllowed(host) {
+		// host is not valid according to network policy
+		return info, protocolstate.ErrHostDenied.Msgf(host)
+	}
+	conn, err := protocolstate.Dialer.Dial(context.TODO(), "tcp", net.JoinHostPort(host, fmt.Sprintf("%d", port)))
+	if err != nil {
+		return info, err
+	}
+	defer conn.Close()
+
+	plugin := &mysqlplugin.MYSQLPlugin{}
+	service, err := plugin.Run(conn, 5*time.Second, plugins.Target{Host: host})
+	if err != nil {
+		return info, err
+	}
+	if service == nil {
+		return info, fmt.Errorf("something went wrong got null output")
+	}
+	// fill all fields
+	info.Host = service.Host
+	info.IP = service.IP
+	info.Port = service.Port
+	info.Protocol = service.Protocol
+	info.TLS = service.TLS
+	info.Transport = service.Transport
+	info.Version = service.Version
+	info.Debug = service.Metadata().(plugins.ServiceMySQL)
+	bin, _ := service.Raw.MarshalJSON()
+	info.Raw = string(bin)
+	return info, nil
 }
 
 // ConnectWithDSN connects to MySQL database using given DSN.
 // we override mysql dialer with fastdialer so it respects network policy
 func (c *MySQLClient) ConnectWithDSN(dsn string) (bool, error) {
+	return connectWithDSN(dsn)
+}
+
+func (c *MySQLClient) ExecuteQueryWithOpts(opts DSNOptions, query string) (*utils.SQLResult, error) {
+	if !protocolstate.IsHostAllowed(opts.Host) {
+		// host is not valid according to network policy
+		return nil, protocolstate.ErrHostDenied.Msgf(opts.Host)
+	}
+	dsn, err := BuildDSN(opts)
+	if err != nil {
+		return nil, err
+	}
+
 	db, err := sql.Open("mysql", dsn)
 	if err != nil {
-		return false, err
-	}
-	defer db.Close()
-	db.SetMaxOpenConns(1)
-	db.SetMaxIdleConns(0)
-
-	_, err = db.Exec("select 1")
-	if err != nil {
-		return false, err
-	}
-	return true, nil
-}
-
-func connect(host string, port int, username, password, dbName string) (bool, error) {
-	if host == "" || port <= 0 {
-		return false, fmt.Errorf("invalid host or port")
-	}
-
-	if !protocolstate.IsHostAllowed(host) {
-		// host is not valid according to network policy
-		return false, protocolstate.ErrHostDenied.Msgf(host)
-	}
-
-	target := net.JoinHostPort(host, fmt.Sprintf("%d", port))
-
-	db, err := sql.Open("mysql", fmt.Sprintf("%v:%v@tcp(%v)/%s?allowOldPasswords=1",
-		url.PathEscape(username),
-		url.PathEscape(password),
-		target,
-		dbName))
-	if err != nil {
-		return false, err
-	}
-	defer db.Close()
-	db.SetMaxOpenConns(1)
-	db.SetMaxIdleConns(0)
-
-	_, err = db.Exec("select 1")
-	if err != nil {
-		return false, err
-	}
-	return true, nil
-}
-
-// ExecuteQuery connects to Mysql database using given credentials and database name.
-// and executes a query on the db.
-func (c *MySQLClient) ExecuteQuery(host string, port int, username, password, dbName, query string) (string, error) {
-
-	if !protocolstate.IsHostAllowed(host) {
-		// host is not valid according to network policy
-		return "", protocolstate.ErrHostDenied.Msgf(host)
-	}
-
-	target := net.JoinHostPort(host, fmt.Sprintf("%d", port))
-
-	db, err := sql.Open("mysql", fmt.Sprintf("%v:%v@tcp(%v)/%s",
-		url.PathEscape(username),
-		url.PathEscape(password),
-		target,
-		dbName))
-	if err != nil {
-		return "", err
+		return nil, err
 	}
 	defer db.Close()
 	db.SetMaxOpenConns(1)
@@ -142,13 +144,31 @@ func (c *MySQLClient) ExecuteQuery(host string, port int, username, password, db
 
 	rows, err := db.Query(query)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	resp, err := utils.UnmarshalSQLRows(rows)
+
+	data, err := utils.UnmarshalSQLRows(rows)
 	if err != nil {
-		return "", err
+		if len(data.Rows) > 0 {
+			// allow partial results
+			return data, nil
+		}
+		return nil, err
 	}
-	return string(resp), nil
+	return data, nil
+}
+
+// ExecuteQuery connects to Mysql database using given credentials and database name.
+// and executes a query on the db.
+func (c *MySQLClient) ExecuteQuery(host string, port int, username, password, dbName, query string) (*utils.SQLResult, error) {
+	return c.ExecuteQueryWithOpts(DSNOptions{
+		Host:     host,
+		Port:     port,
+		DbName:   dbName,
+		Protocol: "tcp",
+		Username: username,
+		Password: password,
+	}, query)
 }
 
 func init() {

--- a/pkg/js/libs/mysql/mysql_private.go
+++ b/pkg/js/libs/mysql/mysql_private.go
@@ -27,8 +27,10 @@ func BuildDSN(opts DSNOptions) (string, error) {
 	if opts.Protocol == "" {
 		opts.Protocol = "tcp"
 	}
-	if opts.DbName != "" {
+	if opts.DbName == "" {
 		opts.DbName = "/"
+	} else {
+		opts.DbName = "/" + opts.DbName
 	}
 	target := net.JoinHostPort(opts.Host, fmt.Sprintf("%d", opts.Port))
 	var dsn strings.Builder
@@ -36,7 +38,7 @@ func BuildDSN(opts DSNOptions) (string, error) {
 	dsn.WriteString("@")
 	dsn.WriteString(fmt.Sprintf("%v(%v)", opts.Protocol, target))
 	if opts.DbName != "" {
-		dsn.WriteString(fmt.Sprintf("/%v", opts.DbName))
+		dsn.WriteString(opts.DbName)
 	}
 	if opts.RawQuery != "" {
 		dsn.WriteString(opts.RawQuery)

--- a/pkg/js/libs/mysql/mysql_private.go
+++ b/pkg/js/libs/mysql/mysql_private.go
@@ -1,0 +1,61 @@
+package mysql
+
+import (
+	"database/sql"
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+)
+
+// DSNOptions defines the data source name (DSN) options required to connect to a MySQL database.
+type DSNOptions struct {
+	Host     string // Host is the host name or IP address of the MySQL server.
+	Port     int    // Port is the port number on which the MySQL server is listening.
+	Protocol string // Protocol is the protocol used to connect to the MySQL server (ex: "tcp").
+	Username string // Username is the user name used to authenticate with the MySQL server.
+	Password string // Password is the password used to authenticate with the MySQL server.
+	DbName   string // DbName is the name of the database to connect to on the MySQL server.
+	RawQuery string // QueryStr is the query string to append to the DSN (ex: "?tls=skip-verify").
+}
+
+// BuildDSN builds a MySQL data source name (DSN) from the given options.
+func BuildDSN(opts DSNOptions) (string, error) {
+	if opts.Host == "" || opts.Port <= 0 {
+		return "", fmt.Errorf("invalid host or port")
+	}
+	if opts.Protocol == "" {
+		opts.Protocol = "tcp"
+	}
+	if opts.DbName != "" {
+		opts.DbName = "/"
+	}
+	target := net.JoinHostPort(opts.Host, fmt.Sprintf("%d", opts.Port))
+	var dsn strings.Builder
+	dsn.WriteString(fmt.Sprintf("%v:%v", url.QueryEscape(opts.Username), url.QueryEscape(opts.Password)))
+	dsn.WriteString("@")
+	dsn.WriteString(fmt.Sprintf("%v(%v)", opts.Protocol, target))
+	if opts.DbName != "" {
+		dsn.WriteString(fmt.Sprintf("/%v", opts.DbName))
+	}
+	if opts.RawQuery != "" {
+		dsn.WriteString(opts.RawQuery)
+	}
+	return dsn.String(), nil
+}
+
+func connectWithDSN(dsn string) (bool, error) {
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		return false, err
+	}
+	defer db.Close()
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(0)
+
+	_, err = db.Exec("select 1")
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}

--- a/pkg/js/libs/mysql/mysql_private.go
+++ b/pkg/js/libs/mysql/mysql_private.go
@@ -8,8 +8,9 @@ import (
 	"strings"
 )
 
-// DSNOptions defines the data source name (DSN) options required to connect to a MySQL database.
-type DSNOptions struct {
+// MySQLOptions defines the data source name (DSN) options required to connect to a MySQL database.
+// along with other options like Timeout etc
+type MySQLOptions struct {
 	Host     string // Host is the host name or IP address of the MySQL server.
 	Port     int    // Port is the port number on which the MySQL server is listening.
 	Protocol string // Protocol is the protocol used to connect to the MySQL server (ex: "tcp").
@@ -17,10 +18,11 @@ type DSNOptions struct {
 	Password string // Password is the password used to authenticate with the MySQL server.
 	DbName   string // DbName is the name of the database to connect to on the MySQL server.
 	RawQuery string // QueryStr is the query string to append to the DSN (ex: "?tls=skip-verify").
+	Timeout  int    // Timeout is the timeout in seconds for the connection to the MySQL server.
 }
 
 // BuildDSN builds a MySQL data source name (DSN) from the given options.
-func BuildDSN(opts DSNOptions) (string, error) {
+func BuildDSN(opts MySQLOptions) (string, error) {
 	if opts.Host == "" || opts.Port <= 0 {
 		return "", fmt.Errorf("invalid host or port")
 	}

--- a/pkg/js/libs/postgres/postgres.go
+++ b/pkg/js/libs/postgres/postgres.go
@@ -59,11 +59,10 @@ func (c *PGClient) Connect(host string, port int, username, password string) (bo
 
 // ExecuteQuery connects to Postgres database using given credentials and database name.
 // and executes a query on the db.
-func (c *PGClient) ExecuteQuery(host string, port int, username, password, dbName, query string) (string, error) {
-
+func (c *PGClient) ExecuteQuery(host string, port int, username, password, dbName, query string) (*utils.SQLResult, error) {
 	if !protocolstate.IsHostAllowed(host) {
 		// host is not valid according to network policy
-		return "", protocolstate.ErrHostDenied.Msgf(host)
+		return nil, protocolstate.ErrHostDenied.Msgf(host)
 	}
 
 	target := net.JoinHostPort(host, fmt.Sprintf("%d", port))
@@ -71,18 +70,18 @@ func (c *PGClient) ExecuteQuery(host string, port int, username, password, dbNam
 	connStr := fmt.Sprintf("postgres://%s:%s@%s/%s?sslmode=disable", username, password, target, dbName)
 	db, err := sql.Open("postgres", connStr)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	rows, err := db.Query(query)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	resp, err := utils.UnmarshalSQLRows(rows)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	return string(resp), nil
+	return resp, nil
 }
 
 // ConnectWithDB connects to Postgres database using given credentials and database name.

--- a/pkg/protocols/javascript/js.go
+++ b/pkg/protocols/javascript/js.go
@@ -149,6 +149,7 @@ func (request *Request) Compile(options *protocols.ExecutorOptions) error {
 
 		opts := &compiler.ExecuteOptions{
 			Timeout: request.Timeout,
+			Source:  &request.Init,
 		}
 		// register 'export' function to export variables from init code
 		// these are saved in args and are available in pre-condition and request code
@@ -337,7 +338,8 @@ func (request *Request) ExecuteWithResults(target *contextargs.Context, dynamicV
 		}
 		argsCopy.TemplateCtx = templateCtx.GetAll()
 
-		result, err := request.options.JsCompiler.ExecuteWithOptions(request.preConditionCompiled, argsCopy, &compiler.ExecuteOptions{Timeout: request.Timeout})
+		result, err := request.options.JsCompiler.ExecuteWithOptions(request.preConditionCompiled, argsCopy,
+			&compiler.ExecuteOptions{Timeout: request.Timeout, Source: &request.PreCondition})
 		if err != nil {
 			return errorutil.NewWithTag(request.TemplateID, "could not execute pre-condition: %s", err)
 		}
@@ -469,7 +471,8 @@ func (request *Request) executeRequestWithPayloads(hostPort string, input *conte
 		}
 	}
 
-	results, err := request.options.JsCompiler.ExecuteWithOptions(request.scriptCompiled, argsCopy, &compiler.ExecuteOptions{Timeout: request.Timeout})
+	results, err := request.options.JsCompiler.ExecuteWithOptions(request.scriptCompiled, argsCopy,
+		&compiler.ExecuteOptions{Timeout: request.Timeout, Source: &request.Code})
 	if err != nil {
 		// shouldn't fail even if it returned error instead create a failure event
 		results = compiler.ExecuteResult{"success": false, "error": err.Error()}

--- a/pkg/protocols/javascript/js.go
+++ b/pkg/protocols/javascript/js.go
@@ -210,7 +210,7 @@ func (request *Request) Compile(options *protocols.ExecutorOptions) error {
 		// proceed with whatever args we have
 		args.Args, _ = request.evaluateArgs(allVars, options, true)
 
-		initCompiled, err := goja.Compile("", request.Init, false)
+		initCompiled, err := compiler.WrapScriptNCompile(request.Init, false)
 		if err != nil {
 			return errorutil.NewWithTag(request.TemplateID, "could not compile init code: %s", err)
 		}
@@ -231,7 +231,7 @@ func (request *Request) Compile(options *protocols.ExecutorOptions) error {
 
 	// compile pre-condition if any
 	if request.PreCondition != "" {
-		preConditionCompiled, err := goja.Compile("", request.PreCondition, false)
+		preConditionCompiled, err := compiler.WrapScriptNCompile(request.PreCondition, false)
 		if err != nil {
 			return errorutil.NewWithTag(request.TemplateID, "could not compile pre-condition: %s", err)
 		}
@@ -240,7 +240,7 @@ func (request *Request) Compile(options *protocols.ExecutorOptions) error {
 
 	// compile actual source code
 	if request.Code != "" {
-		scriptCompiled, err := goja.Compile("", request.Code, false)
+		scriptCompiled, err := compiler.WrapScriptNCompile(request.Code, false)
 		if err != nil {
 			return errorutil.NewWithTag(request.TemplateID, "could not compile javascript code: %s", err)
 		}

--- a/pkg/tmplexec/exec.go
+++ b/pkg/tmplexec/exec.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/dop251/goja"
 	"github.com/projectdiscovery/gologger"
+	"github.com/projectdiscovery/nuclei/v3/pkg/js/compiler"
 	"github.com/projectdiscovery/nuclei/v3/pkg/operators/common/dsl"
 	"github.com/projectdiscovery/nuclei/v3/pkg/output"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols"
@@ -48,7 +49,7 @@ func NewTemplateExecuter(requests []protocols.Request, options *protocols.Execut
 		// we use a dummy input here because goal of flow executor at this point is to just check
 		// syntax and other things are correct before proceeding to actual execution
 		// during execution new instance of flow will be created as it is tightly coupled with lot of executor options
-		p, err := goja.Compile("flow.js", options.Flow, false)
+		p, err := compiler.WrapScriptNCompile(options.Flow, false)
 		if err != nil {
 			return nil, fmt.Errorf("could not compile flow: %s", err)
 		}


### PR DESCRIPTION
## Proposed Changes

- Although minimal creating javascript vm has a overhead and creating new vm for every request is bad practice in general ( which is how logic was implemented until now) 
- With recent release javascript vm reuse was introduced but it has come to attention that scripts need to be wrapped in `anonymous functions` and should not modify global values to avoid collisions with other scripts/code when reusing a javascript runtime 

> [!WARNING]
> Issue with implementing IIFE pattern is that values need to be returned explicitly instead of implicitly using last value as output but existing templates do not use `return` keyword and are based on implicit value usage pattern. but to effectively scale js templates reuse is a must, hence with this PR the existing pattern of last expression implicit logging will be soft deprecated and completely removed after some Minor releases [ but will continue to work for some time ]


### Current Last Value Implicit Output Pattern 

```yaml
javascript:
  - pre-condition: isPortOpen(Host,Port)
    code: |
      var m = require("nuclei/ssh");
      var c = m.SSHClient();
      var response = c.ConnectSSHInfoMode(Host, Port);
      to_json(response);
```
^ This is example javascript code of how to log/store response ( just write / use it at end of execution )

### New Style of log/store response for IIFE pattern

```yaml
javascript:
  - pre-condition: isPortOpen(Host,Port)
    code: |
       var m = require("nuclei/ssh");
       var c = m.SSHClient();
       var response = c.ConnectSSHInfoMode(Host, Port);
       Export(response)
```
^ Only change is that to store / log response `Export()` helper function should be used . and this comes with feature additions

>[!TIP]
> 1. `Export(value any)` can be used multiple times (will append data) and anywhere in the program not necessarily on last line
> 2. No need to use `to_json(resp)` anymore exporting with `Export(resp)` will automatically return json if it is a struct/object
> 3. You can now export addition key-value pairs to use in matchers & extractors using `ExportAs(key string,Value any)` helper function 
>```yaml
> javascript:
>  - code: |
>      var m = require("nuclei/net");
>      var conn = m.Open("tcp",address);
>      conn.Send("FIRST")
>      const resp1 = conn.RecvString(4)
>      ExportAs("response_1",resp1) // <- export response_1 variable
>      conn.Send("SECOND")
>      Export(conn.RecvString(6)) // <- export code/script output
>```
> 4. With New Style of output storing js templates can be run with 5x more concurrency than old style of log/store pattern
> 5. This New Export/Storage pattern is Faster and More Efficient in Both CPU and Memory 

## Example Nuclei Runs

###  Current Last Value Implicit Output Pattern 

```console
                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.1.8

		projectdiscovery.io

[INF] Current nuclei version: v3.1.8 (latest)
[INF] Current nuclei-templates version: v9.7.5 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 106
[INF] Templates loaded for current scan: 1
[WRN] Executing 1 unsigned templates. Use with caution.
[INF] Targets loaded for current scan: 1600
...
------------------------------
Command: ./nuclei -l dist/mysql.txt -t a.yaml -nh -stats
Max RSS: 163 MB
Sys Time: 515.073µs
User Time: 698.23µs
Actual Time: 2m34.233860042s
Voluntary Context Switch (nvcsw): 182
```


### New Export Function Output Pattern 

```console 
                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.1.8

		projectdiscovery.io

[INF] Current nuclei version: v3.1.8 (latest)
[INF] Current nuclei-templates version: v9.7.5 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 106
[INF] Templates loaded for current scan: 1
[WRN] Executing 1 unsigned templates. Use with caution.
[INF] Targets loaded for current scan: 1600
...

------------------------------
Command: ./nuclei -l dist/mysql.txt -t a.yaml -nh -stats
Max RSS: 106 MB
Sys Time: 270.38µs
User Time: 349.175µs
Actual Time: 1m17.150404875s
Voluntary Context Switch (nvcsw): 92
```

