### PR TITLE
feat(headless): add `cdp-endpoint` option

### DIFF
--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -407,6 +407,7 @@ on extensive configurability, massive extensibility and ease of use.`)
 		flagSet.BoolVarP(&options.ShowBrowser, "show-browser", "sb", false, "show the browser on the screen when running templates with headless mode"),
 		flagSet.StringSliceVarP(&options.HeadlessOptionalArguments, "headless-options", "ho", nil, "start headless chrome with additional options", goflags.FileCommaSeparatedStringSliceOptions),
 		flagSet.BoolVarP(&options.UseInstalledChrome, "system-chrome", "sc", false, "use local installed Chrome browser instead of nuclei installed"),
+		flagSet.StringVarP(&options.CDPEndpoint, "cdp-endpoint", "cdpe", "", "use remote browser via Chrome DevTools Protocol (CDP) endpoint"),
 		flagSet.BoolVarP(&options.ShowActions, "list-headless-action", "lha", false, "list available headless actions"),
 	)
 

--- a/pkg/protocols/headless/engine/engine.go
+++ b/pkg/protocols/headless/engine/engine.go
@@ -29,61 +29,72 @@ type Browser struct {
 
 // New creates a new nuclei headless browser module
 func New(options *types.Options) (*Browser, error) {
-	dataStore, err := os.MkdirTemp("", "nuclei-*")
-	if err != nil {
-		return nil, errors.Wrap(err, "could not create temporary directory")
-	}
-	previousPIDs := processutil.FindProcesses(processutil.IsChromeProcess)
+	var launcherURL, dataStore string
+	var previousPIDs map[int32]struct{}
+	var err error
 
-	chromeLauncher := launcher.New().
-		Leakless(false).
-		Set("disable-gpu", "true").
-		Set("ignore-certificate-errors", "true").
-		Set("ignore-certificate-errors", "1").
-		Set("disable-crash-reporter", "true").
-		Set("disable-notifications", "true").
-		Set("hide-scrollbars", "true").
-		Set("window-size", fmt.Sprintf("%d,%d", 1080, 1920)).
-		Set("mute-audio", "true").
-		Set("incognito", "true").
-		Delete("use-mock-keychain").
-		UserDataDir(dataStore)
+	chromeLauncher := launcher.New()
 
-	if MustDisableSandbox() {
-		chromeLauncher = chromeLauncher.NoSandbox(true)
-	}
+	if options.CDPEndpoint == "" {
+		previousPIDs = processutil.FindProcesses(processutil.IsChromeProcess)
 
-	executablePath, err := os.Executable()
-	if err != nil {
-		return nil, err
-	}
-
-	// if musl is used, most likely we are on alpine linux which is not supported by go-rod, so we fallback to default chrome
-	useMusl, _ := fileutil.UseMusl(executablePath)
-	if options.UseInstalledChrome || useMusl {
-		if chromePath, hasChrome := launcher.LookPath(); hasChrome {
-			chromeLauncher.Bin(chromePath)
-		} else {
-			return nil, errors.New("the chrome browser is not installed")
+		dataStore, err = os.MkdirTemp("", "nuclei-*")
+		if err != nil {
+			return nil, errors.Wrap(err, "could not create temporary directory")
 		}
-	}
 
-	if options.ShowBrowser {
-		chromeLauncher = chromeLauncher.Headless(false)
+		chromeLauncher = chromeLauncher.
+			Leakless(false).
+			Set("disable-gpu", "true").
+			Set("ignore-certificate-errors", "true").
+			Set("ignore-certificate-errors", "1").
+			Set("disable-crash-reporter", "true").
+			Set("disable-notifications", "true").
+			Set("hide-scrollbars", "true").
+			Set("window-size", fmt.Sprintf("%d,%d", 1080, 1920)).
+			Set("mute-audio", "true").
+			Set("incognito", "true").
+			Delete("use-mock-keychain").
+			UserDataDir(dataStore)
+
+		if MustDisableSandbox() {
+			chromeLauncher = chromeLauncher.NoSandbox(true)
+		}
+
+		executablePath, err := os.Executable()
+		if err != nil {
+			return nil, err
+		}
+
+		// if musl is used, most likely we are on alpine linux which is not supported by go-rod, so we fallback to default chrome
+		useMusl, _ := fileutil.UseMusl(executablePath)
+		if options.UseInstalledChrome || useMusl {
+			if chromePath, hasChrome := launcher.LookPath(); hasChrome {
+				chromeLauncher.Bin(chromePath)
+			} else {
+				return nil, errors.New("the chrome browser is not installed")
+			}
+		}
+
+		if options.ShowBrowser {
+			chromeLauncher = chromeLauncher.Headless(false)
+		} else {
+			chromeLauncher = chromeLauncher.Headless(true)
+		}
+		if types.ProxyURL != "" {
+			chromeLauncher = chromeLauncher.Proxy(types.ProxyURL)
+		}
+
+		for k, v := range options.ParseHeadlessOptionalArguments() {
+			chromeLauncher.Set(flags.Flag(k), v)
+		}
+
+		launcherURL, err = chromeLauncher.Launch()
+		if err != nil {
+			return nil, err
+		}
 	} else {
-		chromeLauncher = chromeLauncher.Headless(true)
-	}
-	if types.ProxyURL != "" {
-		chromeLauncher = chromeLauncher.Proxy(types.ProxyURL)
-	}
-
-	for k, v := range options.ParseHeadlessOptionalArguments() {
-		chromeLauncher.Set(flags.Flag(k), v)
-	}
-
-	launcherURL, err := chromeLauncher.Launch()
-	if err != nil {
-		return nil, err
+		launcherURL = options.CDPEndpoint
 	}
 
 	browser := rod.New().ControlURL(launcherURL)
@@ -135,7 +146,13 @@ func (b *Browser) UserAgent() string {
 }
 
 // Close closes the browser engine
+//
+// When connected over CDP, it does NOT close the browsers.
 func (b *Browser) Close() {
+	if b.options.CDPEndpoint != "" {
+		return
+	}
+
 	b.engine.Close()
 	os.RemoveAll(b.tempDir)
 	processutil.CloseProcesses(processutil.IsChromeProcess, b.previousPIDs)

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -167,6 +167,8 @@ type Options struct {
 	ForceAttemptHTTP2 bool
 	// StatsJSON writes stats output in JSON format
 	StatsJSON bool
+	// CDPEndpoint specifies the endpoint for Chrome DevTools Protocol (CDP)
+	CDPEndpoint string
 	// Headless specifies whether to allow headless mode templates
 	Headless bool
 	// ShowBrowser specifies whether the show the browser in headless mode


### PR DESCRIPTION
## Proposed changes

Close #5692 

### How has this been tested?


```bash
# tty1
/path/to/chrome --headless --remote-debugging-port=9222 --ignore-certificate-errors --ignore-ssl-errors
```

```bash
# tty2
go run cmd/nuclei/main.go -headless -t headless-template-1.yaml -u http://scanme.sh -cdp-endpoint "CHROME_DEVTOOLS_ENDPOINT_URL"
```


## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)