### PR TITLE
fix `-u` input read

### DIFF
--- a/cmd/integration-test/profile-loader.go
+++ b/cmd/integration-test/profile-loader.go
@@ -16,12 +16,12 @@ var profileLoaderTestcases = []TestCaseInfo{
 type profileLoaderByRelFile struct{}
 
 func (h *profileLoaderByRelFile) Execute(testName string) error {
-	results, err := testutils.RunNucleiWithArgsAndGetResults(false, "-tl", "-tp", "kev.yml")
+	results, err := testutils.RunNucleiWithArgsAndGetResults(false, "-tl", "-tp", "cloud.yml")
 	if err != nil {
 		return errorutil.NewWithErr(err).Msgf("failed to load template with id")
 	}
-	if len(results) < 267 {
-		return fmt.Errorf("incorrect result: expected more results than %d, got %v", 267, len(results))
+	if len(results) < 100 {
+		return fmt.Errorf("incorrect result: expected more results than %d, got %v", 100, len(results))
 	}
 	return nil
 }
@@ -29,12 +29,12 @@ func (h *profileLoaderByRelFile) Execute(testName string) error {
 type profileLoaderById struct{}
 
 func (h *profileLoaderById) Execute(testName string) error {
-	results, err := testutils.RunNucleiWithArgsAndGetResults(false, "-tl", "-tp", "kev")
+	results, err := testutils.RunNucleiWithArgsAndGetResults(false, "-tl", "-tp", "cloud")
 	if err != nil {
 		return errorutil.NewWithErr(err).Msgf("failed to load template with id")
 	}
-	if len(results) < 267 {
-		return fmt.Errorf("incorrect result: expected more results than %d, got %v", 267, len(results))
+	if len(results) < 100 {
+		return fmt.Errorf("incorrect result: expected more results than %d, got %v", 100, len(results))
 	}
 	return nil
 }

--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -200,7 +200,7 @@ on extensive configurability, massive extensibility and ease of use.`)
 	*/
 
 	flagSet.CreateGroup("input", "Target",
-		flagSet.StringSliceVarP(&options.Targets, "target", "u", nil, "target URLs/hosts to scan", goflags.StringSliceOptions),
+		flagSet.StringSliceVarP(&options.Targets, "target", "u", nil, "target URLs/hosts to scan", goflags.CommaSeparatedStringSliceOptions),
 		flagSet.StringVarP(&options.TargetsFilePath, "list", "l", "", "path to file containing a list of target URLs/hosts to scan (one per line)"),
 		flagSet.StringSliceVarP(&options.ExcludeTargets, "exclude-hosts", "eh", nil, "hosts to exclude to scan from the input list (ip, cidr, hostname)", goflags.FileCommaSeparatedStringSliceOptions),
 		flagSet.StringVar(&options.Resume, "resume", "", "resume scan using resume.cfg (clustering will be disabled)"),


### PR DESCRIPTION
## Proposed changes

Closes #5141

before:
```console
go run . -u http://scanme.sh,https://www.hackerone.com -s low,medium,high,critical

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.2.6

                projectdiscovery.io

[INF] Current nuclei version: v3.2.6 (latest)
[INF] Current nuclei-templates version: v9.8.5 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 142
[INF] Templates loaded for current scan: 4242
[INF] Executing 4194 signed templates from projectdiscovery/nuclei-templates
[WRN] Loading 48 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] Templates clustered: 301 (Reduced 264 Requests)
[INF] Skipped [scanme.sh,https:]:80 from target list as found unresponsive 30 times
[INF] No results found. Better luck next time!
```

after:
```console
go run . -u http://scanme.sh,https://www.hackerone.com -s low,medium,high,critical

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.2.6

                projectdiscovery.io

[INF] Current nuclei version: v3.2.6 (latest)
[INF] Current nuclei-templates version: v9.8.5 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 142
[INF] Templates loaded for current scan: 4242
[INF] Executing 4194 signed templates from projectdiscovery/nuclei-templates
[WRN] Loading 48 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 2
[INF] Templates clustered: 301 (Reduced 528 Requests)
...
```


doc: https://docs.projectdiscovery.io/tools/nuclei/input-formats#list-type

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)