### PR TITLE
Moving failure check past interactsh eviction

### DIFF
--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -91,8 +91,20 @@ type InternalWrappedEvent struct {
 	// Only applicable if interactsh is used
 	// This is used to avoid duplicate successful interactsh events
 	InteractshMatched atomic.Bool
+
+	// DeferredEvents are events that are deferred until the first eviction from cache
+	DeferredEvents []func()
 }
 
+// AddDeferEvent adds a deferred event to execute after the cache eviction
+func (iwe *InternalWrappedEvent) AddDeferEvent(f func()) {
+	iwe.Lock()
+	defer iwe.Unlock()
+
+	iwe.DeferredEvents = append(iwe.DeferredEvents, f)
+}
+
+// HasOperatorResult checks if the wrapped event has an operator result
 func (iwe *InternalWrappedEvent) HasOperatorResult() bool {
 	iwe.RLock()
 	defer iwe.RUnlock()
@@ -100,6 +112,7 @@ func (iwe *InternalWrappedEvent) HasOperatorResult() bool {
 	return iwe.OperatorsResult != nil
 }
 
+// HasResults checks if the wrapped event has results
 func (iwe *InternalWrappedEvent) HasResults() bool {
 	iwe.RLock()
 	defer iwe.RUnlock()
@@ -107,6 +120,7 @@ func (iwe *InternalWrappedEvent) HasResults() bool {
 	return len(iwe.Results) > 0
 }
 
+// SetOperatorResult sets the operator result for the wrapped event
 func (iwe *InternalWrappedEvent) SetOperatorResult(operatorResult *operators.Result) {
 	iwe.Lock()
 	defer iwe.Unlock()


### PR DESCRIPTION
## Proposed changes
Cherry picking interactsh hotfix for #4980 from #5018 via yet another callback (deferred failure write to the very end based on the reasoning that matching are impossible post eviction)

Before:
```console
$ time go run . -u http://scanme.sh -t test.yaml -v -ms -duc -timeout 50

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.2.4

                projectdiscovery.io

[VER] Started metrics server at localhost:9092
[ERR] Could not read nuclei-ignore file: open /Users/user/Library/Application Support/nuclei/.nuclei-ignore: no such file or directory
[INF] Current nuclei version: v3.2.4 (outdated)
[INF] Current nuclei-templates version: v9.7.8 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 126
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] Using Interactsh Server: oast.live
[VER] [boh] Sent HTTP request to http://scanme.sh
[boh] [failed] [http] [info] scanme.sh
[boh] [matched] [http] [info] http://scanme.sh
[boh] [matched] [http] [info] http://scanme.sh

real    0m41.893s
user    0m34.471s
sys     0m11.788s
```

After:
```console
$ time go run . -u http://scanme.sh -t test.yaml -v -ms -duc -timeout 50

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.2.4

                projectdiscovery.io

[VER] Started metrics server at localhost:9092
[ERR] Could not read nuclei-ignore file: open /Users/user/Library/Application Support/nuclei/.nuclei-ignore: no such file or directory
[INF] Current nuclei version: v3.2.4 (outdated)
[INF] Current nuclei-templates version: v9.7.8 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 126
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] Using Interactsh Server: oast.site
[VER] [boh] Sent HTTP request to http://scanme.sh
[boh] [matched] [http] [info] http://scanme.sh

real    0m28.958s
user    0m13.103s
sys     0m6.098s
```

Interactsh were simulated via this snippet at `github.com/projectdiscovery/nuclei/pkg/protocols/common/interactsh/interactsh.go` in func `NewURLWithData(...)`
```go
func (c *Client) NewURLWithData(data string) (string, error) {
	url, err := c.URL()
	if err != nil {
		return "", err
	}
	if url == "" {
		return "", errors.New("empty interactsh url")
	}
	_ = c.interactshURLs.SetWithExpire(url, data, defaultInteractionDuration)

	go func() {
		for {
			time.Sleep(1 * time.Second)
			resp, err := http.Get("http://" + url)
			if err != nil {
				log.Printf("Error making HTTP request: %v", err)
				continue
			}
			io.Copy(io.Discard, resp.Body)
			resp.Body.Close()
		}
	}()

	return url, nil
}
```

## Checklist
- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)