### PR TITLE
Add loadConfig S3 based on AWS_PROFILE ~/.aws/credentials

### DIFF
--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -235,15 +235,21 @@ func validateMissingS3Options(options *types.Options) []string {
 	if options.AwsBucketName == "" {
 		missing = append(missing, "AWS_TEMPLATE_BUCKET")
 	}
-	if options.AwsAccessKey == "" {
-		missing = append(missing, "AWS_ACCESS_KEY")
+	if options.AwsProfile == "" {
+		if options.AwsAccessKey == "" {
+			missing = append(missing, "AWS_ACCESS_KEY")
+		}
+		if options.AwsSecretKey == "" {
+			missing = append(missing, "AWS_SECRET_KEY")
+		}
+		if options.AwsRegion == "" {
+			missing = append(missing, "AWS_REGION")
+		}
 	}
-	if options.AwsSecretKey == "" {
-		missing = append(missing, "AWS_SECRET_KEY")
+	if (options.AwsAccessKey == "" || options.AwsSecretKey == "" || options.AwsRegion == "") && options.AwsProfile == "" {
+		missing = append(missing, "AWS_PROFILE")
 	}
-	if options.AwsRegion == "" {
-		missing = append(missing, "AWS_REGION")
-	}
+
 	return missing
 }
 
@@ -449,6 +455,7 @@ func readEnvInputVars(options *types.Options) {
 	options.AwsSecretKey = os.Getenv("AWS_SECRET_KEY")
 	options.AwsBucketName = os.Getenv("AWS_TEMPLATE_BUCKET")
 	options.AwsRegion = os.Getenv("AWS_REGION")
+	options.AwsProfile = os.Getenv("AWS_PROFILE")
 
 	// Azure options for downloading templates from an Azure Blob Storage container
 	options.AzureContainerName = os.Getenv("AZURE_CONTAINER_NAME")

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -236,18 +236,22 @@ func validateMissingS3Options(options *types.Options) []string {
 		missing = append(missing, "AWS_TEMPLATE_BUCKET")
 	}
 	if options.AwsProfile == "" {
+		var missingCreds []string
 		if options.AwsAccessKey == "" {
-			missing = append(missing, "AWS_ACCESS_KEY")
+			missingCreds = append(missingCreds, "AWS_ACCESS_KEY")
 		}
 		if options.AwsSecretKey == "" {
-			missing = append(missing, "AWS_SECRET_KEY")
+			missingCreds = append(missingCreds, "AWS_SECRET_KEY")
 		}
 		if options.AwsRegion == "" {
-			missing = append(missing, "AWS_REGION")
+			missingCreds = append(missingCreds, "AWS_REGION")
 		}
-	}
-	if (options.AwsAccessKey == "" || options.AwsSecretKey == "" || options.AwsRegion == "") && options.AwsProfile == "" {
-		missing = append(missing, "AWS_PROFILE")
+
+		missing = append(missing, missingCreds...)
+
+		if len(missingCreds) > 0 {
+			missing = append(missing, "AWS_PROFILE")
+		}
 	}
 
 	return missing

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -345,6 +345,8 @@ type Options struct {
 	GitLabTemplateRepositoryIDs []int
 	// GitLabTemplateDisableDownload disables downloading templates from custom GitLab repositories
 	GitLabTemplateDisableDownload bool
+	// AWS access profile from ~/.aws/credentials file for downloading templates from S3 bucket
+	AwsProfile string
 	// AWS access key for downloading templates from S3 bucket
 	AwsAccessKey string
 	// AWS secret key for downloading templates from S3 bucket


### PR DESCRIPTION
## Proposed changes
To retrieve a S3 bucket based on a loacConfid, i have added a feature allowing to use AWS_PROFILE from ~/.aws/credentials file. 

The aim is to be able to use the profile option from aws cli like 
`aws s3 ls --profile my-profile`


## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for configuring AWS credentials via an AWS profile (using the AWS_PROFILE environment variable) for S3 operations.
  - Improved validation of AWS settings to offer clearer error messages when required credentials or configurations are missing.
  - Enhanced the S3 client initialization to accept an AWS profile parameter for more flexible credential management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->