### PR TITLE
fix(engine): Resolve issue with ExecuteWithResults function not returning expected results

### DIFF
--- a/pkg/core/executors.go
+++ b/pkg/core/executors.go
@@ -27,7 +27,7 @@ func (e *Engine) executeAllSelfContained(ctx context.Context, alltemplates []*te
 			var match bool
 			ctx := scan.NewScanContext(ctx, contextargs.New(ctx))
 			if e.Callback != nil {
-				if results, err := template.Executer.ExecuteWithResults(ctx); err != nil {
+				if results, err := template.Executer.ExecuteWithResults(ctx); err == nil {
 					for _, result := range results {
 						e.Callback(result)
 					}
@@ -129,7 +129,7 @@ func (e *Engine) executeTemplateWithTargets(ctx context.Context, template *templ
 				match = e.executeWorkflow(ctx, template.CompiledWorkflow)
 			default:
 				if e.Callback != nil {
-					if results, err := template.Executer.ExecuteWithResults(ctx); err != nil {
+					if results, err := template.Executer.ExecuteWithResults(ctx); err == nil {
 						for _, result := range results {
 							e.Callback(result)
 						}
@@ -194,7 +194,7 @@ func (e *Engine) executeTemplatesOnTarget(ctx context.Context, alltemplates []*t
 				match = e.executeWorkflow(ctx, template.CompiledWorkflow)
 			default:
 				if e.Callback != nil {
-					if results, err := template.Executer.ExecuteWithResults(ctx); err != nil {
+					if results, err := template.Executer.ExecuteWithResults(ctx); err == nil {
 						for _, result := range results {
 							e.Callback(result)
 						}


### PR DESCRIPTION
When attempting to use the `ExecuteWithResults` function, users were finding that the function was not returning the expected results. This fix addresses the root cause of this problem.

### example code
```go
	v := nuclei.VerbosityOptions{
		Verbose:       true,
		Silent:        false,
		Debug:         true,
		DebugRequest:  false,
		DebugResponse: false,
		ShowVarDump:   false,
	}
	ne, err := nuclei.NewNucleiEngine(
		nuclei.WithVerbosity(v),
	)
	if err != nil {
		panic(err)
	}
	defer ne.Close()
	httpProvider := provider.NewSimpleInputProvider()
	httpProvider.Set("https://x.hacking8.com")

	filename := "1.yaml"
	data, err := ioutil.ReadFile(filename)
	if err != nil {
		panic(err)
	}
	poc, err := ne.ParseTemplate(data)
	if err != nil {
		panic(err)
	}
	pocList := []*templates.Template{
		poc,
	}
	engine := ne.Engine()
	engine.ExecuteWithResults(context.Background(), pocList, httpProvider, func(event *output.ResultEvent) {
		fmt.Println(1)
		fmt.Println(event)
	})
	engine.WorkPool().Wait()

```
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->


## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)