### PR TITLE
Fix: LDAP metadata collection err

### DIFF
--- a/pkg/js/libs/ldap/ldap.go
+++ b/pkg/js/libs/ldap/ldap.go
@@ -279,9 +279,10 @@ func (c *Client) CollectMetadata() Metadata {
 	}
 	metadata.BaseDN = c.BaseDN
 
+	// Use scope as Base since Root DSE doesn't have subentries
 	srMetadata := ldap.NewSearchRequest(
 		"",
-		ldap.ScopeWholeSubtree,
+		ldap.ScopeBaseObject,
 		ldap.NeverDerefAliases,
 		0, 0, false,
 		"(objectClass=*)",


### PR DESCRIPTION
- closes: #5446 
## Test

<details>

<summary> Local setup </summary>

__docker-compose.yaml__

```yaml
version: '3.8'

networks:
  openldap-network:
    driver: bridge
services:
  openldap:
    image: bitnami/openldap:latest
    ports:
      - '1389:1389'
      - '1636:1636'
    environment:
      - LDAP_ADMIN_USERNAME=admin
      - LDAP_ADMIN_PASSWORD=adminpassword
      - LDAP_USERS=user01,user02
      - LDAP_PASSWORDS=password1,password2
    networks:
      - openldap-network
    volumes:
      - 'openldap_data:/bitnami/openldap'

volumes:
  openldap_data:
    driver: local
```

```bash
$ docker compose up -d 
```

</details>

<details>

<summary> Template </summary>

```yaml
id: ldap-default-creds

info:
  name: LDAP Default Credential - Bruteforce
  author: pussycat0x
  severity: info
  description: |
    Attempts to guess username/password combinations over LDAP.
  metadata:
    shodan-query: ldap
  tags: js,network,ldap,enum

javascript:
  - code: |
      const ldap = require('nuclei/ldap');
      const cfg = new ldap.Config();
      cfg.Upgrade = true;
      const client = ldap.Client(Url, Realm, cfg);
      const metadata = client.CollectMetadata();
      log(to_json(metadata))

    args:
      Host: "ldap://{{Host}}"
      Port: 1389
      Url: "ldap://{{Host}}:{{Port}}"
      Realm: "example.org"

    matchers:
      - type: dsl
        dsl:
          - 'success == true'
```

</details>

```console
✗./nuclei -t test.yaml -u localhost -debug

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.3.4

                projectdiscovery.io

[INF] Current nuclei version: v3.3.4 (latest)
[INF] Current nuclei-templates version: v10.0.1 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 86
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[JS] {
  "BaseDN": "dc=example,dc=org",
  "Domain": "example.org",
  "DefaultNamingContext": "",
  "DomainFunctionality": "",
  "ForestFunctionality": "",
  "DomainControllerFunctionality": "",
  "DnsHostName": ""
}
[DBG] [ldap-default-creds] Dumped Javascript request for localhost:1389:
Variables:
        1. Host => ldap://localhost
        2. Port => 1389
        3. Realm => example.org
        4. Url => ldap://localhost:1389 address=localhost:1389
[DBG]  [ldap-default-creds] Javascript Code:

        const ldap = require('nuclei/ldap');
        const cfg = new ldap.Config();
        cfg.Upgrade = true;
        const client = ldap.Client(Url, Realm, cfg);
        const metadata = client.CollectMetadata();
        log(to_json(metadata))

[DBG] [ldap-default-creds] Dumped Javascript response for localhost:1389:
        1. response => {   "BaseDN": "dc=example .... "",   "DnsHostName": "" }
        2. success => true address=localhost:1389
[ldap-default-creds:dsl-1] [javascript] [info] localhost:1389
```

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)