### PR TITLE
adding automatic service check on query

### DIFF
--- a/pkg/js/libs/mysql/mysql.go
+++ b/pkg/js/libs/mysql/mysql.go
@@ -187,6 +187,15 @@ func (c *MySQLClient) ExecuteQueryWithOpts(opts MySQLOptions, query string) (*ut
 		return nil, err
 	}
 
+	// executing queries implies the remote mysql service
+	ok, err := c.IsMySQL(opts.Host, opts.Port)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, fmt.Errorf("not a mysql service")
+	}
+
 	db, err := sql.Open("mysql", dsn)
 	if err != nil {
 		return nil, err
@@ -220,6 +229,15 @@ func (c *MySQLClient) ExecuteQueryWithOpts(opts MySQLOptions, query string) (*ut
 // log(to_json(result));
 // ```
 func (c *MySQLClient) ExecuteQuery(host string, port int, username, password, query string) (*utils.SQLResult, error) {
+	// executing queries implies the remote mysql service
+	ok, err := c.IsMySQL(host, port)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, fmt.Errorf("not a mysql service")
+	}
+
 	return c.ExecuteQueryWithOpts(MySQLOptions{
 		Host:     host,
 		Port:     port,

--- a/pkg/js/libs/postgres/postgres.go
+++ b/pkg/js/libs/postgres/postgres.go
@@ -88,6 +88,15 @@ func (c *PGClient) Connect(host string, port int, username, password string) (bo
 // log(to_json(result));
 // ```
 func (c *PGClient) ExecuteQuery(host string, port int, username, password, dbName, query string) (*utils.SQLResult, error) {
+	// executing queries implies the remote postgres service
+	ok, err := c.IsPostgres(host, port)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, fmt.Errorf("not a postgres service")
+	}
+
 	return memoizedexecuteQuery(host, port, username, password, dbName, query)
 }
 
@@ -149,10 +158,10 @@ func connect(host string, port int, username string, password string, dbName str
 	defer cancel()
 
 	db := pg.Connect(&pg.Options{
-		Addr:               target,
-		User:               username,
-		Password:           password,
-		Database:           dbName,
+		Addr:     target,
+		User:     username,
+		Password: password,
+		Database: dbName,
 		Dialer: func(network, addr string) (net.Conn, error) {
 			return protocolstate.Dialer.Dial(context.Background(), network, addr)
 		},

--- a/pkg/js/libs/postgres/postgres.go
+++ b/pkg/js/libs/postgres/postgres.go
@@ -37,6 +37,7 @@ type (
 // const isPostgres = postgres.IsPostgres('acme.com', 5432);
 // ```
 func (c *PGClient) IsPostgres(host string, port int) (bool, error) {
+	// todo: why this is exposed? Service fingerprint should be automatic
 	return memoizedisPostgres(host, port)
 }
 
@@ -74,6 +75,13 @@ func isPostgres(host string, port int) (bool, error) {
 // const connected = client.Connect('acme.com', 5432, 'username', 'password');
 // ```
 func (c *PGClient) Connect(host string, port int, username, password string) (bool, error) {
+	ok, err := c.IsPostgres(host, port)
+	if err != nil {
+		return false, err
+	}
+	if !ok {
+		return false, fmt.Errorf("not a postgres service")
+	}
 	return memoizedconnect(host, port, username, password, "postgres")
 }
 
@@ -88,7 +96,6 @@ func (c *PGClient) Connect(host string, port int, username, password string) (bo
 // log(to_json(result));
 // ```
 func (c *PGClient) ExecuteQuery(host string, port int, username, password, dbName, query string) (*utils.SQLResult, error) {
-	// executing queries implies the remote postgres service
 	ok, err := c.IsPostgres(host, port)
 	if err != nil {
 		return nil, err
@@ -138,6 +145,14 @@ func executeQuery(host string, port int, username string, password string, dbNam
 // const connected = client.ConnectWithDB('acme.com', 5432, 'username', 'password', 'dbname');
 // ```
 func (c *PGClient) ConnectWithDB(host string, port int, username, password, dbName string) (bool, error) {
+	ok, err := c.IsPostgres(host, port)
+	if err != nil {
+		return false, err
+	}
+	if !ok {
+		return false, fmt.Errorf("not a postgres service")
+	}
+
 	return memoizedconnect(host, port, username, password, dbName)
 }
 


### PR DESCRIPTION
## Proposed changes
Partially Closes #5254 (early exit skipping memory leak path under investigation via service fingerprint)

Todo:
- [ ] Investigate Internal buffer leak due to connection wrapper allocating continously buffer (maybe caused by `recover()`?)

## Checklist
- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)