### PR TITLE
Update LICENSE.md, fix copyright license year

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 ProjectDiscovery, Inc.
+Copyright (c) 2025 ProjectDiscovery, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Yearly copyright bump. Padding my changed LOC! 😛

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the copyright year in the MIT License from 2022 to 2025 for ProjectDiscovery, Inc.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->