### PR TITLE
fix openapi import nil deref

### DIFF
--- a/pkg/input/formats/openapi/generator.go
+++ b/pkg/input/formats/openapi/generator.go
@@ -179,6 +179,10 @@ func generateRequestsFromOp(opts *generateReqOptions) error {
 	for _, parameter := range reqParams {
 		value := parameter.Value
 
+		if value.Schema == nil || value.Schema.Value == nil {
+			continue
+		}
+
 		// paramValue or default value to use
 		var paramValue interface{}
 


### PR DESCRIPTION
## Proposed changes

Closes #5070

```console
$ go run . -sf secrets.yml -im openapi -l openapi.yml

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.2.4

                projectdiscovery.io

[INF] Current nuclei version: v3.2.4 (latest)
[INF] Current nuclei-templates version: v9.8.1 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 77
[INF] Templates loaded for current scan: 24
[INF] Executing 21 signed templates from projectdiscovery/nuclei-templates
[WRN] Loading 3 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] Using Interactsh Server: oast.site
[INF] No results found. Better luck next time!
```


## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)