### PR TITLE
chore(deps): bump go module version to 1.22.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,8 @@
 module github.com/projectdiscovery/nuclei/v3
 
-go 1.21.0
-toolchain go1.22.5
+go 1.22.0
+
+toolchain go1.22.11
 
 require (
 	github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible


### PR DESCRIPTION
## Proposed changes

Hotfix for compatibility issues.

```
go: golang.org/x/exp@v0.0.0-20250106191152-7588d65b2ba8 requires go >= 1.22.0 (running go 1.21.0)
go: github.com/gaissmai/bart@v0.17.8: module github.com/gaissmai/bart@v0.17.8 requires go >= 1.22.0 (running go 1.21.0)
```

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Go version from 1.21.0 to 1.22.0
  - Updated toolchain version to go1.22.11
  - Added retraction for version v3.2.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->