### PR TITLE
Fix overriding the predefined ratelimiter by WithGlobalRateLimit

### DIFF
--- a/lib/sdk_private.go
+++ b/lib/sdk_private.go
@@ -159,12 +159,14 @@ func (e *NucleiEngine) init() error {
 		Browser:         e.browserInstance,
 	}
 
-	if e.opts.RateLimitMinute > 0 {
-		e.executerOpts.RateLimiter = ratelimit.New(context.Background(), uint(e.opts.RateLimitMinute), time.Minute)
-	} else if e.opts.RateLimit > 0 {
-		e.executerOpts.RateLimiter = ratelimit.New(context.Background(), uint(e.opts.RateLimit), time.Second)
-	} else {
-		e.executerOpts.RateLimiter = ratelimit.NewUnlimited(context.Background())
+	if e.executerOpts.RateLimiter == nil {
+		if e.opts.RateLimitMinute > 0 {
+			e.executerOpts.RateLimiter = ratelimit.New(context.Background(), uint(e.opts.RateLimitMinute), time.Minute)
+		} else if e.opts.RateLimit > 0 {
+			e.executerOpts.RateLimiter = ratelimit.New(context.Background(), uint(e.opts.RateLimit), time.Second)
+		} else {
+			e.executerOpts.RateLimiter = ratelimit.NewUnlimited(context.Background())
+		}
 	}
 
 	e.engine = core.New(e.opts)


### PR DESCRIPTION
## Proposed changes
I noticed that the `e.rateLimiter` set in `WithGlobalRateLimit` was overwritten in `sdk_private.go` and the RPS was unlimited every time, so I fixed it.

I ran `WithGlobalRateLimit(10, time.Second)` in `examples/simple/simple.go` to verify that the RPS is correctly below 10.

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)