### PR TITLE
fix multiple panics & missing matcher-status in flow templates

### DIFF
--- a/pkg/templates/cluster.go
+++ b/pkg/templates/cluster.go
@@ -59,6 +59,14 @@ func Cluster(list []*Template) [][]*Template {
 			final = append(final, []*Template{template})
 			continue
 		}
+
+		// it is not possible to cluster flow and multiprotocol due to dependent execution
+		if template.Flow != "" || template.Options.IsMultiProtocol {
+			_ = skip.Set(key, struct{}{})
+			final = append(final, []*Template{template})
+			continue
+		}
+
 		_ = skip.Set(key, struct{}{})
 
 		var templateType types.ProtocolType
@@ -78,6 +86,13 @@ func Cluster(list []*Template) [][]*Template {
 			otherKey := other.Path
 
 			if skip.Has(otherKey) {
+				continue
+			}
+
+			// it is not possible to cluster flow and multiprotocol due to dependent execution
+			if other.Flow != "" || other.Options.IsMultiProtocol {
+				_ = skip.Set(otherKey, struct{}{})
+				final = append(final, []*Template{other})
 				continue
 			}
 

--- a/pkg/templates/cluster_test.go
+++ b/pkg/templates/cluster_test.go
@@ -3,15 +3,25 @@ package templates
 import (
 	"testing"
 
+	"github.com/projectdiscovery/nuclei/v3/pkg/model"
+	"github.com/projectdiscovery/nuclei/v3/pkg/model/types/severity"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/dns"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/http"
+	"github.com/projectdiscovery/nuclei/v3/pkg/testutils"
 	"github.com/stretchr/testify/require"
 )
 
 func TestClusterTemplates(t *testing.T) {
+	// state of whether template is flow or multiprotocol is stored in executerOptions i.e why we need to pass it
+	execOptions := testutils.NewMockExecuterOptions(testutils.DefaultOptions, &testutils.TemplateInfo{
+		ID:   "templateID",
+		Info: model.Info{SeverityHolder: severity.Holder{Severity: severity.Low}, Name: "test"},
+	})
 	t.Run("http-cluster-get", func(t *testing.T) {
 		tp1 := &Template{Path: "first.yaml", RequestsHTTP: []*http.Request{{Path: []string{"{{BaseURL}}"}}}}
 		tp2 := &Template{Path: "second.yaml", RequestsHTTP: []*http.Request{{Path: []string{"{{BaseURL}}"}}}}
+		tp1.Options = execOptions
+		tp2.Options = execOptions
 		tpls := []*Template{tp1, tp2}
 		// cluster 0
 		expected := []*Template{tp1, tp2}
@@ -21,6 +31,8 @@ func TestClusterTemplates(t *testing.T) {
 	t.Run("no-http-cluster", func(t *testing.T) {
 		tp1 := &Template{Path: "first.yaml", RequestsHTTP: []*http.Request{{Path: []string{"{{BaseURL}}/random"}}}}
 		tp2 := &Template{Path: "second.yaml", RequestsHTTP: []*http.Request{{Path: []string{"{{BaseURL}}/another"}}}}
+		tp1.Options = execOptions
+		tp2.Options = execOptions
 		tpls := []*Template{tp1, tp2}
 		expected := [][]*Template{{tp1}, {tp2}}
 		got := Cluster(tpls)
@@ -29,6 +41,8 @@ func TestClusterTemplates(t *testing.T) {
 	t.Run("dns-cluster", func(t *testing.T) {
 		tp1 := &Template{Path: "first.yaml", RequestsDNS: []*dns.Request{{Name: "{{Hostname}}"}}}
 		tp2 := &Template{Path: "second.yaml", RequestsDNS: []*dns.Request{{Name: "{{Hostname}}"}}}
+		tp1.Options = execOptions
+		tp2.Options = execOptions
 		tpls := []*Template{tp1, tp2}
 		// cluster 0
 		expected := []*Template{tp1, tp2}

--- a/pkg/tmplexec/exec.go
+++ b/pkg/tmplexec/exec.go
@@ -92,7 +92,11 @@ func (e *TemplateExecuter) Requests() int {
 
 // Execute executes the protocol group and returns true or false if results were found.
 func (e *TemplateExecuter) Execute(ctx *scan.ScanContext) (bool, error) {
-	results := &atomic.Bool{}
+	// executed contains status of execution if it was successfully executed or not
+	// doesn't matter if it was matched or not
+	executed := &atomic.Bool{}
+	// matched in this case means something was exported / written to output
+	matched := &atomic.Bool{}
 	defer func() {
 		// it is essential to remove template context of `Scan i.e template x input pair`
 		// since it is of no use after scan is completed (regardless of success or failure)
@@ -101,11 +105,11 @@ func (e *TemplateExecuter) Execute(ctx *scan.ScanContext) (bool, error) {
 
 	var lastMatcherEvent *output.InternalWrappedEvent
 	writeFailureCallback := func(event *output.InternalWrappedEvent, matcherStatus bool) {
-		if !results.Load() && matcherStatus {
+		if !matched.Load() && matcherStatus {
 			if err := e.options.Output.WriteFailure(event); err != nil {
 				gologger.Warning().Msgf("Could not write failure event to output: %s\n", err)
 			}
-			results.CompareAndSwap(false, true)
+			executed.CompareAndSwap(false, true)
 		}
 	}
 
@@ -133,11 +137,11 @@ func (e *TemplateExecuter) Execute(ctx *scan.ScanContext) (bool, error) {
 		// If no results were found, and also interactsh is not being used
 		// in that case we can skip it, otherwise we've to show failure in
 		// case of matcher-status flag.
-		if !event.HasOperatorResult() && !event.UsesInteractsh {
+		if !event.HasOperatorResult() && event.InternalEvent != nil {
 			lastMatcherEvent = event
 		} else {
 			if writer.WriteResult(event, e.options.Output, e.options.Progress, e.options.IssuesClient) {
-				results.CompareAndSwap(false, true)
+				matched.Store(true)
 			} else {
 				lastMatcherEvent = event
 			}
@@ -152,7 +156,7 @@ func (e *TemplateExecuter) Execute(ctx *scan.ScanContext) (bool, error) {
 	// so in compile step earlier we compile it to validate javascript syntax and other things
 	// and while executing we create new instance of flow executor everytime
 	if e.options.Flow != "" {
-		flowexec, err := flow.NewFlowExecutor(e.requests, ctx, e.options, results, e.program)
+		flowexec, err := flow.NewFlowExecutor(e.requests, ctx, e.options, executed, e.program)
 		if err != nil {
 			ctx.LogError(err)
 			return false, fmt.Errorf("could not create flow executor: %s", err)
@@ -169,7 +173,7 @@ func (e *TemplateExecuter) Execute(ctx *scan.ScanContext) (bool, error) {
 	if lastMatcherEvent != nil {
 		writeFailureCallback(lastMatcherEvent, e.options.Options.MatcherStatus)
 	}
-	return results.Load(), errx
+	return executed.Load(), errx
 }
 
 // ExecuteWithResults executes the protocol requests and returns results instead of writing them.

--- a/pkg/tmplexec/exec.go
+++ b/pkg/tmplexec/exec.go
@@ -173,7 +173,7 @@ func (e *TemplateExecuter) Execute(ctx *scan.ScanContext) (bool, error) {
 	if lastMatcherEvent != nil {
 		writeFailureCallback(lastMatcherEvent, e.options.Options.MatcherStatus)
 	}
-	return executed.Load(), errx
+	return executed.Load() || matched.Load(), errx
 }
 
 // ExecuteWithResults executes the protocol requests and returns results instead of writing them.


### PR DESCRIPTION
### Proposed Changes

- closes https://github.com/projectdiscovery/nuclei/issues/4979
```console
$ ./nuclei -u http://50.204.179.175:8090 -t a.yaml -v -ms 

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.2.3-dev

		projectdiscovery.io

[VER] Started metrics server at localhost:9092
[INF] Current nuclei version: v3.2.3-dev (development)
[INF] Current nuclei-templates version: v9.8.0 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 85
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] Using Interactsh Server: oast.online
[WRN] [CVE-2023-5830] Could not execute request for http://50.204.179.175:8090: [:RUNTIME] got err while executing http://50.204.179.175:8090/api/authentication/login <- context deadline exceeded
[CVE-2023-5830] [failed] [http] [critical] 50.204.179.175:8090

```
- fix panic when clustering muliprotocol & flow templates ( this is not supported yet or going to be soon so disabled it)
   -  closes #4977
   - closes #4965 
- fix missing matcher-status on certain flow templates 
   - closes #4984 
```console
$ ./nuclei -t a.yaml  -u "$TARGET" -ms                      

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.2.3-dev

		projectdiscovery.io

[INF] Current nuclei version: v3.2.3-dev (development)
[INF] Current nuclei-templates version: v9.8.0 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 85
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[JS] true
[JS] false
[CVE-2021-28164] [failed] [http] [medium] $TARGET
```
- follow-up https://github.com/projectdiscovery/nuclei/issues/4980