### PR TITLE
fix(http): prevent `addCNameIfAvailable` from using closed `Dialer`

### DIFF
--- a/pkg/protocols/http/request.go
+++ b/pkg/protocols/http/request.go
@@ -1042,6 +1042,10 @@ func (request *Request) validateNFixEvent(input *contextargs.Context, gr *genera
 
 // addCNameIfAvailable adds the cname to the event if available
 func (request *Request) addCNameIfAvailable(hostname string, outputEvent map[string]interface{}) {
+	if protocolstate.Dialer == nil {
+		return
+	}
+
 	data, err := protocolstate.Dialer.GetDNSData(hostname)
 	if err == nil {
 		switch len(data.CNAME) {


### PR DESCRIPTION
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->

added a check in `addCNameIfAvailable` to ensure
the `Dialer` isnot NIL before attempting to fetch
DNS data.

this prevents potential panics (ex. SIGSEGV) when
the `Dialer` is closed due to an interruption.

Close #5664 

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)