### PR TITLE
fix(http): use insecure cipher suites

### DIFF
--- a/pkg/protocols/http/httpclientpool/clientpool.go
+++ b/pkg/protocols/http/httpclientpool/clientpool.go
@@ -208,11 +208,20 @@ func wrappedGet(options *types.Options, configuration *Configuration) (*retryabl
 		disableKeepAlives = configuration.Connection.DisableKeepAlive
 	}
 
+	unsafeCipherSuites := make([]uint16, 0, len(tls.InsecureCipherSuites())+len(tls.CipherSuites()))
+	for _, suite := range tls.InsecureCipherSuites() {
+		unsafeCipherSuites = append(unsafeCipherSuites, suite.ID)
+	}
+	for _, suite := range tls.CipherSuites() {
+		unsafeCipherSuites = append(unsafeCipherSuites, suite.ID)
+	}
+
 	// Set the base TLS configuration definition
 	tlsConfig := &tls.Config{
 		Renegotiation:      tls.RenegotiateOnceAsClient,
 		InsecureSkipVerify: true,
 		MinVersion:         tls.VersionTLS10,
+		CipherSuites:       unsafeCipherSuites,
 	}
 
 	if options.SNI != "" {


### PR DESCRIPTION
## Proposed changes

Go 1.22 disabled the RSA key exchange cipher suites:
https://github.com/golang/go/issues/63413

In order to be able to scan servers only supporting these cipher suites, the http client needs to explicitly support these.

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)