### PR TITLE
fix: respond with boolean on successful ldap authentication

### DIFF
--- a/pkg/js/libs/ldap/ldap.go
+++ b/pkg/js/libs/ldap/ldap.go
@@ -155,7 +155,7 @@ func NewClient(call goja.ConstructorCall, runtime *goja.Runtime) *goja.Object {
 // const client = new ldap.Client('ldap://ldap.example.com', 'acme.com');
 // client.Authenticate('user', 'password');
 // ```
-func (c *Client) Authenticate(username, password string) {
+func (c *Client) Authenticate(username, password string) bool {
 	c.nj.Require(c.conn != nil, "no existing connection")
 	if c.BaseDN == "" {
 		c.BaseDN = fmt.Sprintf("dc=%s", strings.Join(strings.Split(c.Realm, "."), ",dc="))
@@ -163,19 +163,21 @@ func (c *Client) Authenticate(username, password string) {
 	if err := c.conn.NTLMBind(c.Realm, username, password); err == nil {
 		// if bind with NTLMBind(), there is nothing
 		// else to do, you are authenticated
-		return
+		return true
 	}
 
+	var err error
 	switch password {
 	case "":
-		if err := c.conn.UnauthenticatedBind(username); err != nil {
+		if err = c.conn.UnauthenticatedBind(username); err != nil {
 			c.nj.ThrowError(err)
 		}
 	default:
-		if err := c.conn.Bind(username, password); err != nil {
+		if err = c.conn.Bind(username, password); err != nil {
 			c.nj.ThrowError(err)
 		}
 	}
+	return err == nil
 }
 
 // AuthenticateWithNTLMHash authenticates with the ldap server using the given username and NTLM hash
@@ -185,14 +187,16 @@ func (c *Client) Authenticate(username, password string) {
 // const client = new ldap.Client('ldap://ldap.example.com', 'acme.com');
 // client.AuthenticateWithNTLMHash('pdtm', 'hash');
 // ```
-func (c *Client) AuthenticateWithNTLMHash(username, hash string) {
+func (c *Client) AuthenticateWithNTLMHash(username, hash string) bool {
 	c.nj.Require(c.conn != nil, "no existing connection")
 	if c.BaseDN == "" {
 		c.BaseDN = fmt.Sprintf("dc=%s", strings.Join(strings.Split(c.Realm, "."), ",dc="))
 	}
-	if err := c.conn.NTLMBindWithHash(c.Realm, username, hash); err != nil {
+	var err error
+	if err = c.conn.NTLMBindWithHash(c.Realm, username, hash); err != nil {
 		c.nj.ThrowError(err)
 	}
+	return err == nil
 }
 
 // Search accepts whatever filter and returns a list of maps having provided attributes


### PR DESCRIPTION
- closes: #5447 

## Test

<details>

<summary> Local setup </summary>

__docker-compose.yaml__

```yaml
version: '3.8'

networks:
  openldap-network:
    driver: bridge
services:
  openldap:
    image: bitnami/openldap:latest
    ports:
      - '1389:1389'
      - '1636:1636'
    environment:
      - LDAP_ADMIN_USERNAME=admin
      - LDAP_ADMIN_PASSWORD=adminpassword
      - LDAP_USERS=user01,user02
      - LDAP_PASSWORDS=password1,password2
    networks:
      - openldap-network
    volumes:
      - 'openldap_data:/bitnami/openldap'

volumes:
  openldap_data:
    driver: local
```

```bash
$ docker compose up -d 
```

</details>

<details>

<summary> Template </summary>

```yaml
id: ldap-default-creds

info:
  name: LDAP Default Credential - Bruteforce
  author: pussycat0x
  severity: info
  description: |
    Attempts to guess username/password combinations over LDAP.
  metadata:
    shodan-query: ldap
  tags: js,network,ldap,enum

javascript:
  - code: |
      const ldap = require('nuclei/ldap');
      const cfg = new ldap.Config();
      cfg.Upgrade = true;
      const client = ldap.Client(Url, Realm, cfg);
      const response = client.Authenticate(User, Pass);
      log(response);

    args:
      Host: "ldap://{{Host}}"
      Port: 1389
      Url: "ldap://{{Host}}:{{Port}}"
      Realm: "example.org"
      User: "{{usernames}}"
      Pass: "{{passwords}}"

    attack: clusterbomb
    payloads:
      usernames:
        - cn=admin,dc=example,dc=org
      passwords:
        - adminpassword

    matchers:
      - type: dsl
        dsl:
          - 'success == true'

```

</details>

```console
✗ ./nuclei -t test.yaml -u localhost -debug

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.3.4

                projectdiscovery.io

[INF] Current nuclei version: v3.3.4 (latest)
[INF] Current nuclei-templates version: v10.0.1 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 316
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[JS] true
[DBG] [ldap-default-creds] Dumped Javascript request for localhost:1389:
Variables:
        1. Host => ldap://localhost
        2. Pass => adminpassword
        3. Port => 1389
        4. Realm => example.org
        5. Url => ldap://localhost:1389
        6. User => cn=admin,dc=example,dc=org address=localhost:1389
[DBG]  [ldap-default-creds] Javascript Code:

        const ldap = require('nuclei/ldap');
        const cfg = new ldap.Config();
        cfg.Upgrade = true;
        const client = ldap.Client(Url, Realm, cfg);
        const response = client.Authenticate(User, Pass);
        log(response);

[DBG] [ldap-default-creds] Dumped Javascript response for localhost:1389:
        1. response => true
        2. success => true address=localhost:1389
[ldap-default-creds:dsl-1] [javascript] [info] localhost:1389 [passwords="adminpassword",usernames="cn=admin,dc=example,dc=org"]
```

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)