### PR TITLE
Unlock memguard global change mutex only when locked

### DIFF
--- a/pkg/protocols/common/protocolstate/memguardian.go
+++ b/pkg/protocols/common/protocolstate/memguardian.go
@@ -77,9 +77,8 @@ var muGlobalChange sync.Mutex
 
 // Global setting
 func GlobalGuardBytesBufferAlloc() error {
-	if muGlobalChange.TryLock() {
+	if !muGlobalChange.TryLock() {
 		return nil
-
 	}
 	defer muGlobalChange.Unlock()
 
@@ -95,9 +94,8 @@ func GlobalGuardBytesBufferAlloc() error {
 
 // Global setting
 func GlobalRestoreBytesBufferAlloc() {
-	if muGlobalChange.TryLock() {
+	if !muGlobalChange.TryLock() {
 		return
-
 	}
 	defer muGlobalChange.Unlock()
 


### PR DESCRIPTION
- Unlock the memguard global change mutex only when locked, otherwise could panic on concurrent operations

## Proposed changes

Unlock the memgoard global change mutex only when locked.

## Checklist

- [X] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [X] All checks passed (lint, unit/integration/regression tests etc.) with my changes