### PR TITLE
fix nuclei loading ignored templates

### DIFF
--- a/pkg/catalog/loader/filter/tag_filter.go
+++ b/pkg/catalog/loader/filter/tag_filter.go
@@ -408,7 +408,8 @@ func New(config *Config) (*TagFilter, error) {
 			if _, ok := filter.allowedTags[val]; !ok {
 				filter.allowedTags[val] = struct{}{}
 			}
-			delete(filter.block, val)
+			// Note: only tags specified in IncludeTags should be removed from the block list
+			// not normal tags like config.Tags
 		}
 	}
 	for _, tag := range config.IncludeTags {

--- a/pkg/catalog/loader/filter/tag_filter_test.go
+++ b/pkg/catalog/loader/filter/tag_filter_test.go
@@ -85,7 +85,7 @@ func TestTagBasedFilter(t *testing.T) {
 	})
 	t.Run("match-includes", func(t *testing.T) {
 		filter, err := New(&Config{
-			Tags:        []string{"fuzz"},
+			IncludeTags: []string{"fuzz"},
 			ExcludeTags: []string{"fuzz"},
 		})
 		require.Nil(t, err)

--- a/pkg/output/format_screen.go
+++ b/pkg/output/format_screen.go
@@ -60,7 +60,7 @@ func (w *StandardWriter) formatScreen(output *ResultEvent) []byte {
 		for i, item := range output.ExtractedResults {
 			// trim trailing space
 			item = strings.TrimSpace(item)
-			item = strconv.QuoteToASCII(item)
+			item = strings.ReplaceAll(item, "\n", "\\n") // only replace newlines
 			builder.WriteString(w.aurora.BrightCyan(item).String())
 
 			if i != len(output.ExtractedResults)-1 {

--- a/pkg/protocols/code/code.go
+++ b/pkg/protocols/code/code.go
@@ -317,7 +317,7 @@ func interpretEnvVars(source string, vars map[string]interface{}) string {
 	// bash mode
 	if strings.Contains(source, "$") {
 		for k, v := range vars {
-			source = strings.ReplaceAll(source, "$"+k, fmt.Sprintf("'%s'", v))
+			source = strings.ReplaceAll(source, "$"+k, fmt.Sprintf("%s", v))
 		}
 	}
 	// python mode


### PR DESCRIPTION
## Proposed Changes

- closes #4841 
- closes #4850 
- As shown below when using `-tags dos` templates with dos tags are loaded even though this tag is ignored as per `.nuclei-ignore` file, this behaviour is expected for `-itags` and not  `-tags` and is resolved now

### Debug Data
```console
 ./nuclei -tags dos -tl -debug

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.2.0-dev

		projectdiscovery.io

[INF] exclude tags: [fuzz dos local brute-force bruteforce] , tags: [dos]
[INF] Loaded template /Users/tarun/nuclei-templates/http/vulnerabilities/wordpress/wordpress-wp-cron.yaml
[INF] Loaded template /Users/tarun/nuclei-templates/http/cves/2019/CVE-2019-15043.yaml
[DBG] templateTag: 'cve', blocked: 'false', allowed: 'false' excluded: map[brute-force:{} bruteforce:{} fuzz:{} local:{}]
[DBG] templateTag: 'cve2020', blocked: 'false', allowed: 'false' excluded: map[brute-force:{} bruteforce:{} fuzz:{} local:{}]
[DBG] templateTag: 'dos', blocked: 'false', allowed: 'false' excluded: map[brute-force:{} bruteforce:{} fuzz:{} local:{}]
[DBG] templateTag: 'cisco', blocked: 'false', allowed: 'false' excluded: map[brute-force:{} bruteforce:{} fuzz:{} local:{}]
[DBG] templateTag: 'packetstorm', blocked: 'false', allowed: 'false' excluded: map[brute-force:{} bruteforce:{} fuzz:{} local:{}]
[INF] Loaded template /Users/tarun/nuclei-templates/http/cves/2020/CVE-2020-16139.yaml
```

### After fix

```console
$ ./nuclei -tags dos -tl                                                                                          130 ↵

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.2.0-dev

		projectdiscovery.io


Listing available v9.7.7 nuclei templates for /Users/tarun/nuclei-templates

```