### PR TITLE
Implement more granular, issue tracker level filtering

### DIFF
--- a/cmd/nuclei/issue-tracker-config.yaml
+++ b/cmd/nuclei/issue-tracker-config.yaml
@@ -1,3 +1,8 @@
+# global allow/deny list. this will affect both exporters
+# as well as issue trackers. you can filter trackers with
+# a tracker level filter on top of an exporter by setting
+# allow-list/deny-list per tracker.
+#
 #allow-list:
 #  severity: high, critical
 #deny-list:
@@ -17,6 +22,15 @@
 #  project-name: test-project
 #  # issue-label is the label of the created issue type
 #  issue-label: bug
+#  # allow-list sets a tracker level filter to only create issues for templates with
+#  # these severity labels or tags (does not affect exporters. set those globally)
+#  allow-list:
+#    severity: high, critical
+#    tags: network
+#  # deny-list sets a tracker level filter to never create issues for templates with
+#  # these severity labels or tags (does not affect exporters. set those globally)
+#  deny-list:
+#    severity: low
 #  # duplicate-issue-check flag to enable duplicate tracking issue check.
 #  duplicate-issue-check: false
 #
@@ -32,6 +46,15 @@
 #  project-name: "1234"
 #  # issue-label is the label of the created issue type
 #  issue-label: bug
+#  # allow-list sets a tracker level filter to only create issues for templates with
+#  # these severity labels or tags (does not affect exporters. set those globally)
+#  allow-list:
+#    severity: high, critical
+#    tags: network
+#  # deny-list sets a tracker level filter to never create issues for templates with
+#  # these severity labels or tags (does not affect exporters. set those globally)
+#  deny-list:
+#    severity: low
 #
 # Gitea contains configuration options for a gitea issue tracker
 #gitea:
@@ -47,6 +70,15 @@
 #  issue-label: bug
 #  # severity-as-label (optional) adds the severity as a label of the created issue
 #  severity-as-label: true
+#  # allow-list sets a tracker level filter to only create issues for templates with
+#  # these severity labels or tags (does not affect exporters. set those globally)
+#  allow-list:
+#    severity: high, critical
+#    tags: network
+#  # deny-list sets a tracker level filter to never create issues for templates with
+#  # these severity labels or tags (does not affect exporters. set those globally)
+#  deny-list:
+#    severity: low
 #  # duplicate-issue-check (optional) flag to enable duplicate tracking issue check
 #  duplicate-issue-check: false
 #
@@ -71,6 +103,15 @@
 #  # SeverityAsLabel (optional) sends the severity as the label of the created issue
 #  # User custom fields for Jira Cloud instead
 #  severity-as-label: true
+#  # allow-list sets a tracker level filter to only create issues for templates with
+#  # these severity labels or tags (does not affect exporters. set those globally)
+#  allow-list:
+#    severity: high, critical
+#    tags: network
+#  # deny-list sets a tracker level filter to never create issues for templates with
+#  # these severity labels or tags (does not affect exporters. set those globally)
+#  deny-list:
+#    severity: low
 #  # Whatever your final status is that you want to use as a closed ticket - Closed, Done, Remediated, etc
 #  # When checking for duplicates, the JQL query will filter out status's that match this.
 #  # If it finds a match _and_ the ticket does have this status, a new one will be created.

--- a/pkg/reporting/options.go
+++ b/pkg/reporting/options.go
@@ -7,6 +7,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/reporting/exporters/markdown"
 	"github.com/projectdiscovery/nuclei/v3/pkg/reporting/exporters/sarif"
 	"github.com/projectdiscovery/nuclei/v3/pkg/reporting/exporters/splunk"
+	"github.com/projectdiscovery/nuclei/v3/pkg/reporting/trackers/filters"
 	"github.com/projectdiscovery/nuclei/v3/pkg/reporting/trackers/gitea"
 	"github.com/projectdiscovery/nuclei/v3/pkg/reporting/trackers/github"
 	"github.com/projectdiscovery/nuclei/v3/pkg/reporting/trackers/gitlab"
@@ -17,9 +18,9 @@ import (
 // Options is a configuration file for nuclei reporting module
 type Options struct {
 	// AllowList contains a list of allowed events for reporting module
-	AllowList *Filter `yaml:"allow-list"`
+	AllowList *filters.Filter `yaml:"allow-list"`
 	// DenyList contains a list of denied events for reporting module
-	DenyList *Filter `yaml:"deny-list"`
+	DenyList *filters.Filter `yaml:"deny-list"`
 	// GitHub contains configuration options for GitHub Issue Tracker
 	GitHub *github.Options `yaml:"github"`
 	// GitLab contains configuration options for GitLab Issue Tracker

--- a/pkg/reporting/reporting.go
+++ b/pkg/reporting/reporting.go
@@ -201,6 +201,7 @@ func CreateConfigIfNotExists() error {
 		DenyList:              &Filter{Tags: values},
 		GitHub:                &github.Options{},
 		GitLab:                &gitlab.Options{},
+		Gitea:                 &gitea.Options{},
 		Jira:                  &jira.Options{},
 		MarkdownExporter:      &markdown.Options{},
 		SarifExporter:         &sarif.Options{},

--- a/pkg/reporting/trackers/filters/filters.go
+++ b/pkg/reporting/trackers/filters/filters.go
@@ -1,0 +1,47 @@
+package filters
+
+import (
+	"github.com/projectdiscovery/nuclei/v3/pkg/model/types/severity"
+	"github.com/projectdiscovery/nuclei/v3/pkg/model/types/stringslice"
+	"github.com/projectdiscovery/nuclei/v3/pkg/output"
+
+	sliceutil "github.com/projectdiscovery/utils/slice"
+)
+
+// Filter filters the received event and decides whether to perform
+// reporting for it or not.
+type Filter struct {
+	Severities severity.Severities     `yaml:"severity"`
+	Tags       stringslice.StringSlice `yaml:"tags"`
+}
+
+// GetMatch returns true if a filter matches result event
+func (filter *Filter) GetMatch(event *output.ResultEvent) bool {
+	return isSeverityMatch(event, filter) && isTagMatch(event, filter) // TODO revisit this
+}
+
+func isTagMatch(event *output.ResultEvent, filter *Filter) bool {
+	filterTags := filter.Tags
+	if filterTags.IsEmpty() {
+		return true
+	}
+
+	tags := event.Info.Tags.ToSlice()
+	for _, filterTag := range filterTags.ToSlice() {
+		if sliceutil.Contains(tags, filterTag) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func isSeverityMatch(event *output.ResultEvent, filter *Filter) bool {
+	resultEventSeverity := event.Info.SeverityHolder.Severity // TODO review
+
+	if len(filter.Severities) == 0 {
+		return true
+	}
+
+	return sliceutil.Contains(filter.Severities, resultEventSeverity)
+}

--- a/pkg/reporting/trackers/gitea/gitea.go
+++ b/pkg/reporting/trackers/gitea/gitea.go
@@ -10,6 +10,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/output"
 	"github.com/projectdiscovery/nuclei/v3/pkg/reporting/exporters/markdown/util"
 	"github.com/projectdiscovery/nuclei/v3/pkg/reporting/format"
+	"github.com/projectdiscovery/nuclei/v3/pkg/reporting/trackers/filters"
 	"github.com/projectdiscovery/retryablehttp-go"
 )
 
@@ -34,6 +35,10 @@ type Options struct {
 	// SeverityAsLabel (optional) adds the severity as the label of the created
 	// issue.
 	SeverityAsLabel bool `yaml:"severity-as-label"`
+	// AllowList contains a list of allowed events for this tracker
+	AllowList *filters.Filter `yaml:"allow-list"`
+	// DenyList contains a list of denied events for this tracker
+	DenyList *filters.Filter `yaml:"deny-list"`
 	// DuplicateIssueCheck is a bool to enable duplicate tracking issue check and update the newest
 	DuplicateIssueCheck bool `yaml:"duplicate-issue-check" default:"false"`
 
@@ -114,6 +119,19 @@ func (i *Integration) CreateIssue(event *output.ResultEvent) error {
 	})
 
 	return err
+}
+
+// ShouldFilter determines if an issue should be logged to this tracker
+func (i *Integration) ShouldFilter(event *output.ResultEvent) bool {
+	if i.options.AllowList != nil && i.options.AllowList.GetMatch(event) {
+		return true
+	}
+
+	if i.options.DenyList != nil && i.options.DenyList.GetMatch(event) {
+		return true
+	}
+
+	return false
 }
 
 func (i *Integration) findIssueByTitle(title string) (*gitea.Issue, error) {

--- a/pkg/reporting/trackers/gitlab/gitlab.go
+++ b/pkg/reporting/trackers/gitlab/gitlab.go
@@ -8,6 +8,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/output"
 	"github.com/projectdiscovery/nuclei/v3/pkg/reporting/exporters/markdown/util"
 	"github.com/projectdiscovery/nuclei/v3/pkg/reporting/format"
+	"github.com/projectdiscovery/nuclei/v3/pkg/reporting/trackers/filters"
 	"github.com/projectdiscovery/retryablehttp-go"
 )
 
@@ -33,6 +34,10 @@ type Options struct {
 	// SeverityAsLabel (optional) sends the severity as the label of the created
 	// issue.
 	SeverityAsLabel bool `yaml:"severity-as-label"`
+	// AllowList contains a list of allowed events for this tracker
+	AllowList *filters.Filter `yaml:"allow-list"`
+	// DenyList contains a list of denied events for this tracker
+	DenyList *filters.Filter `yaml:"deny-list"`
 	// DuplicateIssueCheck is a bool to enable duplicate tracking issue check and update the newest
 	DuplicateIssueCheck bool `yaml:"duplicate-issue-check" default:"false"`
 
@@ -111,4 +116,17 @@ func (i *Integration) CreateIssue(event *output.ResultEvent) error {
 	})
 
 	return err
+}
+
+// ShouldFilter determines if an issue should be logged to this tracker
+func (i *Integration) ShouldFilter(event *output.ResultEvent) bool {
+	if i.options.AllowList != nil && i.options.AllowList.GetMatch(event) {
+		return true
+	}
+
+	if i.options.DenyList != nil && i.options.DenyList.GetMatch(event) {
+		return true
+	}
+
+	return false
 }


### PR DESCRIPTION
## Proposed changes

This PR is an implementation proposal for #4779, making it possible to further apply issue/tag filters to issue trackers via a new, per tracker `allow-list` / `deny-list` options key. This makes it possible to have everything written via an exporter, but only certain issues logged in a tracker.

I wanted to reuse the existing code used for a `Filter`, but to prevent a cyclic dependency in issue trackers I had to move that out to a new package. Next, I had to extend the `Tracker` interface to include a `ShouldFilter`. I don't particularly like this because of the duplicate code, but I am hesitant to change the internal structure too much.

## Checklist

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)