### PR TITLE
Add more support for `fs.FS` in the disk catalog

### DIFF
--- a/pkg/catalog/disk/find.go
+++ b/pkg/catalog/disk/find.go
@@ -218,10 +218,16 @@ func (c *DiskCatalog) findFileMatches(absPath string, processed map[string]struc
 	if c.templatesFS != nil {
 		absPath = strings.TrimPrefix(absPath, "/")
 	}
+
 	var info fs.File
 	if c.templatesFS == nil {
 		info, err = os.Open(absPath)
 	} else {
+		// If we were given no path, then it's not a file, it's the root, and we can quietly return.
+		if absPath == "" {
+			return "", false, nil
+		}
+
 		info, err = c.templatesFS.Open(absPath)
 	}
 	if err != nil {
@@ -263,6 +269,11 @@ func (c *DiskCatalog) findDirectoryMatches(absPath string, processed map[string]
 			},
 		)
 	} else {
+		// For the special case of the root directory, we need to pass "." to `fs.WalkDir`.
+		if absPath == "" {
+			absPath = "."
+		}
+
 		err = fs.WalkDir(
 			c.templatesFS,
 			absPath,

--- a/pkg/catalog/disk/find.go
+++ b/pkg/catalog/disk/find.go
@@ -218,7 +218,6 @@ func (c *DiskCatalog) findFileMatches(absPath string, processed map[string]struc
 	if c.templatesFS != nil {
 		absPath = strings.TrimPrefix(absPath, "/")
 	}
-
 	var info fs.File
 	if c.templatesFS == nil {
 		info, err = os.Open(absPath)

--- a/pkg/catalog/disk/find.go
+++ b/pkg/catalog/disk/find.go
@@ -217,6 +217,7 @@ func (c *DiskCatalog) findGlobPathMatches(absPath string, processed map[string]s
 func (c *DiskCatalog) findFileMatches(absPath string, processed map[string]struct{}) (match string, matched bool, err error) {
 	if c.templatesFS != nil {
 		absPath = strings.TrimPrefix(absPath, "/")
+		absPath = strings.TrimSuffix(absPath, "/")
 	}
 	var info fs.File
 	if c.templatesFS == nil {
@@ -272,6 +273,7 @@ func (c *DiskCatalog) findDirectoryMatches(absPath string, processed map[string]
 		if absPath == "" {
 			absPath = "."
 		}
+		absPath = strings.TrimSuffix(absPath, "/")
 
 		err = fs.WalkDir(
 			c.templatesFS,

--- a/pkg/catalog/disk/path.go
+++ b/pkg/catalog/disk/path.go
@@ -63,8 +63,7 @@ func (c *DiskCatalog) tryResolve(fullPath string) (string, error) {
 			return fullPath, nil
 		}
 	} else {
-		_, err := fs.Stat(c.templatesFS, fullPath)
-		if err == nil {
+		if _, err := fs.Stat(c.templatesFS, fullPath); err == nil {
 			return fullPath, nil
 		}
 	}

--- a/pkg/catalog/disk/path.go
+++ b/pkg/catalog/disk/path.go
@@ -67,11 +67,6 @@ func (c *DiskCatalog) tryResolve(fullPath string) (string, error) {
 		if err == nil {
 			return fullPath, nil
 		}
-		/*
-			if _, err := c.OpenFile(fullPath); err == nil {
-				return fullPath, nil
-			}
-		*/
 	}
 	return "", errNoValidCombination
 }

--- a/pkg/catalog/disk/path.go
+++ b/pkg/catalog/disk/path.go
@@ -2,6 +2,7 @@ package disk
 
 import (
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -21,6 +22,11 @@ func (c *DiskCatalog) ResolvePath(templateName, second string) (string, error) {
 	if filepath.IsAbs(templateName) {
 		return templateName, nil
 	}
+	if c.templatesFS != nil {
+		if potentialPath, err := c.tryResolve(templateName); err != errNoValidCombination {
+			return potentialPath, nil
+		}
+	}
 	if second != "" {
 		secondBasePath := filepath.Join(filepath.Dir(second), templateName)
 		if potentialPath, err := c.tryResolve(secondBasePath); err != errNoValidCombination {
@@ -28,17 +34,19 @@ func (c *DiskCatalog) ResolvePath(templateName, second string) (string, error) {
 		}
 	}
 
-	curDirectory, err := os.Getwd()
-	if err != nil {
-		return "", err
+	if c.templatesFS == nil {
+		curDirectory, err := os.Getwd()
+		if err != nil {
+			return "", err
+		}
+
+		templatePath := filepath.Join(curDirectory, templateName)
+		if potentialPath, err := c.tryResolve(templatePath); err != errNoValidCombination {
+			return potentialPath, nil
+		}
 	}
 
-	templatePath := filepath.Join(curDirectory, templateName)
-	if potentialPath, err := c.tryResolve(templatePath); err != errNoValidCombination {
-		return potentialPath, nil
-	}
-
-	templatePath = filepath.Join(config.DefaultConfig.GetTemplateDir(), templateName)
+	templatePath := filepath.Join(config.DefaultConfig.GetTemplateDir(), templateName)
 	if potentialPath, err := c.tryResolve(templatePath); err != errNoValidCombination {
 		return potentialPath, nil
 	}
@@ -50,8 +58,20 @@ var errNoValidCombination = errors.New("no valid combination found")
 
 // tryResolve attempts to load locate the target by iterating across all the folders tree
 func (c *DiskCatalog) tryResolve(fullPath string) (string, error) {
-	if fileutil.FileOrFolderExists(fullPath) {
-		return fullPath, nil
+	if c.templatesFS == nil {
+		if fileutil.FileOrFolderExists(fullPath) {
+			return fullPath, nil
+		}
+	} else {
+		_, err := fs.Stat(c.templatesFS, fullPath)
+		if err == nil {
+			return fullPath, nil
+		}
+		/*
+			if _, err := c.OpenFile(fullPath); err == nil {
+				return fullPath, nil
+			}
+		*/
 	}
 	return "", errNoValidCombination
 }

--- a/pkg/protocols/common/generators/validate.go
+++ b/pkg/protocols/common/generators/validate.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/config"
 	"github.com/projectdiscovery/nuclei/v3/pkg/types"
-	fileutil "github.com/projectdiscovery/utils/file"
 	folderutil "github.com/projectdiscovery/utils/folder"
 )
 
@@ -23,11 +22,11 @@ func (g *PayloadGenerator) validate(payloads map[string]interface{}, templatePat
 			}
 
 			// check if it's a file and try to load it
-			if fileutil.FileExists(payloadType) {
+			if _, err := g.catalog.OpenFile(payloadType); err == nil {
 				continue
 			}
 			// if file already exists in nuclei-templates directory, skip any further checks
-			if fileutil.FileExists(filepath.Join(config.DefaultConfig.GetTemplateDir(), payloadType)) {
+			if _, err := g.catalog.OpenFile(filepath.Join(config.DefaultConfig.GetTemplateDir(), payloadType)); err == nil {
 				continue
 			}
 
@@ -47,7 +46,7 @@ func (g *PayloadGenerator) validate(payloads map[string]interface{}, templatePat
 			payloadPathsToProbe, _ := templatePathInfo.MeshWith(payloadType)
 
 			for _, payloadPath := range payloadPathsToProbe {
-				if fileutil.FileExists(payloadPath) {
+				if _, err := g.catalog.OpenFile(payloadPath); err == nil {
 					payloads[name] = payloadPath
 					changed = true
 					break

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -539,7 +539,8 @@ func (options *Options) ParseHeadlessOptionalArguments() map[string]string {
 func (options *Options) LoadHelperFile(helperFile, templatePath string, catalog catalog.Catalog) (io.ReadCloser, error) {
 	if !options.AllowLocalFileAccess {
 		// if global file access is disabled try loading with restrictions
-		absPath, err := catalog.ResolvePath(helperFile, templatePath)
+		//absPath, err := options.GetValidAbsPath(helperFile, templatePath) // ORIGINAL
+		absPath, err := catalog.ResolvePath(helperFile, templatePath) // PROPOSED CHANGE (USE THE CATALOG)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"io"
-	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -540,13 +539,13 @@ func (options *Options) ParseHeadlessOptionalArguments() map[string]string {
 func (options *Options) LoadHelperFile(helperFile, templatePath string, catalog catalog.Catalog) (io.ReadCloser, error) {
 	if !options.AllowLocalFileAccess {
 		// if global file access is disabled try loading with restrictions
-		absPath, err := options.GetValidAbsPath(helperFile, templatePath)
+		absPath, err := catalog.ResolvePath(helperFile, templatePath)
 		if err != nil {
 			return nil, err
 		}
 		helperFile = absPath
 	}
-	f, err := os.Open(helperFile)
+	f, err := catalog.OpenFile(helperFile)
 	if err != nil {
 		return nil, errorutil.NewWithErr(err).Msgf("could not open file %v", helperFile)
 	}


### PR DESCRIPTION
## Proposed changes

This adds more support for `fs.FS` in the disk catalog.  This fixes some places where direct `os` file-related calls were being made to use the catalog interface instead.

Note that the JavaScript compiler *still* does not work in any context where the `pkg/js/libs/fs` package is used.  In particular, the `ReadFilesFromDir` function is hard-coded to use the `os` package and not respect the catalog.

A couple of unit tests are failing, and I'd like some help to understand what's going on with them.  So much of the code seems to be built around a strange history of path-tweaking, and it's not clear to me how to reconcile these legacy tweaks with the modern understanding of a disk catalog.

## Checklist
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)