### PR TITLE
feat: improve ldap output with custom type:

### DIFF
--- a/pkg/js/compiler/pool.go
+++ b/pkg/js/compiler/pool.go
@@ -241,5 +241,5 @@ func stringify(gojaValue goja.Value, runtime *goja.Runtime) string {
 		}
 	}
 	// for everything else stringify
-	return fmt.Sprintf("%v", value)
+	return fmt.Sprintf("%+v", value)
 }

--- a/pkg/js/generated/go/libldap/ldap.go
+++ b/pkg/js/generated/go/libldap/ldap.go
@@ -53,10 +53,12 @@ func init() {
 			"FilterWorkstationTrustAccount":    lib_ldap.FilterWorkstationTrustAccount,
 
 			// Objects / Classes
-			"ADObject": gojs.GetClassConstructor[lib_ldap.ADObject](&lib_ldap.ADObject{}),
-			"Client":   lib_ldap.NewClient,
-			"Config":   gojs.GetClassConstructor[lib_ldap.Config](&lib_ldap.Config{}),
-			"Metadata": gojs.GetClassConstructor[lib_ldap.Metadata](&lib_ldap.Metadata{}),
+			"Client":         lib_ldap.NewClient,
+			"Config":         gojs.GetClassConstructor[lib_ldap.Config](&lib_ldap.Config{}),
+			"LdapAttributes": gojs.GetClassConstructor[lib_ldap.LdapAttributes](&lib_ldap.LdapAttributes{}),
+			"LdapEntry":      gojs.GetClassConstructor[lib_ldap.LdapEntry](&lib_ldap.LdapEntry{}),
+			"Metadata":       gojs.GetClassConstructor[lib_ldap.Metadata](&lib_ldap.Metadata{}),
+			"SearchResult":   gojs.GetClassConstructor[lib_ldap.SearchResult](&lib_ldap.SearchResult{}),
 		},
 	).Register()
 }

--- a/pkg/js/generated/ts/kerberos.ts
+++ b/pkg/js/generated/ts/kerberos.ts
@@ -212,9 +212,9 @@ export interface BitString {
  */
 export interface BitString {
     
-    BitLength?: number,
-    
     Bytes?: Uint8Array,
+    
+    BitLength?: number,
 }
 
 
@@ -246,8 +246,6 @@ export interface EncTicketPart {
     
     CRealm?: string,
     
-    CAddr?: HostAddress,
-    
     AuthorizationData?: AuthorizationDataEntry,
     
     Flags?: BitString,
@@ -257,6 +255,8 @@ export interface EncTicketPart {
     CName?: PrincipalName,
     
     Transited?: TransitedEncoding,
+    
+    CAddr?: HostAddress,
 }
 
 
@@ -266,11 +266,11 @@ export interface EncTicketPart {
  */
 export interface EncryptedData {
     
-    KVNO?: number,
-    
     Cipher?: Uint8Array,
     
     EType?: number,
+    
+    KVNO?: number,
 }
 
 
@@ -318,29 +318,11 @@ export interface HostAddress {
  */
 export interface LibDefaults {
     
-    NoAddresses?: boolean,
-    
-    RealmTryDomains?: number,
-    
-    DNSLookupKDC?: boolean,
-    
-    DefaultRealm?: string,
-    
-    SafeChecksumType?: number,
-    
-    VerifyAPReqNofail?: boolean,
-    
-    AllowWeakCrypto?: boolean,
-    
     DefaultTGSEnctypes?: string[],
-    
-    DefaultTktEnctypeIDs?: number[],
-    
-    IgnoreAcceptorHostname?: boolean,
     
     K5LoginAuthoritative?: boolean,
     
-    PermittedEnctypes?: string[],
+    K5LoginDirectory?: string,
     
     /**
     * time in nanoseconds
@@ -348,43 +330,47 @@ export interface LibDefaults {
     
     Clockskew?: number,
     
-    DNSCanonicalizeHostname?: boolean,
-    
-    Proxiable?: boolean,
-    
-    RDNS?: boolean,
-    
-    /**
-    * time in nanoseconds
-    */
-    
-    TicketLifetime?: number,
-    
-    DefaultClientKeytabName?: string,
-    
-    PermittedEnctypeIDs?: number[],
-    
-    UDPPreferenceLimit?: number,
-    
     DefaultTGSEnctypeIDs?: number[],
-    
-    DefaultTktEnctypes?: string[],
-    
-    CCacheType?: number,
     
     DNSLookupRealm?: boolean,
     
-    ExtraAddresses?: Uint8Array,
+    Forwardable?: boolean,
     
-    PreferredPreauthTypes?: number[],
+    DefaultTktEnctypes?: string[],
+    
+    Proxiable?: boolean,
+    
+    DefaultRealm?: string,
+    
+    DefaultKeytabName?: string,
+    
+    NoAddresses?: boolean,
+    
+    RealmTryDomains?: number,
+    
+    PermittedEnctypeIDs?: number[],
+    
+    RDNS?: boolean,
+    
+    SafeChecksumType?: number,
     
     Canonicalize?: boolean,
     
-    Forwardable?: boolean,
+    DefaultTktEnctypeIDs?: number[],
     
-    K5LoginDirectory?: string,
+    DNSCanonicalizeHostname?: boolean,
     
     KDCTimeSync?: number,
+    
+    PermittedEnctypes?: string[],
+    
+    VerifyAPReqNofail?: boolean,
+    
+    CCacheType?: number,
+    
+    DNSLookupKDC?: boolean,
+    
+    ExtraAddresses?: Uint8Array,
     
     /**
     * time in nanoseconds
@@ -392,7 +378,21 @@ export interface LibDefaults {
     
     RenewLifetime?: number,
     
-    DefaultKeytabName?: string,
+    UDPPreferenceLimit?: number,
+    
+    AllowWeakCrypto?: boolean,
+    
+    DefaultClientKeytabName?: string,
+    
+    IgnoreAcceptorHostname?: boolean,
+    
+    PreferredPreauthTypes?: number[],
+    
+    /**
+    * time in nanoseconds
+    */
+    
+    TicketLifetime?: number,
     
     KDCDefaultOptions?: BitString,
 }
@@ -416,17 +416,17 @@ export interface PrincipalName {
  */
 export interface Realm {
     
-    AdminServer?: string[],
-    
-    DefaultDomain?: string,
-    
-    KDC?: string[],
-    
     KPasswdServer?: string[],
     
     MasterKDC?: string[],
     
     Realm?: string,
+    
+    AdminServer?: string[],
+    
+    DefaultDomain?: string,
+    
+    KDC?: string[],
 }
 
 

--- a/pkg/js/generated/ts/kerberos.ts
+++ b/pkg/js/generated/ts/kerberos.ts
@@ -188,9 +188,9 @@ export class Config {
  */
 export interface AuthorizationDataEntry {
     
-    ADType?: number,
-    
     ADData?: Uint8Array,
+    
+    ADType?: number,
 }
 
 
@@ -200,9 +200,9 @@ export interface AuthorizationDataEntry {
  */
 export interface BitString {
     
-    BitLength?: number,
-    
     Bytes?: Uint8Array,
+    
+    BitLength?: number,
 }
 
 
@@ -236,17 +236,15 @@ export interface Config {
  */
 export interface EncTicketPart {
     
-    AuthTime?: Date,
-    
-    StartTime?: Date,
-    
     EndTime?: Date,
     
     RenewTill?: Date,
     
     CRealm?: string,
     
-    AuthorizationData?: AuthorizationDataEntry,
+    AuthTime?: Date,
+    
+    StartTime?: Date,
     
     Flags?: BitString,
     
@@ -257,6 +255,8 @@ export interface EncTicketPart {
     Transited?: TransitedEncoding,
     
     CAddr?: HostAddress,
+    
+    AuthorizationData?: AuthorizationDataEntry,
 }
 
 
@@ -266,11 +266,11 @@ export interface EncTicketPart {
  */
 export interface EncryptedData {
     
-    Cipher?: Uint8Array,
-    
     EType?: number,
     
     KVNO?: number,
+    
+    Cipher?: Uint8Array,
 }
 
 
@@ -318,59 +318,27 @@ export interface HostAddress {
  */
 export interface LibDefaults {
     
-    DefaultTGSEnctypes?: string[],
+    CCacheType?: number,
     
     K5LoginAuthoritative?: boolean,
     
-    K5LoginDirectory?: string,
-    
-    /**
-    * time in nanoseconds
-    */
-    
-    Clockskew?: number,
-    
-    DefaultTGSEnctypeIDs?: number[],
-    
-    DNSLookupRealm?: boolean,
-    
-    Forwardable?: boolean,
-    
-    DefaultTktEnctypes?: string[],
-    
     Proxiable?: boolean,
-    
-    DefaultRealm?: string,
-    
-    DefaultKeytabName?: string,
-    
-    NoAddresses?: boolean,
-    
-    RealmTryDomains?: number,
-    
-    PermittedEnctypeIDs?: number[],
     
     RDNS?: boolean,
     
-    SafeChecksumType?: number,
-    
-    Canonicalize?: boolean,
-    
-    DefaultTktEnctypeIDs?: number[],
-    
-    DNSCanonicalizeHostname?: boolean,
+    K5LoginDirectory?: string,
     
     KDCTimeSync?: number,
     
-    PermittedEnctypes?: string[],
-    
     VerifyAPReqNofail?: boolean,
     
-    CCacheType?: number,
+    DefaultTGSEnctypes?: string[],
     
-    DNSLookupKDC?: boolean,
+    DefaultTGSEnctypeIDs?: number[],
     
-    ExtraAddresses?: Uint8Array,
+    DNSCanonicalizeHostname?: boolean,
+    
+    Forwardable?: boolean,
     
     /**
     * time in nanoseconds
@@ -378,21 +346,53 @@ export interface LibDefaults {
     
     RenewLifetime?: number,
     
-    UDPPreferenceLimit?: number,
-    
-    AllowWeakCrypto?: boolean,
-    
-    DefaultClientKeytabName?: string,
-    
-    IgnoreAcceptorHostname?: boolean,
-    
-    PreferredPreauthTypes?: number[],
-    
     /**
     * time in nanoseconds
     */
     
     TicketLifetime?: number,
+    
+    DefaultClientKeytabName?: string,
+    
+    DefaultTktEnctypeIDs?: number[],
+    
+    DNSLookupRealm?: boolean,
+    
+    ExtraAddresses?: Uint8Array,
+    
+    DefaultRealm?: string,
+    
+    NoAddresses?: boolean,
+    
+    PreferredPreauthTypes?: number[],
+    
+    PermittedEnctypeIDs?: number[],
+    
+    RealmTryDomains?: number,
+    
+    DefaultKeytabName?: string,
+    
+    DefaultTktEnctypes?: string[],
+    
+    DNSLookupKDC?: boolean,
+    
+    IgnoreAcceptorHostname?: boolean,
+    
+    AllowWeakCrypto?: boolean,
+    
+    Canonicalize?: boolean,
+    
+    SafeChecksumType?: number,
+    
+    UDPPreferenceLimit?: number,
+    
+    /**
+    * time in nanoseconds
+    */
+    
+    Clockskew?: number,
+    
+    PermittedEnctypes?: string[],
     
     KDCDefaultOptions?: BitString,
 }
@@ -416,10 +416,6 @@ export interface PrincipalName {
  */
 export interface Realm {
     
-    KPasswdServer?: string[],
-    
-    MasterKDC?: string[],
-    
     Realm?: string,
     
     AdminServer?: string[],
@@ -427,6 +423,10 @@ export interface Realm {
     DefaultDomain?: string,
     
     KDC?: string[],
+    
+    KPasswdServer?: string[],
+    
+    MasterKDC?: string[],
 }
 
 

--- a/pkg/js/generated/ts/ldap.ts
+++ b/pkg/js/generated/ts/ldap.ts
@@ -209,8 +209,8 @@ export class Client {
     * log(to_json(users));
     * ```
     */
-    public FindADObjects(filter: string): ADObject[] {
-        return [];
+    public FindADObjects(filter: string): SearchResult | null {
+        return null;
     }
     
 
@@ -225,8 +225,8 @@ export class Client {
     * log(to_json(users));
     * ```
     */
-    public GetADUsers(): ADObject[] {
-        return [];
+    public GetADUsers(): SearchResult | null {
+        return null;
     }
     
 
@@ -241,8 +241,8 @@ export class Client {
     * log(to_json(users));
     * ```
     */
-    public GetADActiveUsers(): ADObject[] {
-        return [];
+    public GetADActiveUsers(): SearchResult | null {
+        return null;
     }
     
 
@@ -257,8 +257,8 @@ export class Client {
     * log(to_json(users));
     * ```
     */
-    public GetADUserWithNeverExpiringPasswords(): ADObject[] {
-        return [];
+    public GetADUserWithNeverExpiringPasswords(): SearchResult | null {
+        return null;
     }
     
 
@@ -273,8 +273,8 @@ export class Client {
     * log(to_json(users));
     * ```
     */
-    public GetADUserTrustedForDelegation(): ADObject[] {
-        return [];
+    public GetADUserTrustedForDelegation(): SearchResult | null {
+        return null;
     }
     
 
@@ -289,8 +289,8 @@ export class Client {
     * log(to_json(users));
     * ```
     */
-    public GetADUserWithPasswordNotRequired(): ADObject[] {
-        return [];
+    public GetADUserWithPasswordNotRequired(): SearchResult | null {
+        return null;
     }
     
 
@@ -305,8 +305,8 @@ export class Client {
     * log(to_json(groups));
     * ```
     */
-    public GetADGroups(): ADObject[] {
-        return [];
+    public GetADGroups(): SearchResult | null {
+        return null;
     }
     
 
@@ -321,8 +321,8 @@ export class Client {
     * log(to_json(dcs));
     * ```
     */
-    public GetADDCList(): ADObject[] {
-        return [];
+    public GetADDCList(): SearchResult | null {
+        return null;
     }
     
 
@@ -337,8 +337,8 @@ export class Client {
     * log(to_json(admins));
     * ```
     */
-    public GetADAdmins(): ADObject[] {
-        return [];
+    public GetADAdmins(): SearchResult | null {
+        return null;
     }
     
 
@@ -353,8 +353,8 @@ export class Client {
     * log(to_json(kerberoastable));
     * ```
     */
-    public GetADUserKerberoastable(): ADObject[] {
-        return [];
+    public GetADUserKerberoastable(): SearchResult | null {
+        return null;
     }
     
 
@@ -369,8 +369,8 @@ export class Client {
     * log(to_json(AsRepRoastable));
     * ```
     */
-    public GetADUserAsRepRoastable(): ADObject[] {
-        return [];
+    public GetADUserAsRepRoastable(): SearchResult | null {
+        return null;
     }
     
 
@@ -482,33 +482,6 @@ export class Client {
 
 
 /**
- * ADObject represents an Active Directory object
- * @example
- * ```javascript
- * const ldap = require('nuclei/ldap');
- * const client = new ldap.Client('ldap://ldap.example.com', 'acme.com');
- * const users = client.GetADUsers();
- * log(to_json(users));
- * ```
- */
-export interface ADObject {
-    
-    DistinguishedName?: string,
-    
-    SAMAccountName?: string,
-    
-    PWDLastSet?: string,
-    
-    LastLogon?: string,
-    
-    MemberOf?: string[],
-    
-    ServicePrincipalName?: string[],
-}
-
-
-
-/**
  * Config is extra configuration for the ldap client
  * @example
  * ```javascript
@@ -561,6 +534,191 @@ export interface EntryAttribute {
 
 
 /**
+ * LdapAttributes represents all LDAP attributes of a particular
+ * ldap entry
+ */
+export interface LdapAttributes {
+    
+    /**
+    * CurrentTime contains current time
+    */
+    
+    CurrentTime?: string[],
+    
+    /**
+    * SubschemaSubentry contains subschema subentry
+    */
+    
+    SubschemaSubentry?: string[],
+    
+    /**
+    * DsServiceName contains ds service name
+    */
+    
+    DsServiceName?: string[],
+    
+    /**
+    * NamingContexts contains naming contexts
+    */
+    
+    NamingContexts?: string[],
+    
+    /**
+    * DefaultNamingContext contains default naming context
+    */
+    
+    DefaultNamingContext?: string[],
+    
+    /**
+    * SchemaNamingContext contains schema naming context
+    */
+    
+    SchemaNamingContext?: string[],
+    
+    /**
+    * ConfigurationNamingContext contains configuration naming context
+    */
+    
+    ConfigurationNamingContext?: string[],
+    
+    /**
+    * RootDomainNamingContext contains root domain naming context
+    */
+    
+    RootDomainNamingContext?: string[],
+    
+    /**
+    * SupportedLDAPVersion contains supported LDAP version
+    */
+    
+    SupportedLDAPVersion?: string[],
+    
+    /**
+    * HighestCommittedUSN contains highest committed USN
+    */
+    
+    HighestCommittedUSN?: string[],
+    
+    /**
+    * SupportedSASLMechanisms contains supported SASL mechanisms
+    */
+    
+    SupportedSASLMechanisms?: string[],
+    
+    /**
+    * DnsHostName contains DNS host name
+    */
+    
+    DnsHostName?: string[],
+    
+    /**
+    * LdapServiceName contains LDAP service name
+    */
+    
+    LdapServiceName?: string[],
+    
+    /**
+    * ServerName contains server name
+    */
+    
+    ServerName?: string[],
+    
+    /**
+    * IsSynchronized contains is synchronized
+    */
+    
+    IsSynchronized?: string[],
+    
+    /**
+    * IsGlobalCatalogReady contains is global catalog ready
+    */
+    
+    IsGlobalCatalogReady?: string[],
+    
+    /**
+    * DomainFunctionality contains domain functionality
+    */
+    
+    DomainFunctionality?: string[],
+    
+    /**
+    * ForestFunctionality contains forest functionality
+    */
+    
+    ForestFunctionality?: string[],
+    
+    /**
+    * DomainControllerFunctionality contains domain controller functionality
+    */
+    
+    DomainControllerFunctionality?: string[],
+    
+    /**
+    * DistinguishedName contains the distinguished name
+    */
+    
+    DistinguishedName?: string[],
+    
+    /**
+    * SAMAccountName contains the SAM account name
+    */
+    
+    SAMAccountName?: string[],
+    
+    /**
+    * PWDLastSet contains the password last set time
+    */
+    
+    PWDLastSet?: string[],
+    
+    /**
+    * LastLogon contains the last logon time
+    */
+    
+    LastLogon?: string[],
+    
+    /**
+    * MemberOf contains the groups the entry is a member of
+    */
+    
+    MemberOf?: string[],
+    
+    /**
+    * ServicePrincipalName contains the service principal names
+    */
+    
+    ServicePrincipalName?: string[],
+    
+    /**
+    * Extra contains other extra fields which might be present
+    */
+    
+    Extra?: Record<string, any>,
+}
+
+
+
+/**
+ * LdapEntry represents a single LDAP entry
+ */
+export interface LdapEntry {
+    
+    /**
+    * DN contains distinguished name
+    */
+    
+    DN?: string,
+    
+    /**
+    * Attributes contains list of attributes
+    */
+    
+    Attributes?: LdapAttributes,
+}
+
+
+
+/**
  * Metadata is the metadata for ldap server.
  * this is returned by CollectMetadata method
  */
@@ -591,5 +749,37 @@ export interface SearchResult {
     Referrals?: string[],
     
     Entries?: Entry,
+}
+
+
+
+/**
+ * SearchResult contains search result of any / all ldap search request
+ * @example
+ * ```javascript
+ * const ldap = require('nuclei/ldap');
+ * const client = new ldap.Client('ldap://ldap.example.com', 'acme.com');
+ * const results = client.Search('(objectinterface=*)', 'cn', 'mail');
+ * ```
+ */
+export interface SearchResult {
+    
+    /**
+    * Referrals contains list of referrals
+    */
+    
+    Referrals?: string[],
+    
+    /**
+    * Controls contains list of controls
+    */
+    
+    Controls?: string[],
+    
+    /**
+    * Entries contains list of entries
+    */
+    
+    Entries?: LdapEntry[],
 }
 

--- a/pkg/js/generated/ts/ldap.ts
+++ b/pkg/js/generated/ts/ldap.ts
@@ -428,8 +428,8 @@ export class Client {
     * const results = client.Search('(objectClass=*)', 'cn', 'mail');
     * ```
     */
-    public Search(filter: string, attributes: any): Record<string, string[]>[] {
-        return [];
+    public Search(filter: string, attributes: any): SearchResult | null {
+        return null;
     }
     
 
@@ -503,32 +503,6 @@ export interface Config {
     ServerName?: string,
     
     Upgrade?: boolean,
-}
-
-
-
-/**
- * Entry Interface
- */
-export interface Entry {
-    
-    DN?: string,
-    
-    Attributes?: EntryAttribute,
-}
-
-
-
-/**
- * EntryAttribute Interface
- */
-export interface EntryAttribute {
-    
-    Name?: string,
-    
-    Values?: string[],
-    
-    ByteValues?: Uint8Array,
 }
 
 
@@ -737,18 +711,6 @@ export interface Metadata {
     DomainControllerFunctionality?: string,
     
     DnsHostName?: string,
-}
-
-
-
-/**
- * SearchResult Interface
- */
-export interface SearchResult {
-    
-    Referrals?: string[],
-    
-    Entries?: Entry,
 }
 
 

--- a/pkg/js/generated/ts/mysql.ts
+++ b/pkg/js/generated/ts/mysql.ts
@@ -209,9 +209,9 @@ export interface MySQLOptions {
  */
 export interface SQLResult {
     
-    Columns?: string[],
-    
     Count?: number,
+    
+    Columns?: string[],
 }
 
 

--- a/pkg/js/generated/ts/mysql.ts
+++ b/pkg/js/generated/ts/mysql.ts
@@ -209,9 +209,9 @@ export interface MySQLOptions {
  */
 export interface SQLResult {
     
-    Count?: number,
-    
     Columns?: string[],
+    
+    Count?: number,
 }
 
 

--- a/pkg/js/generated/ts/rdp.ts
+++ b/pkg/js/generated/ts/rdp.ts
@@ -78,14 +78,6 @@ export interface IsRDPResponse {
  */
 export interface ServiceRDP {
     
-    DNSDomainName?: string,
-    
-    ForestName?: string,
-    
-    OSFingerprint?: string,
-    
-    OSVersion?: string,
-    
     TargetName?: string,
     
     NetBIOSComputerName?: string,
@@ -93,5 +85,13 @@ export interface ServiceRDP {
     NetBIOSDomainName?: string,
     
     DNSComputerName?: string,
+    
+    DNSDomainName?: string,
+    
+    ForestName?: string,
+    
+    OSFingerprint?: string,
+    
+    OSVersion?: string,
 }
 

--- a/pkg/js/generated/ts/rdp.ts
+++ b/pkg/js/generated/ts/rdp.ts
@@ -78,6 +78,12 @@ export interface IsRDPResponse {
  */
 export interface ServiceRDP {
     
+    ForestName?: string,
+    
+    OSFingerprint?: string,
+    
+    OSVersion?: string,
+    
     TargetName?: string,
     
     NetBIOSComputerName?: string,
@@ -87,11 +93,5 @@ export interface ServiceRDP {
     DNSComputerName?: string,
     
     DNSDomainName?: string,
-    
-    ForestName?: string,
-    
-    OSFingerprint?: string,
-    
-    OSVersion?: string,
 }
 

--- a/pkg/js/generated/ts/smb.ts
+++ b/pkg/js/generated/ts/smb.ts
@@ -113,6 +113,12 @@ export interface HeaderLog {
  */
 export interface NegotiationLog {
     
+    SystemTime?: number,
+    
+    ServerStartTime?: number,
+    
+    AuthenticationTypes?: string[],
+    
     SecurityMode?: number,
     
     DialectRevision?: number,
@@ -120,12 +126,6 @@ export interface NegotiationLog {
     ServerGuid?: Uint8Array,
     
     Capabilities?: number,
-    
-    SystemTime?: number,
-    
-    ServerStartTime?: number,
-    
-    AuthenticationTypes?: string[],
     
     HeaderLog?: HeaderLog,
 }
@@ -137,10 +137,6 @@ export interface NegotiationLog {
  */
 export interface SMBCapabilities {
     
-    LargeMTU?: boolean,
-    
-    MultiChan?: boolean,
-    
     Persist?: boolean,
     
     DirLeasing?: boolean,
@@ -150,6 +146,10 @@ export interface SMBCapabilities {
     DFSSupport?: boolean,
     
     Leasing?: boolean,
+    
+    LargeMTU?: boolean,
+    
+    MultiChan?: boolean,
 }
 
 
@@ -169,13 +169,13 @@ export interface SMBLog {
     
     HasNTLM?: boolean,
     
-    Version?: SMBVersions,
-    
-    Capabilities?: SMBCapabilities,
-    
     NegotiationLog?: NegotiationLog,
     
     SessionSetupLog?: SessionSetupLog,
+    
+    Version?: SMBVersions,
+    
+    Capabilities?: SMBCapabilities,
 }
 
 
@@ -201,6 +201,12 @@ export interface SMBVersions {
  */
 export interface ServiceSMB {
     
+    ForestName?: string,
+    
+    SigningEnabled?: boolean,
+    
+    SigningRequired?: boolean,
+    
     OSVersion?: string,
     
     NetBIOSComputerName?: string,
@@ -210,12 +216,6 @@ export interface ServiceSMB {
     DNSComputerName?: string,
     
     DNSDomainName?: string,
-    
-    ForestName?: string,
-    
-    SigningEnabled?: boolean,
-    
-    SigningRequired?: boolean,
 }
 
 
@@ -225,11 +225,11 @@ export interface ServiceSMB {
  */
 export interface SessionSetupLog {
     
-    NegotiateFlags?: number,
-    
     SetupFlags?: number,
     
     TargetName?: string,
+    
+    NegotiateFlags?: number,
     
     HeaderLog?: HeaderLog,
 }

--- a/pkg/js/generated/ts/smb.ts
+++ b/pkg/js/generated/ts/smb.ts
@@ -113,12 +113,6 @@ export interface HeaderLog {
  */
 export interface NegotiationLog {
     
-    SystemTime?: number,
-    
-    ServerStartTime?: number,
-    
-    AuthenticationTypes?: string[],
-    
     SecurityMode?: number,
     
     DialectRevision?: number,
@@ -126,6 +120,12 @@ export interface NegotiationLog {
     ServerGuid?: Uint8Array,
     
     Capabilities?: number,
+    
+    SystemTime?: number,
+    
+    ServerStartTime?: number,
+    
+    AuthenticationTypes?: string[],
     
     HeaderLog?: HeaderLog,
 }
@@ -137,12 +137,6 @@ export interface NegotiationLog {
  */
 export interface SMBCapabilities {
     
-    Persist?: boolean,
-    
-    DirLeasing?: boolean,
-    
-    Encryption?: boolean,
-    
     DFSSupport?: boolean,
     
     Leasing?: boolean,
@@ -150,6 +144,12 @@ export interface SMBCapabilities {
     LargeMTU?: boolean,
     
     MultiChan?: boolean,
+    
+    Persist?: boolean,
+    
+    DirLeasing?: boolean,
+    
+    Encryption?: boolean,
 }
 
 
@@ -159,23 +159,23 @@ export interface SMBCapabilities {
  */
 export interface SMBLog {
     
-    SupportV1?: boolean,
-    
-    NativeOs?: string,
-    
     NTLM?: string,
     
     GroupName?: string,
     
     HasNTLM?: boolean,
     
-    NegotiationLog?: NegotiationLog,
+    SupportV1?: boolean,
     
-    SessionSetupLog?: SessionSetupLog,
+    NativeOs?: string,
     
     Version?: SMBVersions,
     
     Capabilities?: SMBCapabilities,
+    
+    NegotiationLog?: NegotiationLog,
+    
+    SessionSetupLog?: SessionSetupLog,
 }
 
 
@@ -185,13 +185,13 @@ export interface SMBLog {
  */
 export interface SMBVersions {
     
-    VerString?: string,
-    
     Major?: number,
     
     Minor?: number,
     
     Revision?: number,
+    
+    VerString?: string,
 }
 
 
@@ -200,12 +200,6 @@ export interface SMBVersions {
  * ServiceSMB Interface
  */
 export interface ServiceSMB {
-    
-    ForestName?: string,
-    
-    SigningEnabled?: boolean,
-    
-    SigningRequired?: boolean,
     
     OSVersion?: string,
     
@@ -216,6 +210,12 @@ export interface ServiceSMB {
     DNSComputerName?: string,
     
     DNSDomainName?: string,
+    
+    ForestName?: string,
+    
+    SigningEnabled?: boolean,
+    
+    SigningRequired?: boolean,
 }
 
 

--- a/pkg/js/generated/ts/ssh.ts
+++ b/pkg/js/generated/ts/ssh.ts
@@ -159,13 +159,13 @@ export interface DirectionAlgorithms {
  */
 export interface EndpointId {
     
+    SoftwareVersion?: string,
+    
     Comment?: string,
     
     Raw?: string,
     
     ProtoVersion?: string,
-    
-    SoftwareVersion?: string,
 }
 
 
@@ -197,34 +197,34 @@ export interface HandshakeLog {
  */
 export interface KexInitMsg {
     
+    KexAlgos?: string[],
+    
+    CiphersClientServer?: string[],
+    
+    MACsServerClient?: string[],
+    
+    LanguagesClientServer?: string[],
+    
+    CompressionClientServer?: string[],
+    
+    CompressionServerClient?: string[],
+    
+    Reserved?: number,
+    
+    MACsClientServer?: string[],
+    
     /**
     * fixed size array of length: [16]
     */
     
     Cookie?: Uint8Array,
     
-    LanguagesClientServer?: string[],
-    
-    KexAlgos?: string[],
+    ServerHostKeyAlgos?: string[],
     
     CiphersServerClient?: string[],
     
-    MACsClientServer?: string[],
-    
-    CompressionClientServer?: string[],
-    
-    FirstKexFollows?: boolean,
-    
-    ServerHostKeyAlgos?: string[],
-    
-    CiphersClientServer?: string[],
-    
-    MACsServerClient?: string[],
-    
-    CompressionServerClient?: string[],
-    
     LanguagesServerClient?: string[],
     
-    Reserved?: number,
+    FirstKexFollows?: boolean,
 }
 

--- a/pkg/js/generated/ts/ssh.ts
+++ b/pkg/js/generated/ts/ssh.ts
@@ -133,9 +133,9 @@ export interface Algorithms {
     
     HostKey?: string,
     
-    R?: DirectionAlgorithms,
-    
     W?: DirectionAlgorithms,
+    
+    R?: DirectionAlgorithms,
 }
 
 
@@ -159,13 +159,13 @@ export interface DirectionAlgorithms {
  */
 export interface EndpointId {
     
+    Comment?: string,
+    
     Raw?: string,
     
     ProtoVersion?: string,
     
     SoftwareVersion?: string,
-    
-    Comment?: string,
 }
 
 
@@ -197,34 +197,34 @@ export interface HandshakeLog {
  */
 export interface KexInitMsg {
     
-    Reserved?: number,
-    
     /**
     * fixed size array of length: [16]
     */
     
     Cookie?: Uint8Array,
     
-    CiphersClientServer?: string[],
-    
-    MACsClientServer?: string[],
-    
-    MACsServerClient?: string[],
-    
-    CompressionServerClient?: string[],
-    
     LanguagesClientServer?: string[],
-    
-    FirstKexFollows?: boolean,
     
     KexAlgos?: string[],
     
     CiphersServerClient?: string[],
     
+    MACsClientServer?: string[],
+    
     CompressionClientServer?: string[],
+    
+    FirstKexFollows?: boolean,
+    
+    ServerHostKeyAlgos?: string[],
+    
+    CiphersClientServer?: string[],
+    
+    MACsServerClient?: string[],
+    
+    CompressionServerClient?: string[],
     
     LanguagesServerClient?: string[],
     
-    ServerHostKeyAlgos?: string[],
+    Reserved?: number,
 }
 

--- a/pkg/js/libs/ldap/adenum.go
+++ b/pkg/js/libs/ldap/adenum.go
@@ -74,25 +74,6 @@ func NegativeFilter(filter string) string {
 	return fmt.Sprintf("(!%s)", filter)
 }
 
-type (
-	// ADObject represents an Active Directory object
-	// @example
-	// ```javascript
-	// const ldap = require('nuclei/ldap');
-	// const client = new ldap.Client('ldap://ldap.example.com', 'acme.com');
-	// const users = client.GetADUsers();
-	// log(to_json(users));
-	// ```
-	ADObject struct {
-		DistinguishedName    string
-		SAMAccountName       string
-		PWDLastSet           string
-		LastLogon            string
-		MemberOf             []string
-		ServicePrincipalName []string
-	}
-)
-
 // FindADObjects finds AD objects based on a filter
 // and returns them as a list of ADObject
 // @example
@@ -102,7 +83,7 @@ type (
 // const users = client.FindADObjects(ldap.FilterIsPerson);
 // log(to_json(users));
 // ```
-func (c *Client) FindADObjects(filter string) []ADObject {
+func (c *Client) FindADObjects(filter string) SearchResult {
 	c.nj.Require(c.conn != nil, "no existing connection")
 	sr := ldap.NewSearchRequest(
 		c.BaseDN, ldap.ScopeWholeSubtree,
@@ -121,19 +102,7 @@ func (c *Client) FindADObjects(filter string) []ADObject {
 
 	res, err := c.conn.Search(sr)
 	c.nj.HandleError(err, "ldap search request failed")
-
-	var objects []ADObject
-	for _, obj := range res.Entries {
-		objects = append(objects, ADObject{
-			DistinguishedName:    obj.GetAttributeValue("distinguishedName"),
-			SAMAccountName:       obj.GetAttributeValue("sAMAccountName"),
-			PWDLastSet:           DecodeADTimestamp(obj.GetAttributeValue("pwdLastSet")),
-			LastLogon:            DecodeADTimestamp(obj.GetAttributeValue("lastLogon")),
-			MemberOf:             obj.GetAttributeValues("memberOf"),
-			ServicePrincipalName: obj.GetAttributeValues("servicePrincipalName"),
-		})
-	}
-	return objects
+	return *getSearchResult(res)
 }
 
 // GetADUsers returns all AD users
@@ -145,7 +114,7 @@ func (c *Client) FindADObjects(filter string) []ADObject {
 // const users = client.GetADUsers();
 // log(to_json(users));
 // ```
-func (c *Client) GetADUsers() []ADObject {
+func (c *Client) GetADUsers() SearchResult {
 	return c.FindADObjects(FilterIsPerson)
 }
 
@@ -158,7 +127,7 @@ func (c *Client) GetADUsers() []ADObject {
 // const users = client.GetADActiveUsers();
 // log(to_json(users));
 // ```
-func (c *Client) GetADActiveUsers() []ADObject {
+func (c *Client) GetADActiveUsers() SearchResult {
 	return c.FindADObjects(JoinFilters(FilterIsPerson, FilterAccountEnabled))
 }
 
@@ -171,7 +140,7 @@ func (c *Client) GetADActiveUsers() []ADObject {
 // const users = client.GetADUserWithNeverExpiringPasswords();
 // log(to_json(users));
 // ```
-func (c *Client) GetADUserWithNeverExpiringPasswords() []ADObject {
+func (c *Client) GetADUserWithNeverExpiringPasswords() SearchResult {
 	return c.FindADObjects(JoinFilters(FilterIsPerson, FilterDontExpirePassword))
 }
 
@@ -184,7 +153,7 @@ func (c *Client) GetADUserWithNeverExpiringPasswords() []ADObject {
 // const users = client.GetADUserTrustedForDelegation();
 // log(to_json(users));
 // ```
-func (c *Client) GetADUserTrustedForDelegation() []ADObject {
+func (c *Client) GetADUserTrustedForDelegation() SearchResult {
 	return c.FindADObjects(JoinFilters(FilterIsPerson, FilterTrustedForDelegation))
 }
 
@@ -197,7 +166,7 @@ func (c *Client) GetADUserTrustedForDelegation() []ADObject {
 // const users = client.GetADUserWithPasswordNotRequired();
 // log(to_json(users));
 // ```
-func (c *Client) GetADUserWithPasswordNotRequired() []ADObject {
+func (c *Client) GetADUserWithPasswordNotRequired() SearchResult {
 	return c.FindADObjects(JoinFilters(FilterIsPerson, FilterPasswordNotRequired))
 }
 
@@ -210,7 +179,7 @@ func (c *Client) GetADUserWithPasswordNotRequired() []ADObject {
 // const groups = client.GetADGroups();
 // log(to_json(groups));
 // ```
-func (c *Client) GetADGroups() []ADObject {
+func (c *Client) GetADGroups() SearchResult {
 	return c.FindADObjects(FilterIsGroup)
 }
 
@@ -223,7 +192,7 @@ func (c *Client) GetADGroups() []ADObject {
 // const dcs = client.GetADDCList();
 // log(to_json(dcs));
 // ```
-func (c *Client) GetADDCList() []ADObject {
+func (c *Client) GetADDCList() SearchResult {
 	return c.FindADObjects(JoinFilters(FilterIsComputer, FilterAccountEnabled, FilterServerTrustAccount))
 }
 
@@ -236,7 +205,7 @@ func (c *Client) GetADDCList() []ADObject {
 // const admins = client.GetADAdmins();
 // log(to_json(admins));
 // ```
-func (c *Client) GetADAdmins() []ADObject {
+func (c *Client) GetADAdmins() SearchResult {
 	return c.FindADObjects(JoinFilters(FilterIsPerson, FilterAccountEnabled, FilterIsAdmin))
 }
 
@@ -249,7 +218,7 @@ func (c *Client) GetADAdmins() []ADObject {
 // const kerberoastable = client.GetADUserKerberoastable();
 // log(to_json(kerberoastable));
 // ```
-func (c *Client) GetADUserKerberoastable() []ADObject {
+func (c *Client) GetADUserKerberoastable() SearchResult {
 	return c.FindADObjects(JoinFilters(FilterIsPerson, FilterAccountEnabled, FilterHasServicePrincipalName))
 }
 
@@ -262,7 +231,7 @@ func (c *Client) GetADUserKerberoastable() []ADObject {
 // const AsRepRoastable = client.GetADUserAsRepRoastable();
 // log(to_json(AsRepRoastable));
 // ```
-func (c *Client) GetADUserAsRepRoastable() []ADObject {
+func (c *Client) GetADUserAsRepRoastable() SearchResult {
 	return c.FindADObjects(JoinFilters(FilterIsPerson, FilterDontRequirePreauth))
 }
 

--- a/pkg/js/libs/ldap/adenum.go
+++ b/pkg/js/libs/ldap/adenum.go
@@ -251,7 +251,7 @@ func (c *Client) GetADDomainSID() string {
 			if sid, ok := sid.([]string); ok {
 				return DecodeSID(sid[0])
 			} else {
-				c.nj.HandleError(fmt.Errorf("invalid objectSid type: %T", sid), "invalid objectSid type")
+				c.nj.HandleError(fmt.Errorf("invalid objectSid type: %T", entry.Attributes.Extra["objectSid"]), "invalid objectSid type")
 			}
 		}
 	}

--- a/pkg/js/libs/ldap/ldap.go
+++ b/pkg/js/libs/ldap/ldap.go
@@ -203,7 +203,7 @@ func (c *Client) AuthenticateWithNTLMHash(username, hash string) {
 // const client = new ldap.Client('ldap://ldap.example.com', 'acme.com');
 // const results = client.Search('(objectClass=*)', 'cn', 'mail');
 // ```
-func (c *Client) Search(filter string, attributes ...string) []map[string][]string {
+func (c *Client) Search(filter string, attributes ...string) SearchResult {
 	c.nj.Require(c.conn != nil, "no existing connection")
 	c.nj.Require(c.BaseDN != "", "base dn cannot be empty")
 	c.nj.Require(len(attributes) > 0, "attributes cannot be empty")
@@ -211,7 +211,7 @@ func (c *Client) Search(filter string, attributes ...string) []map[string][]stri
 	res, err := c.conn.Search(
 		ldap.NewSearchRequest(
 			"",
-			ldap.ScopeBaseObject,
+			ldap.ScopeWholeSubtree,
 			ldap.NeverDerefAliases,
 			0, 0, false,
 			filter,
@@ -220,28 +220,7 @@ func (c *Client) Search(filter string, attributes ...string) []map[string][]stri
 		),
 	)
 	c.nj.HandleError(err, "ldap search request failed")
-	if len(res.Entries) == 0 {
-		// return empty list
-		return nil
-	}
-
-	// convert ldap.Entry to []map[string][]string
-	var out []map[string][]string
-	for _, r := range res.Entries {
-		app := make(map[string][]string)
-		empty := true
-		for _, a := range attributes {
-			v := r.GetAttributeValues(a)
-			if len(v) > 0 {
-				app[a] = v
-				empty = false
-			}
-		}
-		if !empty {
-			out = append(out, app)
-		}
-	}
-	return out
+	return *getSearchResult(res)
 }
 
 // AdvancedSearch accepts all values of search request type and return Ldap Entry
@@ -257,7 +236,7 @@ func (c *Client) AdvancedSearch(
 	TypesOnly bool,
 	Filter string,
 	Attributes []string,
-	Controls []ldap.Control) ldap.SearchResult {
+	Controls []ldap.Control) SearchResult {
 	c.nj.Require(c.conn != nil, "no existing connection")
 	if c.BaseDN == "" {
 		c.BaseDN = fmt.Sprintf("dc=%s", strings.Join(strings.Split(c.Realm, "."), ",dc="))
@@ -266,7 +245,7 @@ func (c *Client) AdvancedSearch(
 	res, err := c.conn.Search(req)
 	c.nj.HandleError(err, "ldap search request failed")
 	c.nj.Require(res != nil, "ldap search request failed got nil response")
-	return *res
+	return *getSearchResult(res)
 }
 
 type (
@@ -302,7 +281,7 @@ func (c *Client) CollectMetadata() Metadata {
 
 	srMetadata := ldap.NewSearchRequest(
 		"",
-		ldap.ScopeBaseObject,
+		ldap.ScopeWholeSubtree,
 		ldap.NeverDerefAliases,
 		0, 0, false,
 		"(objectClass=*)",

--- a/pkg/js/libs/ldap/utils.go
+++ b/pkg/js/libs/ldap/utils.go
@@ -5,7 +5,188 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/go-ldap/ldap/v3"
 )
+
+type (
+	// SearchResult contains search result of any / all ldap search request
+	// @example
+	// ```javascript
+	// const ldap = require('nuclei/ldap');
+	// const client = new ldap.Client('ldap://ldap.example.com', 'acme.com');
+	// const results = client.Search('(objectClass=*)', 'cn', 'mail');
+	// ```
+	SearchResult struct {
+		// Referrals contains list of referrals
+		Referrals []string `json:"referrals"`
+		// Controls contains list of controls
+		Controls []string `json:"controls"`
+		// Entries contains list of entries
+		Entries []LdapEntry `json:"entries"`
+	}
+
+	// LdapEntry represents a single LDAP entry
+	LdapEntry struct {
+		// DN contains distinguished name
+		DN string `json:"dn"`
+		// Attributes contains list of attributes
+		Attributes LdapAttributes `json:"attributes"`
+	}
+
+	// LdapAttributes represents all LDAP attributes of a particular
+	// ldap entry
+	LdapAttributes struct {
+		// CurrentTime contains current time
+		CurrentTime []string `json:"currentTime,omitempty"`
+		// SubschemaSubentry contains subschema subentry
+		SubschemaSubentry []string `json:"subschemaSubentry,omitempty"`
+		// DsServiceName contains ds service name
+		DsServiceName []string `json:"dsServiceName,omitempty"`
+		// NamingContexts contains naming contexts
+		NamingContexts []string `json:"namingContexts,omitempty"`
+		// DefaultNamingContext contains default naming context
+		DefaultNamingContext []string `json:"defaultNamingContext,omitempty"`
+		// SchemaNamingContext contains schema naming context
+		SchemaNamingContext []string `json:"schemaNamingContext,omitempty"`
+		// ConfigurationNamingContext contains configuration naming context
+		ConfigurationNamingContext []string `json:"configurationNamingContext,omitempty"`
+		// RootDomainNamingContext contains root domain naming context
+		RootDomainNamingContext []string `json:"rootDomainNamingContext,omitempty"`
+		// SupportedLDAPVersion contains supported LDAP version
+		SupportedLDAPVersion []string `json:"supportedLDAPVersion,omitempty"`
+		// HighestCommittedUSN contains highest committed USN
+		HighestCommittedUSN []string `json:"highestCommittedUSN,omitempty"`
+		// SupportedSASLMechanisms contains supported SASL mechanisms
+		SupportedSASLMechanisms []string `json:"supportedSASLMechanisms,omitempty"`
+		// DnsHostName contains DNS host name
+		DnsHostName []string `json:"dnsHostName,omitempty"`
+		// LdapServiceName contains LDAP service name
+		LdapServiceName []string `json:"ldapServiceName,omitempty"`
+		// ServerName contains server name
+		ServerName []string `json:"serverName,omitempty"`
+		// IsSynchronized contains is synchronized
+		IsSynchronized []string `json:"isSynchronized,omitempty"`
+		// IsGlobalCatalogReady contains is global catalog ready
+		IsGlobalCatalogReady []string `json:"isGlobalCatalogReady,omitempty"`
+		// DomainFunctionality contains domain functionality
+		DomainFunctionality []string `json:"domainFunctionality,omitempty"`
+		// ForestFunctionality contains forest functionality
+		ForestFunctionality []string `json:"forestFunctionality,omitempty"`
+		// DomainControllerFunctionality contains domain controller functionality
+		DomainControllerFunctionality []string `json:"domainControllerFunctionality,omitempty"`
+		// DistinguishedName contains the distinguished name
+		DistinguishedName []string `json:"distinguishedName,omitempty"`
+		// SAMAccountName contains the SAM account name
+		SAMAccountName []string `json:"sAMAccountName,omitempty"`
+		// PWDLastSet contains the password last set time
+		PWDLastSet []string `json:"pwdLastSet,omitempty"`
+		// LastLogon contains the last logon time
+		LastLogon []string `json:"lastLogon,omitempty"`
+		// MemberOf contains the groups the entry is a member of
+		MemberOf []string `json:"memberOf,omitempty"`
+		// ServicePrincipalName contains the service principal names
+		ServicePrincipalName []string `json:"servicePrincipalName,omitempty"`
+		// Extra contains other extra fields which might be present
+		Extra map[string]any `json:"extra,omitempty"`
+	}
+)
+
+// getSearchResult converts a ldap.SearchResult to a SearchResult
+func getSearchResult(sr *ldap.SearchResult) *SearchResult {
+	t := &SearchResult{
+		Referrals: []string{},
+		Controls:  []string{},
+		Entries:   []LdapEntry{},
+	}
+	// add referrals
+	t.Referrals = append(t.Referrals, sr.Referrals...)
+	// add controls
+	for _, ctrl := range sr.Controls {
+		t.Controls = append(t.Controls, ctrl.String())
+	}
+	// add entries
+	for _, entry := range sr.Entries {
+		t.Entries = append(t.Entries, parseLdapEntry(entry))
+	}
+	return t
+}
+
+func parseLdapEntry(entry *ldap.Entry) LdapEntry {
+	e := LdapEntry{
+		DN: entry.DN,
+	}
+	attrs := LdapAttributes{
+		Extra: make(map[string]any),
+	}
+	for _, attr := range entry.Attributes {
+		switch attr.Name {
+		case "currentTime":
+			attrs.CurrentTime = decodeTimestamps(attr.Values)
+		case "subschemaSubentry":
+			attrs.SubschemaSubentry = attr.Values
+		case "dsServiceName":
+			attrs.DsServiceName = attr.Values
+		case "namingContexts":
+			attrs.NamingContexts = attr.Values
+		case "defaultNamingContext":
+			attrs.DefaultNamingContext = attr.Values
+		case "schemaNamingContext":
+			attrs.SchemaNamingContext = attr.Values
+		case "configurationNamingContext":
+			attrs.ConfigurationNamingContext = attr.Values
+		case "rootDomainNamingContext":
+			attrs.RootDomainNamingContext = attr.Values
+		case "supportedLDAPVersion":
+			attrs.SupportedLDAPVersion = attr.Values
+		case "highestCommittedUSN":
+			attrs.HighestCommittedUSN = attr.Values
+		case "supportedSASLMechanisms":
+			attrs.SupportedSASLMechanisms = attr.Values
+		case "dnsHostName":
+			attrs.DnsHostName = attr.Values
+		case "ldapServiceName":
+			attrs.LdapServiceName = attr.Values
+		case "serverName":
+			attrs.ServerName = attr.Values
+		case "isSynchronized":
+			attrs.IsSynchronized = attr.Values
+		case "isGlobalCatalogReady":
+			attrs.IsGlobalCatalogReady = attr.Values
+		case "domainFunctionality":
+			attrs.DomainFunctionality = attr.Values
+		case "forestFunctionality":
+			attrs.ForestFunctionality = attr.Values
+		case "domainControllerFunctionality":
+			attrs.DomainControllerFunctionality = attr.Values
+		case "distinguishedName":
+			attrs.DistinguishedName = attr.Values
+		case "sAMAccountName":
+			attrs.SAMAccountName = attr.Values
+		case "pwdLastSet":
+			attrs.PWDLastSet = decodeTimestamps(attr.Values)
+		case "lastLogon":
+			attrs.LastLogon = decodeTimestamps(attr.Values)
+		case "memberOf":
+			attrs.MemberOf = attr.Values
+		case "servicePrincipalName":
+			attrs.ServicePrincipalName = attr.Values
+		default:
+			attrs.Extra[attr.Name] = attr.Values
+		}
+	}
+	e.Attributes = attrs
+	return e
+}
+
+// decodeTimestamps  decodes multiple timestamps
+func decodeTimestamps(timestamps []string) []string {
+	res := []string{}
+	for _, timestamp := range timestamps {
+		res = append(res, DecodeADTimestamp(timestamp))
+	}
+	return res
+}
 
 // DecodeSID decodes a SID string
 // @example


### PR DESCRIPTION
## Proposed Changes

- in ldap module earlier we were only returning a very small portion of what's available and i.e why it most of times returned empty response , this is now fixed by adding new type with some normalization
- closes #5388 

### Before

```console
$ nuclei -u x.x.x.x:3268 -t x.yaml               

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.2.9

		projectdiscovery.io

[INF] Current nuclei version: v3.2.9 (latest)
[INF] Current nuclei-templates version: v9.9.0 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 164
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[ldap-obb] [javascript] [high] x.x.x.x:3268 ["DistinguishedName: '' ,SAMAccountName: '' ,PWDLastSet: 'Not Set' ,LastLogon: 'Not Set' ,MemberOf: '' ,ServicePrincipalName: '' ,"]
```

### After
```console
$ ./nuclei -u x.x.x.x:3268 -t a.yaml                                                                                             

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.3.0-dev

		projectdiscovery.io

[INF] Current nuclei version: v3.3.0-dev (development)
[INF] Current nuclei-templates version: v9.9.0 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 164
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[ldap-obb] [javascript] [high] x.x.x.x:3268 ["[{DN: Attributes:{CurrentTime:[Not Set] SubschemaSubentry:[CN=Aggregate,CN=Schema,CN=Configuration,DC=cloudshark-a,DC=example,DC=com] DsServiceName:[CN=NTDS Settings,CN=AD1,CN=Servers,CN=Default-First-Site-Name,CN=Sites,CN=Configuration,DC=cloudshark-a,DC=example,DC=com] NamingContexts:[DC=cloudshark-a,DC=example,DC=com CN=Configuration,DC=cloudshark-a,DC=example,DC=com CN=Schema,CN=Configuration,DC=cloudshark-a,DC=example,DC=com DC=DomainDnsZones,DC=cloudshark-a,DC=example,DC=com DC=ForestDnsZones,DC=cloudshark-a,DC=example,DC=com] DefaultNamingContext:[DC=cloudshark-a,DC=example,DC=com] SchemaNamingContext:[CN=Schema,CN=Configuration,DC=cloudshark-a,DC=example,DC=com] ConfigurationNamingContext:[CN=Configuration,DC=cloudshark-a,DC=example,DC=com] RootDomainNamingContext:[DC=cloudshark-a,DC=example,DC=com] SupportedLDAPVersion:[3 2] HighestCommittedUSN:[16423] SupportedSASLMechanisms:[GSSAPI GSS-SPNEGO EXTERNAL DIGEST-MD5] DnsHostName:[AD1.cloudshark-a.example.com] LdapServiceName:[cloudshark-a.example.com:ad1$@CLOUDSHARK-A.EXAMPLE.COM] ServerName:[CN=AD1,CN=Servers,CN=Default-First-Site-Name,CN=Sites,CN=Configuration,DC=cloudshark-a,DC=example,DC=com] IsSynchronized:[TRUE] IsGlobalCatalogReady:[TRUE] DomainFunctionality:[2] ForestFunctionality:[2] DomainControllerFunctionality:[4] DistinguishedName:[] SAMAccountName:[] PWDLastSet:[] LastLogon:[] MemberOf:[] ServicePrincipalName:[] Extra:map[supportedCapabilities:[1.2.840.113556.1.4.800 1.2.840.113556.1.4.1670 1.2.840.113556.1.4.1791 1.2.840.113556.1.4.1935 1.2.840.113556.1.4.2080] supportedControl:[1.2.840.113556.1.4.319 1.2.840.113556.1.4.801 1.2.840.113556.1.4.473 1.2.840.113556.1.4.528 1.2.840.113556.1.4.417 1.2.840.113556.1.4.619 1.2.840.113556.1.4.841 1.2.840.113556.1.4.529 1.2.840.113556.1.4.805 1.2.840.113556.1.4.521 1.2.840.113556.1.4.970 1.2.840.113556.1.4.1338 1.2.840.113556.1.4.474 1.2.840.113556.1.4.1339 1.2.840.113556.1.4.1340 1.2.840.113556.1.4.1413 2.16.840.1.113730.3.4.9 2.16.840.1.113730.3.4.10 1.2.840.113556.1.4.1504 1.2.840.113556.1.4.1852 1.2.840.113556.1.4.802 1.2.840.113556.1.4.1907 1.2.840.113556.1.4.1948 1.2.840.113556.1.4.1974 1.2.840.113556.1.4.1341 1.2.840.113556.1.4.2026 1.2.840.113556.1.4.2064 1.2.840.113556.1.4.2065 1.2.840.113556.1.4.2066] supportedExtension:[1.3.6.1.4.1.1466.20037 1.3.6.1.4.1.1466.101.119.1 1.2.840.113556.1.4.1781 1.3.6.1.4.1.4203.1.11.3] supportedLDAPPolicies:[MaxPoolThreads MaxDatagramRecv MaxReceiveBuffer InitRecvTimeout MaxConnections MaxConnIdleTime MaxPageSize MaxQueryDuration MaxTempTableSize MaxResultSetSize MinResultSets MaxResultSetsPerConn MaxNotificationPerConn MaxValRange]]}}]"]
```

**Complete Info**
```json
{
  "Controls": [],
  "Entries": [
    {
      "Attributes": {
        "ConfigurationNamingContext": [
          "CN=Configuration,DC=cloudshark-a,DC=example,DC=com"
        ],
        "CurrentTime": [
          "Not Set"
        ],
        "DefaultNamingContext": [
          "DC=cloudshark-a,DC=example,DC=com"
        ],
        "DistinguishedName": [],
        "DnsHostName": [
          "AD1.cloudshark-a.example.com"
        ],
        "DomainControllerFunctionality": [
          "4"
        ],
        "DomainFunctionality": [
          "2"
        ],
        "DsServiceName": [
          "CN=NTDS Settings,CN=AD1,CN=Servers,CN=Default-First-Site-Name,CN=Sites,CN=Configuration,DC=cloudshark-a,DC=example,DC=com"
        ],
        "Extra": {
          "supportedCapabilities": [
            "1.2.840.113556.1.4.800",
            "1.2.840.113556.1.4.1670",
            "1.2.840.113556.1.4.1791",
            "1.2.840.113556.1.4.1935",
            "1.2.840.113556.1.4.2080"
          ],
          "supportedControl": [
            "1.2.840.113556.1.4.319",
            "1.2.840.113556.1.4.801",
            "1.2.840.113556.1.4.473",
            "1.2.840.113556.1.4.528",
            "1.2.840.113556.1.4.417",
            "1.2.840.113556.1.4.619",
            "1.2.840.113556.1.4.841",
            "1.2.840.113556.1.4.529",
            "1.2.840.113556.1.4.805",
            "1.2.840.113556.1.4.521",
            "1.2.840.113556.1.4.970",
            "1.2.840.113556.1.4.1338",
            "1.2.840.113556.1.4.474",
            "1.2.840.113556.1.4.1339",
            "1.2.840.113556.1.4.1340",
            "1.2.840.113556.1.4.1413",
            "2.16.840.1.113730.3.4.9",
            "2.16.840.1.113730.3.4.10",
            "1.2.840.113556.1.4.1504",
            "1.2.840.113556.1.4.1852",
            "1.2.840.113556.1.4.802",
            "1.2.840.113556.1.4.1907",
            "1.2.840.113556.1.4.1948",
            "1.2.840.113556.1.4.1974",
            "1.2.840.113556.1.4.1341",
            "1.2.840.113556.1.4.2026",
            "1.2.840.113556.1.4.2064",
            "1.2.840.113556.1.4.2065",
            "1.2.840.113556.1.4.2066"
          ],
          "supportedExtension": [
            "1.3.6.1.4.1.1466.20037",
            "1.3.6.1.4.1.1466.101.119.1",
            "1.2.840.113556.1.4.1781",
            "1.3.6.1.4.1.4203.1.11.3"
          ],
          "supportedLDAPPolicies": [
            "MaxPoolThreads",
            "MaxDatagramRecv",
            "MaxReceiveBuffer",
            "InitRecvTimeout",
            "MaxConnections",
            "MaxConnIdleTime",
            "MaxPageSize",
            "MaxQueryDuration",
            "MaxTempTableSize",
            "MaxResultSetSize",
            "MinResultSets",
            "MaxResultSetsPerConn",
            "MaxNotificationPerConn",
            "MaxValRange"
          ]
        },
        "ForestFunctionality": [
          "2"
        ],
        "HighestCommittedUSN": [
          "16423"
        ],
        "IsGlobalCatalogReady": [
          "TRUE"
        ],
        "IsSynchronized": [
          "TRUE"
        ],
        "LastLogon": [],
        "LdapServiceName": [
          "cloudshark-a.example.com:ad1$@CLOUDSHARK-A.EXAMPLE.COM"
        ],
        "MemberOf": [],
        "NamingContexts": [
          "DC=cloudshark-a,DC=example,DC=com",
          "CN=Configuration,DC=cloudshark-a,DC=example,DC=com",
          "CN=Schema,CN=Configuration,DC=cloudshark-a,DC=example,DC=com",
          "DC=DomainDnsZones,DC=cloudshark-a,DC=example,DC=com",
          "DC=ForestDnsZones,DC=cloudshark-a,DC=example,DC=com"
        ],
        "PWDLastSet": [],
        "RootDomainNamingContext": [
          "DC=cloudshark-a,DC=example,DC=com"
        ],
        "SAMAccountName": [],
        "SchemaNamingContext": [
          "CN=Schema,CN=Configuration,DC=cloudshark-a,DC=example,DC=com"
        ],
        "ServerName": [
          "CN=AD1,CN=Servers,CN=Default-First-Site-Name,CN=Sites,CN=Configuration,DC=cloudshark-a,DC=example,DC=com"
        ],
        "ServicePrincipalName": [],
        "SubschemaSubentry": [
          "CN=Aggregate,CN=Schema,CN=Configuration,DC=cloudshark-a,DC=example,DC=com"
        ],
        "SupportedLDAPVersion": [
          "3",
          "2"
        ],
        "SupportedSASLMechanisms": [
          "GSSAPI",
          "GSS-SPNEGO",
          "EXTERNAL",
          "DIGEST-MD5"
        ]
      },
      "DN": ""
    }
  ],
  "Referrals": []
}
```