### PR TITLE
Make self-contained optional in http request

### DIFF
--- a/pkg/protocols/http/http.go
+++ b/pkg/protocols/http/http.go
@@ -135,7 +135,7 @@ type Request struct {
 
 	// description: |
 	//   SelfContained specifies if the request is self-contained.
-	SelfContained bool `yaml:"self-contained" json:"self-contained"`
+	SelfContained bool `yaml:"self-contained,omitempty" json:"self-contained,omitempty"`
 
 	// description: |
 	//   Signature is the request signature method


### PR DESCRIPTION
## Proposed changes
```yaml
id: CVE-2021-28937

info:
  name: Acexy Wireless-N WiFi Repeater REV 1.0 - Repeater Password Disclosure
  author: geeknik
  severity: high
  description: Acexy Wireless-N WiFi Repeater REV 1.0 is vulnerable to password disclosure because the password.html page of the web management interface contains the administrator account password in plaintext.
  metadata:
    max-request: 1
    vendor: acexy
    product: wireless-n_wifi_repeater_firmware
  tags: cve2021,cve,acexy,disclosure,iot
  
http:
  - method: GET
    path:
      - "{{BaseURL}}/password.html"
    matchers-condition: and
    matchers:
      - type: word
        words:
          - "Password Setting"
          - "addCfg('username'"
          - "addCfg('newpass'"
        condition: and

      - type: status
        status:
          - 200
```
Currently this template is not validating without `self-contained` property under `http`.

Expected that template needs to validate without `self-contained` under `http` block.

Ref: https://github.com/projectdiscovery/nuclei/blob/dev/nuclei-jsonschema.json#L917
## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)