### PR TITLE
Remove trailing comma from JSONL format

### DIFF
--- a/pkg/reporting/exporters/jsonl/jsonl.go
+++ b/pkg/reporting/exporters/jsonl/jsonl.go
@@ -87,7 +87,7 @@ func (exporter *Exporter) WriteRows() error {
 		}
 
 		// Add a trailing newline to the JSON byte array to confirm with the JSONL format
-		obj = append(obj, ',', '\n')
+		obj = append(obj, '\n')
 
 		// Attempt to append the JSON line to file specified in options.JSONLExport
 		if _, err = exporter.outputFile.Write(obj); err != nil {


### PR DESCRIPTION
## Proposed changes

Addresses #5860 by removing the trailing comma from the JSONL format.

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected the JSONL output format by removing an extraneous comma, ensuring each JSON object is now properly formatted as a single line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->