### PR TITLE
Feat 5059

### DIFF
--- a/lib/config.go
+++ b/lib/config.go
@@ -10,6 +10,7 @@ import (
 	"github.com/projectdiscovery/ratelimit"
 
 	"github.com/projectdiscovery/nuclei/v3/pkg/authprovider"
+	"github.com/projectdiscovery/nuclei/v3/pkg/catalog"
 	"github.com/projectdiscovery/nuclei/v3/pkg/model/types/severity"
 	"github.com/projectdiscovery/nuclei/v3/pkg/output"
 	"github.com/projectdiscovery/nuclei/v3/pkg/progress"
@@ -422,6 +423,14 @@ func DASTMode() NucleiSDKOptions {
 func SignedTemplatesOnly() NucleiSDKOptions {
 	return func(e *NucleiEngine) error {
 		e.opts.DisableUnsignedTemplates = true
+		return nil
+	}
+}
+
+// UseSuppliedCatalog uses a supplied catalog
+func UseSuppliedCatalog(cat catalog.Catalog) NucleiSDKOptions {
+	return func(e *NucleiEngine) error {
+		e.catalog = cat
 		return nil
 	}
 }

--- a/lib/config.go
+++ b/lib/config.go
@@ -427,8 +427,8 @@ func SignedTemplatesOnly() NucleiSDKOptions {
 	}
 }
 
-// UseSuppliedCatalog uses a supplied catalog
-func UseSuppliedCatalog(cat catalog.Catalog) NucleiSDKOptions {
+// WithCatalog uses a supplied catalog
+func WithCatalog(cat catalog.Catalog) NucleiSDKOptions {
 	return func(e *NucleiEngine) error {
 		e.catalog = cat
 		return nil

--- a/lib/sdk.go
+++ b/lib/sdk.go
@@ -6,7 +6,7 @@ import (
 	"io"
 
 	"github.com/projectdiscovery/nuclei/v3/pkg/authprovider"
-	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/disk"
+	"github.com/projectdiscovery/nuclei/v3/pkg/catalog"
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/loader"
 	"github.com/projectdiscovery/nuclei/v3/pkg/core"
 	"github.com/projectdiscovery/nuclei/v3/pkg/input/provider"
@@ -63,7 +63,7 @@ type NucleiEngine struct {
 
 	// unexported core fields
 	interactshClient *interactsh.Client
-	catalog          *disk.DiskCatalog
+	catalog          catalog.Catalog
 	rateLimiter      *ratelimit.Limiter
 	store            *loader.Store
 	httpxClient      providerTypes.InputLivenessProbe

--- a/lib/sdk_private.go
+++ b/lib/sdk_private.go
@@ -146,7 +146,9 @@ func (e *NucleiEngine) init() error {
 		return err
 	}
 
-	e.catalog = disk.NewCatalog(config.DefaultConfig.TemplatesDirectory)
+	if e.catalog == nil {
+		e.catalog = disk.NewCatalog(config.DefaultConfig.TemplatesDirectory)
+	}
 
 	e.executerOpts = protocols.ExecutorOptions{
 		Output:          e.customWriter,


### PR DESCRIPTION
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->

Currently, `protocols.ExecutorOptions.Catalog` uses `catalog.Catalog` while `lib.NucleiEngine.Catalog` uses `*disk.DiskCatalog`. However, `disk.DiskCatalog` satisfies the `catalog.Catalog` interface by design.

changes:

1. change `lib.NucleiEngine.Catalog` to `catalog.Catalog`
2. add a `lib.NucleiSDKOptions` function `UseSuppliedCatalog(cat catalog.Catalog)` which assigns the supplied catalog to `NucleiEngine.catalog`
3. add a nil check to `NucleiEngine.init()` to use the default `disk.DiskCatalog` when `NucleiEngine.catalog` is nil (not assigned by UseSuppliedCatalog`)

https://github.com/projectdiscovery/nuclei/issues/5059

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)