### PR TITLE
add callback support to StandardWriter

### DIFF
--- a/lib/sdk_private.go
+++ b/lib/sdk_private.go
@@ -58,6 +58,27 @@ func (e *NucleiEngine) applyRequiredDefaults() {
 			mockoutput.FailureCallback = e.onFailureCallback
 		}
 		e.customWriter = mockoutput
+	} else {
+		if standardWriter, ok := e.customWriter.(*output.StandardWriter); ok {
+			standardWriter.WriteCallback = func(event *output.ResultEvent) {
+				if len(e.resultCallbacks) > 0 {
+					for _, callback := range e.resultCallbacks {
+						if callback != nil {
+							callback(event)
+						}
+					}
+					return
+				}
+				sb := strings.Builder{}
+				sb.WriteString(fmt.Sprintf("[%v] ", event.TemplateID))
+				if event.Matched != "" {
+					sb.WriteString(event.Matched)
+				} else {
+					sb.WriteString(event.Host)
+				}
+				fmt.Println(sb.String())
+			}
+		}
 	}
 	if e.customProgress == nil {
 		e.customProgress = &testutils.MockProgressClient{}

--- a/lib/sdk_private.go
+++ b/lib/sdk_private.go
@@ -59,6 +59,7 @@ func (e *NucleiEngine) applyRequiredDefaults() {
 		}
 		e.customWriter = mockoutput
 	} else {
+		//FIXME: this is a hack to support callbacks in custom output writer
 		if standardWriter, ok := e.customWriter.(*output.StandardWriter); ok {
 			standardWriter.WriteCallback = func(event *output.ResultEvent) {
 				if len(e.resultCallbacks) > 0 {

--- a/lib/sdk_private.go
+++ b/lib/sdk_private.go
@@ -34,53 +34,35 @@ import (
 
 // applyRequiredDefaults to options
 func (e *NucleiEngine) applyRequiredDefaults() {
-	if e.customWriter == nil {
-		mockoutput := testutils.NewMockOutputWriter(e.opts.OmitTemplate)
-		mockoutput.WriteCallback = func(event *output.ResultEvent) {
-			if len(e.resultCallbacks) > 0 {
-				for _, callback := range e.resultCallbacks {
-					if callback != nil {
-						callback(event)
-					}
+	mockoutput := testutils.NewMockOutputWriter(e.opts.OmitTemplate)
+	mockoutput.WriteCallback = func(event *output.ResultEvent) {
+		if len(e.resultCallbacks) > 0 {
+			for _, callback := range e.resultCallbacks {
+				if callback != nil {
+					callback(event)
 				}
-				return
 			}
-			sb := strings.Builder{}
-			sb.WriteString(fmt.Sprintf("[%v] ", event.TemplateID))
-			if event.Matched != "" {
-				sb.WriteString(event.Matched)
-			} else {
-				sb.WriteString(event.Host)
-			}
-			fmt.Println(sb.String())
+			return
 		}
-		if e.onFailureCallback != nil {
-			mockoutput.FailureCallback = e.onFailureCallback
+		sb := strings.Builder{}
+		sb.WriteString(fmt.Sprintf("[%v] ", event.TemplateID))
+		if event.Matched != "" {
+			sb.WriteString(event.Matched)
+		} else {
+			sb.WriteString(event.Host)
 		}
-		e.customWriter = mockoutput
-	} else {
-		//FIXME: this is a hack to support callbacks in custom output writer
-		if standardWriter, ok := e.customWriter.(*output.StandardWriter); ok {
-			standardWriter.WriteCallback = func(event *output.ResultEvent) {
-				if len(e.resultCallbacks) > 0 {
-					for _, callback := range e.resultCallbacks {
-						if callback != nil {
-							callback(event)
-						}
-					}
-					return
-				}
-				sb := strings.Builder{}
-				sb.WriteString(fmt.Sprintf("[%v] ", event.TemplateID))
-				if event.Matched != "" {
-					sb.WriteString(event.Matched)
-				} else {
-					sb.WriteString(event.Host)
-				}
-				fmt.Println(sb.String())
-			}
-		}
+		fmt.Println(sb.String())
 	}
+	if e.onFailureCallback != nil {
+		mockoutput.FailureCallback = e.onFailureCallback
+	}
+
+	if e.customWriter != nil {
+		e.customWriter = output.NewMultiWriter(e.customWriter, mockoutput)
+	} else {
+		e.customWriter = mockoutput
+	}
+
 	if e.customProgress == nil {
 		e.customProgress = &testutils.MockProgressClient{}
 	}

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -66,6 +66,7 @@ type StandardWriter struct {
 	omitTemplate          bool
 	DisableStdout         bool
 	AddNewLinesOutputFile bool // by default this is only done for stdout
+	WriteCallback         func(o *ResultEvent)
 }
 
 var decolorizerRegex = regexp.MustCompile(`\x1B\[[0-9;]*[a-zA-Z]`)
@@ -229,6 +230,10 @@ func NewStandardWriter(options *types.Options) (*StandardWriter, error) {
 
 // Write writes the event to file and/or screen.
 func (w *StandardWriter) Write(event *ResultEvent) error {
+	if w.WriteCallback != nil {
+		w.WriteCallback(event)
+	}
+
 	// Enrich the result event with extra metadata on the template-path and url.
 	if event.TemplatePath != "" {
 		event.Template, event.TemplateURL = utils.TemplatePathURL(types.ToString(event.TemplatePath), types.ToString(event.TemplateID))

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -66,7 +66,6 @@ type StandardWriter struct {
 	omitTemplate          bool
 	DisableStdout         bool
 	AddNewLinesOutputFile bool // by default this is only done for stdout
-	WriteCallback         func(o *ResultEvent)
 }
 
 var decolorizerRegex = regexp.MustCompile(`\x1B\[[0-9;]*[a-zA-Z]`)
@@ -230,10 +229,6 @@ func NewStandardWriter(options *types.Options) (*StandardWriter, error) {
 
 // Write writes the event to file and/or screen.
 func (w *StandardWriter) Write(event *ResultEvent) error {
-	if w.WriteCallback != nil {
-		w.WriteCallback(event)
-	}
-
 	// Enrich the result event with extra metadata on the template-path and url.
 	if event.TemplatePath != "" {
 		event.Template, event.TemplateURL = utils.TemplatePathURL(types.ToString(event.TemplatePath), types.ToString(event.TemplateID))


### PR DESCRIPTION
## Proposed changes

Closes #4329

```console
$ go run .
BEEP FOUND RESULT
{"template":"ssl/tls-version.yaml","template-url":"https://cloud.projectdiscovery.io/public/tls-version","template-id":"tls-version","template-path":"/Users/dogancanbakir/nuclei-templates/ssl/tls-version.yaml","info":{"name":"TLS Version - Detect","author":["pdteam","pussycat0x"],"tags":["ssl","tls"],"description":"TLS version detection is a security process used to determine the version of the Transport Layer Security (TLS) protocol used by a computer or server.\nIt is important to detect the TLS version in order to ensure secure communication between two computers or servers.\n","severity":"info","metadata":{"max-request":4}},"type":"ssl","host":"scanme.sh","port":"443","matched-at":"scanme.sh:443","extracted-results":["tls10"],"ip":"128.199.158.128","timestamp":"2024-03-06T15:23:31.957787+03:00","matcher-status":true}
[0:00:01] | Templates: 1 | Hosts: 3 | RPS: 0 | Matched: 1 | Errors: 0 | Requests: 0/12 (0%)
BEEP FOUND RESULT
{"template":"ssl/tls-version.yaml","template-url":"https://cloud.projectdiscovery.io/public/tls-version","template-id":"tls-version","template-path":"/Users/dogancanbakir/nuclei-templates/ssl/tls-version.yaml","info":{"name":"TLS Version - Detect","author":["pdteam","pussycat0x"],"tags":["ssl","tls"],"description":"TLS version detection is a security process used to determine the version of the Transport Layer Security (TLS) protocol used by a computer or server.\nIt is important to detect the TLS version in order to ensure secure communication between two computers or servers.\n","severity":"info","metadata":{"max-request":4}},"type":"ssl","host":"scanme.sh","port":"443","matched-at":"scanme.sh:443","extracted-results":["tls11"],"ip":"128.199.158.128","timestamp":"2024-03-06T15:23:32.677028+03:00","matcher-status":true}
...
^Csignal: interrupt

```

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)