### PR TITLE
scan error formatting

### DIFF
--- a/pkg/scan/scan_context.go
+++ b/pkg/scan/scan_context.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/projectdiscovery/nuclei/v3/pkg/output"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/contextargs"
+	"github.com/projectdiscovery/utils/errkit"
 )
 
 type ScanContextOption func(*ScanContext)
@@ -30,7 +31,7 @@ type ScanContext struct {
 	OnWarning func(string)
 
 	// unexported state fields
-	errors   []error
+	error    error
 	warnings []string
 	events   []*output.InternalWrappedEvent
 	results  []*output.ResultEvent
@@ -52,8 +53,8 @@ func (s *ScanContext) Context() context.Context {
 	return s.ctx
 }
 
-func (s *ScanContext) GenerateErrorMessage() string {
-	return joinErrors(s.errors)
+func (s *ScanContext) GenerateErrorMessage() error {
+	return s.error
 }
 
 // GenerateResult returns final results slice from all events
@@ -94,13 +95,16 @@ func (s *ScanContext) LogError(err error) {
 	if err == nil {
 		return
 	}
-
 	if s.OnError != nil {
 		s.OnError(err)
 	}
-	s.errors = append(s.errors, err)
+	if s.error == nil {
+		s.error = err
+	} else {
+		s.error = errkit.Append(s.error, err)
+	}
 
-	errorMessage := s.GenerateErrorMessage()
+	errorMessage := s.GenerateErrorMessage().Error()
 
 	for _, result := range s.results {
 		result.Error = errorMessage
@@ -128,15 +132,4 @@ func (s *ScanContext) LogWarning(format string, args ...any) {
 			e.InternalEvent["warning"] = strings.Join(s.warnings, "; ")
 		}
 	}
-}
-
-// joinErrors joins multiple errors and returns a single error string
-func joinErrors(errors []error) string {
-	var errorMessages []string
-	for _, e := range errors {
-		if e != nil {
-			errorMessages = append(errorMessages, e.Error())
-		}
-	}
-	return strings.Join(errorMessages, "; ")
 }

--- a/pkg/tmplexec/exec.go
+++ b/pkg/tmplexec/exec.go
@@ -20,7 +20,6 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/tmplexec/flow"
 	"github.com/projectdiscovery/nuclei/v3/pkg/tmplexec/generic"
 	"github.com/projectdiscovery/nuclei/v3/pkg/tmplexec/multiproto"
-	"github.com/projectdiscovery/nuclei/v3/pkg/types/nucleierr"
 	"github.com/projectdiscovery/utils/errkit"
 )
 
@@ -207,7 +206,7 @@ func (e *TemplateExecuter) Execute(ctx *scan.ScanContext) (bool, error) {
 	ctx.LogError(errx)
 
 	if lastMatcherEvent != nil {
-		lastMatcherEvent.InternalEvent["error"] = tryParseCause(fmt.Errorf("%s", ctx.GenerateErrorMessage()))
+		lastMatcherEvent.InternalEvent["error"] = getErrorCause(ctx.GenerateErrorMessage())
 		writeFailureCallback(lastMatcherEvent, e.options.Options.MatcherStatus)
 	}
 
@@ -222,7 +221,7 @@ func (e *TemplateExecuter) Execute(ctx *scan.ScanContext) (bool, error) {
 					Info:       e.options.TemplateInfo,
 					Type:       e.getTemplateType(),
 					Host:       ctx.Input.MetaInput.Input,
-					Error:      tryParseCause(fmt.Errorf("%s", ctx.GenerateErrorMessage())),
+					Error:      getErrorCause(ctx.GenerateErrorMessage()),
 				},
 			},
 			OperatorsResult: &operators.Result{
@@ -235,31 +234,27 @@ func (e *TemplateExecuter) Execute(ctx *scan.ScanContext) (bool, error) {
 	return executed.Load() || matched.Load(), errx
 }
 
-// tryParseCause tries to parse the cause of given error
+// getErrorCause tries to parse the cause of given error
 // this is legacy support due to use of errorutil in existing libraries
 // but this should not be required once all libraries are updated
-func tryParseCause(err error) string {
-	errStr := ""
-	errX := errkit.FromError(err)
-	if errX != nil {
-		var errCause error
-
-		if len(errX.Errors()) > 1 {
-			errCause = errX.Errors()[0]
-		}
-		if errCause == nil {
-			errCause = errX
-		}
-
-		msg := strings.Trim(errCause.Error(), "{} ")
-		parts := strings.Split(msg, ":")
-		errCause = errkit.New("%s", parts[len(parts)-1])
-		errKind := errkit.GetErrorKind(err, nucleierr.ErrTemplateLogic).String()
-		errStr = errCause.Error()
-		errStr = strings.TrimSpace(strings.Replace(errStr, "errKind="+errKind, "", -1))
+func getErrorCause(err error) string {
+	if err == nil {
+		return ""
 	}
-
-	return errStr
+	errx := errkit.FromError(err)
+	var cause error
+	for _, e := range errx.Errors() {
+		if e != nil && strings.Contains(e.Error(), "context deadline exceeded") {
+			continue
+		}
+		cause = e
+		break
+	}
+	if cause == nil {
+		cause = errkit.Append(errkit.New("could not get error cause"), errx)
+	}
+	// parseScanError prettifies the error message and removes everything except the cause
+	return parseScanError(cause.Error())
 }
 
 // ExecuteWithResults executes the protocol requests and returns results instead of writing them.


### PR DESCRIPTION
### Proposed Changes

- format and improve scan error cleaning using regex

## Before

```console
$  nuclei -u apollox.s3.amazonaws.com:21 -id proftpd-backdoor -j -ms -timeout 10 | jq .                                                tarun@Taruns-MacBook-Pro

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.3.2

		projectdiscovery.io

[INF] Current nuclei version: v3.3.2 (latest)
[INF] Current nuclei-templates version: v10.0.0 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 255
[INF] Templates loaded for current scan: 1
[INF] Executing 1 signed templates from projectdiscovery/nuclei-templates
[INF] Targets loaded for current scan: 1
{
  "template": "javascript/backdoor/proftpd-backdoor.yaml",
  "template-url": "https://cloud.projectdiscovery.io/public/proftpd-backdoor",
  "template-id": "proftpd-backdoor",
  "template-path": "/Users/tarun/nuclei-templates/javascript/backdoor/proftpd-backdoor.yaml",
  "info": {
    "name": "ProFTPd-1.3.3c - Backdoor Command Execution",
    "author": [
      "pussycat0x"
    ],
    "tags": [
      "js",
      "network",
      "proftpd",
      "ftp",
      "backdoor"
    ],
    "description": "This backdoor was present in the proftpd-1.3.3c.\n",
    "reference": [
      "https://github.com/shafdo/ProFTPD-1.3.3c-Backdoor_Command_Execution_Automated_Script/blob/main/README.md",
      "https://www.rapid7.com/db/modules/exploit/unix/ftp/proftpd_133c_backdoor/"
    ],
    "severity": "critical",
    "metadata": {
      "max-request": 1,
      "shodan-query": "product:\"ProFTPD\""
    }
  },
  "type": "javascript",
  "host": "apollox.s3.amazonaws.com:21",
  "port": "21",
  "url": "apollox.s3.amazonaws.com:21",
  "request": "const data = [\"HELP ACIDBITCHEZ\\n\", \"id\"];\nconst c = require(\"nuclei/net\");\nlet conn = c.Open('tcp', `${Host}:${Port}`);\nlet resp = conn.RecvFullString();\nif (resp.includes(\"ProFTPD 1.3.3c\")) {\n    for (let i = 0; i < data.length; i++) {\n        conn.Send(data[i]);\n        console.log('Sending:', data[i]);\n        let resp = conn.RecvFullString();\n        resp\n    }\n} else {\n    exit();\n}",
  "ip": "16.12.1.9",
  "timestamp": "2024-09-13T19:34:35.932854+05:30",
  "matcher-status": false,
  "error": "21] port closed or filtered"
}

```

## After

```console
$ ./nuclei -u apollox.s3.amazonaws.com:21 -id proftpd-backdoor -j -ms -timeout 10 | jq .                                              tarun@Taruns-MacBook-Pro

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.3.2

		projectdiscovery.io

[INF] Current nuclei version: v3.3.2 (latest)
[INF] Current nuclei-templates version: v10.0.0 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 255
[INF] Templates loaded for current scan: 1
[INF] Executing 1 signed templates from projectdiscovery/nuclei-templates
[INF] Targets loaded for current scan: 1
{
  "template": "javascript/backdoor/proftpd-backdoor.yaml",
  "template-url": "https://cloud.projectdiscovery.io/public/proftpd-backdoor",
  "template-id": "proftpd-backdoor",
  "template-path": "/Users/tarun/nuclei-templates/javascript/backdoor/proftpd-backdoor.yaml",
  "info": {
    "name": "ProFTPd-1.3.3c - Backdoor Command Execution",
    "author": [
      "pussycat0x"
    ],
    "tags": [
      "js",
      "network",
      "proftpd",
      "ftp",
      "backdoor"
    ],
    "description": "This backdoor was present in the proftpd-1.3.3c.\n",
    "reference": [
      "https://github.com/shafdo/ProFTPD-1.3.3c-Backdoor_Command_Execution_Automated_Script/blob/main/README.md",
      "https://www.rapid7.com/db/modules/exploit/unix/ftp/proftpd_133c_backdoor/"
    ],
    "severity": "critical",
    "metadata": {
      "max-request": 1,
      "shodan-query": "product:\"ProFTPD\""
    }
  },
  "type": "javascript",
  "host": "apollox.s3.amazonaws.com:21",
  "port": "21",
  "url": "apollox.s3.amazonaws.com:21",
  "request": "const data = [\"HELP ACIDBITCHEZ\\n\", \"id\"];\nconst c = require(\"nuclei/net\");\nlet conn = c.Open('tcp', `${Host}:${Port}`);\nlet resp = conn.RecvFullString();\nif (resp.includes(\"ProFTPD 1.3.3c\")) {\n    for (let i = 0; i < data.length; i++) {\n        conn.Send(data[i]);\n        console.log('Sending:', data[i]);\n        let resp = conn.RecvFullString();\n        resp\n    }\n} else {\n    exit();\n}",
  "ip": "16.12.2.5",
  "timestamp": "2024-09-13T19:31:29.829687+05:30",
  "matcher-status": false,
  "error": "port closed or filtered"
}
```