### PR TITLE
Remove conflicting `-U` option for `apk` in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN go build ./cmd/nuclei
 
 # Release
 FROM alpine:3.18.6
-RUN apk -U upgrade --no-cache \
+RUN apk upgrade --no-cache \
     && apk add --no-cache bind-tools chromium ca-certificates
 COPY --from=build-env /app/nuclei /usr/local/bin/
 


### PR DESCRIPTION
## Proposed changes

The `--no-cache` option updates the index and avoids temporary files, making `-U` unnecessary, consistent with the subsequent `apk add`.

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)