### PR TITLE
validate code template in workflows

### DIFF
--- a/pkg/templates/workflows.go
+++ b/pkg/templates/workflows.go
@@ -83,11 +83,12 @@ func parseWorkflowTemplate(workflow *workflows.WorkflowTemplate, preprocessor Pr
 		if len(template.RequestsCode) > 0 {
 			if !options.Options.EnableCodeTemplates {
 				gologger.Warning().Msgf("`-code` flag not found, skipping code template from workflow: %v\n", path)
+				continue
 			} else if !template.Verified {
 				// unverfied code templates are not allowed in workflows
 				gologger.Warning().Msgf("skipping unverified code template from workflow: %v\n", path)
+				continue
 			}
-			continue
 		}
 		workflowTemplates = append(workflowTemplates, template)
 	}

--- a/pkg/templates/workflows.go
+++ b/pkg/templates/workflows.go
@@ -80,6 +80,15 @@ func parseWorkflowTemplate(workflow *workflows.WorkflowTemplate, preprocessor Pr
 			gologger.Warning().Msgf("Could not parse workflow template %s: no executer found\n", path)
 			continue
 		}
+		if len(template.RequestsCode) > 0 {
+			if !options.Options.EnableCodeTemplates {
+				gologger.Warning().Msgf("`-code` flag not found, skipping code template from workflow: %v\n", path)
+			} else if !template.Verified {
+				// unverfied code templates are not allowed in workflows
+				gologger.Warning().Msgf("skipping unverified code template from workflow: %v\n", path)
+			}
+			continue
+		}
 		workflowTemplates = append(workflowTemplates, template)
 	}
 


### PR DESCRIPTION
### Proposed Changes

- validate code protocol templates in workflow according to existing rules
- closes #4796 

```console
$  ./nuclei -w workflow.yaml -debug -v -u https://scanme.sh 

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.2.0-dev

		projectdiscovery.io

[WRN] `-code` flag not found, skipping code template from workflow: /Users/tarun/Codebase2/nuclei/test.yaml
[INF] Current nuclei version: v3.2.0-dev (development)
[INF] Current nuclei-templates version: v9.7.6 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] Workflows loaded for current scan: 1
[WRN] Executing 1 unsigned templates. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] No results found. Better luck next time!
```

```console
$  ./nuclei -w workflow.yaml -debug -v -u https://scanme.sh  -code

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.2.0-dev

		projectdiscovery.io

[WRN] skipping unverified code template from workflow: /Users/tarun/Codebase2/nuclei/test.yaml
[INF] Current nuclei version: v3.2.0-dev (development)
[INF] Current nuclei-templates version: v9.7.6 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] Workflows loaded for current scan: 1
[WRN] Executing 1 unsigned templates. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] No results found. Better luck next time!
```