### PR TITLE
feat(http): assign `customHeaders` to the map directly

### DIFF
--- a/pkg/protocols/http/request.go
+++ b/pkg/protocols/http/request.go
@@ -1083,10 +1083,15 @@ func (request *Request) setCustomHeaders(req *generatedRequest) {
 			req.rawRequest.Headers[k] = v
 		} else {
 			kk, vv := strings.TrimSpace(k), strings.TrimSpace(v)
-			req.request.Header.Set(kk, vv)
+			// NOTE(dwisiswant0): Do we really not need to convert it first into
+			// lowercase?
 			if kk == "Host" {
 				req.request.Host = vv
+
+				continue
 			}
+
+			req.request.Header[kk] = []string{vv}
 		}
 	}
 }


### PR DESCRIPTION
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->

Fix #5288.

[...] also add skip expr if header key is "Host".

### Proof

As [in the doc](https://pkg.go.dev/net/http#Header.Set), "[...] To use non-canonical keys, assign to the map directly".

**Template**:

```yaml
# headers-case-sensitive.yaml

id: test

info:
  name: test
  author: dwisiswant0
  severity: info
  description: test
  tags: test

http:
  - method: GET
    path:
      - "{{BaseURL}}/"
    headers:
      x-request-type: base
  - raw:
      - |
        GET / HTTP/1.1
        Host: {{Hostname}}
        x-request-type: raw

```

**Command**

```bash
go run cmd/nuclei/main.go -H "foo: bar" -H "lOrem: iPsum" -t headers-case-sensitive.yaml -u https://scanme.sh -debug-req
```

**Output**

Before:

```
[INF] [test] Dumped HTTP request for https://scanme.sh/

GET / HTTP/1.1
Host: scanme.sh
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.1.2 Mobile/15E148 Safari/604.1
Connection: close
Accept: */*
Accept-Language: en
Foo: bar
Lorem: iPsum
x-request-type: base
Accept-Encoding: gzip

[INF] [test] Dumped HTTP request for https://scanme.sh

GET / HTTP/1.1
Host: scanme.sh
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Safari/605.2.19
Connection: close
Foo: bar
Lorem: iPsum
x-request-type: raw
Accept-Encoding: gzip

[INF] No results found. Better luck next time!
```

After:

```
[INF] [test] Dumped HTTP request for https://scanme.sh/

GET / HTTP/1.1
Host: scanme.sh
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 14_3_1) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.3.1 Safari/605.1.15
Connection: close
Accept: */*
Accept-Language: en
foo: bar
lOrem: iPsum
x-request-type: base
Accept-Encoding: gzip

[INF] [test] Dumped HTTP request for https://scanme.sh

GET / HTTP/1.1
Host: scanme.sh
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 11_5_1) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.1 Safari/605.1.15
Connection: close
foo: bar
lOrem: iPsum
x-request-type: raw
Accept-Encoding: gzip

[INF] No results found. Better luck next time!
```

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)