### PR TITLE
Add Reporting Feature with SDK Lib

### DIFF
--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -274,7 +274,7 @@ func validateMissingGitLabOptions(options *types.Options) []string {
 	return missing
 }
 
-func createReportingOptions(options *types.Options) (*reporting.Options, error) {
+func CreateReportingOptions(options *types.Options) (*reporting.Options, error) {
 	var reportingOptions = &reporting.Options{}
 	if options.ReportingConfig != "" {
 		file, err := os.Open(options.ReportingConfig)

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -193,7 +193,7 @@ func New(options *types.Options) (*Runner, error) {
 	if err := reporting.CreateConfigIfNotExists(); err != nil {
 		return nil, err
 	}
-	reportingOptions, err := createReportingOptions(options)
+	reportingOptions, err := CreateReportingOptions(options)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -13,14 +13,14 @@ import (
 func TestCreateReportingOptions(t *testing.T) {
 	var options types.Options
 	options.ReportingConfig = "../../integration_tests/test-issue-tracker-config1.yaml"
-	resultOptions, err := createReportingOptions(&options)
+	resultOptions, err := CreateReportingOptions(&options)
 
 	require.Nil(t, err)
 	require.Equal(t, resultOptions.AllowList.Severities, severity.Severities{severity.High, severity.Critical})
 	require.Equal(t, resultOptions.DenyList.Severities, severity.Severities{severity.Low})
 
 	options.ReportingConfig = "../../integration_tests/test-issue-tracker-config2.yaml"
-	resultOptions2, err := createReportingOptions(&options)
+	resultOptions2, err := CreateReportingOptions(&options)
 	require.Nil(t, err)
 	require.Equal(t, resultOptions2.AllowList.Severities, resultOptions.AllowList.Severities)
 	require.Equal(t, resultOptions2.DenyList.Severities, resultOptions.DenyList.Severities)

--- a/lib/config.go
+++ b/lib/config.go
@@ -449,3 +449,19 @@ func DisableUpdateCheck() NucleiSDKOptions {
 		return nil
 	}
 }
+
+type ExporterOptions struct {
+	SarifExport string
+	JSONExport  string
+	JSONLExport string
+}
+
+// WithExportOptions allows setting export options (only Sarif, JSON, JSONL export)
+func WithExportOptions(opts ExporterOptions) NucleiSDKOptions {
+	return func(e *NucleiEngine) error {
+		e.opts.SarifExport = opts.SarifExport
+		e.opts.JSONExport = opts.JSONExport
+		e.opts.JSONLExport = opts.JSONLExport
+		return nil
+	}
+}

--- a/lib/config.go
+++ b/lib/config.go
@@ -450,15 +450,19 @@ func DisableUpdateCheck() NucleiSDKOptions {
 	}
 }
 
-type ExporterOptions struct {
-	SarifExport string
-	JSONExport  string
-	JSONLExport string
+type ExportOptions struct {
+	ReportingConfig string
+	ReportingDB     string
+	SarifExport     string
+	JSONExport      string
+	JSONLExport     string
 }
 
 // WithExportOptions allows setting export options (only Sarif, JSON, JSONL export)
-func WithExportOptions(opts ExporterOptions) NucleiSDKOptions {
+func WithExportReportingOptions(opts ExportOptions) NucleiSDKOptions {
 	return func(e *NucleiEngine) error {
+		e.opts.ReportingConfig = opts.ReportingConfig
+		e.opts.ReportingDB = opts.ReportingDB
 		e.opts.SarifExport = opts.SarifExport
 		e.opts.JSONExport = opts.JSONExport
 		e.opts.JSONLExport = opts.JSONLExport

--- a/lib/sdk_private.go
+++ b/lib/sdk_private.go
@@ -29,10 +29,6 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/http/httpclientpool"
 	"github.com/projectdiscovery/nuclei/v3/pkg/reporting"
-	"github.com/projectdiscovery/nuclei/v3/pkg/reporting/exporters/jsonexporter"
-	"github.com/projectdiscovery/nuclei/v3/pkg/reporting/exporters/jsonl"
-	"github.com/projectdiscovery/nuclei/v3/pkg/reporting/exporters/markdown"
-	"github.com/projectdiscovery/nuclei/v3/pkg/reporting/exporters/sarif"
 	"github.com/projectdiscovery/nuclei/v3/pkg/templates"
 	"github.com/projectdiscovery/nuclei/v3/pkg/testutils"
 	"github.com/projectdiscovery/nuclei/v3/pkg/types"
@@ -41,36 +37,6 @@ import (
 )
 
 var sharedInit *sync.Once
-
-// test reporting options
-func createReportingOptions(options *types.Options) (*reporting.Options, error) {
-	var reportingOptions = &reporting.Options{}
-	if options.MarkdownExportDirectory != "" {
-		reportingOptions.MarkdownExporter = &markdown.Options{
-			Directory: options.MarkdownExportDirectory,
-			OmitRaw:   options.OmitRawRequests,
-			SortMode:  options.MarkdownExportSortMode,
-		}
-	}
-	if options.SarifExport != "" {
-		reportingOptions.SarifExporter = &sarif.Options{File: options.SarifExport}
-	}
-	if options.JSONExport != "" {
-		reportingOptions.JSONExporter = &jsonexporter.Options{
-			File:    options.JSONExport,
-			OmitRaw: options.OmitRawRequests,
-		}
-	}
-	if options.JSONLExport != "" {
-		reportingOptions.JSONLExporter = &jsonl.Options{
-			File:    options.JSONLExport,
-			OmitRaw: options.OmitRawRequests,
-		}
-	}
-
-	reportingOptions.OmitRaw = options.OmitRawRequests
-	return reportingOptions, nil
-}
 
 // applyRequiredDefaults to options
 func (e *NucleiEngine) applyRequiredDefaults(ctx context.Context) {
@@ -177,9 +143,7 @@ func (e *NucleiEngine) init(ctx context.Context) error {
 	if err := reporting.CreateConfigIfNotExists(); err != nil {
 		return err
 	}
-	// we don't support reporting config in sdk mode
-
-	reportingOptions, err := createReportingOptions(e.opts)
+	reportingOptions, err := runner.CreateReportingOptions(e.opts)
 	if err != nil {
 		return err
 	}

--- a/lib/sdk_private.go
+++ b/lib/sdk_private.go
@@ -153,7 +153,7 @@ func (e *NucleiEngine) init(ctx context.Context) error {
 	}
 
 	if reportingOptions != nil {
-		e.rc, err = reporting.New(reportingOptions, "", false)
+		e.rc, err = reporting.New(reportingOptions, e.opts.ReportingDB, false)
 		if err != nil {
 			return err
 		}

--- a/lib/sdk_private.go
+++ b/lib/sdk_private.go
@@ -3,7 +3,6 @@ package nuclei
 import (
 	"context"
 	"fmt"
-	"github.com/projectdiscovery/nuclei/v3/pkg/input"
 	"strings"
 	"sync"
 	"time"
@@ -18,6 +17,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/config"
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/disk"
 	"github.com/projectdiscovery/nuclei/v3/pkg/core"
+	"github.com/projectdiscovery/nuclei/v3/pkg/input"
 	"github.com/projectdiscovery/nuclei/v3/pkg/input/provider"
 	"github.com/projectdiscovery/nuclei/v3/pkg/installer"
 	"github.com/projectdiscovery/nuclei/v3/pkg/output"
@@ -29,6 +29,10 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/http/httpclientpool"
 	"github.com/projectdiscovery/nuclei/v3/pkg/reporting"
+	"github.com/projectdiscovery/nuclei/v3/pkg/reporting/exporters/jsonexporter"
+	"github.com/projectdiscovery/nuclei/v3/pkg/reporting/exporters/jsonl"
+	"github.com/projectdiscovery/nuclei/v3/pkg/reporting/exporters/markdown"
+	"github.com/projectdiscovery/nuclei/v3/pkg/reporting/exporters/sarif"
 	"github.com/projectdiscovery/nuclei/v3/pkg/templates"
 	"github.com/projectdiscovery/nuclei/v3/pkg/testutils"
 	"github.com/projectdiscovery/nuclei/v3/pkg/types"
@@ -37,6 +41,36 @@ import (
 )
 
 var sharedInit *sync.Once
+
+// test reporting options
+func createReportingOptions(options *types.Options) (*reporting.Options, error) {
+	var reportingOptions = &reporting.Options{}
+	if options.MarkdownExportDirectory != "" {
+		reportingOptions.MarkdownExporter = &markdown.Options{
+			Directory: options.MarkdownExportDirectory,
+			OmitRaw:   options.OmitRawRequests,
+			SortMode:  options.MarkdownExportSortMode,
+		}
+	}
+	if options.SarifExport != "" {
+		reportingOptions.SarifExporter = &sarif.Options{File: options.SarifExport}
+	}
+	if options.JSONExport != "" {
+		reportingOptions.JSONExporter = &jsonexporter.Options{
+			File:    options.JSONExport,
+			OmitRaw: options.OmitRawRequests,
+		}
+	}
+	if options.JSONLExport != "" {
+		reportingOptions.JSONLExporter = &jsonl.Options{
+			File:    options.JSONLExport,
+			OmitRaw: options.OmitRawRequests,
+		}
+	}
+
+	reportingOptions.OmitRaw = options.OmitRawRequests
+	return reportingOptions, nil
+}
 
 // applyRequiredDefaults to options
 func (e *NucleiEngine) applyRequiredDefaults(ctx context.Context) {
@@ -144,9 +178,23 @@ func (e *NucleiEngine) init(ctx context.Context) error {
 		return err
 	}
 	// we don't support reporting config in sdk mode
-	if e.rc, err = reporting.New(&reporting.Options{}, "", false); err != nil {
+
+	reportingOptions, err := createReportingOptions(e.opts)
+	if err != nil {
 		return err
 	}
+
+	if reportingOptions != nil && e.httpClient != nil {
+		reportingOptions.HttpClient = e.httpClient
+	}
+
+	if reportingOptions != nil {
+		e.rc, err = reporting.New(reportingOptions, "", false)
+		if err != nil {
+			return err
+		}
+	}
+
 	e.interactshOpts.IssuesClient = e.rc
 	if e.httpClient != nil {
 		e.interactshOpts.HTTPClient = e.httpClient


### PR DESCRIPTION
## Proposed changes
Today, the SDK lib does not handle Reporting. 
I have created a new option with the SDK called _WithExportReportingOptions_ allowing to set up theses options. 
Then, to modify the code as little as possible, I've made the runner function _createReportingOptions_ public, so that it can be used from the SDK lib. 
I don't think this modification will create any security concerns or call into question the architecture of the project. However, I'm open to any objections.

I've made some tests and it works ! :) 

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)