### PR TITLE
fix(authx): avoid override secrets

### DIFF
--- a/pkg/authprovider/authx/basic_auth.go
+++ b/pkg/authprovider/authx/basic_auth.go
@@ -22,10 +22,18 @@ func NewBasicAuthStrategy(data *Secret) *BasicAuthStrategy {
 
 // Apply applies the basic auth strategy to the request
 func (s *BasicAuthStrategy) Apply(req *http.Request) {
-	req.SetBasicAuth(s.Data.Username, s.Data.Password)
+	if _, _, exists := req.BasicAuth(); !exists {
+		// NOTE(dwisiswant0): if the Basic auth is invalid, e.g. "Basic xyz",
+		// `exists` will be `false`. I'm not sure if we should check it through
+		// the presence of an "Authorization" header.
+		req.SetBasicAuth(s.Data.Username, s.Data.Password)
+	}
 }
 
 // ApplyOnRR applies the basic auth strategy to the retryable request
 func (s *BasicAuthStrategy) ApplyOnRR(req *retryablehttp.Request) {
-	req.SetBasicAuth(s.Data.Username, s.Data.Password)
+	if _, _, exists := req.BasicAuth(); !exists {
+		// NOTE(dwisiswant0): See line 26-28.
+		req.SetBasicAuth(s.Data.Username, s.Data.Password)
+	}
 }

--- a/pkg/authprovider/authx/bearer_auth.go
+++ b/pkg/authprovider/authx/bearer_auth.go
@@ -1,6 +1,8 @@
 package authx
 
 import (
+	"strings"
+
 	"net/http"
 
 	"github.com/projectdiscovery/retryablehttp-go"
@@ -22,10 +24,16 @@ func NewBearerTokenAuthStrategy(data *Secret) *BearerTokenAuthStrategy {
 
 // Apply applies the bearer token auth strategy to the request
 func (s *BearerTokenAuthStrategy) Apply(req *http.Request) {
-	req.Header.Set("Authorization", "Bearer "+s.Data.Token)
+	authHeader := req.Header.Get("Authorization")
+	if authHeader == "" || !strings.HasPrefix(authHeader, "Bearer") {
+		req.Header.Set("Authorization", "Bearer "+s.Data.Token)
+	}
 }
 
 // ApplyOnRR applies the bearer token auth strategy to the retryable request
 func (s *BearerTokenAuthStrategy) ApplyOnRR(req *retryablehttp.Request) {
-	req.Header.Set("Authorization", "Bearer "+s.Data.Token)
+	authHeader := req.Header.Get("Authorization")
+	if authHeader == "" || !strings.HasPrefix(authHeader, "Bearer") {
+		req.Header.Set("Authorization", "Bearer "+s.Data.Token)
+	}
 }

--- a/pkg/authprovider/authx/cookies_auth.go
+++ b/pkg/authprovider/authx/cookies_auth.go
@@ -23,21 +23,43 @@ func NewCookiesAuthStrategy(data *Secret) *CookiesAuthStrategy {
 // Apply applies the cookies auth strategy to the request
 func (s *CookiesAuthStrategy) Apply(req *http.Request) {
 	for _, cookie := range s.Data.Cookies {
-		c := &http.Cookie{
-			Name:  cookie.Key,
-			Value: cookie.Value,
+		exists := false
+
+		// check for existing cookies
+		for _, c := range req.Cookies() {
+			if c.Name == cookie.Key {
+				exists = true
+				break
+			}
 		}
-		req.AddCookie(c)
+
+		if !exists {
+			req.AddCookie(&http.Cookie{
+				Name:  cookie.Key,
+				Value: cookie.Value,
+			})
+		}
 	}
 }
 
 // ApplyOnRR applies the cookies auth strategy to the retryable request
 func (s *CookiesAuthStrategy) ApplyOnRR(req *retryablehttp.Request) {
 	for _, cookie := range s.Data.Cookies {
-		c := &http.Cookie{
-			Name:  cookie.Key,
-			Value: cookie.Value,
+		exists := false
+
+		// check for existing cookies
+		for _, c := range req.Cookies() {
+			if c.Name == cookie.Key {
+				exists = true
+				break
+			}
 		}
-		req.AddCookie(c)
+
+		if !exists {
+			req.AddCookie(&http.Cookie{
+				Name:  cookie.Key,
+				Value: cookie.Value,
+			})
+		}
 	}
 }

--- a/pkg/authprovider/authx/headers_auth.go
+++ b/pkg/authprovider/authx/headers_auth.go
@@ -23,8 +23,8 @@ func NewHeadersAuthStrategy(data *Secret) *HeadersAuthStrategy {
 // Apply applies the headers auth strategy to the request
 func (s *HeadersAuthStrategy) Apply(req *http.Request) {
 	for _, header := range s.Data.Headers {
-		if req.Header.Get(header.Key) == "" {
-			req.Header.Set(header.Key, header.Value)
+		if len(req.Header[header.Key]) < 1 {
+			req.Header[header.Key] = []string{header.Value}
 		}
 	}
 }
@@ -32,8 +32,8 @@ func (s *HeadersAuthStrategy) Apply(req *http.Request) {
 // ApplyOnRR applies the headers auth strategy to the retryable request
 func (s *HeadersAuthStrategy) ApplyOnRR(req *retryablehttp.Request) {
 	for _, header := range s.Data.Headers {
-		if req.Header.Get(header.Key) == "" {
-			req.Header.Set(header.Key, header.Value)
+		if len(req.Header[header.Key]) < 1 {
+			req.Header[header.Key] = []string{header.Value}
 		}
 	}
 }

--- a/pkg/authprovider/authx/headers_auth.go
+++ b/pkg/authprovider/authx/headers_auth.go
@@ -23,13 +23,17 @@ func NewHeadersAuthStrategy(data *Secret) *HeadersAuthStrategy {
 // Apply applies the headers auth strategy to the request
 func (s *HeadersAuthStrategy) Apply(req *http.Request) {
 	for _, header := range s.Data.Headers {
-		req.Header.Set(header.Key, header.Value)
+		if req.Header.Get(header.Key) == "" {
+			req.Header.Set(header.Key, header.Value)
+		}
 	}
 }
 
 // ApplyOnRR applies the headers auth strategy to the retryable request
 func (s *HeadersAuthStrategy) ApplyOnRR(req *retryablehttp.Request) {
 	for _, header := range s.Data.Headers {
-		req.Header.Set(header.Key, header.Value)
+		if req.Header.Get(header.Key) == "" {
+			req.Header.Set(header.Key, header.Value)
+		}
 	}
 }

--- a/pkg/authprovider/authx/query_auth.go
+++ b/pkg/authprovider/authx/query_auth.go
@@ -26,7 +26,9 @@ func (s *QueryAuthStrategy) Apply(req *http.Request) {
 	q := urlutil.NewOrderedParams()
 	q.Decode(req.URL.RawQuery)
 	for _, p := range s.Data.Params {
-		q.Add(p.Key, p.Value)
+		if q.Get(p.Key) == "" {
+			q.Add(p.Key, p.Value)
+		}
 	}
 	req.URL.RawQuery = q.Encode()
 }
@@ -36,7 +38,9 @@ func (s *QueryAuthStrategy) ApplyOnRR(req *retryablehttp.Request) {
 	q := urlutil.NewOrderedParams()
 	q.Decode(req.Request.URL.RawQuery)
 	for _, p := range s.Data.Params {
-		q.Add(p.Key, p.Value)
+		if q.Get(p.Key) == "" {
+			q.Add(p.Key, p.Value)
+		}
 	}
 	req.Request.URL.RawQuery = q.Encode()
 }


### PR DESCRIPTION
## Proposed changes

Avoid overriding secrets.

## Proof

**Template**:

```yaml
# secret-file-requests.yaml
id: secret-file-requests

info:
  name: secret-file-requests
  author: dwisiswant0
  severity: info
  description: secret-file-requests
  tags: test

http:
  - raw:
    - | # foo:default
      GET / HTTP/1.1
      Host: {{Hostname}}
      X-Secret-Type: basicauth
      Authorization: Basic Zm9vOmRlZmF1bHQK

    - |
      GET / HTTP/1.1
      Host: {{Hostname}}
      X-Secret-Type: bearertoken
      Authorization: Bearer default

    - |
      GET / HTTP/1.1
      Host: {{Hostname}}
      X-Secret-Type: cookie
      Cookie: foo=default

    - |
      GET /?foo=default HTTP/1.1
      Host: {{Hostname}}
      X-Secret-Type: query

    - |
      GET / HTTP/1.1
      Host: {{Hostname}}
      X-Secret-Type: header
      foo: default
```

**Secret File content**:

```yaml
# secret-file.yaml
static:
  - type: basicauth
    domains:
      - basicauth.oast.fun
    username: foo
    password: OVERRIDEN

  - type: bearertoken
    domains:
      - bearertoken.oast.fun
    token: OVERRIDEN

  - type: cookie
    domains:
      - cookie.oast.fun
    cookies:
      - key: foo
        value: OVERRIDEN
        # raw: "foo=OVERRIDEN"

  - type: query
    domains:
      - query.oast.fun
    params:
      - key: foo
        value: OVERRIDEN

  - type: header
    domains:
      - header.oast.fun
    headers:
      - key: foo
        value: OVERRIDEN
```

**Command**:

```
go run cmd/nuclei/main.go -duc -debug-req -sf secret-file.yaml -t secret-file-requests.yaml -u https://{basicauth,bearertoken,query,header,cookie}.oast.fun
```

> [!NOTE]
> If you spot an OVERRIDEN value in the dumped HTTP request, it means that a hardcoded secret value has been overridden or replaced from the Secret File.

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)