### PR TITLE
Add more `NetworkConfig` options to the SDK

### DIFF
--- a/lib/config.go
+++ b/lib/config.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"github.com/projectdiscovery/gologger"
+	"github.com/projectdiscovery/ratelimit"
+
 	"github.com/projectdiscovery/nuclei/v3/pkg/model/types/severity"
 	"github.com/projectdiscovery/nuclei/v3/pkg/output"
 	"github.com/projectdiscovery/nuclei/v3/pkg/progress"
@@ -13,7 +15,6 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/utils/vardump"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/headless/engine"
 	"github.com/projectdiscovery/nuclei/v3/pkg/templates/types"
-	"github.com/projectdiscovery/ratelimit"
 )
 
 // TemplateSources contains template sources
@@ -220,14 +221,16 @@ func WithVerbosity(opts VerbosityOptions) NucleiSDKOptions {
 // NetworkConfig contains network config options
 // ex: retries , httpx probe , timeout etc
 type NetworkConfig struct {
-	Timeout           int      // Timeout in seconds
-	Retries           int      // Number of retries
-	LeaveDefaultPorts bool     // Leave default ports for http/https
-	MaxHostError      int      // Maximum number of host errors to allow before skipping that host
-	TrackError        []string // Adds given errors to max host error watchlist
-	DisableMaxHostErr bool     // Disable max host error optimization (Hosts are not skipped even if they are not responding)
-	Interface         string   // Interface to use for network scan
-	SourceIP          string   // SourceIP sets custom source IP address for network requests
+	DisableMaxHostErr     bool     // Disable max host error optimization (Hosts are not skipped even if they are not responding)
+	Interface             string   // Interface to use for network scan
+	InternalResolversList []string // Use a list of resolver
+	LeaveDefaultPorts     bool     // Leave default ports for http/https
+	MaxHostError          int      // Maximum number of host errors to allow before skipping that host
+	Retries               int      // Number of retries
+	SourceIP              string   // SourceIP sets custom source IP address for network requests
+	SystemResolvers       bool     // Use system resolvers
+	Timeout               int      // Timeout in seconds
+	TrackError            []string // Adds given errors to max host error watchlist
 }
 
 // WithNetworkConfig allows setting network config options
@@ -242,6 +245,8 @@ func WithNetworkConfig(opts NetworkConfig) NucleiSDKOptions {
 		e.hostErrCache = hosterrorscache.New(opts.MaxHostError, hosterrorscache.DefaultMaxHostsCount, opts.TrackError)
 		e.opts.Interface = opts.Interface
 		e.opts.SourceIP = opts.SourceIP
+		e.opts.SystemResolvers = opts.SystemResolvers
+		e.opts.InternalResolversList = opts.InternalResolversList
 		return nil
 	}
 }


### PR DESCRIPTION
## Proposed changes

With this PR, SDK users can now specify whether to use the `SystemResolvers` and a list of resolvers via `InternalResolversList`.

This fixes issues such as #578 (`no address found for host`) when running the Nuclei SDK in `docker-compose` while targeting a container that is in the same container network (e.g: `http://insecure-endpoint`).


## Checklist

- [X] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [X] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)