### PR TITLE
issue 5212 timeout added to trace and error logs using ts switch

### DIFF
--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -304,13 +304,14 @@ func (w *StandardWriter) Write(event *ResultEvent) error {
 
 // JSONLogRequest is a trace/error log request written to file
 type JSONLogRequest struct {
-	Template string      `json:"template"`
-	Type     string      `json:"type"`
-	Input    string      `json:"input"`
-	Address  string      `json:"address"`
-	Error    string      `json:"error"`
-	Kind     string      `json:"kind,omitempty"`
-	Attrs    interface{} `json:"attrs,omitempty"`
+	Template  string      `json:"template"`
+	Type      string      `json:"type"`
+	Input     string      `json:"input"`
+	Timestamp *time.Time  `json:"timestamp,omitempty"`
+	Address   string      `json:"address"`
+	Error     string      `json:"error"`
+	Kind      string      `json:"kind,omitempty"`
+	Attrs     interface{} `json:"attrs,omitempty"`
 }
 
 // Request writes a log the requests trace log
@@ -322,6 +323,10 @@ func (w *StandardWriter) Request(templatePath, input, requestType string, reques
 		Template: templatePath,
 		Input:    input,
 		Type:     requestType,
+	}
+	if w.timestamp {
+		ts := time.Now()
+		request.Timestamp = &ts
 	}
 	parsed, _ := urlutil.ParseAbsoluteURL(input, false)
 	if parsed != nil {


### PR DESCRIPTION
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->
Enhance proposed in issue #5212 
Added Timestamp field to both trace log and error log only if -ts switch is enabled

Before this PR, trace log and error log look like:
`nuclei -tlog t1.log -tags postgresql -u https://www.example.com -elog e1.log -ts`
`{"template":"pgsql-extensions-rce","type":"javascript","input":"www.example.com:5432","address":"www.example.com:5432","error":"port closed or filtered","kind":"network-permanent-error"}`

After the PR, using -ts switch:
`nuclei -tlog t1.log -tags postgresql -u https://www.example.com -elog e1.log -ts`
`{"template":"pgsql-extensions-rce","type":"javascript","input":"www.example.com:5432","timestamp":"2024-06-14T17:47:05.3112785+02:00","address":"www.example.com:5432","error":"port closed or filtered","kind":"network-permanent-error"}`

Without -ts switch, trace and error log don't include timestamp field


## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)