### PR TITLE
feat: first implementation of global matchers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -276,7 +276,7 @@ require (
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/yl2chen/cidranger v1.0.2 // indirect
 	github.com/ysmood/goob v0.4.0 // indirect
-	github.com/ysmood/gson v0.7.3 // indirect
+	github.com/ysmood/gson v0.7.3
 	github.com/ysmood/leakless v0.8.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
 	github.com/zmap/rc2 v0.0.0-20190804163417-abaa70531248 // indirect

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -43,6 +43,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/automaticscan"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/contextargs"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/globalmatchers"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/hosterrorscache"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/interactsh"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolinit"
@@ -420,6 +421,7 @@ func (r *Runner) RunEnumeration() error {
 		ResumeCfg:       r.resumeCfg,
 		ExcludeMatchers: excludematchers.New(r.options.ExcludeMatchers),
 		InputHelper:     input.NewHelper(),
+		GlobalMatchers:  globalmatchers.New(),
 	}
 
 	if r.options.ShouldUseHostError() {

--- a/pkg/output/format_screen.go
+++ b/pkg/output/format_screen.go
@@ -39,6 +39,11 @@ func (w *StandardWriter) formatScreen(output *ResultEvent) []byte {
 			}
 		}
 
+		if output.Passive {
+			builder.WriteString("] [")
+			builder.WriteString(w.aurora.BrightMagenta("passive").String())
+		}
+
 		builder.WriteString("] [")
 		builder.WriteString(w.aurora.BrightBlue(output.Type).String())
 		builder.WriteString("] ")

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -164,6 +164,8 @@ type ResultEvent struct {
 	MatcherStatus bool `json:"matcher-status"`
 	// Lines is the line count for the specified match
 	Lines []int `json:"matched-line,omitempty"`
+	// Passive specifies whether the match was discovered passively in the response
+	Passive bool `json:"passive,omitempty"`
 
 	FileToIndexPosition map[string]int `json:"-"`
 	Error               string         `json:"error,omitempty"`

--- a/pkg/protocols/common/globalmatchers/globalmatchers.go
+++ b/pkg/protocols/common/globalmatchers/globalmatchers.go
@@ -1,0 +1,62 @@
+package globalmatchers
+
+import (
+	"github.com/projectdiscovery/nuclei/v3/pkg/model"
+	"github.com/projectdiscovery/nuclei/v3/pkg/operators"
+	"github.com/projectdiscovery/nuclei/v3/pkg/output"
+	"golang.org/x/exp/maps"
+)
+
+// Storage is a struct that holds the global matchers
+type Storage struct {
+	requests []*Item
+}
+
+// Item is a struct that holds the global matchers
+// details for a template
+type Item struct {
+	TemplateID   string
+	TemplatePath string
+	TemplateInfo model.Info
+	Operators    []*operators.Operators
+}
+
+// New creates a new storage for global matchers
+func New() *Storage {
+	return &Storage{}
+}
+
+// AddOperator adds a new operator to the global matchers
+func (s *Storage) AddOperator(item *Item) {
+	s.requests = append(s.requests, item)
+}
+
+// HasMatchers returns true if we have global matchers
+func (s *Storage) HasMatchers() bool {
+	return len(s.requests) > 0
+}
+
+// Match matches the global matchers against the response
+func (s *Storage) Match(
+	event output.InternalEvent,
+	matchFunc operators.MatchFunc,
+	extractFunc operators.ExtractFunc,
+	isDebug bool,
+	callback func(event output.InternalEvent, result *operators.Result),
+) {
+	for _, item := range s.requests {
+		for _, operator := range item.Operators {
+			result, matched := operator.Execute(event, matchFunc, extractFunc, isDebug)
+			if !matched {
+				continue
+			}
+
+			eventCopy := maps.Clone(event)
+			eventCopy["template-id"] = item.TemplateID
+			eventCopy["template-info"] = item.TemplateInfo
+			eventCopy["template-path"] = item.TemplatePath
+			eventCopy["passive"] = true
+			callback(eventCopy, result)
+		}
+	}
+}

--- a/pkg/protocols/http/http.go
+++ b/pkg/protocols/http/http.go
@@ -208,6 +208,9 @@ type Request struct {
 	// description: |
 	//  DisablePathAutomerge disables merging target url path with raw request path
 	DisablePathAutomerge bool `yaml:"disable-path-automerge,omitempty" json:"disable-path-automerge,omitempty" jsonschema:"title=disable auto merging of path,description=Disable merging target url path with raw request path"`
+	// description: |
+	//   Passive specifies whether the request should be made in passive mode
+	Passive bool `yaml:"passive,omitempty" json:"passive,omitempty" jsonschema:"title=passive mode,description=Passive mode for the request"`
 }
 
 // Options returns executer options for http request

--- a/pkg/protocols/http/operators.go
+++ b/pkg/protocols/http/operators.go
@@ -157,6 +157,10 @@ func (request *Request) MakeResultEventItem(wrapped *output.InternalWrappedEvent
 	if types.ToString(wrapped.InternalEvent["path"]) != "" {
 		fields.Path = types.ToString(wrapped.InternalEvent["path"])
 	}
+	var isPassive bool
+	if value, ok := wrapped.InternalEvent["passive"]; ok {
+		isPassive = value.(bool)
+	}
 	data := &output.ResultEvent{
 		TemplateID:       types.ToString(wrapped.InternalEvent["template-id"]),
 		TemplatePath:     types.ToString(wrapped.InternalEvent["template-path"]),
@@ -173,6 +177,7 @@ func (request *Request) MakeResultEventItem(wrapped *output.InternalWrappedEvent
 		Timestamp:        time.Now(),
 		MatcherStatus:    true,
 		IP:               fields.Ip,
+		Passive:          isPassive,
 		Request:          types.ToString(wrapped.InternalEvent["request"]),
 		Response:         request.truncateResponse(wrapped.InternalEvent["response"]),
 		CURLCommand:      types.ToString(wrapped.InternalEvent["curl-command"]),

--- a/pkg/protocols/http/request.go
+++ b/pkg/protocols/http/request.go
@@ -791,11 +791,19 @@ func (request *Request) executeRequest(input *contextargs.Context, generatedRequ
 		// prune signature internal values if any
 		request.pruneSignatureInternalValues(generatedRequest.meta)
 
-		event := eventcreator.CreateEventWithAdditionalOptions(request, generators.MergeMaps(generatedRequest.dynamicValues, finalEvent), request.options.Options.Debug || request.options.Options.DebugResponse, func(internalWrappedEvent *output.InternalWrappedEvent) {
+		interimEvent := generators.MergeMaps(generatedRequest.dynamicValues, finalEvent)
+		isDebug := request.options.Options.Debug || request.options.Options.DebugResponse
+		event := eventcreator.CreateEventWithAdditionalOptions(request, interimEvent, isDebug, func(internalWrappedEvent *output.InternalWrappedEvent) {
 			internalWrappedEvent.OperatorsResult.PayloadValues = generatedRequest.meta
 		})
 		if hasInteractMatchers {
 			event.UsesInteractsh = true
+		}
+
+		if request.options.GlobalMatchers.HasMatchers() {
+			request.options.GlobalMatchers.Match(interimEvent, request.Match, request.Extract, isDebug, func(event output.InternalEvent, result *operators.Result) {
+				callback(eventcreator.CreateEventWithOperatorResults(request, event, result))
+			})
 		}
 
 		responseContentType := respChain.Response().Header.Get("Content-Type")

--- a/pkg/protocols/protocols.go
+++ b/pkg/protocols/protocols.go
@@ -21,6 +21,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/progress"
 	"github.com/projectdiscovery/nuclei/v3/pkg/projectfile"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/contextargs"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/globalmatchers"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/hosterrorscache"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/interactsh"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/utils/excludematchers"
@@ -116,6 +117,8 @@ type ExecutorOptions struct {
 	// based on given logic. by default nuclei reverts to using value of `-c` when threads count
 	// is not specified or is 0 in template
 	OverrideThreadsCount PayloadThreadSetterCallback
+	// GlobalMatchers is the storage for global matchers with http passive templates
+	GlobalMatchers *globalmatchers.Storage
 }
 
 // GetThreadsForPayloadRequests returns the number of threads to use as default for


### PR DESCRIPTION
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->

Global matchers are passive templates that are executed in the context of each / every template that is being run , this allows use cases like
- detecting and finding secrets from different situations ( not just homepage but all responses received by nuclei due to all templates )
- detecting waf / rate limit / soft 404 / cloudflare waiting page and more

### TODO
- [ ] Resolve merge conflict
- [ ] Add Simple Integration test ( one with matcher + one with matcher  & extractor )
- [ ] Include origin template info in variables / event data as ( `source-template` , `source-template-info` , `source-template-path` ) 
- [ ] when non-passive http template errors and fails to generate event , create a fake event with info and error in `error` field and run it with passive template operators
- [ ] any other ideas/feature that we can add in this context 


Closes #4549 

``` console
$ ./nuclei -t tmpls -u http://localhost:8000 -debug-re

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.1.10

                projectdiscovery.io

[INF] Current nuclei version: v3.1.10 (latest)
[INF] Current nuclei-templates version: v9.7.5 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 106
[INF] Templates loaded for current scan: 1
[INF] Executing 1 signed templates from projectdiscovery/nuclei-templates
[WRN] Executing 1 unsigned templates. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] [git-config] Dumped HTTP request for http://localhost:8000/.git/config

GET /.git/config HTTP/1.1
Host: localhost:8000
User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:94.0) Gecko/20100101 Firefox/94.0
Connection: close
Accept: */*
Accept-Language: en
Accept-Encoding: gzip

[github-personal-token] [passive] [http] [high] http://localhost:8000/.git/config ["ghp_xyzxxxxxxxxxxxxx"]
[git-config] [http] [medium] http://localhost:8000/.git/config
```

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)