### PR TITLE
fix: types.RequestResponse url field UnmarshalJSON bug

### DIFF
--- a/pkg/input/types/http.go
+++ b/pkg/input/types/http.go
@@ -123,11 +123,15 @@ func (rr *RequestResponse) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &m); err != nil {
 		return err
 	}
-	urlStr, ok := m["url"]
+	urlStrRaw, ok := m["url"]
 	if !ok {
 		return fmt.Errorf("missing url in request response")
 	}
-	parsed, err := urlutil.ParseAbsoluteURL(string(urlStr), false)
+	var urlStr string
+	if err := json.Unmarshal(urlStrRaw, &urlStr); err != nil {
+		return err
+	}
+	parsed, err := urlutil.ParseAbsoluteURL(urlStr, false)
 	if err != nil {
 		return err
 	}

--- a/pkg/input/types/http_test.go
+++ b/pkg/input/types/http_test.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httputil"
@@ -62,6 +63,26 @@ func TestParseHttpRequest(t *testing.T) {
 			}
 
 			t.Log(*rr.Request)
+		})
+	}
+}
+
+func TestUnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name       string
+		rawJSONStr string
+	}{
+		{"basic url", `{"url": "example.com"}`},
+		{"basic url with scheme", `{"url": "http://example.com"}`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var rr RequestResponse
+			err := json.Unmarshal([]byte(tc.rawJSONStr), &rr)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Logf("url: %+v", rr.URL)
 		})
 	}
 }

--- a/pkg/input/types/http_test.go
+++ b/pkg/input/types/http_test.go
@@ -1,7 +1,6 @@
 package types
 
 import (
-	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httputil"
@@ -78,7 +77,7 @@ func TestUnmarshalJSON(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			var rr RequestResponse
-			err := json.Unmarshal([]byte(tc.rawJSONStr), &rr)
+			err := rr.UnmarshalJSON([]byte(tc.rawJSONStr))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/input/types/http_test.go
+++ b/pkg/input/types/http_test.go
@@ -68,11 +68,12 @@ func TestParseHttpRequest(t *testing.T) {
 
 func TestUnmarshalJSON(t *testing.T) {
 	tests := []struct {
-		name       string
-		rawJSONStr string
+		name           string
+		rawJSONStr     string
+		expectedURLStr string
 	}{
-		{"basic url", `{"url": "example.com"}`},
-		{"basic url with scheme", `{"url": "http://example.com"}`},
+		{"basic url", `{"url": "example.com"}`, "example.com"},
+		{"basic url with scheme", `{"url": "http://example.com"}`, "http://example.com"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -81,7 +82,9 @@ func TestUnmarshalJSON(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			t.Logf("url: %+v", rr.URL)
+			if tc.expectedURLStr != "" {
+				require.Equal(t, rr.URL.String(), tc.expectedURLStr)
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Proposed changes

In Go, when you use map[string]json.RawMessage to parse JSON data, the fields retain their original JSON-encoded format. json.RawMessage is essentially a []byte that contains the raw encoded JSON data. This means that if the JSON field is a string, it will include the quotation marks (").
Here’s a quick example to illustrate the situation:

```
package main

import (
    "encoding/json"
    "fmt"
)

func main() {
    data := `{"url": "testphp.vulnweb.com"}`

    var m map[string]json.RawMessage
    err := json.Unmarshal([]byte(data), &m)
    if err != nil {
        fmt.Println(err)
        return
    }

    // Printing the raw message byte array
    fmt.Printf("RawMessage in bytes: %v\n", m["url"])

    // Decode the "url" field
    var url string
    err = json.Unmarshal(m["url"], &url)
    if err != nil {
        fmt.Println(err)
        return
    }

    fmt.Printf("Original RawMessage: %s\n", string(m["url"]))
    fmt.Printf("Parsed URL: %s\n", url)
}
```
When you run this program, the output will be:

```
RawMessage in bytes: [34 116 101 115 116 112 104 112 46 118 117 108 110 119 101 98 46 99 111 109 34]
Original RawMessage: "testphp.vulnweb.com"
Parsed URL: testphp.vulnweb.com
```

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)