### PR TITLE
Fix panic with fuzz template

### DIFF
--- a/integration_tests/fuzz/fuzz-multi-mode.yaml
+++ b/integration_tests/fuzz/fuzz-multi-mode.yaml
@@ -1,0 +1,27 @@
+id: fuzz-multi-mode-test
+
+info:
+  name: multi-mode fuzzing test
+  author: pdteam
+  severity: info
+
+http:
+  - payloads:
+      inject:
+        - nuclei-v1
+        - nuclei-v2
+        - nuclei-v3
+
+    fuzzing:
+      - part: header
+        type: replace
+        mode: multiple
+        fuzz:
+          X-Client-Id: "{{inject}}"
+          X-Secret-Id: "{{inject}}"
+          
+    matchers-condition: or
+    matchers:
+      - type: word
+        words:
+          - "nuclei-v3"

--- a/pkg/fuzz/component/headers.go
+++ b/pkg/fuzz/component/headers.go
@@ -83,6 +83,9 @@ func (q *Header) Delete(key string) error {
 func (q *Header) Rebuild() (*retryablehttp.Request, error) {
 	cloned := q.req.Clone(context.Background())
 	q.value.parsed.Iterate(func(key string, value any) bool {
+		if strings.TrimSpace(key) == "" {
+			return true
+		}
 		if strings.EqualFold(key, "Host") {
 			return true
 		}

--- a/pkg/fuzz/execute.go
+++ b/pkg/fuzz/execute.go
@@ -211,6 +211,14 @@ func (rule *Rule) executeRuleValues(input *ExecuteRuleInput, ruleComponent compo
 		})
 		// if mode is multiple now build and execute it
 		if rule.modeType == multipleModeType {
+			rule.Fuzz.KV.Iterate(func(key, value string) bool {
+				var evaluated string
+				evaluated, input.InteractURLs = rule.executeEvaluate(input, key, "", value, input.InteractURLs)
+				if err := ruleComponent.SetValue(key, evaluated); err != nil {
+					return true
+				}
+				return true
+			})
 			req, err := ruleComponent.Rebuild()
 			if err != nil {
 				return err


### PR DESCRIPTION
## Proposed changes
- closes #5081 

__test.yaml__
```yaml
id: log4j-header-injection

info:
  name: Log-4j Injection In Headers
  author: Nishantbhagat57
  severity: high
  description: Detects potential Out-of-Band Log-4j Injection vulnerabilities, blind testing using payloads in headers.
  reference:
    - https://www.acunetix.com/blog/web-security-zone/critical-alert-log4shell-cve-2021-44228-in-log4j-possibly-the-biggest-impact-vulnerability-ever/
  tags: cmdi, oast, dast, log4j

http:
  - payloads:
      inject:
        - aa

    fuzzing:
      - part: header
        type: replace
        mode: multiple
        fuzz:
          User-Agent: "{{inject}}"
          Referer: "{{inject}}"
          X-Client-IP: "{{inject}}"
          X-Forwarded-For: "{{inject}}"
          X-Api-Version: "{{inject}}"
          
    matchers-condition: or
    matchers:
      - type: word
        words:
          - "test"
```
TEST:
```console
✗ nuclei -t test.yaml -u example.com -dast
```

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)