### PR TITLE
feat(headless): add action wait dialog type

### DIFF
--- a/pkg/protocols/headless/engine/action_types.go
+++ b/pkg/protocols/headless/engine/action_types.go
@@ -11,6 +11,9 @@ import (
 // ActionType defines the action type for a browser action
 type ActionType int8
 
+// ActionData stores the action output data
+type ActionData map[string]any
+
 // Types to be executed by the user.
 // name:ActionType
 const (

--- a/pkg/protocols/headless/engine/action_types.go
+++ b/pkg/protocols/headless/engine/action_types.go
@@ -71,9 +71,9 @@ const (
 	// ActionWaitEvent waits for a specific event.
 	// name:waitevent
 	ActionWaitEvent
-	// ActionDialog handles JavaScript dialog (alert, confirm, prompt, or onbeforeunload).
+	// ActionWaitDialog waits for JavaScript dialog (alert, confirm, prompt, or onbeforeunload).
 	// name:dialog
-	ActionDialog
+	ActionWaitDialog
 	// ActionKeyboard performs a keyboard action event on a page.
 	// name:keyboard
 	ActionKeyboard
@@ -110,7 +110,7 @@ var ActionStringToAction = map[string]ActionType{
 	"deleteheader": ActionDeleteHeader,
 	"setbody":      ActionSetBody,
 	"waitevent":    ActionWaitEvent,
-	"dialog":       ActionDialog,
+	"waitdialog":   ActionWaitDialog,
 	"keyboard":     ActionKeyboard,
 	"debug":        ActionDebug,
 	"sleep":        ActionSleep,
@@ -137,7 +137,7 @@ var ActionToActionString = map[ActionType]string{
 	ActionDeleteHeader: "deleteheader",
 	ActionSetBody:      "setbody",
 	ActionWaitEvent:    "waitevent",
-	ActionDialog:       "dialog",
+	ActionWaitDialog:   "waitdialog",
 	ActionKeyboard:     "keyboard",
 	ActionDebug:        "debug",
 	ActionSleep:        "sleep",

--- a/pkg/protocols/headless/engine/action_types.go
+++ b/pkg/protocols/headless/engine/action_types.go
@@ -68,6 +68,9 @@ const (
 	// ActionWaitEvent waits for a specific event.
 	// name:waitevent
 	ActionWaitEvent
+	// ActionDialog handles JavaScript dialog (alert, confirm, prompt, or onbeforeunload).
+	// name:dialog
+	ActionDialog
 	// ActionKeyboard performs a keyboard action event on a page.
 	// name:keyboard
 	ActionKeyboard
@@ -104,6 +107,7 @@ var ActionStringToAction = map[string]ActionType{
 	"deleteheader": ActionDeleteHeader,
 	"setbody":      ActionSetBody,
 	"waitevent":    ActionWaitEvent,
+	"dialog":       ActionDialog,
 	"keyboard":     ActionKeyboard,
 	"debug":        ActionDebug,
 	"sleep":        ActionSleep,
@@ -130,6 +134,7 @@ var ActionToActionString = map[ActionType]string{
 	ActionDeleteHeader: "deleteheader",
 	ActionSetBody:      "setbody",
 	ActionWaitEvent:    "waitevent",
+	ActionDialog:       "dialog",
 	ActionKeyboard:     "keyboard",
 	ActionDebug:        "debug",
 	ActionSleep:        "sleep",

--- a/pkg/protocols/headless/engine/page.go
+++ b/pkg/protocols/headless/engine/page.go
@@ -45,7 +45,7 @@ type Options struct {
 }
 
 // Run runs a list of actions by creating a new page in the browser.
-func (i *Instance) Run(input *contextargs.Context, actions []*Action, payloads map[string]interface{}, options *Options) (map[string]string, *Page, error) {
+func (i *Instance) Run(input *contextargs.Context, actions []*Action, payloads map[string]interface{}, options *Options) (ActionData, *Page, error) {
 	page, err := i.engine.Page(proto.TargetCreateTarget{})
 	if err != nil {
 		return nil, nil, err

--- a/pkg/protocols/headless/engine/page_actions.go
+++ b/pkg/protocols/headless/engine/page_actions.go
@@ -47,8 +47,8 @@ const (
 )
 
 // ExecuteActions executes a list of actions on a page.
-func (p *Page) ExecuteActions(input *contextargs.Context, actions []*Action, variables map[string]interface{}) (outData map[string]string, err error) {
-	outData = make(map[string]string)
+func (p *Page) ExecuteActions(input *contextargs.Context, actions []*Action, variables map[string]interface{}) (outData ActionData, err error) {
+	outData = make(ActionData)
 	// waitFuncs are function that needs to be executed after navigation
 	// typically used for waitEvent
 	waitFuncs := make([]func() error, 0)
@@ -144,7 +144,7 @@ type rule struct {
 }
 
 // WaitVisible waits until an element appears.
-func (p *Page) WaitVisible(act *Action, out map[string]string) error {
+func (p *Page) WaitVisible(act *Action, out ActionData) error {
 	timeout, err := getTimeout(p, act)
 	if err != nil {
 		return errors.Wrap(err, "Wrong timeout given")
@@ -219,7 +219,7 @@ func geTimeParameter(p *Page, act *Action, parameterName string, defaultValue ti
 }
 
 // ActionAddHeader executes a AddHeader action.
-func (p *Page) ActionAddHeader(act *Action, out map[string]string) error {
+func (p *Page) ActionAddHeader(act *Action, out ActionData) error {
 	in := p.getActionArgWithDefaultValues(act, "part")
 
 	args := make(map[string]string)
@@ -230,7 +230,7 @@ func (p *Page) ActionAddHeader(act *Action, out map[string]string) error {
 }
 
 // ActionSetHeader executes a SetHeader action.
-func (p *Page) ActionSetHeader(act *Action, out map[string]string) error {
+func (p *Page) ActionSetHeader(act *Action, out ActionData) error {
 	in := p.getActionArgWithDefaultValues(act, "part")
 
 	args := make(map[string]string)
@@ -241,7 +241,7 @@ func (p *Page) ActionSetHeader(act *Action, out map[string]string) error {
 }
 
 // ActionDeleteHeader executes a DeleteHeader action.
-func (p *Page) ActionDeleteHeader(act *Action, out map[string]string) error {
+func (p *Page) ActionDeleteHeader(act *Action, out ActionData) error {
 	in := p.getActionArgWithDefaultValues(act, "part")
 
 	args := make(map[string]string)
@@ -251,7 +251,7 @@ func (p *Page) ActionDeleteHeader(act *Action, out map[string]string) error {
 }
 
 // ActionSetBody executes a SetBody action.
-func (p *Page) ActionSetBody(act *Action, out map[string]string) error {
+func (p *Page) ActionSetBody(act *Action, out ActionData) error {
 	in := p.getActionArgWithDefaultValues(act, "part")
 
 	args := make(map[string]string)
@@ -261,7 +261,7 @@ func (p *Page) ActionSetBody(act *Action, out map[string]string) error {
 }
 
 // ActionSetMethod executes an SetMethod action.
-func (p *Page) ActionSetMethod(act *Action, out map[string]string) error {
+func (p *Page) ActionSetMethod(act *Action, out ActionData) error {
 	in := p.getActionArgWithDefaultValues(act, "part")
 
 	args := make(map[string]string)
@@ -271,7 +271,7 @@ func (p *Page) ActionSetMethod(act *Action, out map[string]string) error {
 }
 
 // NavigateURL executes an ActionLoadURL actions loading a URL for the page.
-func (p *Page) NavigateURL(action *Action, out map[string]string, allvars map[string]interface{}) error {
+func (p *Page) NavigateURL(action *Action, out ActionData, allvars map[string]interface{}) error {
 	// input <- is input url from cli
 	// target <- is the url from template (ex: {{BaseURL}}/test)
 	input, err := urlutil.Parse(p.input.MetaInput.Input)
@@ -327,7 +327,7 @@ func (p *Page) NavigateURL(action *Action, out map[string]string, allvars map[st
 }
 
 // RunScript runs a script on the loaded page
-func (p *Page) RunScript(action *Action, out map[string]string) error {
+func (p *Page) RunScript(action *Action, out ActionData) error {
 	code := p.getActionArgWithDefaultValues(action, "code")
 	if code == "" {
 		return errinvalidArguments
@@ -348,7 +348,7 @@ func (p *Page) RunScript(action *Action, out map[string]string) error {
 }
 
 // ClickElement executes click actions for an element.
-func (p *Page) ClickElement(act *Action, out map[string]string) error {
+func (p *Page) ClickElement(act *Action, out ActionData) error {
 	element, err := p.pageElementBy(act.Data)
 	if err != nil {
 		return errors.Wrap(err, errCouldNotGetElement)
@@ -363,12 +363,12 @@ func (p *Page) ClickElement(act *Action, out map[string]string) error {
 }
 
 // KeyboardAction executes a keyboard action on the page.
-func (p *Page) KeyboardAction(act *Action, out map[string]string) error {
+func (p *Page) KeyboardAction(act *Action, out ActionData) error {
 	return p.page.Keyboard.Type([]input.Key(p.getActionArgWithDefaultValues(act, "keys"))...)
 }
 
 // RightClickElement executes right click actions for an element.
-func (p *Page) RightClickElement(act *Action, out map[string]string) error {
+func (p *Page) RightClickElement(act *Action, out ActionData) error {
 	element, err := p.pageElementBy(act.Data)
 	if err != nil {
 		return errors.Wrap(err, errCouldNotGetElement)
@@ -383,7 +383,7 @@ func (p *Page) RightClickElement(act *Action, out map[string]string) error {
 }
 
 // Screenshot executes screenshot action on a page
-func (p *Page) Screenshot(act *Action, out map[string]string) error {
+func (p *Page) Screenshot(act *Action, out ActionData) error {
 	to := p.getActionArgWithDefaultValues(act, "to")
 	if to == "" {
 		to = ksuid.New().String()
@@ -446,7 +446,7 @@ func (p *Page) Screenshot(act *Action, out map[string]string) error {
 }
 
 // InputElement executes input element actions for an element.
-func (p *Page) InputElement(act *Action, out map[string]string) error {
+func (p *Page) InputElement(act *Action, out ActionData) error {
 	value := p.getActionArgWithDefaultValues(act, "value")
 	if value == "" {
 		return errinvalidArguments
@@ -465,7 +465,7 @@ func (p *Page) InputElement(act *Action, out map[string]string) error {
 }
 
 // TimeInputElement executes time input on an element
-func (p *Page) TimeInputElement(act *Action, out map[string]string) error {
+func (p *Page) TimeInputElement(act *Action, out ActionData) error {
 	value := p.getActionArgWithDefaultValues(act, "value")
 	if value == "" {
 		return errinvalidArguments
@@ -488,7 +488,7 @@ func (p *Page) TimeInputElement(act *Action, out map[string]string) error {
 }
 
 // SelectInputElement executes select input statement action on a element
-func (p *Page) SelectInputElement(act *Action, out map[string]string) error {
+func (p *Page) SelectInputElement(act *Action, out ActionData) error {
 	value := p.getActionArgWithDefaultValues(act, "value")
 	if value == "" {
 		return errinvalidArguments
@@ -513,7 +513,7 @@ func (p *Page) SelectInputElement(act *Action, out map[string]string) error {
 }
 
 // WaitLoad waits for the page to load
-func (p *Page) WaitLoad(act *Action, out map[string]string) error {
+func (p *Page) WaitLoad(act *Action, out ActionData) error {
 	p.page.Timeout(2 * time.Second).WaitNavigation(proto.PageLifecycleEventNameFirstMeaningfulPaint)()
 
 	// Wait for the window.onload event and also wait for the network requests
@@ -527,7 +527,7 @@ func (p *Page) WaitLoad(act *Action, out map[string]string) error {
 }
 
 // GetResource gets a resource from an element from page.
-func (p *Page) GetResource(act *Action, out map[string]string) error {
+func (p *Page) GetResource(act *Action, out ActionData) error {
 	element, err := p.pageElementBy(act.Data)
 	if err != nil {
 		return errors.Wrap(err, errCouldNotGetElement)
@@ -543,7 +543,7 @@ func (p *Page) GetResource(act *Action, out map[string]string) error {
 }
 
 // FilesInput acts with a file input element on page
-func (p *Page) FilesInput(act *Action, out map[string]string) error {
+func (p *Page) FilesInput(act *Action, out ActionData) error {
 	element, err := p.pageElementBy(act.Data)
 	if err != nil {
 		return errors.Wrap(err, errCouldNotGetElement)
@@ -560,7 +560,7 @@ func (p *Page) FilesInput(act *Action, out map[string]string) error {
 }
 
 // ExtractElement extracts from an element on the page.
-func (p *Page) ExtractElement(act *Action, out map[string]string) error {
+func (p *Page) ExtractElement(act *Action, out ActionData) error {
 	element, err := p.pageElementBy(act.Data)
 	if err != nil {
 		return errors.Wrap(err, errCouldNotGetElement)
@@ -594,7 +594,7 @@ func (p *Page) ExtractElement(act *Action, out map[string]string) error {
 }
 
 // WaitEvent waits for an event to happen on the page.
-func (p *Page) WaitEvent(act *Action, out map[string]string) (func() error, error) {
+func (p *Page) WaitEvent(act *Action, out ActionData) (func() error, error) {
 	event := p.getActionArgWithDefaultValues(act, "event")
 	if event == "" {
 		return nil, errors.New("event not recognized")
@@ -633,7 +633,7 @@ func (p *Page) WaitEvent(act *Action, out map[string]string) (func() error, erro
 }
 
 // HandleDialog handles JavaScript dialog (alert, confirm, prompt, or onbeforeunload).
-func (p *Page) HandleDialog(act *Action, out map[string]string) error {
+func (p *Page) HandleDialog(act *Action, out ActionData) error {
 	value := p.getActionArgWithDefaultValues(act, "value")
 	maxDuration := 10 * time.Second
 
@@ -705,14 +705,14 @@ func (p *Page) pageElementBy(data map[string]string) (*rod.Element, error) {
 }
 
 // DebugAction enables debug action on a page.
-func (p *Page) DebugAction(act *Action, out map[string]string) error {
+func (p *Page) DebugAction(act *Action, out ActionData) error {
 	p.instance.browser.engine.SlowMotion(5 * time.Second)
 	p.instance.browser.engine.Trace(true)
 	return nil
 }
 
 // SleepAction sleeps on the page for a specified duration
-func (p *Page) SleepAction(act *Action, out map[string]string) error {
+func (p *Page) SleepAction(act *Action, out ActionData) error {
 	seconds := act.Data["duration"]
 	if seconds == "" {
 		seconds = "5"

--- a/pkg/protocols/headless/engine/page_actions.go
+++ b/pkg/protocols/headless/engine/page_actions.go
@@ -100,7 +100,7 @@ func (p *Page) ExecuteActions(input *contextargs.Context, actions []*Action, var
 			if waitFunc != nil {
 				waitFuncs = append(waitFuncs, waitFunc)
 			}
-		case ActionDialog:
+		case ActionWaitDialog:
 			err = p.HandleDialog(act, outData)
 		case ActionFilesInput:
 			if p.options.Options.AllowLocalFileAccess {

--- a/pkg/protocols/headless/engine/page_actions_test.go
+++ b/pkg/protocols/headless/engine/page_actions_test.go
@@ -38,7 +38,7 @@ func TestActionNavigate(t *testing.T) {
 
 	actions := []*Action{{ActionType: ActionTypeHolder{ActionType: ActionNavigate}, Data: map[string]string{"url": "{{BaseURL}}"}}, {ActionType: ActionTypeHolder{ActionType: ActionWaitLoad}}}
 
-	testHeadlessSimpleResponse(t, response, actions, 20*time.Second, func(page *Page, err error, out map[string]string) {
+	testHeadlessSimpleResponse(t, response, actions, 20*time.Second, func(page *Page, err error, out ActionData) {
 		require.Nilf(t, err, "could not run page actions")
 		require.Equal(t, "Nuclei Test Page", page.Page().MustInfo().Title, "could not navigate correctly")
 	})
@@ -63,7 +63,7 @@ func TestActionScript(t *testing.T) {
 			{ActionType: ActionTypeHolder{ActionType: ActionScript}, Name: "test", Data: map[string]string{"code": "() => window.test"}},
 		}
 
-		testHeadlessSimpleResponse(t, response, actions, timeout, func(page *Page, err error, out map[string]string) {
+		testHeadlessSimpleResponse(t, response, actions, timeout, func(page *Page, err error, out ActionData) {
 			require.Nil(t, err, "could not run page actions")
 			require.Equal(t, "Nuclei Test Page", page.Page().MustInfo().Title, "could not navigate correctly")
 			require.Equal(t, "some-data", out["test"], "could not run js and get results correctly")
@@ -77,7 +77,7 @@ func TestActionScript(t *testing.T) {
 			{ActionType: ActionTypeHolder{ActionType: ActionWaitLoad}},
 			{ActionType: ActionTypeHolder{ActionType: ActionScript}, Name: "test", Data: map[string]string{"code": "() => window.test"}},
 		}
-		testHeadlessSimpleResponse(t, response, actions, timeout, func(page *Page, err error, out map[string]string) {
+		testHeadlessSimpleResponse(t, response, actions, timeout, func(page *Page, err error, out ActionData) {
 			require.Nil(t, err, "could not run page actions")
 			require.Equal(t, "Nuclei Test Page", page.Page().MustInfo().Title, "could not navigate correctly")
 			require.Equal(t, "some-data", out["test"], "could not run js and get results correctly with js hook")
@@ -101,7 +101,7 @@ func TestActionClick(t *testing.T) {
 		{ActionType: ActionTypeHolder{ActionType: ActionClick}, Data: map[string]string{"selector": "button"}}, // Use css selector for clicking
 	}
 
-	testHeadlessSimpleResponse(t, response, actions, 20*time.Second, func(page *Page, err error, out map[string]string) {
+	testHeadlessSimpleResponse(t, response, actions, 20*time.Second, func(page *Page, err error, out ActionData) {
 		require.Nil(t, err, "could not run page actions")
 		require.Equal(t, "Nuclei Test Page", page.Page().MustInfo().Title, "could not navigate correctly")
 		el := page.Page().MustElement("button")
@@ -134,7 +134,7 @@ func TestActionRightClick(t *testing.T) {
 		{ActionType: ActionTypeHolder{ActionType: ActionRightClick}, Data: map[string]string{"selector": "button"}}, // Use css selector for clicking
 	}
 
-	testHeadlessSimpleResponse(t, response, actions, 20*time.Second, func(page *Page, err error, out map[string]string) {
+	testHeadlessSimpleResponse(t, response, actions, 20*time.Second, func(page *Page, err error, out ActionData) {
 		require.Nil(t, err, "could not run page actions")
 		require.Equal(t, "Nuclei Test Page", page.Page().MustInfo().Title, "could not navigate correctly")
 		el := page.Page().MustElement("button")
@@ -159,7 +159,7 @@ func TestActionTextInput(t *testing.T) {
 		{ActionType: ActionTypeHolder{ActionType: ActionTextInput}, Data: map[string]string{"selector": "input", "value": "test"}},
 	}
 
-	testHeadlessSimpleResponse(t, response, actions, 20*time.Second, func(page *Page, err error, out map[string]string) {
+	testHeadlessSimpleResponse(t, response, actions, 20*time.Second, func(page *Page, err error, out ActionData) {
 		require.Nil(t, err, "could not run page actions")
 		require.Equal(t, "Nuclei Test Page", page.Page().MustInfo().Title, "could not navigate correctly")
 		el := page.Page().MustElement("input")
@@ -182,7 +182,7 @@ func TestActionHeadersChange(t *testing.T) {
 		}
 	}
 
-	testHeadless(t, actions, 20*time.Second, handler, func(page *Page, err error, out map[string]string) {
+	testHeadless(t, actions, 20*time.Second, handler, func(page *Page, err error, out ActionData) {
 		require.Nil(t, err, "could not run page actions")
 		require.Equal(t, "found", strings.ToLower(strings.TrimSpace(page.Page().MustElement("html").MustText())), "could not set header correctly")
 	})
@@ -205,7 +205,7 @@ func TestActionScreenshot(t *testing.T) {
 		{ActionType: ActionTypeHolder{ActionType: ActionScreenshot}, Data: map[string]string{"to": filePath}},
 	}
 
-	testHeadlessSimpleResponse(t, response, actions, 20*time.Second, func(page *Page, err error, out map[string]string) {
+	testHeadlessSimpleResponse(t, response, actions, 20*time.Second, func(page *Page, err error, out ActionData) {
 		require.Nil(t, err, "could not run page actions")
 		require.Equal(t, "Nuclei Test Page", page.Page().MustInfo().Title, "could not navigate correctly")
 		_ = page.Page()
@@ -233,7 +233,7 @@ func TestActionScreenshotToDir(t *testing.T) {
 		{ActionType: ActionTypeHolder{ActionType: ActionScreenshot}, Data: map[string]string{"to": filePath, "mkdir": "true"}},
 	}
 
-	testHeadlessSimpleResponse(t, response, actions, 20*time.Second, func(page *Page, err error, out map[string]string) {
+	testHeadlessSimpleResponse(t, response, actions, 20*time.Second, func(page *Page, err error, out ActionData) {
 		require.Nil(t, err, "could not run page actions")
 		require.Equal(t, "Nuclei Test Page", page.Page().MustInfo().Title, "could not navigate correctly")
 		_ = page.Page()
@@ -260,7 +260,7 @@ func TestActionTimeInput(t *testing.T) {
 		{ActionType: ActionTypeHolder{ActionType: ActionTimeInput}, Data: map[string]string{"selector": "input", "value": "2006-01-02T15:04:05Z"}},
 	}
 
-	testHeadlessSimpleResponse(t, response, actions, 20*time.Second, func(page *Page, err error, out map[string]string) {
+	testHeadlessSimpleResponse(t, response, actions, 20*time.Second, func(page *Page, err error, out ActionData) {
 		require.Nil(t, err, "could not run page actions")
 		require.Equal(t, "Nuclei Test Page", page.Page().MustInfo().Title, "could not navigate correctly")
 		el := page.Page().MustElement("input")
@@ -288,7 +288,7 @@ func TestActionSelectInput(t *testing.T) {
 		{ActionType: ActionTypeHolder{ActionType: ActionSelectInput}, Data: map[string]string{"by": "x", "xpath": "//select[@id='test']", "value": "Test2", "selected": "true"}},
 	}
 
-	testHeadlessSimpleResponse(t, response, actions, 20*time.Second, func(page *Page, err error, out map[string]string) {
+	testHeadlessSimpleResponse(t, response, actions, 20*time.Second, func(page *Page, err error, out ActionData) {
 		require.Nil(t, err, "could not run page actions")
 		el := page.Page().MustElement("select")
 		require.Equal(t, "Test2", el.MustText(), "could not get input change value")
@@ -311,7 +311,7 @@ func TestActionFilesInput(t *testing.T) {
 		{ActionType: ActionTypeHolder{ActionType: ActionFilesInput}, Data: map[string]string{"selector": "input", "value": "test1.pdf"}},
 	}
 
-	testHeadlessSimpleResponse(t, response, actions, 20*time.Second, func(page *Page, err error, out map[string]string) {
+	testHeadlessSimpleResponse(t, response, actions, 20*time.Second, func(page *Page, err error, out ActionData) {
 		require.Nil(t, err, "could not run page actions")
 		require.Equal(t, "Nuclei Test Page", page.Page().MustInfo().Title, "could not navigate correctly")
 		el := page.Page().MustElement("input")
@@ -337,7 +337,7 @@ func TestActionFilesInputNegative(t *testing.T) {
 	}
 	t.Setenv("LOCAL_FILE_ACCESS", "false")
 
-	testHeadlessSimpleResponse(t, response, actions, 20*time.Second, func(page *Page, err error, out map[string]string) {
+	testHeadlessSimpleResponse(t, response, actions, 20*time.Second, func(page *Page, err error, out ActionData) {
 		require.ErrorContains(t, err, ErrLFAccessDenied.Error(), "got file access when -lfa is false")
 	})
 }
@@ -359,7 +359,7 @@ func TestActionWaitLoad(t *testing.T) {
 		{ActionType: ActionTypeHolder{ActionType: ActionWaitLoad}},
 	}
 
-	testHeadlessSimpleResponse(t, response, actions, 20*time.Second, func(page *Page, err error, out map[string]string) {
+	testHeadlessSimpleResponse(t, response, actions, 20*time.Second, func(page *Page, err error, out ActionData) {
 		require.Nil(t, err, "could not run page actions")
 		el := page.Page().MustElement("button")
 		style, attributeErr := el.Attribute("style")
@@ -384,9 +384,12 @@ func TestActionGetResource(t *testing.T) {
 		{ActionType: ActionTypeHolder{ActionType: ActionGetResource}, Data: map[string]string{"by": "x", "xpath": "//img[@id='test']"}, Name: "src"},
 	}
 
-	testHeadlessSimpleResponse(t, response, actions, 20*time.Second, func(page *Page, err error, out map[string]string) {
+	testHeadlessSimpleResponse(t, response, actions, 20*time.Second, func(page *Page, err error, out ActionData) {
 		require.Nil(t, err, "could not run page actions")
-		require.Equal(t, len(out["src"]), 121808, "could not find resource")
+
+		src, ok := out["src"].([]string)
+		require.True(t, ok, "could not assert src to int")
+		require.Equal(t, len(src), 121808, "could not find resource")
 	})
 }
 
@@ -404,7 +407,7 @@ func TestActionExtract(t *testing.T) {
 		{ActionType: ActionTypeHolder{ActionType: ActionExtract}, Data: map[string]string{"by": "x", "xpath": "//button[@id='test']"}, Name: "extract"},
 	}
 
-	testHeadlessSimpleResponse(t, response, actions, 20*time.Second, func(page *Page, err error, out map[string]string) {
+	testHeadlessSimpleResponse(t, response, actions, 20*time.Second, func(page *Page, err error, out ActionData) {
 		require.Nil(t, err, "could not run page actions")
 		require.Equal(t, "Wait for me!", out["extract"], "could not extract text")
 	})
@@ -423,7 +426,7 @@ func TestActionSetMethod(t *testing.T) {
 		{ActionType: ActionTypeHolder{ActionType: ActionSetMethod}, Data: map[string]string{"part": "x", "method": "SET"}},
 	}
 
-	testHeadlessSimpleResponse(t, response, actions, 20*time.Second, func(page *Page, err error, out map[string]string) {
+	testHeadlessSimpleResponse(t, response, actions, 20*time.Second, func(page *Page, err error, out ActionData) {
 		require.Nil(t, err, "could not run page actions")
 		require.Equal(t, "SET", page.rules[0].Args["method"], "could not find resource")
 	})
@@ -442,7 +445,7 @@ func TestActionAddHeader(t *testing.T) {
 		}
 	}
 
-	testHeadless(t, actions, 20*time.Second, handler, func(page *Page, err error, out map[string]string) {
+	testHeadless(t, actions, 20*time.Second, handler, func(page *Page, err error, out ActionData) {
 		require.Nil(t, err, "could not run page actions")
 		require.Equal(t, "found", strings.ToLower(strings.TrimSpace(page.Page().MustElement("html").MustText())), "could not set header correctly")
 	})
@@ -463,7 +466,7 @@ func TestActionDeleteHeader(t *testing.T) {
 		}
 	}
 
-	testHeadless(t, actions, 20*time.Second, handler, func(page *Page, err error, out map[string]string) {
+	testHeadless(t, actions, 20*time.Second, handler, func(page *Page, err error, out ActionData) {
 		require.Nil(t, err, "could not run page actions")
 		require.Equal(t, "header deleted", strings.ToLower(strings.TrimSpace(page.Page().MustElement("html").MustText())), "could not delete header correctly")
 	})
@@ -481,7 +484,7 @@ func TestActionSetBody(t *testing.T) {
 		_, _ = fmt.Fprintln(w, string(body))
 	}
 
-	testHeadless(t, actions, 20*time.Second, handler, func(page *Page, err error, out map[string]string) {
+	testHeadless(t, actions, 20*time.Second, handler, func(page *Page, err error, out ActionData) {
 		require.Nil(t, err, "could not run page actions")
 		require.Equal(t, "hello", strings.ToLower(strings.TrimSpace(page.Page().MustElement("html").MustText())), "could not set header correctly")
 	})
@@ -505,7 +508,7 @@ func TestActionKeyboard(t *testing.T) {
 		{ActionType: ActionTypeHolder{ActionType: ActionKeyboard}, Data: map[string]string{"keys": "Test2"}},
 	}
 
-	testHeadlessSimpleResponse(t, response, actions, 20*time.Second, func(page *Page, err error, out map[string]string) {
+	testHeadlessSimpleResponse(t, response, actions, 20*time.Second, func(page *Page, err error, out ActionData) {
 		require.Nil(t, err, "could not run page actions")
 		el := page.Page().MustElement("input")
 		require.Equal(t, "Test2", el.MustText(), "could not get input change value")
@@ -529,7 +532,7 @@ func TestActionSleep(t *testing.T) {
 		{ActionType: ActionTypeHolder{ActionType: ActionSleep}, Data: map[string]string{"duration": "2"}},
 	}
 
-	testHeadlessSimpleResponse(t, response, actions, 20*time.Second, func(page *Page, err error, out map[string]string) {
+	testHeadlessSimpleResponse(t, response, actions, 20*time.Second, func(page *Page, err error, out ActionData) {
 		require.Nil(t, err, "could not run page actions")
 		require.True(t, page.Page().MustElement("button").MustVisible(), "could not get button")
 	})
@@ -553,7 +556,7 @@ func TestActionWaitVisible(t *testing.T) {
 	}
 
 	t.Run("wait for an element being visible", func(t *testing.T) {
-		testHeadlessSimpleResponse(t, response, actions, 2*time.Second, func(page *Page, err error, out map[string]string) {
+		testHeadlessSimpleResponse(t, response, actions, 2*time.Second, func(page *Page, err error, out ActionData) {
 			require.Nil(t, err, "could not run page actions")
 
 			page.Page().MustElement("button").MustVisible()
@@ -562,21 +565,21 @@ func TestActionWaitVisible(t *testing.T) {
 
 	t.Run("timeout because of element not visible", func(t *testing.T) {
 		// increased timeout from time.Second/2 to time.Second due to random fails (probably due to overhead and system)
-		testHeadlessSimpleResponse(t, response, actions, time.Second, func(page *Page, err error, out map[string]string) {
+		testHeadlessSimpleResponse(t, response, actions, time.Second, func(page *Page, err error, out ActionData) {
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "Element did not appear in the given amount of time")
 		})
 	})
 }
 
-func testHeadlessSimpleResponse(t *testing.T, response string, actions []*Action, timeout time.Duration, assert func(page *Page, pageErr error, out map[string]string)) {
+func testHeadlessSimpleResponse(t *testing.T, response string, actions []*Action, timeout time.Duration, assert func(page *Page, pageErr error, out ActionData)) {
 	t.Helper()
 	testHeadless(t, actions, timeout, func(w http.ResponseWriter, r *http.Request) {
 		_, _ = fmt.Fprintln(w, response)
 	}, assert)
 }
 
-func testHeadless(t *testing.T, actions []*Action, timeout time.Duration, handler func(w http.ResponseWriter, r *http.Request), assert func(page *Page, pageErr error, extractedData map[string]string)) {
+func testHeadless(t *testing.T, actions []*Action, timeout time.Duration, handler func(w http.ResponseWriter, r *http.Request), assert func(page *Page, pageErr error, extractedData ActionData)) {
 	t.Helper()
 
 	lfa := getBoolFromEnv("LOCAL_FILE_ACCESS", true)

--- a/pkg/protocols/headless/request.go
+++ b/pkg/protocols/headless/request.go
@@ -183,7 +183,7 @@ func (request *Request) executeRequestWithPayloads(input *contextargs.Context, p
 		responseBody, _ = html.HTML()
 	}
 
-	outputEvent := request.responseToDSLMap(responseBody, out["header"], out["status_code"], reqBuilder.String(), input.MetaInput.Input, navigatedURL, page.DumpHistory())
+	outputEvent := request.responseToDSLMap(responseBody, out["header"].(string), out["status_code"].(string), reqBuilder.String(), input.MetaInput.Input, navigatedURL, page.DumpHistory())
 	// add response fields to template context and merge templatectx variables to output event
 	request.options.AddTemplateVars(input.MetaInput, request.Type(), request.ID, outputEvent)
 	if request.options.HasTemplateCtx(input.MetaInput) {


### PR DESCRIPTION
## Proposed changes

Close #5526

### How has this been tested?

```yaml
# headless-waitdialog-action.yaml
id: headless-waitdialog-action

info:
  name: Headless Wait Dialog Action
  author: dwisiswant0
  severity: info
  tags: headless,test,xss

headless:
  - steps:
      - action: navigate
        args:
          url: "{{BaseURL}}/?_={{url_encode(concat('<script>', dialog, '</script>'))}}"

      # The 'name' property needs to be defined so that the output variable can
      # be exposed and used later by matchers or extractors.
      - action: waitdialog
        name: alert
        args:
          max-duration: 10ms # it doesn't take a long time to trigger a dialog.

        # Output variables of ActionWaitDialog:
        # * NAME (boolean), indicator of JavaScript dialog triggered.
        # * NAME_type (string), dialog type (alert, confirm, prompt, or
        #   onbeforeunload).
        # * NAME_message (string), displayed message dialog.

    payloads:
      dialog:
        - alert(1)
        - invalidX(1)
        - confirm(1)
        - invalidY(1)
        - prompt(1)
        - invalidZ(1)
        - window.onbeforeunload = () => { return 'ya sure?' }; # nope (unless *Page.Close)

    matchers:
      - type: dsl
        dsl:
          - alert # short of 'alert == true' expr

    extractors:
      - type: dsl
        dsl:
          - "'type: ' + alert_type"
          - "'message: ' + alert_message"

```

```console
$ go run cmd/nuclei/main.go -headless -t headless-waitdialog-action.yaml -u http://honey.scanme.sh
[headless-waitdialog-action] [headless] [info] http://honey.scanme.sh/?_=%3Cscript%3Ealert%281%29%3C%2Fscript%3E ["type: alert","message: 1"]
[headless-waitdialog-action] [headless] [info] http://honey.scanme.sh/?_=%3Cscript%3Econfirm%281%29%3C%2Fscript%3E ["message: 1","type: confirm"]
[headless-waitdialog-action] [headless] [info] http://honey.scanme.sh/?_=%3Cscript%3Eprompt%281%29%3C%2Fscript%3E ["type: prompt","message: 1"]
``` 

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)