### PR TITLE
allow specifying self-contained at http request level

### DIFF
--- a/pkg/js/generated/go/liboracle/oracle.go
+++ b/pkg/js/generated/go/liboracle/oracle.go
@@ -15,12 +15,12 @@ func init() {
 	module.Set(
 		gojs.Objects{
 			// Functions
+			"IsOracle": lib_oracle.IsOracle,
 
 			// Var and consts
 
 			// Objects / Classes
 			"IsOracleResponse": gojs.GetClassConstructor[lib_oracle.IsOracleResponse](&lib_oracle.IsOracleResponse{}),
-			"OracleClient":     gojs.GetClassConstructor[lib_oracle.OracleClient](&lib_oracle.OracleClient{}),
 		},
 	).Register()
 }

--- a/pkg/js/generated/go/libpop3/pop3.go
+++ b/pkg/js/generated/go/libpop3/pop3.go
@@ -15,12 +15,12 @@ func init() {
 	module.Set(
 		gojs.Objects{
 			// Functions
+			"IsPOP3": lib_pop3.IsPOP3,
 
 			// Var and consts
 
 			// Objects / Classes
 			"IsPOP3Response": gojs.GetClassConstructor[lib_pop3.IsPOP3Response](&lib_pop3.IsPOP3Response{}),
-			"Pop3Client":     gojs.GetClassConstructor[lib_pop3.Pop3Client](&lib_pop3.Pop3Client{}),
 		},
 	).Register()
 }

--- a/pkg/js/generated/go/librdp/rdp.go
+++ b/pkg/js/generated/go/librdp/rdp.go
@@ -15,13 +15,14 @@ func init() {
 	module.Set(
 		gojs.Objects{
 			// Functions
+			"CheckRDPAuth": lib_rdp.CheckRDPAuth,
+			"IsRDP":        lib_rdp.IsRDP,
 
 			// Var and consts
 
 			// Objects / Classes
 			"CheckRDPAuthResponse": gojs.GetClassConstructor[lib_rdp.CheckRDPAuthResponse](&lib_rdp.CheckRDPAuthResponse{}),
 			"IsRDPResponse":        gojs.GetClassConstructor[lib_rdp.IsRDPResponse](&lib_rdp.IsRDPResponse{}),
-			"RDPClient":            gojs.GetClassConstructor[lib_rdp.RDPClient](&lib_rdp.RDPClient{}),
 		},
 	).Register()
 }

--- a/pkg/js/generated/go/librsync/rsync.go
+++ b/pkg/js/generated/go/librsync/rsync.go
@@ -15,12 +15,12 @@ func init() {
 	module.Set(
 		gojs.Objects{
 			// Functions
+			"IsRsync": lib_rsync.IsRsync,
 
 			// Var and consts
 
 			// Objects / Classes
 			"IsRsyncResponse": gojs.GetClassConstructor[lib_rsync.IsRsyncResponse](&lib_rsync.IsRsyncResponse{}),
-			"RsyncClient":     gojs.GetClassConstructor[lib_rsync.RsyncClient](&lib_rsync.RsyncClient{}),
 		},
 	).Register()
 }

--- a/pkg/js/generated/go/libsmtp/smtp.go
+++ b/pkg/js/generated/go/libsmtp/smtp.go
@@ -15,13 +15,14 @@ func init() {
 	module.Set(
 		gojs.Objects{
 			// Functions
+			"NewSMTPClient": lib_smtp.NewSMTPClient,
 
 			// Var and consts
 
 			// Objects / Classes
-			"IsSMTPResponse": gojs.GetClassConstructor[lib_smtp.IsSMTPResponse](&lib_smtp.IsSMTPResponse{}),
-			"SMTPClient":     gojs.GetClassConstructor[lib_smtp.SMTPClient](&lib_smtp.SMTPClient{}),
-			"SMTPMessage":    gojs.GetClassConstructor[lib_smtp.SMTPMessage](&lib_smtp.SMTPMessage{}),
+			"Client":       lib_smtp.NewSMTPClient,
+			"SMTPMessage":  gojs.GetClassConstructor[lib_smtp.SMTPMessage](&lib_smtp.SMTPMessage{}),
+			"SMTPResponse": gojs.GetClassConstructor[lib_smtp.SMTPResponse](&lib_smtp.SMTPResponse{}),
 		},
 	).Register()
 }

--- a/pkg/js/generated/go/libtelnet/telnet.go
+++ b/pkg/js/generated/go/libtelnet/telnet.go
@@ -15,12 +15,12 @@ func init() {
 	module.Set(
 		gojs.Objects{
 			// Functions
+			"IsTelnet": lib_telnet.IsTelnet,
 
 			// Var and consts
 
 			// Objects / Classes
 			"IsTelnetResponse": gojs.GetClassConstructor[lib_telnet.IsTelnetResponse](&lib_telnet.IsTelnetResponse{}),
-			"TelnetClient":     gojs.GetClassConstructor[lib_telnet.TelnetClient](&lib_telnet.TelnetClient{}),
 		},
 	).Register()
 }

--- a/pkg/js/generated/go/libvnc/vnc.go
+++ b/pkg/js/generated/go/libvnc/vnc.go
@@ -15,12 +15,12 @@ func init() {
 	module.Set(
 		gojs.Objects{
 			// Functions
+			"IsVNC": lib_vnc.IsVNC,
 
 			// Var and consts
 
 			// Objects / Classes
 			"IsVNCResponse": gojs.GetClassConstructor[lib_vnc.IsVNCResponse](&lib_vnc.IsVNCResponse{}),
-			"VNCClient":     gojs.GetClassConstructor[lib_vnc.VNCClient](&lib_vnc.VNCClient{}),
 		},
 	).Register()
 }

--- a/pkg/js/generated/ts/ikev2.ts
+++ b/pkg/js/generated/ts/ikev2.ts
@@ -96,6 +96,7 @@ export class IKEMessage {
  * const ikev2 = require('nuclei/ikev2');
  * const nonce = new ikev2.IKENonce();
  * nonce.NonceData = [1, 2, 3];
+ * ```
  */
 export interface IKENonce {
     

--- a/pkg/js/generated/ts/kerberos.ts
+++ b/pkg/js/generated/ts/kerberos.ts
@@ -236,6 +236,8 @@ export interface Config {
  */
 export interface EncTicketPart {
     
+    RenewTill?: Date,
+    
     CRealm?: string,
     
     AuthTime?: Date,
@@ -244,19 +246,17 @@ export interface EncTicketPart {
     
     EndTime?: Date,
     
-    RenewTill?: Date,
+    Transited?: TransitedEncoding,
+    
+    CAddr?: HostAddress,
+    
+    AuthorizationData?: AuthorizationDataEntry,
     
     Flags?: BitString,
     
     Key?: EncryptionKey,
     
     CName?: PrincipalName,
-    
-    Transited?: TransitedEncoding,
-    
-    CAddr?: HostAddress,
-    
-    AuthorizationData?: AuthorizationDataEntry,
 }
 
 
@@ -266,11 +266,11 @@ export interface EncTicketPart {
  */
 export interface EncryptedData {
     
+    Cipher?: Uint8Array,
+    
     EType?: number,
     
     KVNO?: number,
-    
-    Cipher?: Uint8Array,
 }
 
 
@@ -318,15 +318,15 @@ export interface HostAddress {
  */
 export interface LibDefaults {
     
-    NoAddresses?: boolean,
+    /**
+    * time in nanoseconds
+    */
     
-    CCacheType?: number,
-    
-    DefaultClientKeytabName?: string,
-    
-    DNSCanonicalizeHostname?: boolean,
+    Clockskew?: number,
     
     KDCTimeSync?: number,
+    
+    SafeChecksumType?: number,
     
     /**
     * time in nanoseconds
@@ -334,9 +334,49 @@ export interface LibDefaults {
     
     TicketLifetime?: number,
     
+    Forwardable?: boolean,
+    
+    K5LoginAuthoritative?: boolean,
+    
+    AllowWeakCrypto?: boolean,
+    
+    DefaultClientKeytabName?: string,
+    
+    DefaultTktEnctypes?: string[],
+    
+    ExtraAddresses?: Uint8Array,
+    
+    K5LoginDirectory?: string,
+    
+    PreferredPreauthTypes?: number[],
+    
+    RDNS?: boolean,
+    
+    DefaultKeytabName?: string,
+    
+    DefaultRealm?: string,
+    
+    DefaultTGSEnctypeIDs?: number[],
+    
+    DNSCanonicalizeHostname?: boolean,
+    
+    PermittedEnctypes?: string[],
+    
+    VerifyAPReqNofail?: boolean,
+    
+    DNSLookupRealm?: boolean,
+    
+    UDPPreferenceLimit?: number,
+    
     Canonicalize?: boolean,
     
-    IgnoreAcceptorHostname?: boolean,
+    CCacheType?: number,
+    
+    DefaultTGSEnctypes?: string[],
+    
+    Proxiable?: boolean,
+    
+    DNSLookupKDC?: boolean,
     
     RealmTryDomains?: number,
     
@@ -346,53 +386,13 @@ export interface LibDefaults {
     
     RenewLifetime?: number,
     
-    DefaultTGSEnctypeIDs?: number[],
-    
-    DefaultTktEnctypes?: string[],
-    
-    DNSLookupKDC?: boolean,
-    
-    ExtraAddresses?: Uint8Array,
-    
-    PreferredPreauthTypes?: number[],
-    
-    DefaultTGSEnctypes?: string[],
-    
     DefaultTktEnctypeIDs?: number[],
     
-    DefaultKeytabName?: string,
+    IgnoreAcceptorHostname?: boolean,
     
-    RDNS?: boolean,
-    
-    SafeChecksumType?: number,
-    
-    UDPPreferenceLimit?: number,
-    
-    VerifyAPReqNofail?: boolean,
-    
-    PermittedEnctypes?: string[],
-    
-    Forwardable?: boolean,
-    
-    DefaultRealm?: string,
-    
-    /**
-    * time in nanoseconds
-    */
-    
-    Clockskew?: number,
-    
-    DNSLookupRealm?: boolean,
-    
-    K5LoginAuthoritative?: boolean,
-    
-    K5LoginDirectory?: string,
+    NoAddresses?: boolean,
     
     PermittedEnctypeIDs?: number[],
-    
-    Proxiable?: boolean,
-    
-    AllowWeakCrypto?: boolean,
     
     KDCDefaultOptions?: BitString,
 }
@@ -416,17 +416,17 @@ export interface PrincipalName {
  */
 export interface Realm {
     
-    KDC?: string[],
-    
-    KPasswdServer?: string[],
-    
-    MasterKDC?: string[],
-    
     Realm?: string,
     
     AdminServer?: string[],
     
     DefaultDomain?: string,
+    
+    KDC?: string[],
+    
+    KPasswdServer?: string[],
+    
+    MasterKDC?: string[],
 }
 
 
@@ -450,15 +450,15 @@ export interface TGS {
  */
 export interface Ticket {
     
+    Realm?: string,
+    
     TktVNO?: number,
     
-    Realm?: string,
+    SName?: PrincipalName,
     
     EncPart?: EncryptedData,
     
     DecryptedEncPart?: EncTicketPart,
-    
-    SName?: PrincipalName,
 }
 
 

--- a/pkg/js/generated/ts/kerberos.ts
+++ b/pkg/js/generated/ts/kerberos.ts
@@ -246,6 +246,8 @@ export interface EncTicketPart {
     
     RenewTill?: Date,
     
+    Flags?: BitString,
+    
     Key?: EncryptionKey,
     
     CName?: PrincipalName,
@@ -255,8 +257,6 @@ export interface EncTicketPart {
     CAddr?: HostAddress,
     
     AuthorizationData?: AuthorizationDataEntry,
-    
-    Flags?: BitString,
 }
 
 
@@ -266,11 +266,11 @@ export interface EncTicketPart {
  */
 export interface EncryptedData {
     
-    Cipher?: Uint8Array,
-    
     EType?: number,
     
     KVNO?: number,
+    
+    Cipher?: Uint8Array,
 }
 
 
@@ -306,9 +306,9 @@ export interface EnumerateUserResponse {
  */
 export interface HostAddress {
     
-    Address?: Uint8Array,
-    
     AddrType?: number,
+    
+    Address?: Uint8Array,
 }
 
 
@@ -318,29 +318,15 @@ export interface HostAddress {
  */
 export interface LibDefaults {
     
-    DefaultTGSEnctypes?: string[],
-    
-    DefaultTktEnctypes?: string[],
-    
-    K5LoginDirectory?: string,
-    
-    RealmTryDomains?: number,
-    
-    Canonicalize?: boolean,
-    
-    K5LoginAuthoritative?: boolean,
-    
     NoAddresses?: boolean,
     
-    SafeChecksumType?: number,
+    CCacheType?: number,
     
     DefaultClientKeytabName?: string,
     
-    DNSLookupKDC?: boolean,
+    DNSCanonicalizeHostname?: boolean,
     
-    IgnoreAcceptorHostname?: boolean,
-    
-    Proxiable?: boolean,
+    KDCTimeSync?: number,
     
     /**
     * time in nanoseconds
@@ -348,35 +334,11 @@ export interface LibDefaults {
     
     TicketLifetime?: number,
     
-    DefaultKeytabName?: string,
+    Canonicalize?: boolean,
     
-    DefaultTktEnctypeIDs?: number[],
+    IgnoreAcceptorHostname?: boolean,
     
-    Forwardable?: boolean,
-    
-    PermittedEnctypeIDs?: number[],
-    
-    PreferredPreauthTypes?: number[],
-    
-    UDPPreferenceLimit?: number,
-    
-    VerifyAPReqNofail?: boolean,
-    
-    /**
-    * time in nanoseconds
-    */
-    
-    Clockskew?: number,
-    
-    RDNS?: boolean,
-    
-    DNSCanonicalizeHostname?: boolean,
-    
-    KDCTimeSync?: number,
-    
-    PermittedEnctypes?: string[],
-    
-    DefaultRealm?: string,
+    RealmTryDomains?: number,
     
     /**
     * time in nanoseconds
@@ -384,13 +346,51 @@ export interface LibDefaults {
     
     RenewLifetime?: number,
     
-    CCacheType?: number,
-    
     DefaultTGSEnctypeIDs?: number[],
+    
+    DefaultTktEnctypes?: string[],
+    
+    DNSLookupKDC?: boolean,
+    
+    ExtraAddresses?: Uint8Array,
+    
+    PreferredPreauthTypes?: number[],
+    
+    DefaultTGSEnctypes?: string[],
+    
+    DefaultTktEnctypeIDs?: number[],
+    
+    DefaultKeytabName?: string,
+    
+    RDNS?: boolean,
+    
+    SafeChecksumType?: number,
+    
+    UDPPreferenceLimit?: number,
+    
+    VerifyAPReqNofail?: boolean,
+    
+    PermittedEnctypes?: string[],
+    
+    Forwardable?: boolean,
+    
+    DefaultRealm?: string,
+    
+    /**
+    * time in nanoseconds
+    */
+    
+    Clockskew?: number,
     
     DNSLookupRealm?: boolean,
     
-    ExtraAddresses?: Uint8Array,
+    K5LoginAuthoritative?: boolean,
+    
+    K5LoginDirectory?: string,
+    
+    PermittedEnctypeIDs?: number[],
+    
+    Proxiable?: boolean,
     
     AllowWeakCrypto?: boolean,
     
@@ -416,8 +416,6 @@ export interface PrincipalName {
  */
 export interface Realm {
     
-    DefaultDomain?: string,
-    
     KDC?: string[],
     
     KPasswdServer?: string[],
@@ -427,6 +425,8 @@ export interface Realm {
     Realm?: string,
     
     AdminServer?: string[],
+    
+    DefaultDomain?: string,
 }
 
 
@@ -454,11 +454,11 @@ export interface Ticket {
     
     Realm?: string,
     
-    SName?: PrincipalName,
-    
     EncPart?: EncryptedData,
     
     DecryptedEncPart?: EncTicketPart,
+    
+    SName?: PrincipalName,
 }
 
 

--- a/pkg/js/generated/ts/ldap.ts
+++ b/pkg/js/generated/ts/ldap.ts
@@ -473,6 +473,7 @@ export class Client {
  * const client = new ldap.Client('ldap://ldap.example.com', 'acme.com');
  * const users = client.GetADUsers();
  * log(to_json(users));
+ * ```
  */
 export interface ADObject {
     

--- a/pkg/js/generated/ts/mssql.ts
+++ b/pkg/js/generated/ts/mssql.ts
@@ -6,7 +6,7 @@
  * @example
  * ```javascript
  * const mssql = require('nuclei/mssql');
- * const client = new mssql.Client();
+ * const client = new mssql.MSSQLClient;
  * ```
  */
 export class MSSQLClient {
@@ -22,7 +22,7 @@ export class MSSQLClient {
     * @example
     * ```javascript
     * const mssql = require('nuclei/mssql');
-    * const client = new mssql.Client();
+    * const client = new mssql.MSSQLClient;
     * const connected = client.Connect('acme.com', 1433, 'username', 'password');
     * ```
     */
@@ -39,7 +39,7 @@ export class MSSQLClient {
     * @example
     * ```javascript
     * const mssql = require('nuclei/mssql');
-    * const client = new mssql.Client();
+    * const client = new mssql.MSSQLClient;
     * const connected = client.ConnectWithDB('acme.com', 1433, 'username', 'password', 'master');
     * ```
     */

--- a/pkg/js/generated/ts/mysql.ts
+++ b/pkg/js/generated/ts/mysql.ts
@@ -23,7 +23,7 @@ export function BuildDSN(opts: MySQLOptions): string | null {
  * @example
  * ```javascript
  * const mysql = require('nuclei/mysql');
- * const client = new mysql.Client();
+ * const client = new mysql.MySQLClient;
  * ```
  */
 export class MySQLClient {
@@ -54,7 +54,7 @@ export class MySQLClient {
     * @example
     * ```javascript
     * const mysql = require('nuclei/mysql');
-    * const client = new mysql.Client();
+    * const client = new mysql.MySQLClient;
     * const connected = client.Connect('acme.com', 3306, 'username', 'password');
     * ```
     */
@@ -84,7 +84,7 @@ export class MySQLClient {
     * @example
     * ```javascript
     * const mysql = require('nuclei/mysql');
-    * const client = new mysql.Client();
+    * const client = new mysql.MySQLClient;
     * const connected = client.ConnectWithDSN('username:password@tcp(acme.com:3306)/');
     * ```
     */
@@ -221,10 +221,10 @@ export interface SQLResult {
  */
 export interface ServiceMySQL {
     
-    PacketType?: string,
-    
     ErrorMessage?: string,
     
     ErrorCode?: number,
+    
+    PacketType?: string,
 }
 

--- a/pkg/js/generated/ts/mysql.ts
+++ b/pkg/js/generated/ts/mysql.ts
@@ -209,9 +209,9 @@ export interface MySQLOptions {
  */
 export interface SQLResult {
     
-    Count?: number,
-    
     Columns?: string[],
+    
+    Count?: number,
 }
 
 
@@ -221,10 +221,10 @@ export interface SQLResult {
  */
 export interface ServiceMySQL {
     
+    PacketType?: string,
+    
     ErrorMessage?: string,
     
     ErrorCode?: number,
-    
-    PacketType?: string,
 }
 

--- a/pkg/js/generated/ts/net.ts
+++ b/pkg/js/generated/ts/net.ts
@@ -115,14 +115,32 @@ export class NetConn {
     
 
     /**
-    * Recv receives data from the connection with a timeout.
+    * RecvFull receives data from the connection with a timeout.
     * If N is 0, it will read all data sent by the server with 8MB limit.
     * it tries to read until N bytes or timeout is reached.
     * @example
     * ```javascript
     * const net = require('nuclei/net');
     * const conn = net.Open('tcp', 'acme.com:80');
+    * const data = conn.RecvFull(1024);
+    * ```
+    */
+    public RecvFull(N: number): Uint8Array | null {
+        return null;
+    }
+    
+
+    /**
+    * Recv is similar to RecvFull but does not guarantee full read instead
+    * it creates a buffer of N bytes and returns whatever is returned by the connection
+    * for reading headers or initial bytes from the server this is usually used.
+    * for reading a fixed number of already known bytes (ex: body based on content-length) use RecvFull.
+    * @example
+    * ```javascript
+    * const net = require('nuclei/net');
+    * const conn = net.Open('tcp', 'acme.com:80');
     * const data = conn.Recv(1024);
+    * log(`Received ${data.length} bytes from the server`)
     * ```
     */
     public Recv(N: number): Uint8Array | null {
@@ -131,26 +149,26 @@ export class NetConn {
     
 
     /**
-    * RecvPartial is similar to Recv but it does not perform full read instead
-    * it creates a buffer of N bytes and returns whatever is returned by the connection
-    * this is usually used when fingerprinting services to get initial bytes from the server.
+    * RecvFullString receives data from the connection with a timeout
+    * output is returned as a string.
+    * If N is 0, it will read all data sent by the server with 8MB limit.
     * @example
     * ```javascript
     * const net = require('nuclei/net');
     * const conn = net.Open('tcp', 'acme.com:80');
-    * const data = conn.RecvPartial(1024);
-    * log(`Received ${data.length} bytes from the server`)
+    * const data = conn.RecvFullString(1024);
     * ```
     */
-    public RecvPartial(N: number): Uint8Array | null {
+    public RecvFullString(N: number): string | null {
         return null;
     }
     
 
     /**
-    * RecvString receives data from the connection with a timeout
-    * output is returned as a string.
-    * If N is 0, it will read all data sent by the server with 8MB limit.
+    * RecvString is similar to RecvFullString but does not guarantee full read, instead
+    * it creates a buffer of N bytes and returns whatever is returned by the connection
+    * for reading headers or initial bytes from the server this is usually used.
+    * for reading a fixed number of already known bytes (ex: body based on content-length) use RecvFullString.
     * @example
     * ```javascript
     * const net = require('nuclei/net');
@@ -164,9 +182,27 @@ export class NetConn {
     
 
     /**
-    * RecvHex receives data from the connection with a timeout
+    * RecvFullHex receives data from the connection with a timeout
     * in hex format.
     * If N is 0,it will read all data sent by the server with 8MB limit.
+    * until N bytes or timeout is reached.
+    * @example
+    * ```javascript
+    * const net = require('nuclei/net');
+    * const conn = net.Open('tcp', 'acme.com:80');
+    * const data = conn.RecvFullHex(1024);
+    * ```
+    */
+    public RecvFullHex(N: number): string | null {
+        return null;
+    }
+    
+
+    /**
+    * RecvHex is similar to RecvFullHex but does not guarantee full read instead
+    * it creates a buffer of N bytes and returns whatever is returned by the connection
+    * for reading headers or initial bytes from the server this is usually used.
+    * for reading a fixed number of already known bytes (ex: body based on content-length) use RecvFull.
     * @example
     * ```javascript
     * const net = require('nuclei/net');

--- a/pkg/js/generated/ts/oracle.ts
+++ b/pkg/js/generated/ts/oracle.ts
@@ -1,32 +1,16 @@
 
 
 /**
- * OracleClient is a minimal Oracle client for nuclei scripts.
+ * IsOracle checks if a host is running an Oracle server
  * @example
  * ```javascript
  * const oracle = require('nuclei/oracle');
- * const client = new oracle.Client();
+ * const isOracle = oracle.IsOracle('acme.com', 1521);
+ * log(toJSON(isOracle));
  * ```
  */
-export class OracleClient {
-    
-
-    // Constructor of OracleClient
-    constructor() {}
-    /**
-    * IsOracle checks if a host is running an Oracle server
-    * @example
-    * ```javascript
-    * const oracle = require('nuclei/oracle');
-    * const isOracle = oracle.IsOracle('acme.com', 1521);
-    * log(toJSON(isOracle));
-    * ```
-    */
-    public IsOracle(host: string, port: number): IsOracleResponse | null {
-        return null;
-    }
-    
-
+export function IsOracle(host: string, port: number): IsOracleResponse | null {
+    return null;
 }
 
 

--- a/pkg/js/generated/ts/pop3.ts
+++ b/pkg/js/generated/ts/pop3.ts
@@ -1,32 +1,16 @@
 
 
 /**
- * Pop3Client is a minimal POP3 client for nuclei scripts.
+ * IsPOP3 checks if a host is running a POP3 server.
  * @example
  * ```javascript
  * const pop3 = require('nuclei/pop3');
- * const client = new pop3.Client();
+ * const isPOP3 = pop3.IsPOP3('acme.com', 110);
+ * log(toJSON(isPOP3));
  * ```
  */
-export class Pop3Client {
-    
-
-    // Constructor of Pop3Client
-    constructor() {}
-    /**
-    * IsPOP3 checks if a host is running a POP3 server.
-    * @example
-    * ```javascript
-    * const pop3 = require('nuclei/pop3');
-    * const isPOP3 = pop3.IsPOP3('acme.com', 110);
-    * log(toJSON(isPOP3));
-    * ```
-    */
-    public IsPOP3(host: string, port: number): IsPOP3Response | null {
-        return null;
-    }
-    
-
+export function IsPOP3(host: string, port: number): IsPOP3Response | null {
+    return null;
 }
 
 

--- a/pkg/js/generated/ts/postgres.ts
+++ b/pkg/js/generated/ts/postgres.ts
@@ -6,7 +6,7 @@
  * @example
  * ```javascript
  * const postgres = require('nuclei/postgres');
- * const client = new postgres.Client();
+ * const client = new postgres.PGClient;
  * ```
  */
 export class PGClient {
@@ -37,7 +37,7 @@ export class PGClient {
     * @example
     * ```javascript
     * const postgres = require('nuclei/postgres');
-    * const client = new postgres.Client();
+    * const client = new postgres.PGClient;
     * const connected = client.Connect('acme.com', 5432, 'username', 'password');
     * ```
     */
@@ -53,7 +53,7 @@ export class PGClient {
     * @example
     * ```javascript
     * const postgres = require('nuclei/postgres');
-    * const client = new postgres.Client();
+    * const client = new postgres.PGClient;
     * const result = client.ExecuteQuery('acme.com', 5432, 'username', 'password', 'dbname', 'select * from users');
     * log(to_json(result));
     * ```
@@ -71,7 +71,7 @@ export class PGClient {
     * @example
     * ```javascript
     * const postgres = require('nuclei/postgres');
-    * const client = new postgres.Client();
+    * const client = new postgres.PGClient;
     * const connected = client.ConnectWithDB('acme.com', 5432, 'username', 'password', 'dbname');
     * ```
     */

--- a/pkg/js/generated/ts/rdp.ts
+++ b/pkg/js/generated/ts/rdp.ts
@@ -78,6 +78,8 @@ export interface IsRDPResponse {
  */
 export interface ServiceRDP {
     
+    DNSDomainName?: string,
+    
     ForestName?: string,
     
     OSFingerprint?: string,
@@ -91,7 +93,5 @@ export interface ServiceRDP {
     NetBIOSDomainName?: string,
     
     DNSComputerName?: string,
-    
-    DNSDomainName?: string,
 }
 

--- a/pkg/js/generated/ts/rdp.ts
+++ b/pkg/js/generated/ts/rdp.ts
@@ -1,51 +1,36 @@
 
 
 /**
- * RDPClient is a minimal RDP client for nuclei scripts.
+ * CheckRDPAuth checks if the given host and port are running rdp server
+ * with authentication and returns their metadata.
+ * If connection is successful, it returns true.
  * @example
  * ```javascript
  * const rdp = require('nuclei/rdp');
- * const client = new rdp.Client();
+ * const checkRDPAuth = rdp.CheckRDPAuth('acme.com', 3389);
+ * log(toJSON(checkRDPAuth));
  * ```
  */
-export class RDPClient {
-    
+export function CheckRDPAuth(host: string, port: number): CheckRDPAuthResponse | null {
+    return null;
+}
 
-    // Constructor of RDPClient
-    constructor() {}
-    /**
-    * IsRDP checks if the given host and port are running rdp server.
-    * If connection is successful, it returns true.
-    * If connection is unsuccessful, it returns false and error.
-    * The Name of the OS is also returned if the connection is successful.
-    * @example
-    * ```javascript
-    * const rdp = require('nuclei/rdp');
-    * const isRDP = rdp.IsRDP('acme.com', 3389);
-    * log(toJSON(isRDP));
-    * ```
-    */
-    public IsRDP(host: string, port: number): IsRDPResponse | null {
-        return null;
-    }
-    
 
-    /**
-    * CheckRDPAuth checks if the given host and port are running rdp server
-    * with authentication and returns their metadata.
-    * If connection is successful, it returns true.
-    * @example
-    * ```javascript
-    * const rdp = require('nuclei/rdp');
-    * const checkRDPAuth = rdp.CheckRDPAuth('acme.com', 3389);
-    * log(toJSON(checkRDPAuth));
-    * ```
-    */
-    public CheckRDPAuth(host: string, port: number): CheckRDPAuthResponse | null {
-        return null;
-    }
-    
 
+/**
+ * IsRDP checks if the given host and port are running rdp server.
+ * If connection is successful, it returns true.
+ * If connection is unsuccessful, it returns false and error.
+ * The Name of the OS is also returned if the connection is successful.
+ * @example
+ * ```javascript
+ * const rdp = require('nuclei/rdp');
+ * const isRDP = rdp.IsRDP('acme.com', 3389);
+ * log(toJSON(isRDP));
+ * ```
+ */
+export function IsRDP(host: string, port: number): IsRDPResponse | null {
+    return null;
 }
 
 
@@ -93,14 +78,6 @@ export interface IsRDPResponse {
  */
 export interface ServiceRDP {
     
-    NetBIOSComputerName?: string,
-    
-    NetBIOSDomainName?: string,
-    
-    DNSComputerName?: string,
-    
-    DNSDomainName?: string,
-    
     ForestName?: string,
     
     OSFingerprint?: string,
@@ -108,5 +85,13 @@ export interface ServiceRDP {
     OSVersion?: string,
     
     TargetName?: string,
+    
+    NetBIOSComputerName?: string,
+    
+    NetBIOSDomainName?: string,
+    
+    DNSComputerName?: string,
+    
+    DNSDomainName?: string,
 }
 

--- a/pkg/js/generated/ts/rsync.ts
+++ b/pkg/js/generated/ts/rsync.ts
@@ -1,32 +1,16 @@
 
 
 /**
- * RsyncClient is a minimal Rsync client for nuclei scripts.
+ * IsRsync checks if a host is running a Rsync server.
  * @example
  * ```javascript
  * const rsync = require('nuclei/rsync');
- * const client = new rsync.Client();
+ * const isRsync = rsync.IsRsync('acme.com', 873);
+ * log(toJSON(isRsync));
  * ```
  */
-export class RsyncClient {
-    
-
-    // Constructor of RsyncClient
-    constructor() {}
-    /**
-    * IsRsync checks if a host is running a Rsync server.
-    * @example
-    * ```javascript
-    * const rsync = require('nuclei/rsync');
-    * const isRsync = rsync.IsRsync('acme.com', 873);
-    * log(toJSON(isRsync));
-    * ```
-    */
-    public IsRsync(host: string, port: number): IsRsyncResponse | null {
-        return null;
-    }
-    
-
+export function IsRsync(host: string, port: number): IsRsyncResponse | null {
+    return null;
 }
 
 

--- a/pkg/js/generated/ts/smb.ts
+++ b/pkg/js/generated/ts/smb.ts
@@ -7,7 +7,7 @@
  * @example
  * ```javascript
  * const smb = require('nuclei/smb');
- * const client = new smb.Client();
+ * const client = new smb.SMBClient();
  * ```
  */
 export class SMBClient {
@@ -23,7 +23,7 @@ export class SMBClient {
     * @example
     * ```javascript
     * const smb = require('nuclei/smb');
-    * const client = new smb.Client();
+    * const client = new smb.SMBClient();
     * const info = client.ConnectSMBInfoMode('acme.com', 445);
     * log(to_json(info));
     * ```
@@ -41,7 +41,7 @@ export class SMBClient {
     * @example
     * ```javascript
     * const smb = require('nuclei/smb');
-    * const client = new smb.Client();
+    * const client = new smb.SMBClient();
     * const metadata = client.ListSMBv2Metadata('acme.com', 445);
     * log(to_json(metadata));
     * ```
@@ -59,7 +59,7 @@ export class SMBClient {
     * @example
     * ```javascript
     * const smb = require('nuclei/smb');
-    * const client = new smb.Client();
+    * const client = new smb.SMBClient();
     * const shares = client.ListShares('acme.com', 445, 'username', 'password');
     * 	for (const share of shares) {
     * 		  log(share);
@@ -137,6 +137,8 @@ export interface NegotiationLog {
  */
 export interface SMBCapabilities {
     
+    DFSSupport?: boolean,
+    
     Leasing?: boolean,
     
     LargeMTU?: boolean,
@@ -148,8 +150,6 @@ export interface SMBCapabilities {
     DirLeasing?: boolean,
     
     Encryption?: boolean,
-    
-    DFSSupport?: boolean,
 }
 
 
@@ -159,15 +159,15 @@ export interface SMBCapabilities {
  */
 export interface SMBLog {
     
+    SupportV1?: boolean,
+    
+    NativeOs?: string,
+    
     NTLM?: string,
     
     GroupName?: string,
     
     HasNTLM?: boolean,
-    
-    SupportV1?: boolean,
-    
-    NativeOs?: string,
     
     Version?: SMBVersions,
     
@@ -201,6 +201,8 @@ export interface SMBVersions {
  */
 export interface ServiceSMB {
     
+    DNSComputerName?: string,
+    
     DNSDomainName?: string,
     
     ForestName?: string,
@@ -214,8 +216,6 @@ export interface ServiceSMB {
     NetBIOSComputerName?: string,
     
     NetBIOSDomainName?: string,
-    
-    DNSComputerName?: string,
 }
 
 

--- a/pkg/js/generated/ts/smb.ts
+++ b/pkg/js/generated/ts/smb.ts
@@ -113,6 +113,8 @@ export interface HeaderLog {
  */
 export interface NegotiationLog {
     
+    SecurityMode?: number,
+    
     DialectRevision?: number,
     
     ServerGuid?: Uint8Array,
@@ -124,8 +126,6 @@ export interface NegotiationLog {
     ServerStartTime?: number,
     
     AuthenticationTypes?: string[],
-    
-    SecurityMode?: number,
     
     HeaderLog?: HeaderLog,
 }
@@ -159,8 +159,6 @@ export interface SMBCapabilities {
  */
 export interface SMBLog {
     
-    SupportV1?: boolean,
-    
     NativeOs?: string,
     
     NTLM?: string,
@@ -169,13 +167,15 @@ export interface SMBLog {
     
     HasNTLM?: boolean,
     
-    Version?: SMBVersions,
+    SupportV1?: boolean,
     
     Capabilities?: SMBCapabilities,
     
     NegotiationLog?: NegotiationLog,
     
     SessionSetupLog?: SessionSetupLog,
+    
+    Version?: SMBVersions,
 }
 
 
@@ -201,12 +201,6 @@ export interface SMBVersions {
  */
 export interface ServiceSMB {
     
-    DNSComputerName?: string,
-    
-    DNSDomainName?: string,
-    
-    ForestName?: string,
-    
     SigningEnabled?: boolean,
     
     SigningRequired?: boolean,
@@ -216,6 +210,12 @@ export interface ServiceSMB {
     NetBIOSComputerName?: string,
     
     NetBIOSDomainName?: string,
+    
+    DNSComputerName?: string,
+    
+    DNSDomainName?: string,
+    
+    ForestName?: string,
 }
 
 
@@ -225,11 +225,11 @@ export interface ServiceSMB {
  */
 export interface SessionSetupLog {
     
+    SetupFlags?: number,
+    
     TargetName?: string,
     
     NegotiateFlags?: number,
-    
-    SetupFlags?: number,
     
     HeaderLog?: HeaderLog,
 }

--- a/pkg/js/generated/ts/smtp.ts
+++ b/pkg/js/generated/ts/smtp.ts
@@ -1,28 +1,31 @@
 
 
 /**
- * SMTPClient is a minimal SMTP client for nuclei scripts.
+ * Client is a minimal SMTP client for nuclei scripts.
  * @example
  * ```javascript
  * const smtp = require('nuclei/smtp');
- * const client = new smtp.Client();
+ * const client = new smtp.Client('acme.com', 25);
  * ```
  */
-export class SMTPClient {
+export class Client {
     
 
-    // Constructor of SMTPClient
-    constructor() {}
+    // Constructor of Client
+    constructor(public host: string, public port: string ) {}
+    
+
     /**
     * IsSMTP checks if a host is running a SMTP server.
     * @example
     * ```javascript
     * const smtp = require('nuclei/smtp');
-    * const isSMTP = smtp.IsSMTP('acme.com', 25);
-    * log(toJSON(isSMTP));
+    * const client = new smtp.Client('acme.com', 25);
+    * const isSMTP = client.IsSMTP();
+    * log(isSMTP)
     * ```
     */
-    public IsSMTP(host: string, port: number): IsSMTPResponse | null {
+    public IsSMTP(): SMTPResponse | null {
         return null;
     }
     
@@ -37,10 +40,11 @@ export class SMTPClient {
     * message.To('xyz2@projectdiscoveyr.io');
     * message.Subject('hello');
     * message.Body('hello');
-    * const isRelay = smtp.IsOpenRelay('acme.com', 25, message);
+    * const client = new smtp.Client('acme.com', 25);
+    * const isRelay = client.IsOpenRelay(message);
     * ```
     */
-    public IsOpenRelay(host: string, port: number, msg: SMTPMessage): boolean | null {
+    public IsOpenRelay(msg: SMTPMessage): boolean | null {
         return null;
     }
     
@@ -55,10 +59,12 @@ export class SMTPClient {
     * message.To('xyz2@projectdiscoveyr.io');
     * message.Subject('hello');
     * message.Body('hello');
-    * const isSent = smtp.SendMail('acme.com', 25, message);
+    * const client = new smtp.Client('acme.com', 25);
+    * const isSent = client.SendMail(message);
+    * log(isSent)
     * ```
     */
-    public SendMail(host: string, port: string, msg: SMTPMessage): boolean | null {
+    public SendMail(msg: SMTPMessage): boolean | null {
         return null;
     }
     
@@ -174,15 +180,16 @@ export class SMTPMessage {
 
 
 /**
- * IsSMTPResponse is the response from the IsSMTP function.
+ * SMTPResponse is the response from the IsSMTP function.
  * @example
  * ```javascript
  * const smtp = require('nuclei/smtp');
- * const isSMTP = smtp.IsSMTP('acme.com', 25);
- * log(toJSON(isSMTP));
+ * const client = new smtp.Client('acme.com', 25);
+ * const isSMTP = client.IsSMTP();
+ * log(isSMTP)
  * ```
  */
-export interface IsSMTPResponse {
+export interface SMTPResponse {
     
     IsSMTP?: boolean,
     

--- a/pkg/js/generated/ts/ssh.ts
+++ b/pkg/js/generated/ts/ssh.ts
@@ -129,13 +129,13 @@ export class SSHClient {
  */
 export interface Algorithms {
     
-    HostKey?: string,
-    
     Kex?: string,
     
-    R?: DirectionAlgorithms,
+    HostKey?: string,
     
     W?: DirectionAlgorithms,
+    
+    R?: DirectionAlgorithms,
 }
 
 
@@ -197,7 +197,17 @@ export interface HandshakeLog {
  */
 export interface KexInitMsg {
     
+    CiphersServerClient?: string[],
+    
+    MACsClientServer?: string[],
+    
+    MACsServerClient?: string[],
+    
     LanguagesClientServer?: string[],
+    
+    KexAlgos?: string[],
+    
+    CiphersClientServer?: string[],
     
     Reserved?: number,
     
@@ -205,19 +215,9 @@ export interface KexInitMsg {
     
     CompressionServerClient?: string[],
     
-    MACsClientServer?: string[],
-    
-    KexAlgos?: string[],
-    
-    CiphersServerClient?: string[],
-    
     LanguagesServerClient?: string[],
     
     FirstKexFollows?: boolean,
-    
-    ServerHostKeyAlgos?: string[],
-    
-    MACsServerClient?: string[],
     
     /**
     * fixed size array of length: [16]
@@ -225,6 +225,6 @@ export interface KexInitMsg {
     
     Cookie?: Uint8Array,
     
-    CiphersClientServer?: string[],
+    ServerHostKeyAlgos?: string[],
 }
 

--- a/pkg/js/generated/ts/ssh.ts
+++ b/pkg/js/generated/ts/ssh.ts
@@ -6,7 +6,7 @@
  * @example
  * ```javascript
  * const ssh = require('nuclei/ssh');
- * const client = new ssh.Client();
+ * const client = new ssh.SSHClient();
  * ```
  */
 export class SSHClient {
@@ -19,7 +19,7 @@ export class SSHClient {
     * @example
     * ```javascript
     * const ssh = require('nuclei/ssh');
-    * const client = new ssh.Client();
+    * const client = new ssh.SSHClient();
     * client.SetTimeout(10);
     * ```
     */
@@ -36,7 +36,7 @@ export class SSHClient {
     * @example
     * ```javascript
     * const ssh = require('nuclei/ssh');
-    * const client = new ssh.Client();
+    * const client = new ssh.SSHClient();
     * const connected = client.Connect('acme.com', 22, 'username', 'password');
     * ```
     */
@@ -53,7 +53,7 @@ export class SSHClient {
     * @example
     * ```javascript
     * const ssh = require('nuclei/ssh');
-    * const client = new ssh.Client();
+    * const client = new ssh.SSHClient();
     * const privateKey = `-----BEGIN RSA PRIVATE KEY----- ...`;
     * const connected = client.ConnectWithKey('acme.com', 22, 'username', privateKey);
     * ```
@@ -73,7 +73,7 @@ export class SSHClient {
     * @example
     * ```javascript
     * const ssh = require('nuclei/ssh');
-    * const client = new ssh.Client();
+    * const client = new ssh.SSHClient();
     * const info = client.ConnectSSHInfoMode('acme.com', 22);
     * log(to_json(info));
     * ```
@@ -92,7 +92,7 @@ export class SSHClient {
     * @example
     * ```javascript
     * const ssh = require('nuclei/ssh');
-    * const client = new ssh.Client();
+    * const client = new ssh.SSHClient();
     * client.Connect('acme.com', 22, 'username', 'password');
     * const output = client.Run('id');
     * log(output);
@@ -110,7 +110,7 @@ export class SSHClient {
     * @example
     * ```javascript
     * const ssh = require('nuclei/ssh');
-    * const client = new ssh.Client();
+    * const client = new ssh.SSHClient();
     * client.Connect('acme.com', 22, 'username', 'password');
     * const closed = client.Close();
     * ```
@@ -129,13 +129,13 @@ export class SSHClient {
  */
 export interface Algorithms {
     
-    Kex?: string,
-    
     HostKey?: string,
     
-    W?: DirectionAlgorithms,
+    Kex?: string,
     
     R?: DirectionAlgorithms,
+    
+    W?: DirectionAlgorithms,
 }
 
 
@@ -179,8 +179,6 @@ export interface HandshakeLog {
     
     UserAuth?: string[],
     
-    AlgorithmSelection?: Algorithms,
-    
     ServerID?: EndpointId,
     
     ClientID?: EndpointId,
@@ -188,6 +186,8 @@ export interface HandshakeLog {
     ServerKex?: KexInitMsg,
     
     ClientKex?: KexInitMsg,
+    
+    AlgorithmSelection?: Algorithms,
 }
 
 
@@ -197,27 +197,27 @@ export interface HandshakeLog {
  */
 export interface KexInitMsg {
     
-    CompressionClientServer?: string[],
-    
-    FirstKexFollows?: boolean,
-    
-    MACsClientServer?: string[],
-    
     LanguagesClientServer?: string[],
-    
-    LanguagesServerClient?: string[],
     
     Reserved?: number,
     
-    KexAlgos?: string[],
+    CompressionClientServer?: string[],
     
-    CiphersClientServer?: string[],
+    CompressionServerClient?: string[],
+    
+    MACsClientServer?: string[],
+    
+    KexAlgos?: string[],
     
     CiphersServerClient?: string[],
     
-    MACsServerClient?: string[],
+    LanguagesServerClient?: string[],
     
-    CompressionServerClient?: string[],
+    FirstKexFollows?: boolean,
+    
+    ServerHostKeyAlgos?: string[],
+    
+    MACsServerClient?: string[],
     
     /**
     * fixed size array of length: [16]
@@ -225,6 +225,6 @@ export interface KexInitMsg {
     
     Cookie?: Uint8Array,
     
-    ServerHostKeyAlgos?: string[],
+    CiphersClientServer?: string[],
 }
 

--- a/pkg/js/generated/ts/telnet.ts
+++ b/pkg/js/generated/ts/telnet.ts
@@ -1,32 +1,16 @@
 
 
 /**
- * TelnetClient is a minimal Telnet client for nuclei scripts.
+ * IsTelnet checks if a host is running a Telnet server.
  * @example
  * ```javascript
  * const telnet = require('nuclei/telnet');
- * const client = new telnet.Client();
+ * const isTelnet = telnet.IsTelnet('acme.com', 23);
+ * log(toJSON(isTelnet));
  * ```
  */
-export class TelnetClient {
-    
-
-    // Constructor of TelnetClient
-    constructor() {}
-    /**
-    * IsTelnet checks if a host is running a Telnet server.
-    * @example
-    * ```javascript
-    * const telnet = require('nuclei/telnet');
-    * const isTelnet = telnet.IsTelnet('acme.com', 23);
-    * log(toJSON(isTelnet));
-    * ```
-    */
-    public IsTelnet(host: string, port: number): IsTelnetResponse | null {
-        return null;
-    }
-    
-
+export function IsTelnet(host: string, port: number): IsTelnetResponse | null {
+    return null;
 }
 
 

--- a/pkg/js/generated/ts/vnc.ts
+++ b/pkg/js/generated/ts/vnc.ts
@@ -1,34 +1,18 @@
 
 
 /**
- * VNCClient is a minimal VNC client for nuclei scripts.
+ * IsVNC checks if a host is running a VNC server.
+ * It returns a boolean indicating if the host is running a VNC server
+ * and the banner of the VNC server.
  * @example
  * ```javascript
  * const vnc = require('nuclei/vnc');
- * const client = new vnc.Client();
+ * const isVNC = vnc.IsVNC('acme.com', 5900);
+ * log(toJSON(isVNC));
  * ```
  */
-export class VNCClient {
-    
-
-    // Constructor of VNCClient
-    constructor() {}
-    /**
-    * IsVNC checks if a host is running a VNC server.
-    * It returns a boolean indicating if the host is running a VNC server
-    * and the banner of the VNC server.
-    * @example
-    * ```javascript
-    * const vnc = require('nuclei/vnc');
-    * const isVNC = vnc.IsVNC('acme.com', 5900);
-    * log(toJSON(isVNC));
-    * ```
-    */
-    public IsVNC(host: string, port: number): IsVNCResponse | null {
-        return null;
-    }
-    
-
+export function IsVNC(host: string, port: number): IsVNCResponse | null {
+    return null;
 }
 
 

--- a/pkg/js/libs/kerberos/kerberosx.go
+++ b/pkg/js/libs/kerberos/kerberosx.go
@@ -88,7 +88,7 @@ type (
 	}
 )
 
-// Constructor for KerberosClient
+// Constructor for Kerberos Client
 // Constructor: constructor(public domain: string, public controller?: string)
 // When controller is empty or not given krb5 will perform a DNS lookup for the default KDC server
 // and retrieve its address from the DNS server

--- a/pkg/js/libs/ldap/adenum.go
+++ b/pkg/js/libs/ldap/adenum.go
@@ -82,6 +82,7 @@ type (
 	// const client = new ldap.Client('ldap://ldap.example.com', 'acme.com');
 	// const users = client.GetADUsers();
 	// log(to_json(users));
+	// ```
 	ADObject struct {
 		DistinguishedName    string
 		SAMAccountName       string

--- a/pkg/js/libs/mssql/mssql.go
+++ b/pkg/js/libs/mssql/mssql.go
@@ -20,7 +20,7 @@ type (
 	// @example
 	// ```javascript
 	// const mssql = require('nuclei/mssql');
-	// const client = new mssql.Client();
+	// const client = new mssql.MSSQLClient;
 	// ```
 	MSSQLClient struct{}
 )
@@ -32,7 +32,7 @@ type (
 // @example
 // ```javascript
 // const mssql = require('nuclei/mssql');
-// const client = new mssql.Client();
+// const client = new mssql.MSSQLClient;
 // const connected = client.Connect('acme.com', 1433, 'username', 'password');
 // ```
 func (c *MSSQLClient) Connect(host string, port int, username, password string) (bool, error) {
@@ -46,7 +46,7 @@ func (c *MSSQLClient) Connect(host string, port int, username, password string) 
 // @example
 // ```javascript
 // const mssql = require('nuclei/mssql');
-// const client = new mssql.Client();
+// const client = new mssql.MSSQLClient;
 // const connected = client.ConnectWithDB('acme.com', 1433, 'username', 'password', 'master');
 // ```
 func (c *MSSQLClient) ConnectWithDB(host string, port int, username, password, dbName string) (bool, error) {

--- a/pkg/js/libs/mysql/mysql.go
+++ b/pkg/js/libs/mysql/mysql.go
@@ -22,7 +22,7 @@ type (
 	// @example
 	// ```javascript
 	// const mysql = require('nuclei/mysql');
-	// const client = new mysql.Client();
+	// const client = new mysql.MySQLClient;
 	// ```
 	MySQLClient struct{}
 )
@@ -64,7 +64,7 @@ func (c *MySQLClient) IsMySQL(host string, port int) (bool, error) {
 // @example
 // ```javascript
 // const mysql = require('nuclei/mysql');
-// const client = new mysql.Client();
+// const client = new mysql.MySQLClient;
 // const connected = client.Connect('acme.com', 3306, 'username', 'password');
 // ```
 func (c *MySQLClient) Connect(host string, port int, username, password string) (bool, error) {
@@ -149,7 +149,7 @@ func (c *MySQLClient) FingerprintMySQL(host string, port int) (MySQLInfo, error)
 // @example
 // ```javascript
 // const mysql = require('nuclei/mysql');
-// const client = new mysql.Client();
+// const client = new mysql.MySQLClient;
 // const connected = client.ConnectWithDSN('username:password@tcp(acme.com:3306)/');
 // ```
 func (c *MySQLClient) ConnectWithDSN(dsn string) (bool, error) {

--- a/pkg/js/libs/net/net.go
+++ b/pkg/js/libs/net/net.go
@@ -172,16 +172,16 @@ func (c *NetConn) Send(data string) error {
 	return nil
 }
 
-// Recv receives data from the connection with a timeout.
+// RecvFull receives data from the connection with a timeout.
 // If N is 0, it will read all data sent by the server with 8MB limit.
 // it tries to read until N bytes or timeout is reached.
 // @example
 // ```javascript
 // const net = require('nuclei/net');
 // const conn = net.Open('tcp', 'acme.com:80');
-// const data = conn.Recv(1024);
+// const data = conn.RecvFull(1024);
 // ```
-func (c *NetConn) Recv(N int) ([]byte, error) {
+func (c *NetConn) RecvFull(N int) ([]byte, error) {
 	c.setDeadLine()
 	defer c.unsetDeadLine()
 	if N == 0 {
@@ -195,17 +195,18 @@ func (c *NetConn) Recv(N int) ([]byte, error) {
 	return bin, nil
 }
 
-// RecvPartial is similar to Recv but it does not perform full read instead
+// Recv is similar to RecvFull but does not guarantee full read instead
 // it creates a buffer of N bytes and returns whatever is returned by the connection
-// this is usually used when fingerprinting services to get initial bytes from the server.
+// for reading headers or initial bytes from the server this is usually used.
+// for reading a fixed number of already known bytes (ex: body based on content-length) use RecvFull.
 // @example
 // ```javascript
 // const net = require('nuclei/net');
 // const conn = net.Open('tcp', 'acme.com:80');
-// const data = conn.RecvPartial(1024);
+// const data = conn.Recv(1024);
 // log(`Received ${data.length} bytes from the server`)
 // ```
-func (c *NetConn) RecvPartial(N int) ([]byte, error) {
+func (c *NetConn) Recv(N int) ([]byte, error) {
 	c.setDeadLine()
 	defer c.unsetDeadLine()
 	if N == 0 {
@@ -219,9 +220,27 @@ func (c *NetConn) RecvPartial(N int) ([]byte, error) {
 	return b[:n], nil
 }
 
-// RecvString receives data from the connection with a timeout
+// RecvFullString receives data from the connection with a timeout
 // output is returned as a string.
 // If N is 0, it will read all data sent by the server with 8MB limit.
+// @example
+// ```javascript
+// const net = require('nuclei/net');
+// const conn = net.Open('tcp', 'acme.com:80');
+// const data = conn.RecvFullString(1024);
+// ```
+func (c *NetConn) RecvFullString(N int) (string, error) {
+	bin, err := c.RecvFull(N)
+	if err != nil {
+		return "", err
+	}
+	return string(bin), nil
+}
+
+// RecvString is similar to RecvFullString but does not guarantee full read, instead
+// it creates a buffer of N bytes and returns whatever is returned by the connection
+// for reading headers or initial bytes from the server this is usually used.
+// for reading a fixed number of already known bytes (ex: body based on content-length) use RecvFullString.
 // @example
 // ```javascript
 // const net = require('nuclei/net');
@@ -236,9 +255,28 @@ func (c *NetConn) RecvString(N int) (string, error) {
 	return string(bin), nil
 }
 
-// RecvHex receives data from the connection with a timeout
+// RecvFullHex receives data from the connection with a timeout
 // in hex format.
 // If N is 0,it will read all data sent by the server with 8MB limit.
+// until N bytes or timeout is reached.
+// @example
+// ```javascript
+// const net = require('nuclei/net');
+// const conn = net.Open('tcp', 'acme.com:80');
+// const data = conn.RecvFullHex(1024);
+// ```
+func (c *NetConn) RecvFullHex(N int) (string, error) {
+	bin, err := c.RecvFull(N)
+	if err != nil {
+		return "", err
+	}
+	return hex.Dump(bin), nil
+}
+
+// RecvHex is similar to RecvFullHex but does not guarantee full read instead
+// it creates a buffer of N bytes and returns whatever is returned by the connection
+// for reading headers or initial bytes from the server this is usually used.
+// for reading a fixed number of already known bytes (ex: body based on content-length) use RecvFull.
 // @example
 // ```javascript
 // const net = require('nuclei/net');

--- a/pkg/js/libs/oracle/oracle.go
+++ b/pkg/js/libs/oracle/oracle.go
@@ -12,16 +12,6 @@ import (
 )
 
 type (
-	// OracleClient is a minimal Oracle client for nuclei scripts.
-	// @example
-	// ```javascript
-	// const oracle = require('nuclei/oracle');
-	// const client = new oracle.Client();
-	// ```
-	OracleClient struct{}
-)
-
-type (
 	// IsOracleResponse is the response from the IsOracle function.
 	// this is returned by IsOracle function.
 	// @example
@@ -42,7 +32,7 @@ type (
 // const isOracle = oracle.IsOracle('acme.com', 1521);
 // log(toJSON(isOracle));
 // ```
-func (c *OracleClient) IsOracle(host string, port int) (IsOracleResponse, error) {
+func IsOracle(host string, port int) (IsOracleResponse, error) {
 	resp := IsOracleResponse{}
 
 	timeout := 5 * time.Second

--- a/pkg/js/libs/pop3/pop3.go
+++ b/pkg/js/libs/pop3/pop3.go
@@ -12,16 +12,6 @@ import (
 )
 
 type (
-	// Pop3Client is a minimal POP3 client for nuclei scripts.
-	// @example
-	// ```javascript
-	// const pop3 = require('nuclei/pop3');
-	// const client = new pop3.Client();
-	// ```
-	Pop3Client struct{}
-)
-
-type (
 	// IsPOP3Response is the response from the IsPOP3 function.
 	// this is returned by IsPOP3 function.
 	// @example
@@ -43,7 +33,7 @@ type (
 // const isPOP3 = pop3.IsPOP3('acme.com', 110);
 // log(toJSON(isPOP3));
 // ```
-func (c *Pop3Client) IsPOP3(host string, port int) (IsPOP3Response, error) {
+func IsPOP3(host string, port int) (IsPOP3Response, error) {
 	resp := IsPOP3Response{}
 
 	timeout := 5 * time.Second

--- a/pkg/js/libs/postgres/postgres.go
+++ b/pkg/js/libs/postgres/postgres.go
@@ -22,7 +22,7 @@ type (
 	// @example
 	// ```javascript
 	// const postgres = require('nuclei/postgres');
-	// const client = new postgres.Client();
+	// const client = new postgres.PGClient;
 	// ```
 	PGClient struct{}
 )
@@ -64,7 +64,7 @@ func (c *PGClient) IsPostgres(host string, port int) (bool, error) {
 // @example
 // ```javascript
 // const postgres = require('nuclei/postgres');
-// const client = new postgres.Client();
+// const client = new postgres.PGClient;
 // const connected = client.Connect('acme.com', 5432, 'username', 'password');
 // ```
 func (c *PGClient) Connect(host string, port int, username, password string) (bool, error) {
@@ -77,7 +77,7 @@ func (c *PGClient) Connect(host string, port int, username, password string) (bo
 // @example
 // ```javascript
 // const postgres = require('nuclei/postgres');
-// const client = new postgres.Client();
+// const client = new postgres.PGClient;
 // const result = client.ExecuteQuery('acme.com', 5432, 'username', 'password', 'dbname', 'select * from users');
 // log(to_json(result));
 // ```
@@ -113,7 +113,7 @@ func (c *PGClient) ExecuteQuery(host string, port int, username, password, dbNam
 // @example
 // ```javascript
 // const postgres = require('nuclei/postgres');
-// const client = new postgres.Client();
+// const client = new postgres.PGClient;
 // const connected = client.ConnectWithDB('acme.com', 5432, 'username', 'password', 'dbname');
 // ```
 func (c *PGClient) ConnectWithDB(host string, port int, username, password, dbName string) (bool, error) {

--- a/pkg/js/libs/rdp/rdp.go
+++ b/pkg/js/libs/rdp/rdp.go
@@ -11,16 +11,6 @@ import (
 )
 
 type (
-	// RDPClient is a minimal RDP client for nuclei scripts.
-	// @example
-	// ```javascript
-	// const rdp = require('nuclei/rdp');
-	// const client = new rdp.Client();
-	// ```
-	RDPClient struct{}
-)
-
-type (
 	// IsRDPResponse is the response from the IsRDP function.
 	// this is returned by IsRDP function.
 	// @example
@@ -45,7 +35,7 @@ type (
 // const isRDP = rdp.IsRDP('acme.com', 3389);
 // log(toJSON(isRDP));
 // ```
-func (c *RDPClient) IsRDP(host string, port int) (IsRDPResponse, error) {
+func IsRDP(host string, port int) (IsRDPResponse, error) {
 	resp := IsRDPResponse{}
 
 	timeout := 5 * time.Second
@@ -91,7 +81,7 @@ type (
 // const checkRDPAuth = rdp.CheckRDPAuth('acme.com', 3389);
 // log(toJSON(checkRDPAuth));
 // ```
-func (c *RDPClient) CheckRDPAuth(host string, port int) (CheckRDPAuthResponse, error) {
+func CheckRDPAuth(host string, port int) (CheckRDPAuthResponse, error) {
 	resp := CheckRDPAuthResponse{}
 
 	timeout := 5 * time.Second

--- a/pkg/js/libs/rsync/rsync.go
+++ b/pkg/js/libs/rsync/rsync.go
@@ -12,16 +12,6 @@ import (
 )
 
 type (
-	// RsyncClient is a minimal Rsync client for nuclei scripts.
-	// @example
-	// ```javascript
-	// const rsync = require('nuclei/rsync');
-	// const client = new rsync.Client();
-	// ```
-	RsyncClient struct{}
-)
-
-type (
 	// IsRsyncResponse is the response from the IsRsync function.
 	// this is returned by IsRsync function.
 	// @example
@@ -43,7 +33,7 @@ type (
 // const isRsync = rsync.IsRsync('acme.com', 873);
 // log(toJSON(isRsync));
 // ```
-func (c *RsyncClient) IsRsync(host string, port int) (IsRsyncResponse, error) {
+func IsRsync(host string, port int) (IsRsyncResponse, error) {
 	resp := IsRsyncResponse{}
 
 	timeout := 5 * time.Second

--- a/pkg/js/libs/smb/smb.go
+++ b/pkg/js/libs/smb/smb.go
@@ -18,7 +18,7 @@ type (
 	// @example
 	// ```javascript
 	// const smb = require('nuclei/smb');
-	// const client = new smb.Client();
+	// const client = new smb.SMBClient();
 	// ```
 	SMBClient struct{}
 )
@@ -30,7 +30,7 @@ type (
 // @example
 // ```javascript
 // const smb = require('nuclei/smb');
-// const client = new smb.Client();
+// const client = new smb.SMBClient();
 // const info = client.ConnectSMBInfoMode('acme.com', 445);
 // log(to_json(info));
 // ```
@@ -70,7 +70,7 @@ func (c *SMBClient) ConnectSMBInfoMode(host string, port int) (*smb.SMBLog, erro
 // @example
 // ```javascript
 // const smb = require('nuclei/smb');
-// const client = new smb.Client();
+// const client = new smb.SMBClient();
 // const metadata = client.ListSMBv2Metadata('acme.com', 445);
 // log(to_json(metadata));
 // ```
@@ -89,7 +89,7 @@ func (c *SMBClient) ListSMBv2Metadata(host string, port int) (*plugins.ServiceSM
 // @example
 // ```javascript
 // const smb = require('nuclei/smb');
-// const client = new smb.Client();
+// const client = new smb.SMBClient();
 // const shares = client.ListShares('acme.com', 445, 'username', 'password');
 //
 //	for (const share of shares) {

--- a/pkg/js/libs/smtp/smtp.go
+++ b/pkg/js/libs/smtp/smtp.go
@@ -8,57 +8,92 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/dop251/goja"
 	"github.com/praetorian-inc/fingerprintx/pkg/plugins"
+	"github.com/projectdiscovery/nuclei/v3/pkg/js/utils"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
 
 	pluginsmtp "github.com/praetorian-inc/fingerprintx/pkg/plugins/services/smtp"
 )
 
 type (
-	// SMTPClient is a minimal SMTP client for nuclei scripts.
+	// SMTPResponse is the response from the IsSMTP function.
 	// @example
 	// ```javascript
 	// const smtp = require('nuclei/smtp');
-	// const client = new smtp.Client();
+	// const client = new smtp.Client('acme.com', 25);
+	// const isSMTP = client.IsSMTP();
+	// log(isSMTP)
 	// ```
-	SMTPClient struct{}
-)
-
-type (
-	// IsSMTPResponse is the response from the IsSMTP function.
-	// @example
-	// ```javascript
-	// const smtp = require('nuclei/smtp');
-	// const client = new smtp.Client();
-	// const isSMTP = client.IsSMTP('acme.com', 25);
-	// log(toJSON(isSMTP));
-	// ```
-	IsSMTPResponse struct {
+	SMTPResponse struct {
 		IsSMTP bool
 		Banner string
 	}
 )
 
+type (
+	// Client is a minimal SMTP client for nuclei scripts.
+	// @example
+	// ```javascript
+	// const smtp = require('nuclei/smtp');
+	// const client = new smtp.Client('acme.com', 25);
+	// ```
+	Client struct {
+		nj   *utils.NucleiJS
+		host string
+		port string
+	}
+)
+
+// Constructor for SMTP Client
+// Constructor: constructor(public host: string, public port: string)
+func NewSMTPClient(call goja.ConstructorCall, runtime *goja.Runtime) *goja.Object {
+	// setup nucleijs utils
+	c := &Client{nj: utils.NewNucleiJS(runtime)}
+	c.nj.ObjectSig = "Client(host, port)" // will be included in error messages
+
+	host, _ := c.nj.GetArg(call.Arguments, 0).(string) // host
+	port, _ := c.nj.GetArg(call.Arguments, 1).(string) // port
+
+	// validate arguments
+	c.nj.Require(host != "", "host cannot be empty")
+	c.nj.Require(port != "", "port cannot be empty")
+
+	// validate port
+	portInt, err := strconv.Atoi(port)
+	c.nj.Require(err == nil && portInt > 0 && portInt < 65536, "port must be a valid number")
+	c.host = host
+	c.port = port
+
+	// check if this is allowed address
+	c.nj.Require(protocolstate.IsHostAllowed(host+":"+port), protocolstate.ErrHostDenied.Msgf(host+":"+port).Error())
+
+	// Link Constructor to Client and return
+	return utils.LinkConstructor(call, runtime, c)
+}
+
 // IsSMTP checks if a host is running a SMTP server.
 // @example
 // ```javascript
 // const smtp = require('nuclei/smtp');
-// const client = new smtp.Client();
-// const isSMTP = client.IsSMTP('acme.com', 25);
-// log(toJSON(isSMTP));
+// const client = new smtp.Client('acme.com', 25);
+// const isSMTP = client.IsSMTP();
+// log(isSMTP)
 // ```
-func (c *SMTPClient) IsSMTP(host string, port int) (IsSMTPResponse, error) {
-	resp := IsSMTPResponse{}
+func (c *Client) IsSMTP() (SMTPResponse, error) {
+	resp := SMTPResponse{}
+	c.nj.Require(c.host != "", "host cannot be empty")
+	c.nj.Require(c.port != "", "port cannot be empty")
 
 	timeout := 5 * time.Second
-	conn, err := protocolstate.Dialer.Dial(context.TODO(), "tcp", net.JoinHostPort(host, strconv.Itoa(port)))
+	conn, err := protocolstate.Dialer.Dial(context.TODO(), "tcp", net.JoinHostPort(c.host, c.port))
 	if err != nil {
 		return resp, err
 	}
 	defer conn.Close()
 
 	smtpPlugin := pluginsmtp.SMTPPlugin{}
-	service, err := smtpPlugin.Run(conn, timeout, plugins.Target{Host: host})
+	service, err := smtpPlugin.Run(conn, timeout, plugins.Target{Host: c.host})
 	if err != nil {
 		return resp, err
 	}
@@ -79,20 +114,20 @@ func (c *SMTPClient) IsSMTP(host string, port int) (IsSMTPResponse, error) {
 // message.To('xyz2@projectdiscoveyr.io');
 // message.Subject('hello');
 // message.Body('hello');
-// const isRelay = smtp.IsOpenRelay('acme.com', 25, message);
+// const client = new smtp.Client('acme.com', 25);
+// const isRelay = client.IsOpenRelay(message);
 // ```
-func (c *SMTPClient) IsOpenRelay(host string, port int, msg *SMTPMessage) (bool, error) {
-	if !protocolstate.IsHostAllowed(host) {
-		return false, protocolstate.ErrHostDenied.Msgf(host)
-	}
+func (c *Client) IsOpenRelay(msg *SMTPMessage) (bool, error) {
+	c.nj.Require(c.host != "", "host cannot be empty")
+	c.nj.Require(c.port != "", "port cannot be empty")
 
-	addr := net.JoinHostPort(host, strconv.Itoa(port))
+	addr := net.JoinHostPort(c.host, c.port)
 	conn, err := protocolstate.Dialer.Dial(context.TODO(), "tcp", addr)
 	if err != nil {
 		return false, err
 	}
 	defer conn.Close()
-	client, err := smtp.NewClient(conn, host)
+	client, err := smtp.NewClient(conn, c.host)
 	if err != nil {
 		return false, err
 	}
@@ -137,20 +172,21 @@ func (c *SMTPClient) IsOpenRelay(host string, port int, msg *SMTPMessage) (bool,
 // message.To('xyz2@projectdiscoveyr.io');
 // message.Subject('hello');
 // message.Body('hello');
-// const isSent = smtp.SendMail('acme.com', 25, message);
+// const client = new smtp.Client('acme.com', 25);
+// const isSent = client.SendMail(message);
+// log(isSent)
 // ```
-func (c *SMTPClient) SendMail(host string, port string, msg *SMTPMessage) (bool, error) {
-	if !protocolstate.IsHostAllowed(host) {
-		return false, protocolstate.ErrHostDenied.Msgf(host)
-	}
+func (c *Client) SendMail(msg *SMTPMessage) (bool, error) {
+	c.nj.Require(c.host != "", "host cannot be empty")
+	c.nj.Require(c.port != "", "port cannot be empty")
 
 	var auth smtp.Auth
 	if msg.user != "" && msg.pass != "" {
-		auth = smtp.PlainAuth("", msg.user, msg.pass, host)
+		auth = smtp.PlainAuth("", msg.user, msg.pass, c.host)
 	}
 
 	// send mail
-	addr := net.JoinHostPort(host, port)
+	addr := net.JoinHostPort(c.host, c.port)
 	if err := smtp.SendMail(addr, auth, msg.from, msg.to, []byte(msg.String())); err != nil {
 		return false, err
 	}

--- a/pkg/js/libs/smtp/smtp.go
+++ b/pkg/js/libs/smtp/smtp.go
@@ -188,7 +188,7 @@ func (c *Client) SendMail(msg *SMTPMessage) (bool, error) {
 	// send mail
 	addr := net.JoinHostPort(c.host, c.port)
 	if err := smtp.SendMail(addr, auth, msg.from, msg.to, []byte(msg.String())); err != nil {
-		return false, err
+		c.nj.Throw("failed to send mail with message(%s) got %v", msg.String(), err)
 	}
 	return true, nil
 }

--- a/pkg/js/libs/smtp/smtp.go
+++ b/pkg/js/libs/smtp/smtp.go
@@ -29,7 +29,8 @@ type (
 	// @example
 	// ```javascript
 	// const smtp = require('nuclei/smtp');
-	// const isSMTP = smtp.IsSMTP('acme.com', 25);
+	// const client = new smtp.Client();
+	// const isSMTP = client.IsSMTP('acme.com', 25);
 	// log(toJSON(isSMTP));
 	// ```
 	IsSMTPResponse struct {
@@ -42,7 +43,8 @@ type (
 // @example
 // ```javascript
 // const smtp = require('nuclei/smtp');
-// const isSMTP = smtp.IsSMTP('acme.com', 25);
+// const client = new smtp.Client();
+// const isSMTP = client.IsSMTP('acme.com', 25);
 // log(toJSON(isSMTP));
 // ```
 func (c *SMTPClient) IsSMTP(host string, port int) (IsSMTPResponse, error) {

--- a/pkg/js/libs/ssh/ssh.go
+++ b/pkg/js/libs/ssh/ssh.go
@@ -16,7 +16,7 @@ type (
 	// @example
 	// ```javascript
 	// const ssh = require('nuclei/ssh');
-	// const client = new ssh.Client();
+	// const client = new ssh.SSHClient();
 	// ```
 	SSHClient struct {
 		connection *ssh.Client
@@ -28,7 +28,7 @@ type (
 // @example
 // ```javascript
 // const ssh = require('nuclei/ssh');
-// const client = new ssh.Client();
+// const client = new ssh.SSHClient();
 // client.SetTimeout(10);
 // ```
 func (c *SSHClient) SetTimeout(sec int) {
@@ -42,7 +42,7 @@ func (c *SSHClient) SetTimeout(sec int) {
 // @example
 // ```javascript
 // const ssh = require('nuclei/ssh');
-// const client = new ssh.Client();
+// const client = new ssh.SSHClient();
 // const connected = client.Connect('acme.com', 22, 'username', 'password');
 // ```
 func (c *SSHClient) Connect(host string, port int, username, password string) (bool, error) {
@@ -67,7 +67,7 @@ func (c *SSHClient) Connect(host string, port int, username, password string) (b
 // @example
 // ```javascript
 // const ssh = require('nuclei/ssh');
-// const client = new ssh.Client();
+// const client = new ssh.SSHClient();
 // const privateKey = `-----BEGIN RSA PRIVATE KEY----- ...`;
 // const connected = client.ConnectWithKey('acme.com', 22, 'username', privateKey);
 // ```
@@ -96,7 +96,7 @@ func (c *SSHClient) ConnectWithKey(host string, port int, username, key string) 
 // @example
 // ```javascript
 // const ssh = require('nuclei/ssh');
-// const client = new ssh.Client();
+// const client = new ssh.SSHClient();
 // const info = client.ConnectSSHInfoMode('acme.com', 22);
 // log(to_json(info));
 // ```
@@ -115,7 +115,7 @@ func (c *SSHClient) ConnectSSHInfoMode(host string, port int) (*ssh.HandshakeLog
 // @example
 // ```javascript
 // const ssh = require('nuclei/ssh');
-// const client = new ssh.Client();
+// const client = new ssh.SSHClient();
 // client.Connect('acme.com', 22, 'username', 'password');
 // const output = client.Run('id');
 // log(output);
@@ -144,7 +144,7 @@ func (c *SSHClient) Run(cmd string) (string, error) {
 // @example
 // ```javascript
 // const ssh = require('nuclei/ssh');
-// const client = new ssh.Client();
+// const client = new ssh.SSHClient();
 // client.Connect('acme.com', 22, 'username', 'password');
 // const closed = client.Close();
 // ```

--- a/pkg/js/libs/telnet/telnet.go
+++ b/pkg/js/libs/telnet/telnet.go
@@ -12,16 +12,6 @@ import (
 )
 
 type (
-	// TelnetClient is a minimal Telnet client for nuclei scripts.
-	// @example
-	// ```javascript
-	// const telnet = require('nuclei/telnet');
-	// const client = new telnet.Client();
-	// ```
-	TelnetClient struct{}
-)
-
-type (
 	// IsTelnetResponse is the response from the IsTelnet function.
 	// this is returned by IsTelnet function.
 	// @example
@@ -43,7 +33,7 @@ type (
 // const isTelnet = telnet.IsTelnet('acme.com', 23);
 // log(toJSON(isTelnet));
 // ```
-func (c *TelnetClient) IsTelnet(host string, port int) (IsTelnetResponse, error) {
+func IsTelnet(host string, port int) (IsTelnetResponse, error) {
 	resp := IsTelnetResponse{}
 
 	timeout := 5 * time.Second

--- a/pkg/js/libs/vnc/vnc.go
+++ b/pkg/js/libs/vnc/vnc.go
@@ -12,16 +12,6 @@ import (
 )
 
 type (
-	// VNCClient is a minimal VNC client for nuclei scripts.
-	// @example
-	// ```javascript
-	// const vnc = require('nuclei/vnc');
-	// const client = new vnc.Client();
-	// ```
-	VNCClient struct{}
-)
-
-type (
 	// IsVNCResponse is the response from the IsVNC function.
 	// @example
 	// ```javascript
@@ -44,7 +34,7 @@ type (
 // const isVNC = vnc.IsVNC('acme.com', 5900);
 // log(toJSON(isVNC));
 // ```
-func (c *VNCClient) IsVNC(host string, port int) (IsVNCResponse, error) {
+func IsVNC(host string, port int) (IsVNCResponse, error) {
 	resp := IsVNCResponse{}
 
 	timeout := 5 * time.Second

--- a/pkg/protocols/common/interactsh/interactsh.go
+++ b/pkg/protocols/common/interactsh/interactsh.go
@@ -170,6 +170,7 @@ func (c *Client) processInteractionForRequest(interaction *server.Interaction, d
 	data.Event.Unlock()
 
 	if data.Operators != nil {
+		fmt.Printf("processing interaction for request %v\n", interaction.UniqueID)
 		result, matched = data.Operators.Execute(data.Event.InternalEvent, data.MatchFunc, data.ExtractFunc, c.options.Debug || c.options.DebugRequest || c.options.DebugResponse)
 	} else {
 		// this is most likely a bug so error instead of warning

--- a/pkg/protocols/common/interactsh/interactsh.go
+++ b/pkg/protocols/common/interactsh/interactsh.go
@@ -170,7 +170,6 @@ func (c *Client) processInteractionForRequest(interaction *server.Interaction, d
 	data.Event.Unlock()
 
 	if data.Operators != nil {
-		fmt.Printf("processing interaction for request %v\n", interaction.UniqueID)
 		result, matched = data.Operators.Execute(data.Event.InternalEvent, data.MatchFunc, data.ExtractFunc, c.options.Debug || c.options.DebugRequest || c.options.DebugResponse)
 	} else {
 		// this is most likely a bug so error instead of warning

--- a/pkg/protocols/http/http.go
+++ b/pkg/protocols/http/http.go
@@ -135,7 +135,7 @@ type Request struct {
 
 	// description: |
 	//   SelfContained specifies if the request is self-contained.
-	SelfContained bool `yaml:"-" json:"-"`
+	SelfContained bool `yaml:"self-contained" json:"self-contained"`
 
 	// description: |
 	//   Signature is the request signature method

--- a/pkg/protocols/javascript/js.go
+++ b/pkg/protocols/javascript/js.go
@@ -447,7 +447,7 @@ func (request *Request) executeRequestParallel(ctxParent context.Context, hostPo
 	}
 }
 
-func (request *Request) executeRequestWithPayloads(hostPort string, input *contextargs.Context, hostname string, payload map[string]interface{}, previous output.InternalEvent, callback protocols.OutputEventCallback, requestOptions *protocols.ExecutorOptions) error {
+func (request *Request) executeRequestWithPayloads(hostPort string, input *contextargs.Context, _ string, payload map[string]interface{}, previous output.InternalEvent, callback protocols.OutputEventCallback, requestOptions *protocols.ExecutorOptions) error {
 	payloadValues := generators.MergeMaps(payload, previous)
 	argsCopy, err := request.getArgsCopy(input, payloadValues, requestOptions, false)
 	if err != nil {
@@ -580,7 +580,7 @@ func (request *Request) getArgsCopy(input *contextargs.Context, payloadValues ma
 }
 
 // evaluateArgs evaluates arguments using available payload values and returns a copy of args
-func (request *Request) evaluateArgs(payloadValues map[string]interface{}, requestOptions *protocols.ExecutorOptions, ignoreErrors bool) (map[string]interface{}, error) {
+func (request *Request) evaluateArgs(payloadValues map[string]interface{}, _ *protocols.ExecutorOptions, ignoreErrors bool) (map[string]interface{}, error) {
 	argsCopy := make(map[string]interface{})
 mainLoop:
 	for k, v := range request.Args {

--- a/pkg/templates/templates.go
+++ b/pkg/templates/templates.go
@@ -371,6 +371,17 @@ func (template *Template) ImportFileRefs(options *protocols.ExecutorOptions) err
 		}
 	}
 
+	// for javascript protocol code references
+	for _, request := range template.RequestsJavascript {
+		// simple test to check if source is a file or a snippet
+		if len(strings.Split(request.Code, "\n")) == 1 && fileutil.FileExists(request.Code) {
+			if val, ok := loadFile(request.Code); ok {
+				template.ImportedFiles = append(template.ImportedFiles, request.Code)
+				request.Code = val
+			}
+		}
+	}
+
 	// flow code references
 	if template.Flow != "" {
 		if len(template.Flow) > 0 && filepath.Ext(template.Flow) == ".js" && fileutil.FileExists(template.Flow) {
@@ -394,6 +405,20 @@ func (template *Template) ImportFileRefs(options *protocols.ExecutorOptions) err
 					if val, ok := loadFile(request.Source); ok {
 						template.ImportedFiles = append(template.ImportedFiles, request.Source)
 						request.Source = val
+					}
+				}
+			}
+		}
+
+		// for javascript protocol code references
+		for _, req := range template.RequestsQueue {
+			if req.Type() == types.JavascriptProtocol {
+				request := req.(*javascript.Request)
+				// simple test to check if source is a file or a snippet
+				if len(strings.Split(request.Code, "\n")) == 1 && fileutil.FileExists(request.Code) {
+					if val, ok := loadFile(request.Code); ok {
+						template.ImportedFiles = append(template.ImportedFiles, request.Code)
+						request.Code = val
 					}
 				}
 			}


### PR DESCRIPTION
### Proposed Changes

- `self-contained` template / feature was set on global template level , but with introduction of `flow` and `multi-protocol` execution sometimes we need a combination of both ( which was original cause behind issue #4788 )
- this is now resolving by allowing to specify `self-contained: true` at request level 
- fixed issue with javascript module examples and misc updates to smtp js module
- closes #4788
- closes #4818 

```yaml
id: stripe-secret-key

info:
  name: Stripe Secret Key
  author: DhiyaneshDk
  severity: high
  tags: exposure,token,stripe

flow: http(1) && http(2)

http:
  - method: GET
    path:
      - "{{BaseURL}}"

    extractors:
      - type: regex
        part: body
        name: token
        regex:
          - 'sk_(?:live|test)_[0-9a-zA-Z]{24}'
        internal: true

  - raw:
      - |
        @Host: https://api.stripe.com:443
        GET /v1/charges?limit=1 HTTP/1.1
        Host: api.stripe.com
        Authorization: Bearer {{token}}

    self-contained: true

    matchers:
      - type: dsl
        dsl:
          - 'status_code == 200'
          - 'contains(body, "billing_details")'
        condition: and
```

>[!NOTE]
> - this feature i.e specifying `self-contained` true at request level does not break / change any behaviour of existing templates and only acts as override of sorts at http protocol / request level
> - specifying `self-contained: true` at global / template level marks all proto requests in template as self-contained while specifying it at http request only affects that http request[s]