### PR TITLE
fix stop-at-first-match issue in http protocol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ pkg/protocols/headless/engine/.cache
 /integration_tests/.cache/
 /integration_tests/.nuclei-config/
 /*.yaml
+/pkg/protocols/headless/engine/.nuclei-config/

--- a/pkg/catalog/config/constants.go
+++ b/pkg/catalog/config/constants.go
@@ -17,7 +17,7 @@ const (
 	CLIConfigFileName               = "config.yaml"
 	ReportingConfigFilename         = "reporting-config.yaml"
 	// Version is the current version of nuclei
-	Version = `v3.1.10`
+	Version = `v3.2.0-dev`
 	// Directory Names of custom templates
 	CustomS3TemplatesDirName     = "s3"
 	CustomGitHubTemplatesDirName = "github"

--- a/pkg/protocols/http/httputils/spm.go
+++ b/pkg/protocols/http/httputils/spm.go
@@ -86,6 +86,7 @@ func (h *StopAtFirstMatchHandler[T]) Trigger() {
 func (h *StopAtFirstMatchHandler[T]) MatchCallback(fn func()) {
 	if !h.stopEnabled {
 		fn()
+		return
 	}
 	h.once.Do(fn)
 }

--- a/pkg/protocols/http/httputils/spm.go
+++ b/pkg/protocols/http/httputils/spm.go
@@ -111,6 +111,15 @@ func (h *StopAtFirstMatchHandler[T]) Done() <-chan struct{} {
 	return h.ctx.Done()
 }
 
+// FoundFirstMatch returns true if first match was found
+// in stop at first match mode
+func (h *StopAtFirstMatchHandler[T]) FoundFirstMatch() bool {
+	if h.ctx.Err() != nil && h.stopEnabled {
+		return true
+	}
+	return false
+}
+
 // Acquire acquires a new work
 func (h *StopAtFirstMatchHandler[T]) Acquire() {
 	switch h.poolType {

--- a/pkg/protocols/http/httputils/spm.go
+++ b/pkg/protocols/http/httputils/spm.go
@@ -1,0 +1,149 @@
+package httputils
+
+import (
+	"context"
+	"sync"
+
+	"github.com/remeh/sizedwaitgroup"
+)
+
+// WorkPoolType is the type of work pool to use
+type WorkPoolType uint
+
+const (
+	// Blocking blocks addition of new work when the pool is full
+	Blocking WorkPoolType = iota
+	// NonBlocking does not block addition of new work when the pool is full
+	NonBlocking
+)
+
+// StopAtFirstMatchHandler is a handler that executes
+// request and stops on first match
+type StopAtFirstMatchHandler[T any] struct {
+	once sync.Once
+	// Result Channel
+	ResultChan chan T
+
+	// work pool and its type
+	poolType WorkPoolType
+	sgPool   sizedwaitgroup.SizedWaitGroup
+	wgPool   *sync.WaitGroup
+
+	// internal / unexported
+	ctx         context.Context
+	cancel      context.CancelFunc
+	internalWg  *sync.WaitGroup
+	results     []T
+	stopEnabled bool
+}
+
+// NewBlockingSPMHandler creates a new stop at first match handler
+func NewBlockingSPMHandler[T any](ctx context.Context, size int, spm bool) *StopAtFirstMatchHandler[T] {
+	ctx1, cancel := context.WithCancel(ctx)
+	s := &StopAtFirstMatchHandler[T]{
+		ResultChan:  make(chan T, 1),
+		poolType:    Blocking,
+		sgPool:      sizedwaitgroup.New(size),
+		internalWg:  &sync.WaitGroup{},
+		ctx:         ctx1,
+		cancel:      cancel,
+		stopEnabled: spm,
+	}
+	s.internalWg.Add(1)
+	go s.run(ctx)
+	return s
+}
+
+// NewNonBlockingSPMHandler creates a new stop at first match handler
+func NewNonBlockingSPMHandler[T any](ctx context.Context, spm bool) *StopAtFirstMatchHandler[T] {
+	ctx1, cancel := context.WithCancel(ctx)
+	s := &StopAtFirstMatchHandler[T]{
+		ResultChan:  make(chan T, 1),
+		poolType:    NonBlocking,
+		wgPool:      &sync.WaitGroup{},
+		internalWg:  &sync.WaitGroup{},
+		ctx:         ctx1,
+		cancel:      cancel,
+		stopEnabled: spm,
+	}
+	s.internalWg.Add(1)
+	go s.run(ctx)
+	return s
+}
+
+// Trigger triggers the stop at first match handler and stops the execution of
+// existing requests
+func (h *StopAtFirstMatchHandler[T]) Trigger() {
+	if h.stopEnabled {
+		h.cancel()
+	}
+}
+
+// MatchCallback is called when a match is found
+// input fn should be the callback that is intended to be called
+// if stop at first is enabled and other conditions are met
+// if it does not meet above conditions, use of this function is discouraged
+func (h *StopAtFirstMatchHandler[T]) MatchCallback(fn func()) {
+	if !h.stopEnabled {
+		fn()
+	}
+	h.once.Do(fn)
+}
+
+// run runs the internal handler
+func (h *StopAtFirstMatchHandler[T]) run(ctx context.Context) {
+	defer h.internalWg.Done()
+	for {
+		select {
+		case <-ctx.Done():
+		case val, ok := <-h.ResultChan:
+			if !ok {
+				return
+			}
+			h.results = append(h.results, val)
+		}
+	}
+}
+
+// Done returns a channel with the context done signal when stop at first match is detected
+func (h *StopAtFirstMatchHandler[T]) Done() <-chan struct{} {
+	return h.ctx.Done()
+}
+
+// Acquire acquires a new work
+func (h *StopAtFirstMatchHandler[T]) Acquire() {
+	switch h.poolType {
+	case Blocking:
+		h.sgPool.Add()
+	case NonBlocking:
+		h.wgPool.Add(1)
+	}
+}
+
+// Release releases a work
+func (h *StopAtFirstMatchHandler[T]) Release() {
+	switch h.poolType {
+	case Blocking:
+		h.sgPool.Done()
+	case NonBlocking:
+		h.wgPool.Done()
+	}
+}
+
+// Wait waits for all work to be done
+func (h *StopAtFirstMatchHandler[T]) Wait() {
+	switch h.poolType {
+	case Blocking:
+		h.sgPool.Wait()
+	case NonBlocking:
+		h.wgPool.Wait()
+	}
+	// after waiting it closes the error channel
+	close(h.ResultChan)
+	h.internalWg.Wait()
+}
+
+// CombinedResults returns the combined results
+func (h *StopAtFirstMatchHandler[T]) CombinedResults() []T {
+	return h.results
+}

--- a/pkg/protocols/http/request.go
+++ b/pkg/protocols/http/request.go
@@ -137,7 +137,11 @@ func (request *Request) executeParallelHTTP(input *contextargs.Context, dynamicV
 	requestErrChan := make(chan error, runtime.NumCPU())
 	spmCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	// synchronize callback execution to avoid duplications (due to race situations)
+	m := &sync.Mutex{}
 	wrappedCallback := func(event *output.InternalWrappedEvent) {
+		m.Lock()
+		defer m.Unlock()
 		if spmCtx.Err() != nil {
 			return
 		}

--- a/pkg/protocols/protocols.go
+++ b/pkg/protocols/protocols.go
@@ -124,13 +124,11 @@ func (e *ExecutorOptions) GetThreadsForNPayloadRequests(totalRequests int, curre
 	if e.OverrideThreadsCount != nil {
 		return e.OverrideThreadsCount(e, totalRequests, currentThreads)
 	}
-	if currentThreads != 0 {
+	if currentThreads > 0 {
 		return currentThreads
-	}
-	if totalRequests <= 0 {
+	} else {
 		return e.Options.TemplateThreads
 	}
-	return totalRequests
 }
 
 // CreateTemplateCtxStore creates template context store (which contains templateCtx for every scan)


### PR DESCRIPTION
### Proposed Changes
- fix stop-at-first-match not working issue in http protocol 
- closes #4744


```yaml
id: flow-spm-bug

info:
  name: Test HTTP Template
  author: pdteam
  severity: info


http:
  - method: GET
    path:
      - "{{BaseURL}}/{{paths}}"

    payloads:
      paths:
        - gg
        - gg
        - gg

    stop-at-first-match: true
    matchers:
      - type: status
        status:
          - 404
```

### Earlier
```console
$  echo https://example.com  | nuclei -t a.yaml

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.1.10

		projectdiscovery.io

[INF] Current nuclei version: v3.1.10 (latest)
[INF] Current nuclei-templates version: v9.7.5 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 106
[INF] Templates loaded for current scan: 1
[WRN] Executing 1 unsigned templates. Use with caution.
[INF] Targets loaded for current scan: 1
[flow-spm-bug] [http] [info] https://example.com/gg [paths="gg"]
[flow-spm-bug] [http] [info] https://example.com/gg [paths="gg"]
[flow-spm-bug] [http] [info] https://example.com/gg [paths="gg"]
```

### Now

```console
$  echo https://example.com  | ./nuclei -t a.yaml

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.2.0-dev

		projectdiscovery.io

[INF] Current nuclei version: v3.2.0-dev (development)
[INF] Current nuclei-templates version: v9.7.5 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 106
[INF] Templates loaded for current scan: 1
[WRN] Executing 1 unsigned templates. Use with caution.
[INF] Targets loaded for current scan: 1
[flow-spm-bug] [http] [info] https://example.com/gg [paths="gg"]

```