### PR TITLE
fix(multiproto): missing previous `InternalEvent`s output when `ExecuteWithResults`

### DIFF
--- a/pkg/tmplexec/multiproto/multi.go
+++ b/pkg/tmplexec/multiproto/multi.go
@@ -2,6 +2,7 @@ package multiproto
 
 import (
 	"strconv"
+	"strings"
 	"sync/atomic"
 
 	"github.com/projectdiscovery/nuclei/v3/pkg/output"
@@ -9,6 +10,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/generators"
 	"github.com/projectdiscovery/nuclei/v3/pkg/scan"
 	"github.com/projectdiscovery/nuclei/v3/pkg/templates/types"
+	mapsutil "github.com/projectdiscovery/utils/maps"
 	stringsutil "github.com/projectdiscovery/utils/strings"
 )
 
@@ -60,41 +62,7 @@ func (m *MultiProtocol) ExecuteWithResults(ctx *scan.ScanContext) error {
 		m.options.GetTemplateCtx(ctx.Input.MetaInput).Set(key, value)
 	})
 
-	// callback to process results from all protocols
-	multiProtoCallback := func(event *output.InternalWrappedEvent) {
-		if event == nil {
-			return
-		}
-		// log event and generate result for the event
-		ctx.LogEvent(event)
-		// export dynamic values from operators (i.e internal:true)
-		if event.OperatorsResult != nil && len(event.OperatorsResult.DynamicValues) > 0 {
-			for k, v := range event.OperatorsResult.DynamicValues {
-				// TBD: iterate-all is only supported in `http` protocol
-				// we either need to add support for iterate-all in other protocols or implement a different logic (specific to template context)
-				// currently if dynamic value array only contains one value we replace it with the value
-				if len(v) == 1 {
-					m.options.GetTemplateCtx(ctx.Input.MetaInput).Set(k, v[0])
-				} else {
-					// Note: if extracted value contains multiple values then they can be accessed by indexing
-					// ex: if values are dynamic = []string{"a","b","c"} then they are available as
-					// dynamic = "a" , dynamic1 = "b" , dynamic2 = "c"
-					// we intentionally omit first index for unknown situations (where no of extracted values are not known)
-					for i, val := range v {
-						if i == 0 {
-							m.options.GetTemplateCtx(ctx.Input.MetaInput).Set(k, val)
-						} else {
-							m.options.GetTemplateCtx(ctx.Input.MetaInput).Set(k+strconv.Itoa(i), val)
-						}
-					}
-				}
-			}
-		}
-
-		// evaluate all variables after execution of each protocol
-		variableMap := m.options.Variables.Evaluate(m.options.GetTemplateCtx(ctx.Input.MetaInput).GetAll())
-		m.options.GetTemplateCtx(ctx.Input.MetaInput).Merge(variableMap) // merge all variables into template context
-	}
+	previous := mapsutil.NewSyncLockMap[string, any]()
 
 	// template context: contains values extracted using `internal` extractor from previous protocols
 	// these values are extracted from each protocol in queue and are passed to next protocol in queue
@@ -117,7 +85,53 @@ func (m *MultiProtocol) ExecuteWithResults(ctx *scan.ScanContext) error {
 		}
 		// FIXME: this hack of using hash to get templateCtx has known issues scan context based approach should be adopted ASAP
 		values := m.options.GetTemplateCtx(inputItem.MetaInput).GetAll()
-		err := req.ExecuteWithResults(inputItem, output.InternalEvent(values), nil, multiProtoCallback)
+		err := req.ExecuteWithResults(inputItem, output.InternalEvent(values), output.InternalEvent(previous.GetAll()), func(event *output.InternalWrappedEvent) {
+			if event == nil {
+				return
+			}
+
+			ID := req.GetID()
+			if ID != "" {
+				builder := &strings.Builder{}
+				for k, v := range event.InternalEvent {
+					builder.WriteString(ID)
+					builder.WriteString("_")
+					builder.WriteString(k)
+					_ = previous.Set(builder.String(), v)
+					builder.Reset()
+				}
+			}
+
+			// log event and generate result for the event
+			ctx.LogEvent(event)
+			// export dynamic values from operators (i.e internal:true)
+			if event.OperatorsResult != nil && len(event.OperatorsResult.DynamicValues) > 0 {
+				for k, v := range event.OperatorsResult.DynamicValues {
+					// TBD: iterate-all is only supported in `http` protocol
+					// we either need to add support for iterate-all in other protocols or implement a different logic (specific to template context)
+					// currently if dynamic value array only contains one value we replace it with the value
+					if len(v) == 1 {
+						m.options.GetTemplateCtx(ctx.Input.MetaInput).Set(k, v[0])
+					} else {
+						// Note: if extracted value contains multiple values then they can be accessed by indexing
+						// ex: if values are dynamic = []string{"a","b","c"} then they are available as
+						// dynamic = "a" , dynamic1 = "b" , dynamic2 = "c"
+						// we intentionally omit first index for unknown situations (where no of extracted values are not known)
+						for i, val := range v {
+							if i == 0 {
+								m.options.GetTemplateCtx(ctx.Input.MetaInput).Set(k, val)
+							} else {
+								m.options.GetTemplateCtx(ctx.Input.MetaInput).Set(k+strconv.Itoa(i), val)
+							}
+						}
+					}
+				}
+			}
+
+			// evaluate all variables after execution of each protocol
+			variableMap := m.options.Variables.Evaluate(m.options.GetTemplateCtx(ctx.Input.MetaInput).GetAll())
+			m.options.GetTemplateCtx(ctx.Input.MetaInput).Merge(variableMap) // merge all variables into template context
+		})
 		// in case of fatal error skip execution of next protocols
 		if err != nil {
 			// always log errors


### PR DESCRIPTION
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->

Close #5748

## Proof of Concept

```yaml
# issue-5748-b.yaml
id: issue-5748-b

info:
  name: issue-5748-b
  author: dwisiswant0
  severity: high

code:
  - engine:
      - sh
      - bash
    source: id

http:
  - raw:
      - |
        GET /1 HTTP/1.1
        Host: {{Hostname}}

      - |
        GET /2 HTTP/1.1
        Host: {{Hostname}}

    extractors:
      - type: dsl
        dsl:
          - 'concat("status_code_1: ", status_code_1)'
          - 'concat("status_code_2: ", status_code_2)'
# digest: 490a0046304402202cd4baf19f0bf2337473efa63e99e086638f4732b283e43e2db30555cee6a09802207ee4b1ad6accfbff9c994531166ff65271211126922beb95dc22d6065f63dfdf:0acbc25bbf526ee86104fe7a57c5a13f
```

```console
$ ./bin/nuclei -code -u http://scanme.sh -t issue-5748-b.yaml -silent
[issue-5748-c] [http] [high] http://scanme.sh/1 ["status_code_1: 200"]
[issue-5748-c] [http] [high] http://scanme.sh/2 ["status_code_1: 200","status_code_2: 200"]
```

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined the result processing mechanism for multi-protocol execution
	- Improved dynamic value management and storage during protocol workflows
	- Enhanced inline function for handling protocol results with more efficient key construction

<!-- end of auto-generated comment: release notes by coderabbit.ai -->