### PR TITLE
Added WithResponseReadSize function to allow SDK users to modify max response read opt

### DIFF
--- a/lib/config.go
+++ b/lib/config.go
@@ -156,11 +156,17 @@ func WithConcurrency(opts Concurrency) NucleiSDKOptions {
 	}
 }
 
-// WithResponseReadSize sets the maximum size of response to read
-func WithResponseReadSize(ResponseReadSize int) NucleiSDKOptions {
+// WithResponseReadSize sets the maximum size of response to read in bytes.
+// A value of 0 means no limit. Recommended values: 1MB (1048576) to 10MB (10485760).
+func WithResponseReadSize(responseReadSize int) NucleiSDKOptions {
 	return func(e *NucleiEngine) error {
-		e.opts.ResponseReadSize = ResponseReadSize
+		if responseReadSize < 0 {
+			return errors.New("response read size must be non-negative")
+		}
+		e.opts.ResponseReadSize = responseReadSize
 		return nil
+	}
+}
 	}
 }
 

--- a/lib/config.go
+++ b/lib/config.go
@@ -126,39 +126,40 @@ func WithConcurrency(opts Concurrency) NucleiSDKOptions {
 		// minimum required is 1
 		if opts.TemplateConcurrency <= 0 {
 			return errors.New("template threads must be at least 1")
-		} else {
-			e.opts.TemplateThreads = opts.TemplateConcurrency
 		}
 		if opts.HostConcurrency <= 0 {
 			return errors.New("host concurrency must be at least 1")
-		} else {
-			e.opts.BulkSize = opts.HostConcurrency
 		}
 		if opts.HeadlessHostConcurrency <= 0 {
 			return errors.New("headless host concurrency must be at least 1")
-		} else {
-			e.opts.HeadlessBulkSize = opts.HeadlessHostConcurrency
 		}
 		if opts.HeadlessTemplateConcurrency <= 0 {
 			return errors.New("headless template threads must be at least 1")
-		} else {
-			e.opts.HeadlessTemplateThreads = opts.HeadlessTemplateConcurrency
 		}
 		if opts.JavascriptTemplateConcurrency <= 0 {
 			return errors.New("js must be at least 1")
-		} else {
-			e.opts.JsConcurrency = opts.JavascriptTemplateConcurrency
 		}
 		if opts.TemplatePayloadConcurrency <= 0 {
 			return errors.New("payload concurrency must be at least 1")
-		} else {
-			e.opts.PayloadConcurrency = opts.TemplatePayloadConcurrency
 		}
 		if opts.ProbeConcurrency <= 0 {
 			return errors.New("probe concurrency must be at least 1")
-		} else {
-			e.opts.ProbeConcurrency = opts.ProbeConcurrency
 		}
+		e.opts.TemplateThreads = opts.TemplateConcurrency
+		e.opts.BulkSize = opts.HostConcurrency
+		e.opts.HeadlessBulkSize = opts.HeadlessHostConcurrency
+		e.opts.HeadlessTemplateThreads = opts.HeadlessTemplateConcurrency
+		e.opts.JsConcurrency = opts.JavascriptTemplateConcurrency
+		e.opts.PayloadConcurrency = opts.TemplatePayloadConcurrency
+		e.opts.ProbeConcurrency = opts.ProbeConcurrency
+		return nil
+	}
+}
+
+// WithResponseReadSize sets the maximum size of response to read
+func WithResponseReadSize(ResponseReadSize int) NucleiSDKOptions {
+	return func(e *NucleiEngine) error {
+		e.opts.ResponseReadSize = ResponseReadSize
 		return nil
 	}
 }

--- a/lib/config.go
+++ b/lib/config.go
@@ -167,8 +167,6 @@ func WithResponseReadSize(responseReadSize int) NucleiSDKOptions {
 		return nil
 	}
 }
-	}
-}
 
 // WithGlobalRateLimit sets global rate (i.e all hosts combined) limit options
 // Deprecated: will be removed in favour of WithGlobalRateLimitCtx in next release


### PR DESCRIPTION
## Proposed changes
This adds a WithResponseReadSize() function so that SDK users can change the max response read size to suit their needs. I also simplified the WithConcurrency() function to reduce the cognitive complexity of it (no functional change).

Related Github issue: #5895 

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [X] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a new configuration option to set maximum response read size.
- **Refactor**
	- Simplified concurrency option handling by removing unnecessary conditional branches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->