### PR TITLE
redact output

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ OUTPUT:
    -se, -sarif-export string     file to export results in SARIF format
    -je, -json-export string      file to export results in JSON format
    -jle, -jsonl-export string    file to export results in JSONL(ine) format
+   -rd, -redact string[]         redact given list of keys from query parameter, request header and body
 
 CONFIGURATIONS:
    -config string                        path to the nuclei configuration file

--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -272,6 +272,7 @@ on extensive configurability, massive extensibility and ease of use.`)
 		flagSet.StringVarP(&options.SarifExport, "sarif-export", "se", "", "file to export results in SARIF format"),
 		flagSet.StringVarP(&options.JSONExport, "json-export", "je", "", "file to export results in JSON format"),
 		flagSet.StringVarP(&options.JSONLExport, "jsonl-export", "jle", "", "file to export results in JSONL(ine) format"),
+		flagSet.StringSliceVarP(&options.Redact, "redact", "rd", nil, "redact given list of keys from query parameter, request header and body", goflags.CommaSeparatedStringSliceOptions),
 	)
 
 	flagSet.CreateGroup("configs", "Configurations",

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -270,6 +270,7 @@ func (w *StandardWriter) Write(event *ResultEvent) error {
 		event.Request = redactKeys(event.Request, w.KeysToRedact)
 		event.Response = redactKeys(event.Response, w.KeysToRedact)
 		event.CURLCommand = redactKeys(event.CURLCommand, w.KeysToRedact)
+		event.Matched = redactKeys(event.Matched, w.KeysToRedact)
 	}
 
 	event.Timestamp = time.Now()

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -312,7 +312,7 @@ func (w *StandardWriter) Write(event *ResultEvent) error {
 
 func redactKeys(data string, keysToRedact []string) string {
 	for _, key := range keysToRedact {
-		keyPattern := regexp.MustCompile(`(?i)(` + regexp.QuoteMeta(key) + `\s*[:=]\s*["']?)[^"'\r\n\s&]+(["']?)`)
+		keyPattern := regexp.MustCompile(fmt.Sprintf(`(?i)(%s\s*[:=]\s*["']?)[^"'\r\n&]+(["'\r\n]?)`, regexp.QuoteMeta(key)))
 		data = keyPattern.ReplaceAllString(data, `$1***$2`)
 	}
 	return data

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -220,6 +220,8 @@ type Options struct {
 	JSONExport string
 	// JSONLExport is the file to export JSONL output format to
 	JSONLExport string
+	// Redact redacts given keys in
+	Redact goflags.StringSlice
 	// EnableProgressBar enables progress bar
 	EnableProgressBar bool
 	// TemplateDisplay displays the template contents


### PR DESCRIPTION
## Proposed changes

Closes #1586

example output when using `-redact`
```console
nuclei -tags cve -u honey.scanme.sh -header "X-API-Key: XXX" -redact x-api-key,cookie -j
```

```diff
{
  "template": "http/cves/2015/CVE-2015-6477.yaml",
  "template-url": "https://cloud.projectdiscovery.io/public/CVE-2015-6477",
  "template-id": "CVE-2015-6477",
  "template-path": "/Users/dogancanbakir/nuclei-templates/http/cves/2015/CVE-2015-6477.yaml",
  "template-encoded": "aWQ6IENWRS0yMDE1LTY0NzcKCmluZm86CiAgbmFtZTogTm9yZGV4IE5DMiAgLSBDcm9zcy1TaXRlIFNjcmlwdGluZwogIGF1dGhvcjogZ2Vla25pawogIHNldmVyaXR5OiBtZWRpdW0KICBkZXNjcmlwdGlvbjogTm9yZGV4IE5DMiBjb250YWlucyBhIGNyb3NzLXNpdGUgc2NyaXB0aW5nIHZ1bG5lcmFiaWxpdHkgd2hpY2ggYWxsb3dzIGFuIGF0dGFja2VyIHRvIGV4ZWN1dGUgYXJiaXRyYXJ5IHNjcmlwdCBjb2RlIGluIHRoZSBicm93c2VyIG9mIGFuIHVuc3VzcGVjdGluZyB1c2VyIGluIHRoZSBjb250ZXh0IG9mIHRoZSBhZmZlY3RlZCBzaXRlLiBUaGlzIGNhbiBhbGxvdyB0aGUgYXR0YWNrZXIgdG8gc3RlYWwgY29va2llLWJhc2VkIGF1dGhlbnRpY2F0aW9uIGNyZWRlbnRpYWxzIGFuZCBsYXVuY2ggb3RoZXIgYXR0YWNrcy4KICBpbXBhY3Q6IHwKICAgIFN1Y2Nlc3NmdWwgZXhwbG9pdGF0aW9uIG9mIHRoaXMgdnVsbmVyYWJpbGl0eSBjb3VsZCBhbGxvdyBhbiBhdHRhY2tlciB0byBleGVjdXRlIG1hbGljaW91cyBzY3JpcHRzIGluIHRoZSBjb250ZXh0IG9mIHRoZSB2aWN0aW0ncyBicm93c2VyLCBwb3RlbnRpYWxseSBsZWFkaW5nIHRvIHNlc3Npb24gaGlqYWNraW5nLCBkZWZhY2VtZW50LCBvciB0aGVmdCBvZiBzZW5zaXRpdmUgaW5mb3JtYXRpb24uCiAgcmVtZWRpYXRpb246IHwKICAgIFVwZ3JhZGUgdG8gdGhlIGxhdGVzdCB2ZXJzaW9uIHRvIG1pdGlnYXRlIHRoaXMgdnVsbmVyYWJpbGl0eS4KICByZWZlcmVuY2U6CiAgICAtIGh0dHBzOi8vc2VjbGlzdHMub3JnL2Z1bGxkaXNjbG9zdXJlLzIwMTUvRGVjLzExNwogICAgLSBodHRwczovL2ljcy1jZXJ0LnVzLWNlcnQuZ292L2Fkdmlzb3JpZXMvSUNTQS0xNS0yODYtMDEKICAgIC0gaHR0cHM6Ly9udmQubmlzdC5nb3YvdnVsbi9kZXRhaWwvQ1ZFLTIwMTUtNjQ3NwogICAgLSBodHRwOi8vcGFja2V0c3Rvcm1zZWN1cml0eS5jb20vZmlsZXMvMTM1MDY4L05vcmRleC1Db250cm9sLTItTkMyLVNDQURBLTE2LUNyb3NzLVNpdGUtU2NyaXB0aW5nLmh0bWwKICAgIC0gaHR0cDovL3NlY2xpc3RzLm9yZy9mdWxsZGlzY2xvc3VyZS8yMDE1L0RlYy8xMTcKICBjbGFzc2lmaWNhdGlvbjoKICAgIGN2c3MtbWV0cmljczogQ1ZTUzoyLjAvQVY6Ti9BQzpNL0F1Ok4vQzpOL0k6UC9BOk4KICAgIGN2c3Mtc2NvcmU6IDQuMwogICAgY3ZlLWlkOiBDVkUtMjAxNS02NDc3CiAgICBjd2UtaWQ6IENXRS03OQogICAgZXBzcy1zY29yZTogMC4wMDI3NwogICAgZXBzcy1wZXJjZW50aWxlOiAwLjY0OTU0CiAgICBjcGU6IGNwZToyLjM6bzpub3JkZXg6bm9yZGV4X2NvbnRyb2xfMl9zY2FkYToqOio6KjoqOio6KjoqOioKICBtZXRhZGF0YToKICAgIG1heC1yZXF1ZXN0OiAxCiAgICB2ZW5kb3I6IG5vcmRleAogICAgcHJvZHVjdDogbm9yZGV4X2NvbnRyb2xfMl9zY2FkYQogIHRhZ3M6IGN2ZTIwMTUsY3ZlLHNlY2xpc3RzLHBhY2tldHN0b3JtLHhzcyxpb3Qsbm9yZGV4LG5jMgoKaHR0cDoKICAtIG1ldGhvZDogUE9TVAogICAgcGF0aDoKICAgICAgLSAie3tCYXNlVVJMfX0vbG9naW4iCgogICAgYm9keTogJ2Nvbm5lY3Rpb249YmFzaWMmdXNlck5hbWU9YWRtaW4lMjclMjIlMjklM0IlN0QlM0MlMkZzY3JpcHQlM0UlM0NzY3JpcHQlM0VhbGVydCUyOCUyNzJqdllVSlcyaUE5QWU4R2NVNDVUcXFlRGs4UiUyNyUyOSUzQyUyRnNjcmlwdCUzRSZwdz1ub3JkZXgmbGFuZ3VhZ2U9ZW4nCgogICAgbWF0Y2hlcnMtY29uZGl0aW9uOiBhbmQKICAgIG1hdGNoZXJzOgogICAgICAtIHR5cGU6IHdvcmQKICAgICAgICBwYXJ0OiBoZWFkZXIKICAgICAgICB3b3JkczoKICAgICAgICAgIC0gInRleHQvaHRtbCIKCiAgICAgIC0gdHlwZTogd29yZAogICAgICAgIHBhcnQ6IGJvZHkKICAgICAgICB3b3JkczoKICAgICAgICAgIC0gIjwvc2NyaXB0PjxzY3JpcHQ+YWxlcnQoJzJqdllVSlcyaUE5QWU4R2NVNDVUcXFlRGs4UicpPC9zY3JpcHQ+IgojIGRpZ2VzdDogNGEwYTAwNDczMDQ1MDIyMTAwZjE3MmU2YThiMDQ1NzQ2NzA0OTFlNzllNzlhMmM5MzU0ZWIzM2U3ZWZkY2QxNWUwNGVlNzdkOTVjMGQwNjVlNjAyMjA3ZTM1MWY0Yjg5ODYwMTA1MWU3Y2MzYTM4MWYzYTcxYWU3MWNmZDQ0OTk2OGJjMmQzODA4Y2I5MGZjNDRiNDlmOjkyMmM2NDU5MDIyMjc5OGJiNzYxZDViNmQ4ZTcyOTUw",
  "info": {
    "name": "Nordex NC2  - Cross-Site Scripting",
    "author": ["geeknik"],
    "tags": [
      "cve2015",
      "cve",
      "seclists",
      "packetstorm",
      "xss",
      "iot",
      "nordex",
      "nc2"
    ],
    "description": "Nordex NC2 contains a cross-site scripting vulnerability which allows an attacker to execute arbitrary script code in the browser of an unsuspecting user in the context of the affected site. This can allow the attacker to steal cookie-based authentication credentials and launch other attacks.",
    "impact": "Successful exploitation of this vulnerability could allow an attacker to execute malicious scripts in the context of the victim's browser, potentially leading to session hijacking, defacement, or theft of sensitive information.\n",
    "reference": [
      "https://seclists.org/fulldisclosure/2015/Dec/117",
      "https://ics-cert.us-cert.gov/advisories/ICSA-15-286-01",
      "https://nvd.nist.gov/vuln/detail/CVE-2015-6477",
      "http://packetstormsecurity.com/files/135068/Nordex-Control-2-NC2-SCADA-16-Cross-Site-Scripting.html",
      "http://seclists.org/fulldisclosure/2015/Dec/117"
    ],
    "severity": "medium",
    "metadata": {
      "vendor": "nordex",
      "product": "nordex_control_2_scada",
      "max-request": 1
    },
    "classification": {
      "cve-id": ["cve-2015-6477"],
      "cwe-id": ["cwe-79"],
      "cvss-metrics": "CVSS:2.0/AV:N/AC:M/Au:N/C:N/I:P/A:N",
      "cvss-score": 4.3,
      "epss-score": 0.00277,
      "epss-percentile": 0.64954,
      "cpe": "cpe:2.3:o:nordex:nordex_control_2_scada:*:*:*:*:*:*:*:*"
    },
    "remediation": "Upgrade to the latest version to mitigate this vulnerability.\n"
  },
  "type": "http",
  "host": "honey.scanme.sh",
  "port": "443",
  "scheme": "https",
  "url": "https://honey.scanme.sh",
  "matched-at": "https://honey.scanme.sh/login",
- "request": "POST /login HTTP/1.1\r\nHost: honey.scanme.sh\r\nUser-Agent: Mozilla/5.0 (Knoppix; Linux i686) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36\r\nConnection: close\r\nContent-Length: 154\r\nAccept: */*\r\nAccept-Language: en\r\nX-API-Key: XXX\r\nAccept-Encoding: gzip\r\n\r\nconnection=basic\u0026userName=admin%27%22%29%3B%7D%3C%2Fscript%3E%3Cscript%3Ealert%28%272jvYUJW2iA9Ae8GcU45TqqeDk8R%27%29%3C%2Fscript%3E\u0026pw=nordex\u0026language=en",
+ "request": "POST /login HTTP/1.1\r\nHost: honey.scanme.sh\r\nUser-Agent: Mozilla/5.0 (Knoppix; Linux i686) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36\r\nConnection: close\r\nContent-Length: 154\r\nAccept: */*\r\nAccept-Language: en\r\nX-API-Key: ***\r\nAccept-Encoding: gzip\r\n\r\nconnection=basic\u0026userName=admin%27%22%29%3B%7D%3C%2Fscript%3E%3Cscript%3Ealert%28%272jvYUJW2iA9Ae8GcU45TqqeDk8R%27%29%3C%2Fscript%3E\u0026pw=nordex\u0026language=en",
- "response": "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 397\r\nContent-Type: text/html\r\nDate: Mon, 29 Jul 2024 16:03:53 GMT\r\n\r\nPOST /login HTTP/1.1\r\nHost: honey.scanme.sh\r\nAccept: */*\r\nAccept-Encoding: gzip\r\nAccept-Language: en\r\nConnection: close\r\nContent-Length: 154\r\nUser-Agent: Mozilla/5.0 (Knoppix; Linux i686) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36\r\nX-Api-Key: XXXr\n\r\nconnection=basic\u0026userName=admin'\");}\u003c/script\u003e\u003cscript\u003ealert('2jvYUJW2iA9Ae8GcU45TqqeDk8R')\u003c/script\u003e\u0026pw=nordex\u0026language=en",
+ "response": "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 397\r\nContent-Type: text/html\r\nDate: Mon, 29 Jul 2024 16:03:53 GMT\r\n\r\nPOST /login HTTP/1.1\r\nHost: honey.scanme.sh\r\nAccept: */*\r\nAccept-Encoding: gzip\r\nAccept-Language: en\r\nConnection: close\r\nContent-Length: 154\r\nUser-Agent: Mozilla/5.0 (Knoppix; Linux i686) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36\r\nX-Api-Key: ***\r\n\r\nconnection=basic\u0026userName=admin'\");}\u003c/script\u003e\u003cscript\u003ealert('2jvYUJW2iA9Ae8GcU45TqqeDk8R')\u003c/script\u003e\u0026pw=nordex\u0026language=en",
  "ip": "67.205.158.113",
  "timestamp": "2024-07-29T19:03:53.901354+03:00",
- "curl-command": "curl -X 'POST' -d 'connection=basic\u0026userName=admin%27%22%29%3B%7D%3C%2Fscript%3E%3Cscript%3Ealert%28%272jvYUJW2iA9Ae8GcU45TqqeDk8R%27%29%3C%2Fscript%3E\u0026pw=nordex\u0026language=en' -H 'Accept: */*' -H 'Accept-Language: en' -H 'User-Agent: Mozilla/5.0 (Knoppix; Linux i686) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36' -H 'X-API-Key: XXX' 'https://honey.scanme.sh/login'",
+ "curl-command": "curl -X 'POST' -d 'connection=basic\u0026userName=admin%27%22%29%3B%7D%3C%2Fscript%3E%3Cscript%3Ealert%28%272jvYUJW2iA9Ae8GcU45TqqeDk8R%27%29%3C%2Fscript%3E\u0026pw=nordex\u0026language=en' -H 'Accept: */*' -H 'Accept-Language: en' -H 'User-Agent: Mozilla/5.0 (Knoppix; Linux i686) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36' -H 'X-API-Key: ***' 'https://honey.scanme.sh/login'",
  "matcher-status": true
}
```


## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)