### PR TITLE
use system resolver first with system-resolvers

### DIFF
--- a/pkg/protocols/common/protocolstate/state.go
+++ b/pkg/protocols/common/protocolstate/state.go
@@ -118,6 +118,7 @@ func Init(options *types.Options) error {
 	}
 
 	if options.SystemResolvers {
+		opts.ResolversFile = true
 		opts.EnableFallback = true
 	}
 	if options.ResolversFile != "" {


### PR DESCRIPTION
## Proposed changes
This PR sort resolvers so that when `-system-resolvers` is used the system defined ones are tried first, potentially cutting down timeouts experienced in #4498

## Checklist
- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)