### PR TITLE
fix dynamic extractor + payloads edgecase by sending req sequentially

### DIFF
--- a/pkg/protocols/http/http.go
+++ b/pkg/protocols/http/http.go
@@ -9,6 +9,7 @@ import (
 	json "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 
+	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz"
 	"github.com/projectdiscovery/nuclei/v3/pkg/operators"
 	"github.com/projectdiscovery/nuclei/v3/pkg/operators/matchers"
@@ -20,7 +21,6 @@ import (
 	httputil "github.com/projectdiscovery/nuclei/v3/pkg/protocols/utils/http"
 	"github.com/projectdiscovery/rawhttp"
 	"github.com/projectdiscovery/retryablehttp-go"
-	"github.com/projectdiscovery/utils/env"
 	fileutil "github.com/projectdiscovery/utils/file"
 )
 
@@ -436,14 +436,31 @@ func (request *Request) Compile(options *protocols.ExecutorOptions) error {
 		}
 	}
 	if len(request.Payloads) > 0 {
-		// specifically for http requests high concurrency and and threads will lead to memory exausthion, hence reduce the maximum parallelism
-		if protocolstate.IsLowOnMemory() {
-			request.Threads = protocolstate.GuardThreadsOrDefault(request.Threads)
+		// due to limitation of https://github.com/projectdiscovery/nuclei/issues/5015
+		// use of dynamic extractor is not allowed with payloads and will be executed via normal engine
+		// without parallelism by forcing threads value to 0
+
+		// this limitation will be removed once we have a better way to handle dynamic extractors with payloads
+		hasMultiReqests := false
+		if len(request.Raw)+len(request.Path) > 1 {
+			hasMultiReqests = true
 		}
-		// if we have payloads, adjust threads if none specified
-		// We only do this in case we have more payload requests than the
-		// specified concurrency threshold.
-		if request.generator.NewIterator().Total() > PayloadAutoConcurrencyThreshold {
+		// look for dynamic extractor ( internal: true with named extractor)
+		hasNamedExtractor := false
+		for _, extractor := range request.Extractors {
+			if extractor.Internal && extractor.Name != "" {
+				hasNamedExtractor = true
+				break
+			}
+		}
+		if hasNamedExtractor && hasMultiReqests {
+			gologger.Warning().Label(options.TemplateID).Msgf("Setting thread count to 0 because dynamic extractors are not supported with payloads yet")
+			request.Threads = 0
+		} else {
+			// specifically for http requests high concurrency and and threads will lead to memory exausthion, hence reduce the maximum parallelism
+			if protocolstate.IsLowOnMemory() {
+				request.Threads = protocolstate.GuardThreadsOrDefault(request.Threads)
+			}
 			request.Threads = options.GetThreadsForNPayloadRequests(request.Requests(), request.Threads)
 		}
 	}
@@ -471,12 +488,4 @@ func (request *Request) Requests() int {
 		return requests
 	}
 	return len(request.Path)
-}
-
-// PayloadAutoConcurrencyThreshold is the threshold for auto adjusting concurrency
-// for payloads in a template.
-var PayloadAutoConcurrencyThreshold int
-
-func init() {
-	PayloadAutoConcurrencyThreshold = env.GetEnvOrDefault[int]("NUCLEI_PAYLOAD_AUTO_CONCURRENCY_THRESHOLD", 100)
 }

--- a/pkg/protocols/http/http.go
+++ b/pkg/protocols/http/http.go
@@ -436,24 +436,25 @@ func (request *Request) Compile(options *protocols.ExecutorOptions) error {
 		}
 	}
 	if len(request.Payloads) > 0 {
-		// due to limitation of https://github.com/projectdiscovery/nuclei/issues/5015
-		// use of dynamic extractor is not allowed with payloads and will be executed via normal engine
-		// without parallelism by forcing threads value to 0
+		// Due to a known issue (https://github.com/projectdiscovery/nuclei/issues/5015),
+		// dynamic extractors cannot be used with payloads. To address this,
+		// execution is handled by the standard engine without concurrency,
+		// achieved by setting the thread count to 0.
 
 		// this limitation will be removed once we have a better way to handle dynamic extractors with payloads
-		hasMultiReqests := false
+		hasMultipleRequests := false
 		if len(request.Raw)+len(request.Path) > 1 {
-			hasMultiReqests = true
+			hasMultipleRequests = true
 		}
 		// look for dynamic extractor ( internal: true with named extractor)
-		hasNamedExtractor := false
+		hasNamedInternalExtractor := false
 		for _, extractor := range request.Extractors {
 			if extractor.Internal && extractor.Name != "" {
-				hasNamedExtractor = true
+				hasNamedInternalExtractor = true
 				break
 			}
 		}
-		if hasNamedExtractor && hasMultiReqests {
+		if hasNamedInternalExtractor && hasMultipleRequests {
 			gologger.Warning().Label(options.TemplateID).Msgf("Setting thread count to 0 because dynamic extractors are not supported with payloads yet")
 			request.Threads = 0
 		} else {


### PR DESCRIPTION
### Proposed Changes

- the crux of #4993 was that using threads with payloads assumes that all requests are independent which necessarily is not the case and depends on usage pattern as we have seen with specified template in the issue
- the 💯 solution for that is to add a feature to iterate over a set of requests with concurrency [ this can be via flow , workflow or updating generators and is open to discussions ]
- a temporary solution for this is to set threads to 0 internally which forces nuclei to use `sequential execution handler` instead of `executeparallelhttp` in turn fixing the issue
- a recently merged hotfix attempted this by adding a high enough (100) value as threshold which is the minimum criteria required to run / use `executeparallelhttp` handler
- since this a special case with combination of ( dynamic extractor + payloads ) and adding a threshold limits concurrency of templates outside of such combination https://github.com/projectdiscovery/nuclei-templates/blob/ed682e6f178a4c8c7f12cbe4fbb40338d4aa3c6e/http/exposures/backups/zip-backup-files.yaml#L4
- to fix this , this pr explicitly handles the situation by detecting the edgecase and resetting threads value to 0 and thus forcing it to run sequentially ( a warning is printed in verbose more about this limitation as well)
- this fix should handle this edgecase regardless of number of requests and thus giving enough time for us to implement new feature or refactor as per convienence
- closes #4993 
- follow-up fix is tracked as enhancement at https://github.com/projectdiscovery/nuclei/issues/5015

### template

```yaml
id: wazuh-default-login

info:
  name: Wazuh - Default Login
  author: theamanrawat
  severity: high
  description: |
    Wazuh contains default credentials. An attacker can obtain access to user accounts and access sensitive information, modify data, and/or execute unauthorized operations.
  reference:
    - https://documentation.wazuh.com/current/user-manual/user-administration/password-management.html
    - https://wazuh.com
  metadata:
    verified: true
    max-request: 4
    shodan-query: title:"Wazuh"
  tags: wazuh,default-login

http:
  - raw:
      - |
        GET / HTTP/1.1
        Host: {{Hostname}}

      - |
        POST /auth/login HTTP/1.1
        Host: {{Hostname}}
        Osd-Version: {{osd}}
        Content-Type: application/json

        {"username":"{{username}}","password":"{{password}}"}

    attack: pitchfork
    payloads:
      username:
        - "admin"
        - "wazuh"
      password:
        - "admin"
        - "wazuh"
    stop-at-first-match: true

    matchers:
      - type: status
        status:
          - 200

    extractors:
      - type: regex
        name: osd
        internal: true
        part: body
        group: 1
        regex:
          - "<h1>(.*)</h1>"
```

### example run ( in verbose mode)

```console
$  ./nuclei -u https://example.com -t ./a.yaml  -v

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.2.3

		projectdiscovery.io

[VER] Started metrics server at localhost:9092
[wazuh-default-login] Setting thread count to 0 because dynamic extractors are not supported with payloads yet
[INF] Current nuclei version: v3.2.3 (latest)
[INF] Current nuclei-templates version: v9.8.0 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 85
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[VER] [wazuh-default-login] Sent HTTP request to https://example.com
[wazuh-default-login] [http] [high] https://example.com [password="admin",username="admin"]
```