### PR TITLE
Fixed issue with `-ms` option to scan non accessible host

### DIFF
--- a/cmd/integration-test/integration-test.go
+++ b/cmd/integration-test/integration-test.go
@@ -55,6 +55,7 @@ var (
 		"dsl":             dslTestcases,
 		"flow":            flowTestcases,
 		"javascript":      jsTestcases,
+		"matcher-status":  matcherStatusTestcases,
 	}
 	// flakyTests are run with a retry count of 3
 	flakyTests = map[string]bool{

--- a/cmd/integration-test/matcher-status.go
+++ b/cmd/integration-test/matcher-status.go
@@ -1,0 +1,1 @@
+package main

--- a/cmd/integration-test/matcher-status.go
+++ b/cmd/integration-test/matcher-status.go
@@ -14,6 +14,7 @@ var matcherStatusTestcases = []TestCaseInfo{
 	{Path: "protocols/headless/headless-basic.yaml", TestCase: &headlessNoAccess{}},
 	{Path: "protocols/javascript/net-https.yaml", TestCase: &javascriptNoAccess{}},
 	{Path: "protocols/websocket/basic.yaml", TestCase: &websocketNoAccess{}},
+	{Path: "protocols/dns/a.yaml", TestCase: &dnsNoAccess{}},
 }
 
 type httpNoAccess struct{}
@@ -88,6 +89,23 @@ type websocketNoAccess struct{}
 // Execute executes a test case and returns an error if occurred
 func (h *websocketNoAccess) Execute(filePath string) error {
 	results, err := testutils.RunNucleiTemplateAndGetResults(filePath, "ws://trust_me_bro.real", debug, "-ms", "-j")
+	if err != nil {
+		return err
+	}
+	event := &output.ResultEvent{}
+	_ = json.Unmarshal([]byte(results[0]), event)
+
+	if event.Error == "" {
+		return fmt.Errorf("unexpected result: expecting an error but got \"%s\"", event.Error)
+	}
+	return nil
+}
+
+type dnsNoAccess struct{}
+
+// Execute executes a test case and returns an error if occurred
+func (h *dnsNoAccess) Execute(filePath string) error {
+	results, err := testutils.RunNucleiTemplateAndGetResults(filePath, "trust_me_bro.real", debug, "-ms", "-j")
 	if err != nil {
 		return err
 	}

--- a/cmd/integration-test/matcher-status.go
+++ b/cmd/integration-test/matcher-status.go
@@ -24,7 +24,7 @@ func (h *httpNoAccess) Execute(filePath string) error {
 		return err
 	}
 	event := &output.ResultEvent{}
-	json.Unmarshal([]byte(results[0]), event)
+	_ = json.Unmarshal([]byte(results[0]), event)
 
 	if event.Error != "no address found for host" {
 		return fmt.Errorf("unexpected result: expecting \"no address found for host\" error but got none")
@@ -41,7 +41,7 @@ func (h *networkNoAccess) Execute(filePath string) error {
 		return err
 	}
 	event := &output.ResultEvent{}
-	json.Unmarshal([]byte(results[0]), event)
+	_ = json.Unmarshal([]byte(results[0]), event)
 
 	if event.Error != "no address found for host" {
 		return fmt.Errorf("unexpected result: expecting \"no address found for host\" error but got \"%s\"", event.Error)
@@ -58,7 +58,7 @@ func (h *headlessNoAccess) Execute(filePath string) error {
 		return err
 	}
 	event := &output.ResultEvent{}
-	json.Unmarshal([]byte(results[0]), event)
+	_ = json.Unmarshal([]byte(results[0]), event)
 
 	if event.Error == "" {
 		return fmt.Errorf("unexpected result: expecting an error but got \"%s\"", event.Error)
@@ -75,7 +75,7 @@ func (h *javascriptNoAccess) Execute(filePath string) error {
 		return err
 	}
 	event := &output.ResultEvent{}
-	json.Unmarshal([]byte(results[0]), event)
+	_ = json.Unmarshal([]byte(results[0]), event)
 
 	if event.Error == "" {
 		return fmt.Errorf("unexpected result: expecting an error but got \"%s\"", event.Error)
@@ -92,7 +92,7 @@ func (h *websocketNoAccess) Execute(filePath string) error {
 		return err
 	}
 	event := &output.ResultEvent{}
-	json.Unmarshal([]byte(results[0]), event)
+	_ = json.Unmarshal([]byte(results[0]), event)
 
 	if event.Error == "" {
 		return fmt.Errorf("unexpected result: expecting an error but got \"%s\"", event.Error)

--- a/cmd/integration-test/matcher-status.go
+++ b/cmd/integration-test/matcher-status.go
@@ -1,1 +1,101 @@
 package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/output"
+	"github.com/projectdiscovery/nuclei/v3/pkg/testutils"
+)
+
+var matcherStatusTestcases = []TestCaseInfo{
+	{Path: "protocols/http/get.yaml", TestCase: &httpNoAccess{}},
+	{Path: "protocols/network/net-https.yaml", TestCase: &networkNoAccess{}},
+	{Path: "protocols/headless/headless-basic.yaml", TestCase: &headlessNoAccess{}},
+	{Path: "protocols/javascript/net-https.yaml", TestCase: &javascriptNoAccess{}},
+	{Path: "protocols/websocket/basic.yaml", TestCase: &websocketNoAccess{}},
+}
+
+type httpNoAccess struct{}
+
+func (h *httpNoAccess) Execute(filePath string) error {
+	results, err := testutils.RunNucleiTemplateAndGetResults(filePath, "trust_me_bro.real", debug, "-ms", "-j")
+	if err != nil {
+		return err
+	}
+	event := &output.ResultEvent{}
+	json.Unmarshal([]byte(results[0]), event)
+
+	if event.Error != "no address found for host" {
+		return fmt.Errorf("unexpected result: expecting \"no address found for host\" error but got none")
+	}
+	return nil
+}
+
+type networkNoAccess struct{}
+
+// Execute executes a test case and returns an error if occurred
+func (h *networkNoAccess) Execute(filePath string) error {
+	results, err := testutils.RunNucleiTemplateAndGetResults(filePath, "trust_me_bro.real", debug, "-ms", "-j")
+	if err != nil {
+		return err
+	}
+	event := &output.ResultEvent{}
+	json.Unmarshal([]byte(results[0]), event)
+
+	if event.Error != "no address found for host" {
+		return fmt.Errorf("unexpected result: expecting \"no address found for host\" error but got \"%s\"", event.Error)
+	}
+	return nil
+}
+
+type headlessNoAccess struct{}
+
+// Execute executes a test case and returns an error if occurred
+func (h *headlessNoAccess) Execute(filePath string) error {
+	results, err := testutils.RunNucleiTemplateAndGetResults(filePath, "trust_me_bro.real", debug, "-headless", "-ms", "-j")
+	if err != nil {
+		return err
+	}
+	event := &output.ResultEvent{}
+	json.Unmarshal([]byte(results[0]), event)
+
+	if event.Error == "" {
+		return fmt.Errorf("unexpected result: expecting an error but got \"%s\"", event.Error)
+	}
+	return nil
+}
+
+type javascriptNoAccess struct{}
+
+// Execute executes a test case and returns an error if occurred
+func (h *javascriptNoAccess) Execute(filePath string) error {
+	results, err := testutils.RunNucleiTemplateAndGetResults(filePath, "trust_me_bro.real", debug, "-ms", "-j")
+	if err != nil {
+		return err
+	}
+	event := &output.ResultEvent{}
+	json.Unmarshal([]byte(results[0]), event)
+
+	if event.Error == "" {
+		return fmt.Errorf("unexpected result: expecting an error but got \"%s\"", event.Error)
+	}
+	return nil
+}
+
+type websocketNoAccess struct{}
+
+// Execute executes a test case and returns an error if occurred
+func (h *websocketNoAccess) Execute(filePath string) error {
+	results, err := testutils.RunNucleiTemplateAndGetResults(filePath, "ws://trust_me_bro.real", debug, "-ms", "-j")
+	if err != nil {
+		return err
+	}
+	event := &output.ResultEvent{}
+	json.Unmarshal([]byte(results[0]), event)
+
+	if event.Error == "" {
+		return fmt.Errorf("unexpected result: expecting an error but got \"%s\"", event.Error)
+	}
+	return nil
+}

--- a/pkg/protocols/dns/request.go
+++ b/pkg/protocols/dns/request.go
@@ -106,7 +106,7 @@ func (request *Request) ExecuteWithResults(input *contextargs.Context, metadata,
 }
 
 func (request *Request) execute(input *contextargs.Context, domain string, metadata, previous output.InternalEvent, vars map[string]interface{}, callback protocols.OutputEventCallback) error {
-
+	var err error
 	if vardump.EnableVarDump {
 		gologger.Debug().Msgf("DNS Protocol request variables: \n%s\n", vardump.DumpVariables(vars))
 	}
@@ -199,7 +199,7 @@ func (request *Request) execute(input *contextargs.Context, domain string, metad
 	}
 
 	callback(event)
-	return nil
+	return err
 }
 
 func (request *Request) parseDNSInput(host string) (string, error) {

--- a/pkg/protocols/network/request.go
+++ b/pkg/protocols/network/request.go
@@ -155,14 +155,13 @@ func (request *Request) executeOnTarget(input *contextargs.Context, visited maps
 		}
 		visited.Set(actualAddress, struct{}{})
 
-		if err := request.executeAddress(variables, actualAddress, address, input, kv.tls, previous, callback); err != nil {
+		if err = request.executeAddress(variables, actualAddress, address, input, kv.tls, previous, callback); err != nil {
 			outputEvent := request.responseToDSLMap("", "", "", address, "")
 			callback(&output.InternalWrappedEvent{InternalEvent: outputEvent})
-			gologger.Warning().Msgf("[%v] Could not make network request for (%s) : %s\n", request.options.TemplateID, actualAddress, err)
 			continue
 		}
 	}
-	return nil
+	return err
 }
 
 // executeAddress executes the request for an address

--- a/pkg/protocols/network/request.go
+++ b/pkg/protocols/network/request.go
@@ -158,6 +158,7 @@ func (request *Request) executeOnTarget(input *contextargs.Context, visited maps
 		if err = request.executeAddress(variables, actualAddress, address, input, kv.tls, previous, callback); err != nil {
 			outputEvent := request.responseToDSLMap("", "", "", address, "")
 			callback(&output.InternalWrappedEvent{InternalEvent: outputEvent})
+			gologger.Warning().Msgf("[%v] Could not make network request for (%s) : %s\n", request.options.TemplateID, actualAddress, err)
 			continue
 		}
 	}

--- a/pkg/protocols/network/request_test.go
+++ b/pkg/protocols/network/request_test.go
@@ -86,7 +86,7 @@ func TestNetworkExecuteWithResults(t *testing.T) {
 		err := request.ExecuteWithResults(ctxArgs, metadata, previous, func(event *output.InternalWrappedEvent) {
 			finalEvent = event
 		})
-		require.Nil(t, err, "could not execute network request")
+		require.NotNil(t, err, "could not execute network request")
 	})
 	require.Nil(t, finalEvent.Results, "could not get event output from request")
 

--- a/pkg/scan/scan_context.go
+++ b/pkg/scan/scan_context.go
@@ -52,6 +52,13 @@ func (s *ScanContext) Context() context.Context {
 	return s.ctx
 }
 
+func (s *ScanContext) GenerateErrorMessage() string {
+	s.m.Lock()
+	defer s.m.Unlock()
+
+	return joinErrors(s.errors)
+}
+
 // GenerateResult returns final results slice from all events
 func (s *ScanContext) GenerateResult() []*output.ResultEvent {
 	s.m.Lock()
@@ -96,7 +103,7 @@ func (s *ScanContext) LogError(err error) {
 	}
 	s.errors = append(s.errors, err)
 
-	errorMessage := joinErrors(s.errors)
+	errorMessage := s.GenerateErrorMessage()
 
 	for _, result := range s.results {
 		result.Error = errorMessage

--- a/pkg/scan/scan_context.go
+++ b/pkg/scan/scan_context.go
@@ -53,9 +53,6 @@ func (s *ScanContext) Context() context.Context {
 }
 
 func (s *ScanContext) GenerateErrorMessage() string {
-	s.m.Lock()
-	defer s.m.Unlock()
-
 	return joinErrors(s.errors)
 }
 

--- a/pkg/tmplexec/exec.go
+++ b/pkg/tmplexec/exec.go
@@ -220,7 +220,7 @@ func (e *TemplateExecuter) Execute(ctx *scan.ScanContext) (bool, error) {
 					Info:       e.options.TemplateInfo,
 					Type:       e.getTemplateType(),
 					Host:       ctx.Input.MetaInput.Input,
-					Error:      tryParseCause(fmt.Errorf(ctx.GenerateErrorMessage())),
+					Error:      tryParseCause(fmt.Errorf("%s", ctx.GenerateErrorMessage())),
 				},
 			},
 			OperatorsResult: &operators.Result{

--- a/pkg/tmplexec/exec.go
+++ b/pkg/tmplexec/exec.go
@@ -218,12 +218,7 @@ func (e *TemplateExecuter) Execute(ctx *scan.ScanContext) (bool, error) {
 					Info:       e.options.TemplateInfo,
 					Type:       e.getTemplateType(),
 					Host:       ctx.Input.MetaInput.Input,
-					Error: func(err error) string {
-						if err == nil {
-							return ""
-						}
-						return err.Error()
-					}(errx),
+					Error:      ctx.GenerateErrorMessage(),
 				},
 			},
 			OperatorsResult: &operators.Result{

--- a/pkg/tmplexec/exec.go
+++ b/pkg/tmplexec/exec.go
@@ -206,6 +206,7 @@ func (e *TemplateExecuter) Execute(ctx *scan.ScanContext) (bool, error) {
 	}
 
 	if lastMatcherEvent != nil {
+		lastMatcherEvent.InternalEvent["error"] = tryParseCause(fmt.Errorf("%s", ctx.GenerateErrorMessage()))
 		writeFailureCallback(lastMatcherEvent, e.options.Options.MatcherStatus)
 	}
 
@@ -227,9 +228,7 @@ func (e *TemplateExecuter) Execute(ctx *scan.ScanContext) (bool, error) {
 				Matched: false,
 			},
 		}
-		if err := e.options.Output.WriteFailure(fakeEvent); err != nil {
-			gologger.Warning().Msgf("Could not write failure event to output: %s\n", err)
-		}
+		writeFailureCallback(fakeEvent, e.options.Options.MatcherStatus)
 	}
 
 	return executed.Load() || matched.Load(), errx

--- a/pkg/tmplexec/exec.go
+++ b/pkg/tmplexec/exec.go
@@ -252,9 +252,10 @@ func tryParseCause(err error) string {
 		}
 
 		msg := errCause.Error()
+		msg = strings.Trim(msg, "{} ")
 		parts := strings.Split(msg, ":")
 		if len(parts) == 1 {
-			return ""
+			return msg
 		}
 		errCause = errkit.New("%s", strings.TrimSpace(parts[len(parts)-1]))
 		errKind := errkit.GetErrorKind(err, nucleierr.ErrTemplateLogic).String()

--- a/pkg/tmplexec/exec.go
+++ b/pkg/tmplexec/exec.go
@@ -251,13 +251,9 @@ func tryParseCause(err error) string {
 			errCause = errX
 		}
 
-		msg := errCause.Error()
-		msg = strings.Trim(msg, "{} ")
+		msg := strings.Trim(errCause.Error(), "{} ")
 		parts := strings.Split(msg, ":")
-		if len(parts) == 1 {
-			return msg
-		}
-		errCause = errkit.New("%s", strings.TrimSpace(parts[len(parts)-1]))
+		errCause = errkit.New("%s", parts[len(parts)-1])
 		errKind := errkit.GetErrorKind(err, nucleierr.ErrTemplateLogic).String()
 		errStr = errCause.Error()
 		errStr = strings.TrimSpace(strings.Replace(errStr, "errKind="+errKind, "", -1))

--- a/pkg/tmplexec/exec.go
+++ b/pkg/tmplexec/exec.go
@@ -204,6 +204,7 @@ func (e *TemplateExecuter) Execute(ctx *scan.ScanContext) (bool, error) {
 	} else {
 		errx = e.engine.ExecuteWithResults(ctx)
 	}
+	ctx.LogError(errx)
 
 	if lastMatcherEvent != nil {
 		lastMatcherEvent.InternalEvent["error"] = tryParseCause(fmt.Errorf("%s", ctx.GenerateErrorMessage()))


### PR DESCRIPTION
## Proposed changes

Closes #5556

This PR triggers a failed event if the OnResult callback is not called, but it does not capture the "exact" error described in the issue's expected behavior section.


## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)