### PR TITLE
fix go install failing

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v3.6.0
+        uses: golangci/golangci-lint-action@v4.0.0
         with:
           version: latest
           args: --timeout 5m

--- a/go.mod
+++ b/go.mod
@@ -349,5 +349,3 @@ require (
 
 // https://go.dev/ref/mod#go-mod-file-retract
 retract v3.2.0 // retract due to broken js protocol issue
-
-replace github.com/go-echarts/go-echarts/v2 => github.com/tarunKoyalwar/go-echarts/v2 v2.1.1

--- a/go.sum
+++ b/go.sum
@@ -1015,8 +1015,6 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/syndtr/goleveldb v1.0.0 h1:fBdIW9lB4Iz0n9khmH8w27SJ3QEJ7+IgjPEwGSZiFdE=
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
-github.com/tarunKoyalwar/go-echarts/v2 v2.1.1 h1:5fsXGPmK+i18J8cDgxy7AJkiXWBARpVTb0Gbv+bAzPo=
-github.com/tarunKoyalwar/go-echarts/v2 v2.1.1/go.mod h1:VEeyPT5Odx/UHeuxtIAHGu2+87MWGA5OBaZ120NFi/w=
 github.com/tidwall/assert v0.1.0 h1:aWcKyRBUAdLoVebxo95N7+YZVTFF/ASTr7BN4sLP6XI=
 github.com/tidwall/assert v0.1.0/go.mod h1:QLYtGyeqse53vuELQheYl9dngGCJQ+mTtlxcktb+Kj8=
 github.com/tidwall/btree v1.7.0 h1:L1fkJH/AuEh5zBnnBbmTwQ5Lt+bRJ5A8EWecslvo9iI=

--- a/integration_tests/fuzz/fuzz-multi-mode.yaml
+++ b/integration_tests/fuzz/fuzz-multi-mode.yaml
@@ -1,0 +1,27 @@
+id: fuzz-multi-mode-test
+
+info:
+  name: multi-mode fuzzing test
+  author: pdteam
+  severity: info
+
+http:
+  - payloads:
+      inject:
+        - nuclei-v1
+        - nuclei-v2
+        - nuclei-v3
+
+    fuzzing:
+      - part: header
+        type: replace
+        mode: multiple
+        fuzz:
+          X-Client-Id: "{{inject}}"
+          X-Secret-Id: "{{inject}}"
+          
+    matchers-condition: or
+    matchers:
+      - type: word
+        words:
+          - "nuclei-v3"

--- a/pkg/fuzz/component/headers.go
+++ b/pkg/fuzz/component/headers.go
@@ -83,6 +83,9 @@ func (q *Header) Delete(key string) error {
 func (q *Header) Rebuild() (*retryablehttp.Request, error) {
 	cloned := q.req.Clone(context.Background())
 	q.value.parsed.Iterate(func(key string, value any) bool {
+		if strings.TrimSpace(key) == "" {
+			return true
+		}
 		if strings.EqualFold(key, "Host") {
 			return true
 		}

--- a/pkg/fuzz/execute.go
+++ b/pkg/fuzz/execute.go
@@ -211,6 +211,14 @@ func (rule *Rule) executeRuleValues(input *ExecuteRuleInput, ruleComponent compo
 		})
 		// if mode is multiple now build and execute it
 		if rule.modeType == multipleModeType {
+			rule.Fuzz.KV.Iterate(func(key, value string) bool {
+				var evaluated string
+				evaluated, input.InteractURLs = rule.executeEvaluate(input, key, "", value, input.InteractURLs)
+				if err := ruleComponent.SetValue(key, evaluated); err != nil {
+					return true
+				}
+				return true
+			})
 			req, err := ruleComponent.Rebuild()
 			if err != nil {
 				return err

--- a/pkg/scan/charts/echarts.go
+++ b/pkg/scan/charts/echarts.go
@@ -38,16 +38,18 @@ func (s *ScanEventsCharts) allCharts(c echo.Context) *components.Page {
 	page := components.NewPage()
 	page.PageTitle = "Nuclei Charts"
 	line1 := s.totalRequestsOverTime(c)
-	line1.SetSpacerHeight(SpacerHeight)
+	// line1.SetSpacerHeight(SpacerHeight)
 	kline := s.topSlowTemplates(c)
-	kline.SetSpacerHeight(SpacerHeight)
+	// kline.SetSpacerHeight(SpacerHeight)
 	line2 := s.requestsVSInterval(c)
-	line2.SetSpacerHeight(SpacerHeight)
+	// line2.SetSpacerHeight(SpacerHeight)
 	line3 := s.concurrencyVsTime(c)
-	line3.SetSpacerHeight(SpacerHeight)
+	// line3.SetSpacerHeight(SpacerHeight)
 	page.AddCharts(line1, kline, line2, line3)
-	page.Validate()
 	page.SetLayout(components.PageCenterLayout)
+	page.Theme = "dark"
+	page.Validate()
+
 	return page
 }
 
@@ -59,7 +61,12 @@ func (s *ScanEventsCharts) TotalRequestsOverTime(c echo.Context) error {
 // totalRequestsOverTime generates a line chart showing total requests count over time
 func (s *ScanEventsCharts) totalRequestsOverTime(c echo.Context) *charts.Line {
 	line := charts.NewLine()
-	line.SetCaption("Chart Shows Total Requests Count Over Time (for each/all Protocols)")
+	line.SetGlobalOptions(
+		charts.WithTitleOpts(opts.Title{
+			Title:    "Nuclei: Total Requests vs Time",
+			Subtitle: "Chart Shows Total Requests Count Over Time (for each/all Protocols)",
+		}),
+	)
 
 	var startTime time.Time = time.Now()
 	var endTime time.Time
@@ -120,8 +127,12 @@ func (s *ScanEventsCharts) TopSlowTemplates(c echo.Context) error {
 // topSlowTemplates generates a Kline chart showing the top slow templates by time taken
 func (s *ScanEventsCharts) topSlowTemplates(c echo.Context) *charts.Kline {
 	kline := charts.NewKLine()
-	kline.SetCaption(fmt.Sprintf("Chart Shows Top Slow Templates (by time taken) (Top %v)", TopK))
-
+	kline.SetGlobalOptions(
+		charts.WithTitleOpts(opts.Title{
+			Title:    "Nuclei: Top Slow Templates",
+			Subtitle: fmt.Sprintf("Chart Shows Top Slow Templates (by time taken) (Top %v)", TopK),
+		}),
+	)
 	ids := map[string][]int64{}
 	var startTime time.Time = time.Now()
 	for _, event := range s.data {
@@ -200,7 +211,12 @@ func (s *ScanEventsCharts) RequestsVSInterval(c echo.Context) error {
 // requestsVSInterval generates a line chart showing requests per second over time
 func (s *ScanEventsCharts) requestsVSInterval(c echo.Context) *charts.Line {
 	line := charts.NewLine()
-	line.SetCaption("Chart Shows RPS (Requests Per Second) Over Time")
+	line.SetGlobalOptions(
+		charts.WithTitleOpts(opts.Title{
+			Title:    "Nuclei: Requests Per Second vs Time",
+			Subtitle: "Chart Shows RPS (Requests Per Second) Over Time",
+		}),
+	)
 
 	sort.Slice(s.data, func(i, j int) bool {
 		return s.data[i].Time.Before(s.data[j].Time)
@@ -267,7 +283,12 @@ func (s *ScanEventsCharts) ConcurrencyVsTime(c echo.Context) error {
 // concurrencyVsTime generates a line chart showing concurrency (total workers) over time
 func (s *ScanEventsCharts) concurrencyVsTime(c echo.Context) *charts.Line {
 	line := charts.NewLine()
-	line.SetCaption("Chart Shows Concurrency (Total Workers) Over Time")
+	line.SetGlobalOptions(
+		charts.WithTitleOpts(opts.Title{
+			Title:    "Nuclei: Concurrency vs Time",
+			Subtitle: "Chart Shows Concurrency (Total Workers) Over Time",
+		}),
+	)
 
 	dataset := sliceutil.Clone(s.data)
 


### PR DESCRIPTION
### Proposed Changes

- remove fork: use official go-echarts
- the primary reason we were using go-echarts because at that time there were some bugs and some indentation issues but now those are fixed in go-echarts upstream
- there is a slight indentation issue ( no space between multiple charts) but that should be ok for now since its meant to for internal purpose
- closes #5082
