### PR TITLE
fix raw req single slash issue

### DIFF
--- a/cmd/integration-test/http.go
+++ b/cmd/integration-test/http.go
@@ -82,6 +82,7 @@ var httpTestcases = []TestCaseInfo{
 	{Path: "protocols/http/multi-request.yaml", TestCase: &httpMultiRequest{}},
 	{Path: "protocols/http/http-matcher-extractor-dy-extractor.yaml", TestCase: &httpMatcherExtractorDynamicExtractor{}},
 	{Path: "protocols/http/multi-http-var-sharing.yaml", TestCase: &httpMultiVarSharing{}},
+	{Path: "protocols/http/raw-path-single-slash.yaml", TestCase: &httpRawPathSingleSlash{}},
 }
 
 type httpMultiVarSharing struct{}
@@ -1559,4 +1560,29 @@ func (h *httpMultiRequest) Execute(filePath string) error {
 	}
 
 	return expectResultsCount(results, 1)
+}
+
+type httpRawPathSingleSlash struct{}
+
+func (h *httpRawPathSingleSlash) Execute(filepath string) error {
+	expectedPath := "/index.php"
+	results, err := testutils.RunNucleiBinaryAndGetCombinedOutput(debug, []string{"-t", filepath, "-u", "scanme.sh/index.php", "-debug-req"})
+	if err != nil {
+		return err
+	}
+
+	var actual string
+	for _, v := range strings.Split(results, "\n") {
+		if strings.Contains(v, "GET") {
+			parts := strings.Fields(v)
+			if len(parts) == 3 {
+				actual = parts[1]
+			}
+		}
+	}
+
+	if actual != expectedPath {
+		return fmt.Errorf("expected: %v\n\nactual: %v", expectedPath, actual)
+	}
+	return nil
 }

--- a/cmd/integration-test/http.go
+++ b/cmd/integration-test/http.go
@@ -83,6 +83,7 @@ var httpTestcases = []TestCaseInfo{
 	{Path: "protocols/http/http-matcher-extractor-dy-extractor.yaml", TestCase: &httpMatcherExtractorDynamicExtractor{}},
 	{Path: "protocols/http/multi-http-var-sharing.yaml", TestCase: &httpMultiVarSharing{}},
 	{Path: "protocols/http/raw-path-single-slash.yaml", TestCase: &httpRawPathSingleSlash{}},
+	{Path: "protocols/http/raw-unsafe-path-single-slash.yaml", TestCase: &httpRawUnsafePathSingleSlash{}},
 }
 
 type httpMultiVarSharing struct{}
@@ -1565,6 +1566,31 @@ func (h *httpMultiRequest) Execute(filePath string) error {
 type httpRawPathSingleSlash struct{}
 
 func (h *httpRawPathSingleSlash) Execute(filepath string) error {
+	expectedPath := "/index.php"
+	results, err := testutils.RunNucleiBinaryAndGetCombinedOutput(debug, []string{"-t", filepath, "-u", "scanme.sh/index.php", "-debug-req"})
+	if err != nil {
+		return err
+	}
+
+	var actual string
+	for _, v := range strings.Split(results, "\n") {
+		if strings.Contains(v, "GET") {
+			parts := strings.Fields(v)
+			if len(parts) == 3 {
+				actual = parts[1]
+			}
+		}
+	}
+
+	if actual != expectedPath {
+		return fmt.Errorf("expected: %v\n\nactual: %v", expectedPath, actual)
+	}
+	return nil
+}
+
+type httpRawUnsafePathSingleSlash struct{}
+
+func (h *httpRawUnsafePathSingleSlash) Execute(filepath string) error {
 	expectedPath := "/index.php"
 	results, err := testutils.RunNucleiBinaryAndGetCombinedOutput(debug, []string{"-t", filepath, "-u", "scanme.sh/index.php", "-debug-req"})
 	if err != nil {

--- a/integration_tests/protocols/http/raw-path-single-slash.yaml
+++ b/integration_tests/protocols/http/raw-path-single-slash.yaml
@@ -1,0 +1,13 @@
+id: raw-path-single-slash
+
+info:
+  name: Test RAW HTTP Template with single slash
+  author: pdteam
+  severity: info
+
+requests:
+  - raw:
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+        Origin: {{BaseURL}}

--- a/integration_tests/protocols/http/raw-unsafe-path-single-slash.yaml
+++ b/integration_tests/protocols/http/raw-unsafe-path-single-slash.yaml
@@ -1,0 +1,15 @@
+id: raw-unsafe-path-single-slash
+
+info:
+  name: Test RAW Unsafe HTTP Template with single slash
+  author: pdteam
+  severity: info
+
+requests:
+  - raw:
+      - |+
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+        Origin: {{BaseURL}}
+    
+    unsafe: true

--- a/pkg/protocols/http/raw/raw.go
+++ b/pkg/protocols/http/raw/raw.go
@@ -85,7 +85,7 @@ func Parse(request string, inputURL *urlutil.URL, unsafe, disablePathAutomerge b
 			// Edgecase if raw request is
 			// GET / HTTP/1.1
 			//use case: https://github.com/projectdiscovery/nuclei/issues/4921
-			if rawrequest.Path == "/" {
+			if rawrequest.Path == "/" && cloned.Path != "" {
 				rawrequest.Path = ""
 			}
 

--- a/pkg/protocols/http/raw/raw.go
+++ b/pkg/protocols/http/raw/raw.go
@@ -82,6 +82,13 @@ func Parse(request string, inputURL *urlutil.URL, unsafe, disablePathAutomerge b
 				}
 			}
 		} else {
+			// Edgecase if raw request is
+			// GET / HTTP/1.1
+			//use case: https://github.com/projectdiscovery/nuclei/issues/4921
+			if rawrequest.Path == "/" {
+				rawrequest.Path = ""
+			}
+
 			if disablePathAutomerge {
 				cloned.Path = ""
 			}

--- a/pkg/protocols/http/raw/raw.go
+++ b/pkg/protocols/http/raw/raw.go
@@ -97,6 +97,13 @@ func Parse(request string, inputURL *urlutil.URL, unsafe, disablePathAutomerge b
 	default:
 		cloned := inputURL.Clone()
 		cloned.Params.IncludeEquals = true
+		// Edgecase if raw request is
+		// GET / HTTP/1.1
+		//use case: https://github.com/projectdiscovery/nuclei/issues/4921
+		if rawrequest.Path == "/" {
+			rawrequest.Path = ""
+		}
+
 		if disablePathAutomerge {
 			cloned.Path = ""
 		}


### PR DESCRIPTION
## Proposed changes

Closes #4921

```console
$ go run .  -t test_template.yaml -u http://testphp.vulnweb.com/index.php -debug-req

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.2.2

                projectdiscovery.io

[WRN] Found 1 templates loaded with deprecated protocol syntax, update before v3 for continued support.
[INF] Current nuclei version: v3.2.2 (latest)
[INF] Current nuclei-templates version: v9.8.0 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 85
[INF] Templates loaded for current scan: 1
[WRN] Loaded 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] [raw-path-single-slash] Dumped HTTP request for http://testphp.vulnweb.com/index.php

GET /index.php HTTP/1.1
Host: testphp.vulnweb.com
User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.79 Safari/537.36
Connection: close
Origin: http://testphp.vulnweb.com/index.php
Accept-Encoding: gzip

[INF] No results found. Better luck next time!
```


## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)