### PR TITLE
fix: MySQL connection with special characters in password

### DIFF
--- a/pkg/js/libs/mysql/mysql_private.go
+++ b/pkg/js/libs/mysql/mysql_private.go
@@ -53,7 +53,7 @@ func BuildDSN(opts MySQLOptions) (string, error) {
 	}
 	target := net.JoinHostPort(opts.Host, fmt.Sprintf("%d", opts.Port))
 	var dsn strings.Builder
-	dsn.WriteString(fmt.Sprintf("%v:%v", url.QueryEscape(opts.Username), url.QueryEscape(opts.Password)))
+	dsn.WriteString(fmt.Sprintf("%v:%v", url.QueryEscape(opts.Username), opts.Password))
 	dsn.WriteString("@")
 	dsn.WriteString(fmt.Sprintf("%v(%v)", opts.Protocol, target))
 	if opts.DbName != "" {


### PR DESCRIPTION
## Proposed changes

- closes: #5205

### Test
<details>
<summary>local mysql setup</summary>

  ```yaml

    version: '3.8'
    
    services:
      mysql:
        image: mysql:latest
        container_name: mysql_container
        environment:
          MYSQL_ROOT_PASSWORD: Hxxxd@9
        ports:
          - "3306:3306"
        networks:
          - mynetwork
    
    networks:
      mynetwork:
        driver: bridge
  
```
</details>

- include `root` and `Hxxxd@9` under usernames and passwords of `mysql-default-login` template.

__cmd:__
```bash
$ ./nuclei -id mysql-default-login -u 127.0.0.1
```


## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)