### PR TITLE
chore: Revert "chore(dependabot): merge 2 groups"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,25 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    allow:
+      - dependency-name: "github.com/projectdiscovery/*"
     groups:
       modules:
         patterns: ["github.com/projectdiscovery/*"]
+    labels:
+      - "Type: Maintenance"
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "dev"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    ignore:
+      - dependency-name: "github.com/projectdiscovery/*"
+    groups:
       security:
         applies-to: "security-updates"
         patterns: ["*"]


### PR DESCRIPTION
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->

This reverts commit f36b851128a5abe72dd204469ba5bcc4b3cfe011.

^ strange that this is creating PRs individually instead of grouping them.

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Dependabot configuration for more granular dependency management
	- Added specific handling for ProjectDiscovery dependencies
	- Introduced maintenance labels for dependency updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->