### PR TITLE
implicit thread count when not specified in payloads + threads support in dns,network

### DIFF
--- a/pkg/protocols/dns/dns.go
+++ b/pkg/protocols/dns/dns.go
@@ -183,7 +183,7 @@ func (request *Request) Compile(options *protocols.ExecutorOptions) error {
 			return errors.Wrap(err, "could not parse payloads")
 		}
 		// default to 20 threads for payload requests
-		request.Threads = protocols.GetThreadsForNPayloadRequests(request.Requests(), request.Threads)
+		request.Threads = options.GetThreadsForNPayloadRequests(request.Requests(), request.Threads)
 	}
 	return nil
 }

--- a/pkg/protocols/dns/dns.go
+++ b/pkg/protocols/dns/dns.go
@@ -74,7 +74,13 @@ type Request struct {
 	//   Payloads support both key-values combinations where a list
 	//   of payloads is provided, or optionally a single file can also
 	//   be provided as payload which will be read on run-time.
-	Payloads  map[string]interface{} `yaml:"payloads,omitempty" json:"payloads,omitempty" jsonschema:"title=payloads for the network request,description=Payloads contains any payloads for the current request"`
+	Payloads map[string]interface{} `yaml:"payloads,omitempty" json:"payloads,omitempty" jsonschema:"title=payloads for the network request,description=Payloads contains any payloads for the current request"`
+	// description: |
+	//    Threads to use when sending iterating over payloads
+	// examples:
+	//   - name: Send requests using 10 concurrent threads
+	//     value: 10
+	Threads   int `yaml:"threads,omitempty" json:"threads,omitempty" jsonschema:"title=threads for sending requests,description=Threads specifies number of threads to use sending requests. This enables Connection Pooling"`
 	generator *generators.PayloadGenerator
 
 	CompiledOperators *operators.Operators `yaml:"-"`
@@ -176,6 +182,8 @@ func (request *Request) Compile(options *protocols.ExecutorOptions) error {
 		if err != nil {
 			return errors.Wrap(err, "could not parse payloads")
 		}
+		// default to 20 threads for payload requests
+		request.Threads = protocols.GetThreadsForNPayloadRequests(request.Requests(), request.Threads)
 	}
 	return nil
 }

--- a/pkg/protocols/dns/request.go
+++ b/pkg/protocols/dns/request.go
@@ -75,14 +75,14 @@ func (request *Request) ExecuteWithResults(input *contextargs.Context, metadata,
 			}
 			value = generators.MergeMaps(vars, value)
 			swg.Add()
-			go func() {
+			go func(newVars map[string]interface{}) {
 				defer swg.Done()
-				if err := request.execute(input, domain, metadata, previous, value, callback); err != nil {
+				if err := request.execute(input, domain, metadata, previous, newVars, callback); err != nil {
 					m.Lock()
 					multiErr = multierr.Append(multiErr, err)
 					m.Unlock()
 				}
-			}()
+			}(value)
 		}
 		swg.Wait()
 		if multiErr != nil {

--- a/pkg/protocols/http/http.go
+++ b/pkg/protocols/http/http.go
@@ -387,6 +387,11 @@ func (request *Request) Compile(options *protocols.ExecutorOptions) error {
 			}
 		}
 	}
+	if len(request.Payloads) > 0 {
+		// default to 20 threads for payload requests
+		request.Threads = protocols.GetThreadsForNPayloadRequests(request.Requests(), request.Threads)
+	}
+
 	return nil
 }
 

--- a/pkg/protocols/http/http.go
+++ b/pkg/protocols/http/http.go
@@ -388,7 +388,7 @@ func (request *Request) Compile(options *protocols.ExecutorOptions) error {
 		}
 	}
 	if len(request.Payloads) > 0 {
-		// default to 20 threads for payload requests
+		// if we have payloads, adjust threads if none specified
 		request.Threads = protocols.GetThreadsForNPayloadRequests(request.Requests(), request.Threads)
 	}
 

--- a/pkg/protocols/http/http.go
+++ b/pkg/protocols/http/http.go
@@ -389,7 +389,7 @@ func (request *Request) Compile(options *protocols.ExecutorOptions) error {
 	}
 	if len(request.Payloads) > 0 {
 		// if we have payloads, adjust threads if none specified
-		request.Threads = protocols.GetThreadsForNPayloadRequests(request.Requests(), request.Threads)
+		request.Threads = options.GetThreadsForNPayloadRequests(request.Requests(), request.Threads)
 	}
 
 	return nil

--- a/pkg/protocols/http/request.go
+++ b/pkg/protocols/http/request.go
@@ -342,14 +342,14 @@ func (request *Request) ExecuteWithResults(input *contextargs.Context, dynamicVa
 		return request.executeRaceRequest(input, dynamicValues, callback)
 	}
 
-	// verify if parallel elaboration was requested
-	if request.Threads > 0 {
-		return request.executeParallelHTTP(input, dynamicValues, callback)
-	}
-
 	// verify if fuzz elaboration was requested
 	if len(request.Fuzzing) > 0 {
 		return request.executeFuzzingRule(input, dynamicValues, callback)
+	}
+
+	// verify if parallel elaboration was requested
+	if request.Threads > 0 {
+		return request.executeParallelHTTP(input, dynamicValues, callback)
 	}
 
 	generator := request.newGenerator(false)

--- a/pkg/protocols/javascript/js.go
+++ b/pkg/protocols/javascript/js.go
@@ -108,7 +108,7 @@ func (request *Request) Compile(options *protocols.ExecutorOptions) error {
 			return errors.Wrap(err, "could not parse payloads")
 		}
 		// default to 20 threads for payload requests
-		request.Threads = protocols.GetThreadsForNPayloadRequests(request.Requests(), request.Threads)
+		request.Threads = options.GetThreadsForNPayloadRequests(request.Requests(), request.Threads)
 	}
 
 	if len(request.Matchers) > 0 || len(request.Extractors) > 0 {

--- a/pkg/protocols/javascript/js.go
+++ b/pkg/protocols/javascript/js.go
@@ -107,6 +107,8 @@ func (request *Request) Compile(options *protocols.ExecutorOptions) error {
 		if err != nil {
 			return errors.Wrap(err, "could not parse payloads")
 		}
+		// default to 20 threads for payload requests
+		request.Threads = protocols.GetThreadsForNPayloadRequests(request.Requests(), request.Threads)
 	}
 
 	if len(request.Matchers) > 0 || len(request.Extractors) > 0 {

--- a/pkg/protocols/network/network.go
+++ b/pkg/protocols/network/network.go
@@ -45,6 +45,15 @@ type Request struct {
 	//   of payloads is provided, or optionally a single file can also
 	//   be provided as payload which will be read on run-time.
 	Payloads map[string]interface{} `yaml:"payloads,omitempty" json:"payloads,omitempty" jsonschema:"title=payloads for the network request,description=Payloads contains any payloads for the current request"`
+	// description: |
+	//   Threads specifies number of threads to use sending requests. This enables Connection Pooling.
+	//
+	//   Connection: Close attribute must not be used in request while using threads flag, otherwise
+	//   pooling will fail and engine will continue to close connections after requests.
+	// examples:
+	//   - name: Send requests using 10 concurrent threads
+	//     value: 10
+	Threads int `yaml:"threads,omitempty" json:"threads,omitempty" jsonschema:"title=threads for sending requests,description=Threads specifies number of threads to use sending requests. This enables Connection Pooling"`
 
 	// description: |
 	//   Inputs contains inputs for the network socket
@@ -219,6 +228,8 @@ func (request *Request) Compile(options *protocols.ExecutorOptions) error {
 		if err != nil {
 			return errors.Wrap(err, "could not parse payloads")
 		}
+		// if we have payloads, adjust threads if none specified
+		request.Threads = protocols.GetThreadsForNPayloadRequests(request.Requests(), request.Threads)
 	}
 
 	// Create a client for the class

--- a/pkg/protocols/network/network.go
+++ b/pkg/protocols/network/network.go
@@ -229,7 +229,7 @@ func (request *Request) Compile(options *protocols.ExecutorOptions) error {
 			return errors.Wrap(err, "could not parse payloads")
 		}
 		// if we have payloads, adjust threads if none specified
-		request.Threads = protocols.GetThreadsForNPayloadRequests(request.Requests(), request.Threads)
+		request.Threads = options.GetThreadsForNPayloadRequests(request.Requests(), request.Threads)
 	}
 
 	// Create a client for the class

--- a/pkg/protocols/protocols.go
+++ b/pkg/protocols/protocols.go
@@ -32,7 +32,22 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/types"
 )
 
-var MaxTemplateFileSizeForEncoding = 1024 * 1024
+var (
+	MaxTemplateFileSizeForEncoding = 1024 * 1024
+	DefaultThreadsForPayloads      = 20
+)
+
+// GetThreadsForPayloadRequests returns the number of threads to use as default for
+// given max-request of payloads
+func GetThreadsForNPayloadRequests(N int, currentThreads int) int {
+	if currentThreads != 0 {
+		return currentThreads
+	}
+	if N <= 0 {
+		return DefaultThreadsForPayloads
+	}
+	return N
+}
 
 // Executer is an interface implemented any protocol based request executer.
 type Executer interface {

--- a/pkg/protocols/protocols.go
+++ b/pkg/protocols/protocols.go
@@ -32,22 +32,12 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/types"
 )
 
+// Optional Callback to update Thread count in payloads across all requests
+type PayloadThreadSetterCallback func(opts *ExecutorOptions, totalRequests, currentThreads int) int
+
 var (
 	MaxTemplateFileSizeForEncoding = 1024 * 1024
-	DefaultThreadsForPayloads      = 20
 )
-
-// GetThreadsForPayloadRequests returns the number of threads to use as default for
-// given max-request of payloads
-func GetThreadsForNPayloadRequests(N int, currentThreads int) int {
-	if currentThreads != 0 {
-		return currentThreads
-	}
-	if N <= 0 {
-		return DefaultThreadsForPayloads
-	}
-	return N
-}
 
 // Executer is an interface implemented any protocol based request executer.
 type Executer interface {
@@ -122,6 +112,25 @@ type ExecutorOptions struct {
 	// JsCompiler is abstracted javascript compiler which adds node modules and provides execution
 	// environment for javascript templates
 	JsCompiler *compiler.Compiler
+	// Optional Callback function to update Thread count in payloads across all protocols
+	// based on given logic. by default nuclei reverts to using value of `-c` when threads count
+	// is not specified or is 0 in template
+	OverrideThreadsCount PayloadThreadSetterCallback
+}
+
+// GetThreadsForPayloadRequests returns the number of threads to use as default for
+// given max-request of payloads
+func (e *ExecutorOptions) GetThreadsForNPayloadRequests(totalRequests int, currentThreads int) int {
+	if e.OverrideThreadsCount != nil {
+		return e.OverrideThreadsCount(e, totalRequests, currentThreads)
+	}
+	if currentThreads != 0 {
+		return currentThreads
+	}
+	if totalRequests <= 0 {
+		return e.Options.TemplateThreads
+	}
+	return totalRequests
 }
 
 // CreateTemplateCtxStore creates template context store (which contains templateCtx for every scan)


### PR DESCRIPTION
## Proposed Changes
- Add `threads` (i.e payload concurrency) support in dns and network protocols
- When `threads` value is not specified it defaults to value of `-c ` flag i.e template concurrency 
- Adds Optional ThreadSetter Callback in ExecuterOptions to allow overriding logic on demand from SDK
- closes #4711 

### Example run before change
```console
$  cmdutil nuclei -id zip-backup-files -stats -u https://scanme.sh                         1 ↵

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.1.8

		projectdiscovery.io

[INF] Current nuclei version: v3.1.8 (latest)
[INF] Current nuclei-templates version: v9.7.5 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 106
[INF] Templates loaded for current scan: 1
[INF] Executing 1 signed templates from projectdiscovery/nuclei-templates
[INF] Targets loaded for current scan: 1
[0:00:05] | Templates: 1 | Hosts: 1 | RPS: 4 | Matched: 0 | Errors: 0 | Requests: 24/1440 (1%)
[0:00:10] | Templates: 1 | Hosts: 1 | RPS: 4 | Matched: 0 | Errors: 0 | Requests: 48/1440 (3%)
[0:00:15] | Templates: 1 | Hosts: 1 | RPS: 4 | Matched: 0 | Errors: 0 | Requests: 73/1440 (5%)
[0:00:20] | Templates: 1 | Hosts: 1 | RPS: 4 | Matched: 0 | Errors: 0 | Requests: 98/1440 (6%)
[0:00:25] | Templates: 1 | Hosts: 1 | RPS: 4 | Matched: 0 | Errors: 0 | Requests: 123/1440 (8%)
[0:00:30] | Templates: 1 | Hosts: 1 | RPS: 4 | Matched: 0 | Errors: 0 | Requests: 147/1440 (10%)
[0:00:35] | Templates: 1 | Hosts: 1 | RPS: 4 | Matched: 0 | Errors: 0 | Requests: 172/1440 (11%)
[0:00:40] | Templates: 1 | Hosts: 1 | RPS: 4 | Matched: 0 | Errors: 0 | Requests: 197/1440 (13%)
[0:00:45] | Templates: 1 | Hosts: 1 | RPS: 4 | Matched: 0 | Errors: 0 | Requests: 220/1440 (15%)
[0:00:50] | Templates: 1 | Hosts: 1 | RPS: 4 | Matched: 0 | Errors: 0 | Requests: 245/1440 (17%)
[0:00:55] | Templates: 1 | Hosts: 1 | RPS: 4 | Matched: 0 | Errors: 0 | Requests: 270/1440 (18%)
[0:01:00] | Templates: 1 | Hosts: 1 | RPS: 4 | Matched: 0 | Errors: 0 | Requests: 295/1440 (20%)
[0:01:05] | Templates: 1 | Hosts: 1 | RPS: 4 | Matched: 0 | Errors: 0 | Requests: 314/1440 (21%)
[0:01:10] | Templates: 1 | Hosts: 1 | RPS: 4 | Matched: 0 | Errors: 0 | Requests: 339/1440 (23%)
[0:01:15] | Templates: 1 | Hosts: 1 | RPS: 4 | Matched: 0 | Errors: 0 | Requests: 365/1440 (25%)
[0:01:20] | Templates: 1 | Hosts: 1 | RPS: 4 | Matched: 0 | Errors: 0 | Requests: 390/1440 (27%)
[0:01:25] | Templates: 1 | Hosts: 1 | RPS: 4 | Matched: 0 | Errors: 0 | Requests: 410/1440 (28%)
[0:01:30] | Templates: 1 | Hosts: 1 | RPS: 4 | Matched: 0 | Errors: 0 | Requests: 435/1440 (30%)
[0:01:35] | Templates: 1 | Hosts: 1 | RPS: 4 | Matched: 0 | Errors: 0 | Requests: 460/1440 (31%)
[0:01:40] | Templates: 1 | Hosts: 1 | RPS: 4 | Matched: 0 | Errors: 0 | Requests: 485/1440 (33%)
[0:01:45] | Templates: 1 | Hosts: 1 | RPS: 4 | Matched: 0 | Errors: 0 | Requests: 510/1440 (35%)
[0:01:50] | Templates: 1 | Hosts: 1 | RPS: 4 | Matched: 0 | Errors: 0 | Requests: 536/1440 (37%)
[0:01:55] | Templates: 1 | Hosts: 1 | RPS: 4 | Matched: 0 | Errors: 0 | Requests: 561/1440 (38%)
[0:02:00] | Templates: 1 | Hosts: 1 | RPS: 4 | Matched: 0 | Errors: 0 | Requests: 586/1440 (40%)
[0:02:05] | Templates: 1 | Hosts: 1 | RPS: 4 | Matched: 0 | Errors: 0 | Requests: 611/1440 (42%)
[0:02:10] | Templates: 1 | Hosts: 1 | RPS: 4 | Matched: 0 | Errors: 0 | Requests: 636/1440 (44%)
[0:02:15] | Templates: 1 | Hosts: 1 | RPS: 4 | Matched: 0 | Errors: 0 | Requests: 661/1440 (45%)
[0:02:20] | Templates: 1 | Hosts: 1 | RPS: 4 | Matched: 0 | Errors: 0 | Requests: 686/1440 (47%)
[0:02:25] | Templates: 1 | Hosts: 1 | RPS: 4 | Matched: 0 | Errors: 0 | Requests: 711/1440 (49%)
[0:02:30] | Templates: 1 | Hosts: 1 | RPS: 4 | Matched: 0 | Errors: 0 | Requests: 736/1440 (51%)
[0:02:35] | Templates: 1 | Hosts: 1 | RPS: 4 | Matched: 0 | Errors: 0 | Requests: 761/1440 (52%)
[0:02:40] | Templates: 1 | Hosts: 1 | RPS: 4 | Matched: 0 | Errors: 0 | Requests: 787/1440 (54%)
[0:02:45] | Templates: 1 | Hosts: 1 | RPS: 4 | Matched: 0 | Errors: 0 | Requests: 812/1440 (56%)
[0:02:50] | Templates: 1 | Hosts: 1 | RPS: 4 | Matched: 0 | Errors: 0 | Requests: 837/1440 (58%)
[0:02:55] | Templates: 1 | Hosts: 1 | RPS: 4 | Matched: 0 | Errors: 0 | Requests: 862/1440 (59%)
[0:03:00] | Templates: 1 | Hosts: 1 | RPS: 4 | Matched: 0 | Errors: 0 | Requests: 887/1440 (61%)
[0:03:05] | Templates: 1 | Hosts: 1 | RPS: 4 | Matched: 0 | Errors: 0 | Requests: 912/1440 (63%)
[0:03:10] | Templates: 1 | Hosts: 1 | RPS: 4 | Matched: 0 | Errors: 0 | Requests: 936/1440 (65%)
[0:03:15] | Templates: 1 | Hosts: 1 | RPS: 4 | Matched: 0 | Errors: 0 | Requests: 961/1440 (66%)
[0:03:20] | Templates: 1 | Hosts: 1 | RPS: 4 | Matched: 0 | Errors: 0 | Requests: 987/1440 (68%)
[0:03:25] | Templates: 1 | Hosts: 1 | RPS: 4 | Matched: 0 | Errors: 0 | Requests: 1013/1440 (70%)
[0:03:30] | Templates: 1 | Hosts: 1 | RPS: 4 | Matched: 0 | Errors: 0 | Requests: 1038/1440 (72%)
[0:03:35] | Templates: 1 | Hosts: 1 | RPS: 4 | Matched: 0 | Errors: 0 | Requests: 1063/1440 (73%)
[0:03:40] | Templates: 1 | Hosts: 1 | RPS: 4 | Matched: 0 | Errors: 0 | Requests: 1088/1440 (75%)
[0:03:45] | Templates: 1 | Hosts: 1 | RPS: 4 | Matched: 0 | Errors: 0 | Requests: 1113/1440 (77%)
[0:03:50] | Templates: 1 | Hosts: 1 | RPS: 4 | Matched: 0 | Errors: 0 | Requests: 1138/1440 (79%)
[0:03:55] | Templates: 1 | Hosts: 1 | RPS: 4 | Matched: 0 | Errors: 0 | Requests: 1162/1440 (80%)
[0:04:00] | Templates: 1 | Hosts: 1 | RPS: 4 | Matched: 0 | Errors: 0 | Requests: 1188/1440 (82%)
[0:04:05] | Templates: 1 | Hosts: 1 | RPS: 4 | Matched: 0 | Errors: 0 | Requests: 1212/1440 (84%)
[0:04:10] | Templates: 1 | Hosts: 1 | RPS: 4 | Matched: 0 | Errors: 0 | Requests: 1237/1440 (85%)
[0:04:15] | Templates: 1 | Hosts: 1 | RPS: 4 | Matched: 0 | Errors: 0 | Requests: 1262/1440 (87%)
[0:04:20] | Templates: 1 | Hosts: 1 | RPS: 4 | Matched: 0 | Errors: 0 | Requests: 1287/1440 (89%)
[0:04:25] | Templates: 1 | Hosts: 1 | RPS: 4 | Matched: 0 | Errors: 0 | Requests: 1310/1440 (90%)
[0:04:30] | Templates: 1 | Hosts: 1 | RPS: 4 | Matched: 0 | Errors: 0 | Requests: 1335/1440 (92%)
[0:04:35] | Templates: 1 | Hosts: 1 | RPS: 4 | Matched: 0 | Errors: 0 | Requests: 1360/1440 (94%)
[0:04:40] | Templates: 1 | Hosts: 1 | RPS: 4 | Matched: 0 | Errors: 0 | Requests: 1385/1440 (96%)
[0:04:45] | Templates: 1 | Hosts: 1 | RPS: 4 | Matched: 0 | Errors: 0 | Requests: 1410/1440 (97%)
[0:04:50] | Templates: 1 | Hosts: 1 | RPS: 4 | Matched: 0 | Errors: 0 | Requests: 1436/1440 (99%)
[INF] No results found. Better luck next time!
[0:04:51] | Templates: 1 | Hosts: 1 | RPS: 4 | Matched: 0 | Errors: 0 | Requests: 1440/1440 (100%)

------------------------------
Command: nuclei -id zip-backup-files -stats -u https://scanme.sh
Max RSS: 204 MB
Sys Time: 456.389µs
User Time: 976.316µs
Actual Time: 4m51.99417775s
Voluntary Context Switch (nvcsw): 135
```

### Example run after change
```console
$  cmdutil ./nuclei -id zip-backup-files -stats -u https://scanme.sh

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.1.8

		projectdiscovery.io

[INF] Current nuclei version: v3.1.8 (latest)
[INF] Current nuclei-templates version: v9.7.5 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 106
[INF] Templates loaded for current scan: 1
[INF] Executing 1 signed templates from projectdiscovery/nuclei-templates
[INF] Targets loaded for current scan: 1
[0:00:05] | Templates: 1 | Hosts: 1 | RPS: 287 | Matched: 0 | Errors: 0 | Requests: 1440/1440 (100%)
[0:00:10] | Templates: 1 | Hosts: 1 | RPS: 143 | Matched: 0 | Errors: 0 | Requests: 1440/1440 (100%)
[INF] No results found. Better luck next time!
[0:00:11] | Templates: 1 | Hosts: 1 | RPS: 125 | Matched: 0 | Errors: 0 | Requests: 1440/1440 (100%)

------------------------------
Command: ./nuclei -id zip-backup-files -stats -u https://scanme.sh
Max RSS: 224 MB
Sys Time: 883.114µs
User Time: 33.076µs
Actual Time: 12.621391459s
Voluntary Context Switch (nvcsw): 94
```