### PR TITLE
allow WithNetworkConfig and WithInteractshOptions to be used by NewThreadSafeNucleiEngineCtx

### DIFF
--- a/lib/config.go
+++ b/lib/config.go
@@ -100,7 +100,8 @@ type InteractshOpts interactsh.Options
 // WithInteractshOptions sets interactsh options
 func WithInteractshOptions(opts InteractshOpts) NucleiSDKOptions {
 	return func(e *NucleiEngine) error {
-		if e.mode == threadSafe {
+		// WithInteractshOptions can be used when creating ThreadSafeNucleiEngine but not after it's initialized
+		if e.mode == threadSafe && e.interactshOpts != nil {
 			return ErrOptionsNotSupported.Msgf("WithInteractshOptions")
 		}
 		optsPtr := &opts
@@ -283,7 +284,8 @@ type NetworkConfig struct {
 // WithNetworkConfig allows setting network config options
 func WithNetworkConfig(opts NetworkConfig) NucleiSDKOptions {
 	return func(e *NucleiEngine) error {
-		if e.mode == threadSafe {
+		// WithNetworkConfig can be used when creating ThreadSafeNucleiEngine but not after it's initialized
+		if e.mode == threadSafe && e.hostErrCache != nil {
 			return ErrOptionsNotSupported.Msgf("WithNetworkConfig")
 		}
 		e.opts.Timeout = opts.Timeout


### PR DESCRIPTION
## Proposed changes
This pull request resolves #5952 
It allows the WithInteractshOptions and WithNetworkConfig to be used if engine.init() has not yet been called by checking if interactshOpts or hostErrCache is nil. 


## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added clarifying comments for configuration functions related to thread-safe engine initialization
	- Improved inline documentation to guide developers on correct usage of configuration methods

<!-- end of auto-generated comment: release notes by coderabbit.ai -->