### PR TITLE
fix empty template-id in scan logs

### DIFF
--- a/pkg/protocols/common/interactsh/interactsh.go
+++ b/pkg/protocols/common/interactsh/interactsh.go
@@ -153,11 +153,6 @@ func requestShouldStopAtFirstMatch(request *RequestData) bool {
 func (c *Client) processInteractionForRequest(interaction *server.Interaction, data *RequestData) bool {
 	var result *operators.Result
 	var matched bool
-	defer func() {
-		if r := recover(); r != nil {
-			gologger.Error().Msgf("panic occurred while processing interaction with result=%v matched=%v err=%v", result, matched, r)
-		}
-	}()
 	data.Event.Lock()
 	data.Event.InternalEvent["interactsh_protocol"] = interaction.Protocol
 	if strings.EqualFold(interaction.Protocol, "dns") {

--- a/pkg/protocols/http/request_fuzz.go
+++ b/pkg/protocols/http/request_fuzz.go
@@ -69,7 +69,7 @@ func (request *Request) executeFuzzingRule(input *contextargs.Context, previous 
 				gologger.Verbose().Msgf("[%s] fuzz: %s\n", request.options.TemplateID, err)
 				return nil
 			}
-			if errors.Is(err, errStopExecution) {
+			if errors.Is(err, ErrMissingVars) {
 				return err
 			}
 			gologger.Verbose().Msgf("[%s] fuzz: payload request execution failed : %s\n", request.options.TemplateID, err)
@@ -98,7 +98,7 @@ func (request *Request) executeFuzzingRule(input *contextargs.Context, previous 
 			gologger.Verbose().Msgf("[%s] fuzz: rule not applicable : %s\n", request.options.TemplateID, err)
 			return nil
 		}
-		if errors.Is(err, errStopExecution) {
+		if errors.Is(err, ErrMissingVars) {
 			return err
 		}
 		gologger.Verbose().Msgf("[%s] fuzz: payload request execution failed : %s\n", request.options.TemplateID, err)
@@ -173,7 +173,7 @@ func (request *Request) executeGeneratedFuzzingRequest(gr fuzz.GeneratedRequest,
 		}
 	}, 0)
 	// If a variable is unresolved, skip all further requests
-	if errors.Is(requestErr, errStopExecution) {
+	if errors.Is(requestErr, ErrMissingVars) {
 		return false
 	}
 	if requestErr != nil {


### PR DESCRIPTION
### Proposed Changes

- fix empty template-id fields when using matcher-status


```console
$  ./nuclei -u http://honey.scanme.sh -c 500 -stats -ms -j > scan_logs.jsonl

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.2.2

		projectdiscovery.io

[INF] Current nuclei version: v3.2.2 (latest)
[INF] Current nuclei-templates version: v9.8.0 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 85
[INF] Templates loaded for current scan: 7802
[INF] Executing 5743 signed templates from projectdiscovery/nuclei-templates
[WRN] Loading 2075 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] Templates clustered: 1464 (Reduced 1428 Requests)
[INF] Using Interactsh Server: oast.pro
{"duration":"0:00:05","errors":"747","hosts":"1","matched":"1","percent":"18","requests":"2253","rps":"450","startedAt":"2024-04-01T02:08:16.05032+05:30","templates":"7802","total":"12252"}
{"duration":"0:00:10","errors":"916","hosts":"1","matched":"48","percent":"23","requests":"2915","rps":"291","startedAt":"2024-04-01T02:08:16.05032+05:30","templates":"7802","total":"12252"}
{"duration":"0:00:15","errors":"920","hosts":"1","matched":"91","percent":"26","requests":"3236","rps":"215","startedAt":"2024-04-01T02:08:16.05032+05:30","templates":"7802","total":"12252"}
{"duration":"0:00:20","errors":"934","hosts":"1","matched":"94","percent":"26","requests":"3269","rps":"163","startedAt":"2024-04-01T02:08:16.05032+05:30","templates":"7802","total":"12252"}
{"duration":"0:00:25","errors":"1500","hosts":"1","matched":"94","percent":"30","requests":"3793","rps":"151","startedAt":"2024-04-01T02:08:16.05032+05:30","templates":"7802","total":"12252"}
{"duration":"0:00:30","errors":"2095","hosts":"1","matched":"94","percent":"35","requests":"4349","rps":"144","startedAt":"2024-04-01T02:08:16.05032+05:30","templates":"7802","total":"12252"}
{"duration":"0:00:35","errors":"2667","hosts":"1","matched":"100","percent":"40","requests":"4904","rps":"140","startedAt":"2024-04-01T02:08:16.05032+05:30","templates":"7802","total":"12252"}
{"duration":"0:00:40","errors":"3121","hosts":"1","matched":"101","percent":"44","requests":"5420","rps":"135","startedAt":"2024-04-01T02:08:16.05032+05:30","templates":"7802","total":"12252"}
{"duration":"0:00:45","errors":"3525","hosts":"1","matched":"112","percent":"52","requests":"6412","rps":"142","startedAt":"2024-04-01T02:08:16.05032+05:30","templates":"7802","total":"12252"}
{"duration":"0:00:50","errors":"3915","hosts":"1","matched":"121","percent":"60","requests":"7446","rps":"148","startedAt":"2024-04-01T02:08:16.05032+05:30","templates":"7802","total":"12252"}
{"duration":"0:00:55","errors":"3923","hosts":"1","matched":"124","percent":"66","requests":"8103","rps":"147","startedAt":"2024-04-01T02:08:16.05032+05:30","templates":"7802","total":"12252"}
{"duration":"0:01:00","errors":"3924","hosts":"1","matched":"130","percent":"71","requests":"8812","rps":"146","startedAt":"2024-04-01T02:08:16.05032+05:30","templates":"7802","total":"12252"}
[INF] Skipped honey.scanme.sh:80 from target list as found unresponsive 31 times
{"duration":"0:01:05","errors":"3928","hosts":"1","matched":"132","percent":"76","requests":"9393","rps":"144","startedAt":"2024-04-01T02:08:16.05032+05:30","templates":"7802","total":"12252"}
{"duration":"0:01:10","errors":"3930","hosts":"1","matched":"132","percent":"82","requests":"10105","rps":"144","startedAt":"2024-04-01T02:08:16.05032+05:30","templates":"7802","total":"12252"}
{"duration":"0:01:15","errors":"3930","hosts":"1","matched":"132","percent":"82","requests":"10141","rps":"135","startedAt":"2024-04-01T02:08:16.05032+05:30","templates":"7802","total":"12252"}
{"duration":"0:01:19","errors":"3930","hosts":"1","matched":"132","percent":"82","requests":"10141","rps":"128","startedAt":"2024-04-01T02:08:16.05032+05:30","templates":"7802","total":"12252"}

```

```console
$ cat scan_logs.jsonl | jq 'select(."template-id" == "" or ."template-id" == null)'

```