### PR TITLE
removed trailing comma from the jsonl exporter

### DIFF
--- a/pkg/reporting/exporters/jsonl/jsonl.go
+++ b/pkg/reporting/exporters/jsonl/jsonl.go
@@ -70,7 +70,7 @@ func (exporter *Exporter) WriteRows() error {
 	var err error
 	if exporter.outputFile == nil {
 		// Open the JSONL file for writing and create it if it doesn't exist
-		exporter.outputFile, err = os.OpenFile(exporter.options.File, os.O_WRONLY|os.O_CREATE, 0644)
+		exporter.outputFile, err = os.OpenFile(exporter.options.File, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 		if err != nil {
 			return errors.Wrap(err, "failed to create JSONL file")
 		}

--- a/pkg/reporting/exporters/jsonl/jsonl.go
+++ b/pkg/reporting/exporters/jsonl/jsonl.go
@@ -86,8 +86,7 @@ func (exporter *Exporter) WriteRows() error {
 			return errors.Wrap(err, "failed to generate row for JSONL report")
 		}
 
-		// Add a trailing newline to the JSON byte array to confirm with the JSONL format
-		obj = append(obj, ',', '\n')
+		obj = append(obj, '\n')
 
 		// Attempt to append the JSON line to file specified in options.JSONLExport
 		if _, err = exporter.outputFile.Write(obj); err != nil {


### PR DESCRIPTION
## Proposed changes

This PR removes the trailing comma from the jsonl exporter (`-jsonl-export` flag) to comply with jsonlines formatting.

This addresses #5860

The current implementation creates a file that is comma **and** newline terminated. While this works as an output file, the file does not work when ingested into other programs:

```
$ nuclei --version
[INF] Nuclei Engine Version: v3.3.6
...omitted...

$ nuclei -t ./template.yaml -jsonl-export output.jsonl -l targets.txt
...omited...

$ cat output.jsonl
{...omitted..., "matcher-status":true},
{...omitted..., "matcher-status":true},
{...omitted..., "matcher-status":true},


$ cat output.jsonl | jq -c '."matcher-status"'                                                    
true
jq: parse error: Expected value before ',' at line 1, column 34721
```

This PR removes the comma from each row in the output:
```
go run cmd/nuclei/main.go -duc -t ./template.yaml -jsonl-export output.jsonl -l targets.txt
...omitted...

$ cat output.jsonl
{...omitted..., "matcher-status":true}
{...omitted..., "matcher-status":true}
{...omitted..., "matcher-status":true}

$ cat output.jsonl | jq -c '."matcher-status"'
true
true
true
```

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved formatting of JSON Lines in the output file for better compliance with JSONL standards. 

- **Bug Fixes**
	- Corrected the output format by ensuring each JSON object is followed only by a newline character.
	- Enhanced file handling to clear existing content before writing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->