### PR TITLE
fix issue with ldap search func

### DIFF
--- a/pkg/catalog/config/constants.go
+++ b/pkg/catalog/config/constants.go
@@ -31,7 +31,7 @@ const (
 	CLIConfigFileName               = "config.yaml"
 	ReportingConfigFilename         = "reporting-config.yaml"
 	// Version is the current version of nuclei
-	Version = `v3.2.9`
+	Version = `v3.3.0-dev`
 	// Directory Names of custom templates
 	CustomS3TemplatesDirName     = "s3"
 	CustomGitHubTemplatesDirName = "github"

--- a/pkg/js/libs/ldap/ldap.go
+++ b/pkg/js/libs/ldap/ldap.go
@@ -205,11 +205,18 @@ func (c *Client) AuthenticateWithNTLMHash(username, hash string) {
 // ```
 func (c *Client) Search(filter string, attributes ...string) []map[string][]string {
 	c.nj.Require(c.conn != nil, "no existing connection")
+	c.nj.Require(c.BaseDN != "", "base dn cannot be empty")
+	c.nj.Require(len(attributes) > 0, "attributes cannot be empty")
 
 	res, err := c.conn.Search(
 		ldap.NewSearchRequest(
-			c.BaseDN, ldap.ScopeWholeSubtree, ldap.NeverDerefAliases,
-			0, 0, false, filter, attributes, nil,
+			"",
+			ldap.ScopeBaseObject,
+			ldap.NeverDerefAliases,
+			0, 0, false,
+			filter,
+			attributes,
+			nil,
 		),
 	)
 	c.nj.HandleError(err, "ldap search request failed")


### PR DESCRIPTION
### Proposed Changes

- fix minor issue with params in ldap search function

```yaml
id: ldap-metadata

info:
  name: LDAP - Enumeration
  author: pussycat0x
  severity: info
  description: |
    Attempts to list the supported capabilities in a SMBv2 server for each enabled dialect.
  reference:
    - https://docs.projectdiscovery.io/templates/protocols/javascript/modules/ldap.Client
  metadata:
    max-request: 1
    shodan-query: ldap
  tags: js,network,ldap,anonymous

javascript:
  - code: |
      const ldap = require('nuclei/ldap');
      const cfg = new ldap.Config();
      cfg.Upgrade = true;
      const client = new ldap.Client(Host, Ldap, Port, cfg);
      const dcs = client.Search('(objectClass=*)', 'cn', 'mail');
      Export(to_json(dcs));

    args:
      Host: "ldap://{{Host}}"
      Ldap: "{{Host}}"
      Port: 389
      
    extractors:  
      - type: json
        json:
          - '.'
          - '"DistinguishedName: " + .DistinguishedName'
          - '"SAMAccountName: " + .SAMAccountName'
          - '"PWDLastSet: "+ .PWDLastSet'
          - '"MemberOf: "+ .MemberOf'
          - '"ServicePrincipalName: " + .ServicePrincipalName'
```

### Before

```console
$  nuclei -u x.x.x.x:3268 -t a.yaml        

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.2.9

		projectdiscovery.io

[INF] Current nuclei version: v3.2.9 (latest)
[INF] Current nuclei-templates version: v9.9.0 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 164
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] No results found. Better luck next time!

```

### Now

```console
$ ./nuclei -u x.x.x.x:3268 -t a.yaml        

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.2.9

		projectdiscovery.io

[INF] Current nuclei version: v3.2.9 (latest)
[INF] Current nuclei-templates version: v9.9.0 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 164
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[ldap-metadata] [javascript] [info] x.x.x.x:3268 ["[]"]
```