### PR TITLE
feat: add `-enable-global-matchers` flag

### DIFF
--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -264,6 +264,7 @@ on extensive configurability, massive extensibility and ease of use.`)
 		flagSet.BoolVar(&options.EnableCodeTemplates, "code", false, "enable loading code protocol-based templates"),
 		flagSet.BoolVarP(&options.DisableUnsignedTemplates, "disable-unsigned-templates", "dut", false, "disable running unsigned templates or templates with mismatched signature"),
 		flagSet.BoolVarP(&options.EnableSelfContainedTemplates, "enable-self-contained", "esc", false, "enable loading self-contained templates"),
+		flagSet.BoolVarP(&options.EnableGlobalMatchersTemplates, "enable-global-matchers", "egm", false, "enable loading global matchers templates"),
 		flagSet.BoolVar(&options.EnableFileTemplates, "file", false, "enable loading file templates"),
 	)
 

--- a/lib/config.go
+++ b/lib/config.go
@@ -393,6 +393,14 @@ func EnableSelfContainedTemplates() NucleiSDKOptions {
 	}
 }
 
+// EnableGlobalMatchersTemplates allows loading/executing global-matchers templates
+func EnableGlobalMatchersTemplates() NucleiSDKOptions {
+	return func(e *NucleiEngine) error {
+		e.opts.EnableGlobalMatchersTemplates = true
+		return nil
+	}
+}
+
 // EnableFileTemplates allows loading/executing file protocol templates
 func EnableFileTemplates() NucleiSDKOptions {
 	return func(e *NucleiEngine) error {

--- a/pkg/templates/compile.go
+++ b/pkg/templates/compile.go
@@ -82,7 +82,7 @@ func Parse(filePath string, preprocessor Preprocessor, options protocols.Executo
 	if err != nil {
 		return nil, err
 	}
-	if template.isGlobalMatchersEnabled() {
+	if template.isGlobalMatchersEnabled(options) {
 		item := &globalmatchers.Item{
 			TemplateID:   template.ID,
 			TemplatePath: filePath,
@@ -119,7 +119,11 @@ func Parse(filePath string, preprocessor Preprocessor, options protocols.Executo
 // templates.
 //
 // TODO: support all protocols.
-func (template *Template) isGlobalMatchersEnabled() bool {
+func (template *Template) isGlobalMatchersEnabled(executorOpts protocols.ExecutorOptions) bool {
+	if !executorOpts.Options.EnableGlobalMatchersTemplates {
+		return false
+	}
+
 	for _, request := range template.RequestsHTTP {
 		if request.GlobalMatchers {
 			return true

--- a/pkg/templates/compile.go
+++ b/pkg/templates/compile.go
@@ -82,7 +82,7 @@ func Parse(filePath string, preprocessor Preprocessor, options protocols.Executo
 	if err != nil {
 		return nil, err
 	}
-	if template.isGlobalMatchersEnabled(options) {
+	if template.isGlobalMatchersEnabled() {
 		item := &globalmatchers.Item{
 			TemplateID:   template.ID,
 			TemplatePath: filePath,
@@ -112,15 +112,16 @@ func Parse(filePath string, preprocessor Preprocessor, options protocols.Executo
 // isGlobalMatchersEnabled checks if any of requests in the template
 // have global matchers enabled. It iterates through all requests and
 // returns true if at least one request has global matchers enabled;
-// otherwise, it returns false.
+// otherwise, it returns false. If global matchers templates are not
+// enabled in the options, the method will immediately return false.
 //
 // Note: This method only checks the `RequestsHTTP`
 // field of the template, which is specific to http-protocol-based
 // templates.
 //
 // TODO: support all protocols.
-func (template *Template) isGlobalMatchersEnabled(executorOpts protocols.ExecutorOptions) bool {
-	if !executorOpts.Options.EnableGlobalMatchersTemplates {
+func (template *Template) isGlobalMatchersEnabled() bool {
+	if !template.Options.Options.EnableGlobalMatchersTemplates {
 		return false
 	}
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -383,8 +383,10 @@ type Options struct {
 	EnableCodeTemplates bool
 	// DisableUnsignedTemplates disables processing of unsigned templates
 	DisableUnsignedTemplates bool
-	// EnableSelfContainedTemplates disables processing of self-contained templates
+	// EnableSelfContainedTemplates enables processing of self-contained templates
 	EnableSelfContainedTemplates bool
+	// EnableGlobalMatchersTemplates enables processing of global-matchers templates
+	EnableGlobalMatchersTemplates bool
 	// EnableFileTemplates enables file templates
 	EnableFileTemplates bool
 	// Disables cloud upload


### PR DESCRIPTION
## Proposed changes

Close #5856 

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new option, `EnableGlobalMatchersTemplates`, allowing users to enable loading of global matchers templates for enhanced configurability.

- **Bug Fixes**
	- Updated comments for clarity regarding the `EnableSelfContainedTemplates` option.

- **Documentation**
	- Improved comments in code to enhance understanding of template processing options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->