### PR TITLE
fix missing port in javascript result

### DIFF
--- a/pkg/protocols/common/protocolstate/state.go
+++ b/pkg/protocols/common/protocolstate/state.go
@@ -132,6 +132,9 @@ func Init(options *types.Options) error {
 
 	opts.WithDialerHistory = true
 	opts.SNIName = options.SNI
+	// this instance is used in javascript protocol libraries and
+	// dial history is required to get dialed ip of a host
+	opts.WithDialerHistory = true
 
 	// fastdialer now by default fallbacks to ztls when there are tls related errors
 	dialer, err := fastdialer.NewDialer(opts)

--- a/pkg/protocols/ssl/ssl.go
+++ b/pkg/protocols/ssl/ssl.go
@@ -282,6 +282,7 @@ func (request *Request) ExecuteWithResults(input *contextargs.Context, dynamicVa
 	} else {
 		data["ip"] = request.dialer.GetDialedIP(hostname)
 	}
+	data["Port"] = port
 	data["template-path"] = requestOptions.TemplatePath
 	data["template-id"] = requestOptions.TemplateID
 	data["template-info"] = requestOptions.TemplateInfo
@@ -404,6 +405,9 @@ func (request *Request) MakeResultEventItem(wrapped *output.InternalWrappedEvent
 	// like 8443 etc
 	if fields.Port == "80" {
 		fields.Port = "443"
+	}
+	if types.ToString(wrapped.InternalEvent["Port"]) != "" {
+		fields.Port = types.ToString(wrapped.InternalEvent["Port"])
 	}
 	data := &output.ResultEvent{
 		TemplateID:       types.ToString(wrapped.InternalEvent["template-id"]),


### PR DESCRIPTION
### Proposed Changes

- add ip support in js output
- js: if dialed ip is missing resolve and get first ip
- fix incorrect port in ssl output
- closes #5021 


```console
$  ./nuclei  -u https://scanme.sh -or -id ssh-auth-methods -j | jq .

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.2.3

		projectdiscovery.io

[INF] Current nuclei version: v3.2.3 (latest)
[INF] Current nuclei-templates version: v9.8.1 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 77
[INF] Templates loaded for current scan: 1
[INF] Executing 1 signed templates from projectdiscovery/nuclei-templates
[INF] Targets loaded for current scan: 1
{
  "template": "javascript/detection/ssh-auth-methods.yaml",
  "template-url": "https://cloud.projectdiscovery.io/public/ssh-auth-methods",
  "template-id": "ssh-auth-methods",
  "template-path": "/Users/tarun/nuclei-templates/javascript/detection/ssh-auth-methods.yaml",
  "info": {
    "name": "SSH Auth Methods - Detection",
    "author": [
      "ice3man543"
    ],
    "tags": [
      "js",
      "detect",
      "ssh",
      "enum",
      "network"
    ],
    "description": "SSH (Secure Shell) authentication modes are methods used to verify the identity of users and ensure secure access to remote systems. Common SSH authentication modes include password-based authentication, which relies on a secret passphrase, and public key authentication, which uses cryptographic keys for a more secure and convenient login process. Additionally, multi-factor authentication (MFA) can be employed to enhance security by requiring users to provide multiple forms of authentication, such as a password and a one-time code.\n",
    "reference": [
      "https://nmap.org/nsedoc/scripts/ssh-auth-methods.html"
    ],
    "severity": "info",
    "metadata": {
      "max-request": 1,
      "shodan-query": "product:\"OpenSSH\""
    }
  },
  "type": "javascript",
  "host": "scanme.sh:22",
  "port": "22",
  "url": "scanme.sh:22",
  "matched-at": "scanme.sh:22",
  "extracted-results": [
    "[\"publickey\",\"password\"]"
  ],
  "ip": "128.199.158.128",
  "timestamp": "2024-04-09T01:30:17.180274+05:30",
  "matcher-status": true
}
```

```console
$  echo www.hackerone.com:8443 | ./nuclei -id ssl-issuer -j -silent|  jq .port
"8443"
```