### PR TITLE
network layer should not have forceful read

### DIFF
--- a/pkg/protocols/network/request.go
+++ b/pkg/protocols/network/request.go
@@ -336,7 +336,7 @@ func (request *Request) executeRequestWithPayloads(variables map[string]interfac
 	final, err := ConnReadNWithTimeout(conn, int64(bufferSize), DefaultReadTimeout)
 	if err != nil {
 		request.options.Output.Request(request.options.TemplatePath, address, request.Type().String(), err)
-		return errors.Wrap(err, "could not read from server")
+		gologger.Verbose().Msgf("could not read more data from %s: %s", actualAddress, err)
 	}
 	responseBuilder.Write(final)
 


### PR DESCRIPTION
## Proposed changes
This PR makes network final read optional, since it's up to the application protocol level to define which interactions requires a final `recv` operation. All C2 templates and those based only on network variables are currently broken if the server doesn't send any data.

Closes #4518 

## Checklist
- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)