### PR TITLE
Ensure Headless protocol accesses flow protocol variables

### DIFF
--- a/pkg/protocols/headless/request.go
+++ b/pkg/protocols/headless/request.go
@@ -52,14 +52,13 @@ func (request *Request) ExecuteWithResults(input *contextargs.Context, metadata,
 	}
 
 	vars := protocolutils.GenerateVariablesWithContextArgs(input, false)
-	payloads := generators.BuildPayloadFromOptions(request.options.Options)
+	optionVars := generators.BuildPayloadFromOptions(request.options.Options)
 	// add templatecontext variables to varMap
-	values := generators.MergeMaps(vars, metadata, payloads)
 	if request.options.HasTemplateCtx(input.MetaInput) {
-		values = generators.MergeMaps(values, request.options.GetTemplateCtx(input.MetaInput).GetAll())
+		vars = generators.MergeMaps(vars, metadata, optionVars, request.options.GetTemplateCtx(input.MetaInput).GetAll())
 	}
-	variablesMap := request.options.Variables.Evaluate(values)
-	payloads = generators.MergeMaps(variablesMap, payloads, request.options.Constants)
+	variablesMap := request.options.Variables.Evaluate(vars)
+	vars = generators.MergeMaps(vars, variablesMap, request.options.Constants)
 
 	// check for operator matches by wrapping callback
 	gotmatches := false
@@ -71,7 +70,7 @@ func (request *Request) ExecuteWithResults(input *contextargs.Context, metadata,
 	}
 	// verify if fuzz elaboration was requested
 	if len(request.Fuzzing) > 0 {
-		return request.executeFuzzingRule(input, payloads, previous, wrappedCallback)
+		return request.executeFuzzingRule(input, vars, previous, wrappedCallback)
 	}
 	if request.generator != nil {
 		iterator := request.generator.NewIterator()
@@ -83,13 +82,13 @@ func (request *Request) ExecuteWithResults(input *contextargs.Context, metadata,
 			if gotmatches && (request.StopAtFirstMatch || request.options.Options.StopAtFirstMatch || request.options.StopAtFirstMatch) {
 				return nil
 			}
-			value = generators.MergeMaps(value, payloads)
+			value = generators.MergeMaps(value, vars)
 			if err := request.executeRequestWithPayloads(input, value, previous, wrappedCallback); err != nil {
 				return err
 			}
 		}
 	} else {
-		value := maps.Clone(payloads)
+		value := maps.Clone(vars)
 		if err := request.executeRequestWithPayloads(input, value, previous, wrappedCallback); err != nil {
 			return err
 		}


### PR DESCRIPTION
## Proposed changes

Closes #6001

```console
$ go run . -u scanme.sh -t test_template.yaml --headless --debug

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.3.8

                projectdiscovery.io

[INF] Current nuclei version: v3.3.8 (latest)
[INF] Current nuclei-templates version: v10.1.2 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 52
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] Running httpx on input host
[INF] Found 1 URL from httpx
[JS] Running http protocol...
[INF] [test] Dumped HTTP request for https://scanme.sh?varFromFlow=works&varFromVariables=works

GET /?varFromFlow=works&varFromVariables=works HTTP/1.1
Host: scanme.sh
User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:89.0) Gecko/20100101 Firefox/89.0
Connection: close
Accept: */*
Accept-Language: en
Accept-Encoding: gzip

[DBG] [test] Dumped HTTP response https://scanme.sh?varFromFlow=works&varFromVariables=works

HTTP/1.1 200 OK
Connection: close
Content-Length: 2
Content-Type: text/plain; charset=utf-8
Date: Fri, 24 Jan 2025 08:35:51 GMT

ok
[JS] Running headless protocol...
[INF] [test] Dumped Headless request for https://scanme.sh?varFromFlow=works&varFromVariables=works
[DBG]   navigate => https://scanme.sh?varFromFlow=works&varFromVariables=works
[DBG] [test] Dumped Headless response for https://scanme.sh

<html><head><meta name="color-scheme" content="light dark"></head><body><pre style="word-wrap: break-word; white-space: pre-wrap;">ok</pre></body></html>
[INF] No results found. Better luck next time!
```

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated internal variable handling in the request execution method
	- Renamed variables to improve clarity and consistency in data processing
	- Streamlined merging of variables and metadata in request execution logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->