### PR TITLE
Purge cache on global callback set

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -320,7 +320,7 @@ require (
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/jcmturner/gokrb5/v8 v8.4.4
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
-	github.com/labstack/gommon v0.4.0
+	github.com/labstack/gommon v0.4.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/nwaples/rardecode v1.1.3 // indirect
 	github.com/pierrec/lz4 v2.6.1+incompatible // indirect

--- a/go.mod
+++ b/go.mod
@@ -320,7 +320,7 @@ require (
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/jcmturner/gokrb5/v8 v8.4.4
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
-	github.com/labstack/gommon v0.4.0 // indirect
+	github.com/labstack/gommon v0.4.0
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/nwaples/rardecode v1.1.3 // indirect
 	github.com/pierrec/lz4 v2.6.1+incompatible // indirect

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -459,6 +459,9 @@ func (r *Runner) RunEnumeration() error {
 	disk.PrintDeprecatedPathsMsgIfApplicable(r.options.Silent)
 	templates.PrintDeprecatedProtocolNameMsgIfApplicable(r.options.Silent, r.options.Verbose)
 
+	// purge cache once everything is loaded
+	templates.PurgeCache()
+
 	// add the hosts from the metadata queries of loaded templates into input provider
 	if r.options.Uncover && len(r.options.UncoverQuery) == 0 {
 		uncoverOpts := &uncoverlib.Options{

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -459,8 +459,8 @@ func (r *Runner) RunEnumeration() error {
 	disk.PrintDeprecatedPathsMsgIfApplicable(r.options.Silent)
 	templates.PrintDeprecatedProtocolNameMsgIfApplicable(r.options.Silent, r.options.Verbose)
 
-	// purge cache once everything is loaded
-	templates.PurgeCache()
+	// purge global caches primarily used for loading templates
+	config.DefaultConfig.PurgeGlobalCache()
 
 	// add the hosts from the metadata queries of loaded templates into input provider
 	if r.options.Uncover && len(r.options.UncoverQuery) == 0 {

--- a/lib/multi.go
+++ b/lib/multi.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/logrusorgru/aurora"
+	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/config"
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/loader"
 	"github.com/projectdiscovery/nuclei/v3/pkg/core"
 	"github.com/projectdiscovery/nuclei/v3/pkg/core/inputs"
@@ -12,7 +13,6 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/parsers"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/contextargs"
-	"github.com/projectdiscovery/nuclei/v3/pkg/templates"
 	"github.com/projectdiscovery/nuclei/v3/pkg/types"
 	"github.com/projectdiscovery/ratelimit"
 	errorutil "github.com/projectdiscovery/utils/errors"
@@ -89,7 +89,7 @@ func (e *ThreadSafeNucleiEngine) GlobalLoadAllTemplates() error {
 // GlobalResultCallback sets a callback function which will be called for each result
 func (e *ThreadSafeNucleiEngine) GlobalResultCallback(callback func(event *output.ResultEvent)) {
 	e.eng.resultCallbacks = []func(*output.ResultEvent){callback}
-	templates.PurgeCache()
+	config.DefaultConfig.PurgeGlobalCache()
 }
 
 // ExecuteWithCallback executes templates on targets and calls callback on each result(only if results are found)

--- a/lib/multi.go
+++ b/lib/multi.go
@@ -12,6 +12,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/parsers"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/contextargs"
+	"github.com/projectdiscovery/nuclei/v3/pkg/templates"
 	"github.com/projectdiscovery/nuclei/v3/pkg/types"
 	"github.com/projectdiscovery/ratelimit"
 	errorutil "github.com/projectdiscovery/utils/errors"
@@ -88,6 +89,7 @@ func (e *ThreadSafeNucleiEngine) GlobalLoadAllTemplates() error {
 // GlobalResultCallback sets a callback function which will be called for each result
 func (e *ThreadSafeNucleiEngine) GlobalResultCallback(callback func(event *output.ResultEvent)) {
 	e.eng.resultCallbacks = []func(*output.ResultEvent){callback}
+	templates.PurgeCache()
 }
 
 // ExecuteWithCallback executes templates on targets and calls callback on each result(only if results are found)

--- a/pkg/catalog/config/nucleiconfig.go
+++ b/pkg/catalog/config/nucleiconfig.go
@@ -46,8 +46,7 @@ type Config struct {
 	LatestNucleiIgnoreHash       string `json:"nuclei-latest-ignore-hash,omitempty"`
 
 	// Other AppLevel/Global Settings
-	DisableGlobalCachePurge bool          `json:"-"` // when enabled disables purging of global cache(useful for app as service)
-	registerdCaches         []GlobalCache `json:"-"` // registered global caches
+	registerdCaches []GlobalCache `json:"-"` // registered global caches
 
 	// internal / unexported fields
 	disableUpdates bool   `json:"-"` // disable updates both version check and template updates
@@ -310,11 +309,6 @@ func (c *Config) RegisterGlobalCache(cache GlobalCache) {
 
 // PurgeGlobalCache purges all registered global caches
 func (c *Config) PurgeGlobalCache() {
-	if c.DisableGlobalCachePurge {
-		// useful for apps running nuclei as background process
-		// where we don't want to purge global cache
-		return
-	}
 	for _, cache := range c.registerdCaches {
 		cache.Purge()
 	}

--- a/pkg/catalog/config/nucleiconfig.go
+++ b/pkg/catalog/config/nucleiconfig.go
@@ -45,6 +45,10 @@ type Config struct {
 	LatestNucleiTemplatesVersion string `json:"nuclei-templates-latest-version"`
 	LatestNucleiIgnoreHash       string `json:"nuclei-latest-ignore-hash,omitempty"`
 
+	// Other AppLevel/Global Settings
+	DisableGlobalCachePurge bool          `json:"-"` // when enabled disables purging of global cache(useful for app as service)
+	registerdCaches         []GlobalCache `json:"-"` // registered global caches
+
 	// internal / unexported fields
 	disableUpdates bool   `json:"-"` // disable updates both version check and template updates
 	homeDir        string `json:"-"` //  User Home Directory
@@ -296,6 +300,24 @@ func (c *Config) WriteTemplatesIndex(index map[string]string) error {
 		_, _ = buff.WriteString(k + "," + v + "\n")
 	}
 	return os.WriteFile(indexFile, buff.Bytes(), 0600)
+}
+
+// RegisterGlobalCache registers a global cache at app level
+// and is available to be purged on demand
+func (c *Config) RegisterGlobalCache(cache GlobalCache) {
+	c.registerdCaches = append(c.registerdCaches, cache)
+}
+
+// PurgeGlobalCache purges all registered global caches
+func (c *Config) PurgeGlobalCache() {
+	if c.DisableGlobalCachePurge {
+		// useful for apps running nuclei as background process
+		// where we don't want to purge global cache
+		return
+	}
+	for _, cache := range c.registerdCaches {
+		cache.Purge()
+	}
 }
 
 // getTemplatesConfigFilePath returns configDir/.templates-config.json file path

--- a/pkg/catalog/config/template.go
+++ b/pkg/catalog/config/template.go
@@ -13,6 +13,13 @@ import (
 	stringsutil "github.com/projectdiscovery/utils/strings"
 )
 
+// GlobalCache are global cache that have global
+// scope and are not purged but can be purged
+// via config.DefaultConfig
+type GlobalCache interface {
+	Purge()
+}
+
 var knownConfigFiles = []string{"cves.json", "contributors.json", "TEMPLATES-STATS.json"}
 
 // TemplateFormat

--- a/pkg/parsers/parser.go
+++ b/pkg/parsers/parser.go
@@ -150,6 +150,7 @@ const (
 
 func init() {
 	parsedTemplatesCache = cache.New()
+	config.DefaultConfig.RegisterGlobalCache(parsedTemplatesCache)
 
 	stats.NewEntry(SyntaxWarningStats, "Found %d templates with syntax warning (use -validate flag for further examination)")
 	stats.NewEntry(SyntaxErrorStats, "Found %d templates with syntax error (use -validate flag for further examination)")

--- a/pkg/templates/cache/cache.go
+++ b/pkg/templates/cache/cache.go
@@ -31,7 +31,7 @@ func (t *Templates) Has(template string) (interface{}, error) {
 
 // Store stores a template with data and error
 func (t *Templates) Store(template string, data interface{}, err error) {
-	t.items.Set(template, parsedTemplateErrHolder{template: data, err: err})
+	_ = t.items.Set(template, parsedTemplateErrHolder{template: data, err: err})
 }
 
 // Purge the cache

--- a/pkg/templates/compile.go
+++ b/pkg/templates/compile.go
@@ -47,6 +47,11 @@ func init() {
 	SignatureStats[Unsigned] = &atomic.Uint64{}
 }
 
+// Purge the cache
+func PurgeCache() {
+	parsedTemplatesCache.Purge()
+}
+
 // Parse parses a yaml request template file
 // TODO make sure reading from the disk the template parsing happens once: see parsers.ParseTemplate vs templates.Parse
 //

--- a/pkg/templates/compile.go
+++ b/pkg/templates/compile.go
@@ -45,11 +45,7 @@ func init() {
 		SignatureStats[verifier.Identifier()] = &atomic.Uint64{}
 	}
 	SignatureStats[Unsigned] = &atomic.Uint64{}
-}
-
-// Purge the cache
-func PurgeCache() {
-	parsedTemplatesCache.Purge()
+	config.DefaultConfig.RegisterGlobalCache(parsedTemplatesCache)
 }
 
 // Parse parses a yaml request template file


### PR DESCRIPTION
## Proposed changes
This PR invalidates internal cache in case of global callback settings which are hold as reference inside template executor. The proper solution would be to have a global parsing logic and executor compilation that should happen in ephemeral lazy mode.

Closes #4836 

## Checklist
- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Example

<details>
  <summary>
    go snippet
  </summary>

  ```go
package main

import (
	"fmt"

	nuclei "github.com/projectdiscovery/nuclei/v3/lib"
	"github.com/projectdiscovery/nuclei/v3/pkg/output"
)

func run() {
	ret := make([]*output.ResultEvent, 0, 10)
	ne, err := nuclei.NewThreadSafeNucleiEngine()
	if err != nil {
		return
	}
	cb := func(event *output.ResultEvent) {
		ret = append(ret, event)
		fmt.Printf("%p, %v\n", ret, ret)
	}
	ne.GlobalResultCallback(cb)

	tf := nuclei.TemplateFilters{IDs: []string{"exposed-redis"}}
	opts := []nuclei.NucleiSDKOptions{
		nuclei.WithTemplateFilters(tf),
	}
	err = ne.ExecuteNucleiWithOpts([]string{"127.0.0.1:6379"}, opts...)
	if err != nil {
		fmt.Println("err: ", err)
	}
	ne.Close()
}

func main() {
	for i := 0; i < 5; i++ {
		run()
	}
}
```
</details>

Start redis:
```console
$ docker run -p 6379:6379 redis/redis-stack-server:latest
```

Before:
```console
$ go run .
0xc000987d10, [0xc001424fc8]
0xc000987d10, [0xc001424fc8 0xc000a82fc8]
0xc000987d10, [0xc001424fc8 0xc000a82fc8 0xc00979c248]
0xc000987d10, [0xc001424fc8 0xc000a82fc8 0xc00979c248 0xc000a83448]
0xc000987d10, [0xc001424fc8 0xc000a82fc8 0xc00979c248 0xc000a83448 0xc00979c908]
```
After:
```console
$ go run .
0xc000c8e190, [0xc0009eafc8]
0xc000d84500, [0xc0009eb448]
0xc001004460, [0xc002e1e248]
0xc000c8f310, [0xc002e1eb48]
0xc000c8fa90, [0xc002e1e6c8]
```
