### PR TITLE
fix: FileAuthProvider stores the same strategy for each entry

### DIFF
--- a/pkg/authprovider/file.go
+++ b/pkg/authprovider/file.go
@@ -51,7 +51,8 @@ func NewFileAuthProvider(path string, callback authx.LazyFetchSecret) (AuthProvi
 
 // init initializes the file auth provider
 func (f *FileAuthProvider) init() {
-	for _, secret := range f.store.Secrets {
+	for _, _secret := range f.store.Secrets {
+		secret := _secret // allocate copy of pointer
 		if len(secret.DomainsRegex) > 0 {
 			for _, domain := range secret.DomainsRegex {
 				if f.compiled == nil {


### PR DESCRIPTION
## Proposed changes
This commit fixes a bug in the FileAuthProvider class when there are multiple secret entries. Currently the same pointer is used for creating the authentication strategy and thus a single credential (that was loaded last) will be tried for each domain.

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [X] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [X] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)