### PR TITLE
Added filename length restriction for debug mode (-srd flag) Issue-5929

### DIFF
--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -512,6 +512,13 @@ func sanitizeFileName(fileName string) string {
 }
 func (w *StandardWriter) WriteStoreDebugData(host, templateID, eventType string, data string) {
 	if w.storeResponse {
+		if len(host) > 60 {
+			host = host[:57] + "..."
+		}
+		if len(templateID) > 100 {
+			templateID = templateID[:97] + "..."
+		}
+
 		filename := sanitizeFileName(fmt.Sprintf("%s_%s", host, templateID))
 		subFolder := filepath.Join(w.storeResponseDir, sanitizeFileName(eventType))
 		if !fileutil.FolderExists(subFolder) {
@@ -526,7 +533,6 @@ func (w *StandardWriter) WriteStoreDebugData(host, templateID, eventType string,
 		_, _ = f.WriteString(fmt.Sprintln(data))
 		f.Close()
 	}
-
 }
 
 // tryParseCause tries to parse the cause of given error


### PR DESCRIPTION
## Proposed changes

Added a file name length restriction in the `WriteStoreDebugData` function for the debug mode triggered by the `-srd` flag. This change ensures that file names generated for debugging purposes are truncated. The update addresses the issue where excessively long file names caused by verbose requests could not be created due to operating system file name length limitations.


## Checklist

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced handling of `host` and `templateID` parameters by truncating their lengths for better filename management.

- **Bug Fixes**
	- Resolved issues with excessively long `host` and `templateID` values in debug data storage.

- **Style**
	- Minor formatting adjustments made for improved code clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->