### PR TITLE
flow: fix empty template.xxx in flow

### DIFF
--- a/pkg/tmplexec/flow/flow_executor.go
+++ b/pkg/tmplexec/flow/flow_executor.go
@@ -226,7 +226,11 @@ func (f *FlowExecutor) ExecuteWithResults(ctx *scan.ScanContext) error {
 		}
 	}
 	// register template object
-	if err := runtime.Set("template", f.options.GetTemplateCtx(f.ctx.Input.MetaInput).GetAll()); err != nil {
+	tmplObj := f.options.GetTemplateCtx(f.ctx.Input.MetaInput).GetAll()
+	if tmplObj == nil {
+		tmplObj = map[string]interface{}{}
+	}
+	if err := runtime.Set("template", tmplObj); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
### Proposed Changes

```
[JS] <nil>
[WRN] [CVE-2024-4040] Could not execute step: [:RUNTIME] failed to execute flow
log(template)
if ( !template.hasOwnProperty('username') || !template.hasOwnProperty('password') ) {
  // if username or password is not provided, run unauthenticated exploit
  http("unauth-exploit")
} else {
  // if username and password is provided, run login script and authenticated exploit
  http("login") && http("auth-exploit")
}

 <- TypeError: Cannot read property 'hasOwnProperty' of undefined or null at <eval>:2:7(6)
[INF] No results found. Better luck next time!
```

- this type error ( javascript ) happens if template is nil , this pr creates a empty map instead of nil/null so that it can be easily used in flow without additional check for ( template != null )