### PR TITLE
ci(compability-check): checks go.mod integrity

### DIFF
--- a/.github/workflows/compability-check.yaml
+++ b/.github/workflows/compability-check.yaml
@@ -12,8 +12,19 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
+    permissions:
+      contents: write
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+      - uses: projectdiscovery/actions/setup/git@v1
       - uses: projectdiscovery/actions/setup/go@v1
       - run: go mod download && go mod verify && go vet ./...
+      - name: Checks go.mod Integrity
+        run: |
+          git diff --exit-code go.mod >/dev/null || {
+            echo "::warning::go.mod is out of sync. Pushing changes to the branch."
+            git add go.{mod,sum}
+            git commit -m "chore(deps): go mod tidy"
+            git push origin $GITHUB_REF
+          }


### PR DESCRIPTION
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->

When Dependabot bumps dependencies, it doesn’t change the go module version but adds a `toolchain` line instead. That value ends up being higher than the module version, so when running `setup/go` action, the installed Go version follows the toolchain, not the module version. - ref: https://github.com/projectdiscovery/nuclei/commit/ceab5964b71b3d853eaed80b0e3499610929e483

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)