### PR TITLE
include cname in http output if available

### DIFF
--- a/pkg/protocols/http/request.go
+++ b/pkg/protocols/http/request.go
@@ -844,6 +844,8 @@ func (request *Request) executeRequest(input *contextargs.Context, generatedRequ
 			outputEvent["ip"] = input.MetaInput.CustomIP
 		} else {
 			outputEvent["ip"] = protocolstate.Dialer.GetDialedIP(hostname)
+			// try getting cname
+			request.addCNameIfAvailable(hostname, outputEvent)
 		}
 
 		if len(generatedRequest.interactshURLs) > 0 {
@@ -940,6 +942,8 @@ func (request *Request) executeRequest(input *contextargs.Context, generatedRequ
 			outputEvent["ip"] = input.MetaInput.CustomIP
 		} else {
 			outputEvent["ip"] = protocolstate.Dialer.GetDialedIP(hostname)
+			// try getting cname
+			request.addCNameIfAvailable(hostname, outputEvent)
 		}
 		if request.options.Interactsh != nil {
 			request.options.Interactsh.MakePlaceholders(generatedRequest.interactshURLs, outputEvent)
@@ -1027,6 +1031,23 @@ func (request *Request) validateNFixEvent(input *contextargs.Context, gr *genera
 		}
 		if err != nil {
 			event.InternalEvent["error"] = err.Error()
+		}
+	}
+}
+
+// addCNameIfAvailable adds the cname to the event if available
+func (request *Request) addCNameIfAvailable(hostname string, outputEvent map[string]interface{}) {
+	data, err := protocolstate.Dialer.GetDNSData(hostname)
+	if err == nil {
+		switch len(data.CNAME) {
+		case 0:
+			return
+		case 1:
+			outputEvent["cname"] = data.CNAME[0]
+		default:
+			// add 1st and put others in cname_all
+			outputEvent["cname"] = data.CNAME[0]
+			outputEvent["cname_all"] = data.CNAME
 		}
 	}
 }


### PR DESCRIPTION
## Proposed Changes

- since dns data is cached in fastdialer on first dial , it is now included in http protocol variables when available thereby removing need of doing one more dns request using protocol

```console
$ ./nuclei -u https://support.hackerone.com -t a.yaml 

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.3.0-dev

		projectdiscovery.io

[INF] Current nuclei version: v3.3.0-dev (development)
[INF] Current nuclei-templates version: v9.9.0 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 164
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[basic-example:cname] [http] [info] https://support.hackerone.com ["2fe254e58a0ea8096400b2fda121ee35.freshdesk.com"]
[basic-example:cname_all] [http] [info] https://support.hackerone.com ["[2fe254e58a0ea8096400b2fda121ee35.freshdesk.com fwfd-use1-lb208.freshdesk.com]"]
```

```yaml
id: basic-example

info:
  name: Test HTTP Template
  author: pdteam
  severity: info

http:
  - method: GET
    path:
      - "{{BaseURL}}"

    extractors:
      - type: dsl
        name: cname
        dsl:
          - "cname"

      - type: dsl
        name: cname_all
        dsl:
          - "cname_all"
```