### PR TITLE
Fixing the server URL path for OpenAPI scanning

### DIFF
--- a/pkg/input/formats/openapi/generator.go
+++ b/pkg/input/formats/openapi/generator.go
@@ -251,7 +251,6 @@ func generateRequestsFromOp(opts *generateReqOptions) error {
 		}
 	}
 	req.URL.RawQuery = query.Encode()
-	req.URL.Path = opts.requestPath
 
 	if opts.op.RequestBody != nil {
 		for content, value := range opts.op.RequestBody.Value.Content {

--- a/pkg/input/formats/swagger/swagger_test.go
+++ b/pkg/input/formats/swagger/swagger_test.go
@@ -27,8 +27,8 @@ func TestSwaggerAPIParser(t *testing.T) {
 	}
 
 	expectedURLs := []string{
-		"https://localhost/users",
-		"https://localhost/users/1?test=asc",
+		"https://localhost/v1/users",
+		"https://localhost/v1/users/1?test=asc",
 	}
 	require.ElementsMatch(t, gotMethodsToURLs, expectedURLs, "could not get swagger urls")
 }


### PR DESCRIPTION
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->
Issue #5503

I discovered in the debug mode of VS Code that a command in the generator.go file of nuclei incorrectly changes the path, resulting in wrong HTTP requests.

Before the command in line 254 :
![image](https://github.com/user-attachments/assets/3dd06bdc-dad5-423f-9a6f-2706ca4c72e4)
After the command in line 254:
![image](https://github.com/user-attachments/assets/c890c9ff-a31e-4b95-afaf-974c2ab0f2f6)

Result after the solution:
![image](https://github.com/user-attachments/assets/5688db4a-faba-4776-bfc0-14ff6f87d23e)



## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)