### PR TITLE
Remove prefix v from Sarif exporters

### DIFF
--- a/pkg/reporting/exporters/sarif/sarif.go
+++ b/pkg/reporting/exporters/sarif/sarif.go
@@ -53,8 +53,8 @@ func (exporter *Exporter) addToolDetails() {
 		FullDescription: &sarif.MultiformatMessageString{
 			Text: "Fast and customizable vulnerability scanner based on simple YAML based DSL",
 		},
-		FullName:        "Nuclei v" + config.Version,
-		SemanticVersion: "v" + config.Version,
+		FullName:        "Nuclei " + config.Version,
+		SemanticVersion: config.Version,
 		DownloadURI:     "https://github.com/projectdiscovery/nuclei/releases",
 		Rules:           exporter.rules,
 	}


### PR DESCRIPTION
because: In config.Version there is already
a `v` prefix, such as `v3.2.2`.

Prior to this commit the versions were being
tagged as `vv3.2.2`

this commit: Removes the 'v' prefix from the
Sarif exporter in the ToolDetails for both
FullName and SemanticVersion.

## Proposed changes

Removes the 'v' prefix from the
Sarif exporter in the ToolDetails for both
FullName and SemanticVersion.


## Checklist

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)