### PR TITLE
Use `fs.FS` when explicitly given

### DIFF
--- a/lib/sdk_private.go
+++ b/lib/sdk_private.go
@@ -231,7 +231,10 @@ func (e *NucleiEngine) init(ctx context.Context) error {
 	// and also upgrade templates to latest version if available
 	installer.NucleiSDKVersionCheck()
 
-	return e.processUpdateCheckResults()
+	if DefaultConfig.CanCheckForUpdates() {
+		return e.processUpdateCheckResults()
+	}
+	return nil
 }
 
 type syncOnce struct {

--- a/pkg/catalog/disk/catalog.go
+++ b/pkg/catalog/disk/catalog.go
@@ -5,7 +5,6 @@ import (
 	"io/fs"
 	"os"
 
-	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/config"
 )
 
@@ -38,8 +37,6 @@ func NewFSCatalog(fs fs.FS, directory string) *DiskCatalog {
 // OpenFile opens a file and returns an io.ReadCloser to the file.
 // It is used to read template and payload files based on catalog responses.
 func (d *DiskCatalog) OpenFile(filename string) (io.ReadCloser, error) {
-	gologger.Debug().Msgf("DiskCatalog: OpenFile: %s", filename)
-
 	if d.templatesFS == nil {
 		file, err := os.Open(filename)
 		if err != nil {

--- a/pkg/catalog/disk/catalog.go
+++ b/pkg/catalog/disk/catalog.go
@@ -29,11 +29,15 @@ func NewCatalog(directory string) *DiskCatalog {
 // OpenFile opens a file and returns an io.ReadCloser to the file.
 // It is used to read template and payload files based on catalog responses.
 func (d *DiskCatalog) OpenFile(filename string) (io.ReadCloser, error) {
-	file, err := os.Open(filename)
-	if err != nil {
-		if file, errx := os.Open(BackwardsCompatiblePaths(d.templatesDirectory, filename)); errx == nil {
-			return file, nil
+	if d.templatesFS == nil {
+		file, err := os.Open(filename)
+		if err != nil {
+			if file, errx := os.Open(BackwardsCompatiblePaths(d.templatesDirectory, filename)); errx == nil {
+				return file, nil
+			}
 		}
+		return file, err
 	}
-	return file, err
+
+	return d.templatesFS.Open(filename)
 }

--- a/pkg/catalog/disk/catalog.go
+++ b/pkg/catalog/disk/catalog.go
@@ -26,6 +26,16 @@ func NewCatalog(directory string) *DiskCatalog {
 	return catalog
 }
 
+// NewFSCatalog creates a new Catalog structure using provided input items
+// using the fs.FS as its filesystem.
+func NewFSCatalog(fs fs.FS, directory string) *DiskCatalog {
+	catalog := &DiskCatalog{
+		templatesDirectory: directory,
+		templatesFS:        fs,
+	}
+	return catalog
+}
+
 // OpenFile opens a file and returns an io.ReadCloser to the file.
 // It is used to read template and payload files based on catalog responses.
 func (d *DiskCatalog) OpenFile(filename string) (io.ReadCloser, error) {

--- a/pkg/catalog/disk/find.go
+++ b/pkg/catalog/disk/find.go
@@ -19,8 +19,6 @@ var deprecatedPathsCounter int
 
 // GetTemplatesPath returns a list of absolute paths for the provided template list.
 func (c *DiskCatalog) GetTemplatesPath(definitions []string) ([]string, map[string]error) {
-	gologger.Debug().Msgf("DiskCatalog: GetTemplatesPath: %q", definitions)
-
 	// keeps track of processed dirs and files
 	processed := make(map[string]bool)
 	allTemplates := []string{}
@@ -67,8 +65,6 @@ func (c *DiskCatalog) GetTemplatesPath(definitions []string) ([]string, map[stri
 // list of finished absolute paths to the templates evaluating any glob patterns
 // or folders provided as in.
 func (c *DiskCatalog) GetTemplatePath(target string) ([]string, error) {
-	gologger.Debug().Msgf("DiskCatalog: GetTemplatePath: %q", target)
-
 	processed := make(map[string]struct{})
 	// Template input includes a wildcard
 	if strings.Contains(target, "*") {
@@ -140,8 +136,6 @@ func (c *DiskCatalog) convertPathToAbsolute(t string) (string, error) {
 
 // findGlobPathMatches returns the matched files from a glob path
 func (c *DiskCatalog) findGlobPathMatches(absPath string, processed map[string]struct{}) ([]string, error) {
-	gologger.Debug().Msgf("DiskCatalog: findGlobPathMatches: %q", absPath)
-
 	// to support globbing on old paths we use brute force to find matches with exit on first match
 	// trim templateDir if any
 	relPath := strings.TrimPrefix(absPath, c.templatesDirectory)
@@ -224,8 +218,6 @@ func (c *DiskCatalog) findFileMatches(absPath string, processed map[string]struc
 	if c.templatesFS != nil {
 		absPath = strings.TrimPrefix(absPath, "/")
 	}
-	gologger.Debug().Msgf("DiskCatalog: findFileMatches: %q (valid: %t)", absPath, fs.ValidPath(absPath))
-
 	var info fs.File
 	if c.templatesFS == nil {
 		info, err = os.Open(absPath)
@@ -251,8 +243,6 @@ func (c *DiskCatalog) findFileMatches(absPath string, processed map[string]struc
 
 // findDirectoryMatches finds matches for templates from a directory
 func (c *DiskCatalog) findDirectoryMatches(absPath string, processed map[string]struct{}) ([]string, error) {
-	gologger.Debug().Msgf("DiskCatalog: findDirectoryMatches: %q", absPath)
-
 	var results []string
 	var err error
 	if c.templatesFS == nil {

--- a/pkg/catalog/disk/find.go
+++ b/pkg/catalog/disk/find.go
@@ -84,19 +84,15 @@ func (c *DiskCatalog) GetTemplatePath(target string) ([]string, error) {
 
 	// try to handle deprecated template paths
 	absPath := target
-	/*
-		absPath := BackwardsCompatiblePaths(c.templatesDirectory, target)
+	if c.templatesFS == nil {
+		absPath = BackwardsCompatiblePaths(c.templatesDirectory, target)
 		if absPath != target && strings.TrimPrefix(absPath, c.templatesDirectory+string(filepath.Separator)) != target {
 			if config.DefaultConfig.LogAllEvents {
 				gologger.DefaultLogger.Print().Msgf("[%v] requested Template path %s is deprecated, please update to %s\n", aurora.Yellow("WRN").String(), target, absPath)
 			}
 			deprecatedPathsCounter++
 		}
-	*/
 
-	// If we're not using a custom FS, then attempt to conver the path to an absolute path.
-	// When using a custom FS, do not attempt to alter the path at all.
-	if false && !c.customTemplatesFS {
 		var err error
 		absPath, err = c.convertPathToAbsolute(absPath)
 		if err != nil {
@@ -158,33 +154,59 @@ func (c *DiskCatalog) findGlobPathMatches(absPath string, processed map[string]s
 			templateDir = "./"
 		}
 
-		sub, err := fs.Sub(c.templatesFS, filepath.Join(templateDir, "http"))
-		if err != nil {
-			return nil
-		}
-		matches, _ := fs.Glob(sub, inputGlob)
-		if len(matches) != 0 {
+		if c.templatesFS == nil {
+			matches, _ := fs.Glob(os.DirFS(filepath.Join(templateDir, "http")), inputGlob)
+			if len(matches) != 0 {
+				return matches
+			}
+
+			// condition to support network cve related globs
+			matches, _ = fs.Glob(os.DirFS(filepath.Join(templateDir, "network")), inputGlob)
+			return matches
+		} else {
+			sub, err := fs.Sub(c.templatesFS, filepath.Join(templateDir, "http"))
+			if err != nil {
+				return nil
+			}
+			matches, _ := fs.Glob(sub, inputGlob)
+			if len(matches) != 0 {
+				return matches
+			}
+
+			// condition to support network cve related globs
+			sub, err = fs.Sub(c.templatesFS, filepath.Join(templateDir, "network"))
+			if err != nil {
+				return nil
+			}
+			matches, _ = fs.Glob(sub, inputGlob)
 			return matches
 		}
-
-		// condition to support network cve related globs
-		sub, err = fs.Sub(c.templatesFS, filepath.Join(templateDir, "network"))
-		if err != nil {
-			return nil
-		}
-		matches, _ = fs.Glob(sub, inputGlob)
-		return matches
 	}
 
 	var matched []string
-	matches, err := fs.Glob(c.templatesFS, relPath)
-	if len(matches) != 0 {
-		matched = append(matched, matches...)
+	var matches []string
+	if c.templatesFS == nil {
+		var err error
+		matches, err = filepath.Glob(relPath)
+		if len(matches) != 0 {
+			matched = append(matched, matches...)
+		} else {
+			matched = append(matched, OldPathsResolver(relPath)...)
+		}
+		if err != nil && len(matched) == 0 {
+			return nil, errors.Errorf("wildcard found, but unable to glob: %s\n", err)
+		}
 	} else {
-		matched = append(matched, OldPathsResolver(relPath)...)
-	}
-	if err != nil && len(matched) == 0 {
-		return nil, errors.Errorf("wildcard found, but unable to glob: %s\n", err)
+		var err error
+		matches, err = fs.Glob(c.templatesFS, relPath)
+		if len(matches) != 0 {
+			matched = append(matched, matches...)
+		} else {
+			matched = append(matched, OldPathsResolver(relPath)...)
+		}
+		if err != nil && len(matched) == 0 {
+			return nil, errors.Errorf("wildcard found, but unable to glob: %s\n", err)
+		}
 	}
 	results := make([]string, 0, len(matches))
 	for _, match := range matches {
@@ -199,9 +221,17 @@ func (c *DiskCatalog) findGlobPathMatches(absPath string, processed map[string]s
 // findFileMatches finds if a path is an absolute file. If the path
 // is a file, it returns true otherwise false with no errors.
 func (c *DiskCatalog) findFileMatches(absPath string, processed map[string]struct{}) (match string, matched bool, err error) {
+	if c.templatesFS != nil {
+		absPath = strings.TrimPrefix(absPath, "/")
+	}
 	gologger.Debug().Msgf("DiskCatalog: findFileMatches: %q (valid: %t)", absPath, fs.ValidPath(absPath))
 
-	info, err := c.templatesFS.Open(absPath)
+	var info fs.File
+	if c.templatesFS == nil {
+		info, err = os.Open(absPath)
+	} else {
+		info, err = c.templatesFS.Open(absPath)
+	}
 	if err != nil {
 		return "", false, err
 	}
@@ -224,23 +254,43 @@ func (c *DiskCatalog) findDirectoryMatches(absPath string, processed map[string]
 	gologger.Debug().Msgf("DiskCatalog: findDirectoryMatches: %q", absPath)
 
 	var results []string
-	err := fs.WalkDir(
-		c.templatesFS,
-		absPath,
-		func(path string, d fs.DirEntry, err error) error {
-			// continue on errors
-			if err != nil {
-				return nil
-			}
-			if !d.IsDir() && config.GetTemplateFormatFromExt(path) != config.Unknown {
-				if _, ok := processed[path]; !ok {
-					results = append(results, path)
-					processed[path] = struct{}{}
+	var err error
+	if c.templatesFS == nil {
+		err = filepath.WalkDir(
+			absPath,
+			func(path string, d fs.DirEntry, err error) error {
+				// continue on errors
+				if err != nil {
+					return nil
 				}
-			}
-			return nil
-		},
-	)
+				if !d.IsDir() && config.GetTemplateFormatFromExt(path) != config.Unknown {
+					if _, ok := processed[path]; !ok {
+						results = append(results, path)
+						processed[path] = struct{}{}
+					}
+				}
+				return nil
+			},
+		)
+	} else {
+		err = fs.WalkDir(
+			c.templatesFS,
+			absPath,
+			func(path string, d fs.DirEntry, err error) error {
+				// continue on errors
+				if err != nil {
+					return nil
+				}
+				if !d.IsDir() && config.GetTemplateFormatFromExt(path) != config.Unknown {
+					if _, ok := processed[path]; !ok {
+						results = append(results, path)
+						processed[path] = struct{}{}
+					}
+				}
+				return nil
+			},
+		)
+	}
 	return results, err
 }
 

--- a/pkg/catalog/disk/path.go
+++ b/pkg/catalog/disk/path.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/config"
 	fileutil "github.com/projectdiscovery/utils/file"
 	urlutil "github.com/projectdiscovery/utils/url"
@@ -18,6 +19,8 @@ import (
 // or checking the nuclei templates directory. If a second path is given,
 // it also tries to find paths relative to that second path.
 func (c *DiskCatalog) ResolvePath(templateName, second string) (string, error) {
+	gologger.Debug().Msgf("DiskCatalog: ResolvePath: %q, %q", templateName, second)
+
 	if filepath.IsAbs(templateName) {
 		return templateName, nil
 	}

--- a/pkg/catalog/disk/path.go
+++ b/pkg/catalog/disk/path.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/config"
 	fileutil "github.com/projectdiscovery/utils/file"
 	urlutil "github.com/projectdiscovery/utils/url"
@@ -19,8 +18,6 @@ import (
 // or checking the nuclei templates directory. If a second path is given,
 // it also tries to find paths relative to that second path.
 func (c *DiskCatalog) ResolvePath(templateName, second string) (string, error) {
-	gologger.Debug().Msgf("DiskCatalog: ResolvePath: %q, %q", templateName, second)
-
 	if filepath.IsAbs(templateName) {
 		return templateName, nil
 	}


### PR DESCRIPTION
## Proposed changes

This updates `DiskCatalog` to use `fs.FS` when explicitly given by a user via `NewFSCatalog`.

The existing code half-used `fs.FS`, but there are _a lot_ of issues with the existing implementation and what needs to be done.  After doing a whole lot of testing (and concerns with https://github.com/golang/go/issues/44279), I believe that the best possible implementation is a 2-track one: we support legacy `os` operations by default, but if someone gives us an `fs.FS` instance, then we'll use that exactly as they intended it.

Long-term, I hope that the `fs.FS` semantics are fixed by Go (or at least that a meaningful package gets built that provides full backward compatibility with the `os` operations).

In my particular case, I have two use cases that both work with these changes:
1. Load files from a directory on disk for local testing.  This uses `NewCatalog`.
2. Load files from a tarball in memory such that the files never touch the disk (Windows Defender and other tools find them and cause all kinds of trouble, and my application really has no business writing to the disk anyway).  This uses `NewFSCatalog` with github.com/quay/claircore/pkg/tarfs to provide the `fs.FS` interface.

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)