### PR TITLE
Added `-ai` option to generate and run nuclei templates on the fly for given prompt 

### DIFF
--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -252,6 +252,7 @@ on extensive configurability, massive extensibility and ease of use.`)
 		flagSet.BoolVarP(&options.AutomaticScan, "automatic-scan", "as", false, "automatic web scan using wappalyzer technology detection to tags mapping"),
 		flagSet.StringSliceVarP(&options.Templates, "templates", "t", nil, "list of template or template directory to run (comma-separated, file)", goflags.FileCommaSeparatedStringSliceOptions),
 		flagSet.StringSliceVarP(&options.TemplateURLs, "template-url", "turl", nil, "template url or list containing template urls to run (comma-separated, file)", goflags.FileCommaSeparatedStringSliceOptions),
+		flagSet.StringVarP(&options.AITemplatePrompt, "prompt", "ai", "", "generate and run template using ai prompt"),
 		flagSet.StringSliceVarP(&options.Workflows, "workflows", "w", nil, "list of workflow or workflow directory to run (comma-separated, file)", goflags.FileCommaSeparatedStringSliceOptions),
 		flagSet.StringSliceVarP(&options.WorkflowURLs, "workflow-url", "wurl", nil, "workflow url or list containing workflow urls to run (comma-separated, file)", goflags.FileCommaSeparatedStringSliceOptions),
 		flagSet.BoolVar(&options.Validate, "validate", false, "validate the passed templates to nuclei"),

--- a/integration_tests/protocols/multi/dynamic-values.yaml
+++ b/integration_tests/protocols/multi/dynamic-values.yaml
@@ -24,6 +24,6 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - contains(body,'introduction') # check for http string
+          - contains(body,'home') # check for http string
           - blogid == 'cname' # check for cname (extracted information from dns response)
         condition: and

--- a/integration_tests/protocols/multi/evaluate-variables.yaml
+++ b/integration_tests/protocols/multi/evaluate-variables.yaml
@@ -24,7 +24,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - contains(http_body,'introduction') # check for http string
+          - contains(http_body,'home') # check for http string
           - cname_filtered == 'cname' # check for cname (extracted information from dns response)
           - ssl_subject_cn == 'docs.projectdiscovery.io'
         condition: and

--- a/integration_tests/protocols/multi/exported-response-vars.yaml
+++ b/integration_tests/protocols/multi/exported-response-vars.yaml
@@ -20,7 +20,7 @@ http:
     matchers:
       - type: dsl
         dsl:
-          - contains(http_body,'introduction') # check for http string
+          - contains(http_body,'home') # check for http string
           - trim_suffix(dns_cname,'.vercel-dns.com') == 'cname' # check for cname (extracted information from dns response)
           - ssl_subject_cn == 'docs.projectdiscovery.io'
         condition: and

--- a/pkg/catalog/loader/ai_loader.go
+++ b/pkg/catalog/loader/ai_loader.go
@@ -33,8 +33,12 @@ type AITemplateResponse struct {
 
 func getAIGeneratedTemplates(prompt string, options *types.Options) ([]string, error) {
 	prompt = strings.TrimSpace(prompt)
-	if prompt == "" {
-		return nil, errorutil.New("No prompt provided")
+	if len(prompt) < 5 {
+		return nil, errorutil.New("Prompt is too short. Please provide a more descriptive prompt")
+	}
+
+	if len(prompt) > 3000 {
+		return nil, errorutil.New("Prompt is too long. Please limit to 3000 characters")
 	}
 
 	template, templateID, err := generateAITemplate(prompt)

--- a/pkg/catalog/loader/ai_loader.go
+++ b/pkg/catalog/loader/ai_loader.go
@@ -1,0 +1,111 @@
+package loader
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/projectdiscovery/gologger"
+	pdcpauth "github.com/projectdiscovery/utils/auth/pdcp"
+	errorutil "github.com/projectdiscovery/utils/errors"
+)
+
+const (
+	aiTemplateAPIEndpoint = "https://api.projectdiscovery.io/v1/template/ai"
+)
+
+type AITemplateResponse struct {
+	CanRun     bool   `json:"canRun"`
+	Comment    string `json:"comment"`
+	Completion string `json:"completion"`
+	Message    string `json:"message"`
+	Name       string `json:"name"`
+	TemplateID string `json:"template_id"`
+}
+
+func getAIGeneratedTemplates(prompt string) ([]string, string, error) {
+	if prompt == "" {
+		return nil, "", nil
+	}
+
+	template, templateID, err := generateAITemplate(prompt)
+	if err != nil {
+		gologger.Info().Msg("Failed to generate template")
+		os.Exit(1)
+	}
+
+	tempDir, err := os.MkdirTemp("", "nuclei-ai-templates-*")
+	if err != nil {
+		gologger.Info().Msg("Failed to generate template")
+		os.Exit(1)
+	}
+
+	tempFile := filepath.Join(tempDir, templateID+".yaml")
+	err = os.WriteFile(tempFile, []byte(template), 0644)
+	if err != nil {
+		os.RemoveAll(tempDir) 
+		gologger.Info().Msg("Failed to generate template")
+		os.Exit(1)
+	}
+
+	gologger.Info().Msgf("Generated template path: %s", tempFile)
+	return []string{tempFile}, tempDir, nil
+}
+
+func generateAITemplate(prompt string) (string, string, error) {
+	reqBody := map[string]string{
+		"prompt": prompt,
+	}
+	jsonBody, err := json.Marshal(reqBody)
+	if err != nil {
+		return "", "", errorutil.New("Failed to generate template")
+	}
+
+	req, err := http.NewRequest(http.MethodPost, aiTemplateAPIEndpoint, bytes.NewBuffer(jsonBody))
+	if err != nil {
+		return "", "", errorutil.New("Failed to generate template")
+	}
+
+	ph := pdcpauth.PDCPCredHandler{}
+	creds, err := ph.GetCreds()
+	if creds == nil {
+		gologger.Info().Msg("PDCP API Key not configured, Create one for free at https://cloud.projectdiscovery.io/")
+		os.Exit(1)
+	}
+	if err != nil {
+		return "", "", errorutil.New("Failed to get PDCP credentials")
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(pdcpauth.ApiKeyHeaderName, creds.APIKey)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", "", errorutil.New("Failed to generate template")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		gologger.Info().Msg("Invalid API Key or API Key not configured, Create one for free at https://cloud.projectdiscovery.io/")
+		os.Exit(1)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", "", errorutil.New("Failed to generate template")
+	}
+
+	var result AITemplateResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", "", errorutil.New("Failed to generate template")
+	}
+
+	if result.TemplateID == "" || result.Completion == "" {
+		return "", "", errorutil.New("Failed to generate template")
+	}
+
+	gologger.Info().Msgf("Generated template available at: https://cloud.projectdiscovery.io/templates/%s", result.TemplateID)
+
+	return result.Completion, result.TemplateID, nil
+} 

--- a/pkg/catalog/loader/ai_loader.go
+++ b/pkg/catalog/loader/ai_loader.go
@@ -97,11 +97,12 @@ func generateAITemplate(prompt string) (string, string, error) {
 
 	ph := pdcpauth.PDCPCredHandler{}
 	creds, err := ph.GetCreds()
-	if creds == nil {
-		return "", "", errorutil.New("PDCP API Key not configured, Create one for free at https://cloud.projectdiscovery.io/")
-	}
 	if err != nil {
 		return "", "", errorutil.New("Failed to get PDCP credentials")
+	}
+
+	if creds == nil {
+		return "", "", errorutil.New("PDCP API Key not configured, Create one for free at https://cloud.projectdiscovery.io/")
 	}
 
 	req.Header.Set("Content-Type", "application/json")

--- a/pkg/catalog/loader/ai_loader.go
+++ b/pkg/catalog/loader/ai_loader.go
@@ -87,18 +87,18 @@ func generateAITemplate(prompt string) (string, string, error) {
 	}
 	jsonBody, err := json.Marshal(reqBody)
 	if err != nil {
-		return "", "", errorutil.New("Failed to generate template")
+		return "", "", errorutil.New("Failed to marshal request body: %v", err)
 	}
 
 	req, err := http.NewRequest(http.MethodPost, aiTemplateGeneratorAPIEndpoint, bytes.NewBuffer(jsonBody))
 	if err != nil {
-		return "", "", errorutil.New("Failed to generate template")
+		return "", "", errorutil.New("Failed to create HTTP request: %v", err)
 	}
 
 	ph := pdcpauth.PDCPCredHandler{}
 	creds, err := ph.GetCreds()
 	if err != nil {
-		return "", "", errorutil.New("Failed to get PDCP credentials")
+		return "", "", errorutil.New("Failed to get PDCP credentials: %v", err)
 	}
 
 	if creds == nil {
@@ -110,7 +110,7 @@ func generateAITemplate(prompt string) (string, string, error) {
 
 	resp, err := retryablehttp.DefaultClient().Do(req)
 	if err != nil {
-		return "", "", errorutil.New("Failed to generate template")
+		return "", "", errorutil.New("Failed to send HTTP request: %v", err)
 	}
 	defer resp.Body.Close()
 
@@ -119,12 +119,12 @@ func generateAITemplate(prompt string) (string, string, error) {
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return "", "", errorutil.New("Failed to generate template")
+		return "", "", errorutil.New("API returned non-OK status code: %d", resp.StatusCode)
 	}
 
 	var result AITemplateResponse
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return "", "", errorutil.New("Failed to generate template")
+		return "", "", errorutil.New("Failed to decode API response: %v", err)
 	}
 
 	if result.TemplateID == "" || result.Completion == "" {

--- a/pkg/catalog/loader/ai_loader.go
+++ b/pkg/catalog/loader/ai_loader.go
@@ -12,6 +12,7 @@ import (
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/config"
 	"github.com/projectdiscovery/nuclei/v3/pkg/types"
+	"github.com/projectdiscovery/retryablehttp-go"
 	pdcpauth "github.com/projectdiscovery/utils/auth/pdcp"
 	errorutil "github.com/projectdiscovery/utils/errors"
 )
@@ -106,7 +107,7 @@ func generateAITemplate(prompt string) (string, string, error) {
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set(pdcpauth.ApiKeyHeaderName, creds.APIKey)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := retryablehttp.DefaultClient().Do(req)
 	if err != nil {
 		return "", "", errorutil.New("Failed to generate template")
 	}

--- a/pkg/catalog/loader/ai_loader.go
+++ b/pkg/catalog/loader/ai_loader.go
@@ -72,6 +72,9 @@ func getAIGeneratedTemplates(prompt string, options *types.Options) ([]string, e
 			}
 		}
 		gologger.Silent().Msgf("\n%s", template)
+		// FIXME: 
+		// we should not be exiting the program here
+		// but we need to find a better way to handle this
 		os.Exit(0)
 	}
 

--- a/pkg/catalog/loader/ai_loader.go
+++ b/pkg/catalog/loader/ai_loader.go
@@ -57,9 +57,11 @@ func getAIGeneratedTemplates(prompt string, options *types.Options) ([]string, s
 	// 1. No targets are provided (-target/-list)
 	// 2. No stdin input is being used
 	hasNoTargets := len(options.Targets) == 0 && options.TargetsFilePath == ""
-	hasNoStdin := !options.Stdin && options.DisableStdin
+	hasNoStdin := !options.Stdin
 	
 	if hasNoTargets && hasNoStdin {
+		gologger.Info().Msgf("Generated template available at: https://cloud.projectdiscovery.io/templates/%s", templateID)
+		gologger.Info().Msgf("Template: %s", tempFile)
 		// Display the template content with syntax highlighting
 		if !options.NoColor {
 			var buf bytes.Buffer
@@ -68,8 +70,7 @@ func getAIGeneratedTemplates(prompt string, options *types.Options) ([]string, s
 				template = buf.String()
 			}
 		}
-		gologger.Silent().Msgf("Template: %s\n\n%s", tempFile, template)
-		gologger.Info().Msgf("Generated template available at: https://cloud.projectdiscovery.io/templates/%s", templateID)
+		gologger.Silent().Msgf("\n%s", template)
 		os.Exit(0)
 	}
 
@@ -127,8 +128,6 @@ func generateAITemplate(prompt string) (string, string, error) {
 	if result.TemplateID == "" || result.Completion == "" {
 		return "", "", errorutil.New("Failed to generate template")
 	}
-
-	gologger.Info().Msgf("Generated template available at: https://cloud.projectdiscovery.io/templates/%s", result.TemplateID)
 
 	return result.Completion, result.TemplateID, nil
 } 

--- a/pkg/catalog/loader/ai_loader.go
+++ b/pkg/catalog/loader/ai_loader.go
@@ -51,6 +51,9 @@ func getAIGeneratedTemplates(prompt string, options *types.Options) ([]string, s
 		return nil, "", errorutil.New("Failed to generate template: %v", err)
 	}
 
+	gologger.Info().Msgf("Generated template available at: https://cloud.projectdiscovery.io/templates/%s", templateID)
+	gologger.Info().Msgf("Generated template path: %s", tempFile)
+	
 	// Check if we should display the template
 	// This happens when:
 	// 1. No targets are provided (-target/-list)
@@ -59,8 +62,6 @@ func getAIGeneratedTemplates(prompt string, options *types.Options) ([]string, s
 	hasNoStdin := !options.Stdin
 
 	if hasNoTargets && hasNoStdin {
-		gologger.Info().Msgf("Generated template available at: https://cloud.projectdiscovery.io/templates/%s", templateID)
-		gologger.Info().Msgf("Template: %s", tempFile)
 		// Display the template content with syntax highlighting
 		if !options.NoColor {
 			var buf bytes.Buffer
@@ -73,7 +74,6 @@ func getAIGeneratedTemplates(prompt string, options *types.Options) ([]string, s
 		os.Exit(0)
 	}
 
-	gologger.Info().Msgf("Generated template path: %s", tempFile)
 	return []string{tempFile}, tempDir, nil
 }
 

--- a/pkg/catalog/loader/ai_loader.go
+++ b/pkg/catalog/loader/ai_loader.go
@@ -46,7 +46,7 @@ func getAIGeneratedTemplates(prompt string, options *types.Options) ([]string, e
 	}
 
 	templateFile := filepath.Join(pdcpTemplateDir, templateID+".yaml")
-	err = os.WriteFile(templateFile, []byte(template), 0600)
+	err = os.WriteFile(templateFile, []byte(template), 0644)
 	if err != nil {
 		return nil, errorutil.New("Failed to generate template: %v", err)
 	}

--- a/pkg/catalog/loader/ai_loader.go
+++ b/pkg/catalog/loader/ai_loader.go
@@ -48,7 +48,6 @@ func getAIGeneratedTemplates(prompt string, options *types.Options) ([]string, e
 	templateFile := filepath.Join(pdcpTemplateDir, templateID+".yaml")
 	err = os.WriteFile(templateFile, []byte(template), 0600)
 	if err != nil {
-		os.RemoveAll(pdcpTemplateDir)
 		return nil, errorutil.New("Failed to generate template: %v", err)
 	}
 
@@ -72,7 +71,7 @@ func getAIGeneratedTemplates(prompt string, options *types.Options) ([]string, e
 			}
 		}
 		gologger.Silent().Msgf("\n%s", template)
-		// FIXME: 
+		// FIXME:
 		// we should not be exiting the program here
 		// but we need to find a better way to handle this
 		os.Exit(0)

--- a/pkg/catalog/loader/ai_loader.go
+++ b/pkg/catalog/loader/ai_loader.go
@@ -3,6 +3,7 @@ package loader
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -119,7 +120,8 @@ func generateAITemplate(prompt string) (string, string, error) {
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return "", "", errorutil.New("API returned non-OK status code: %d", resp.StatusCode)
+		body, _ := io.ReadAll(resp.Body)
+		return "", "", errorutil.New("API returned status code %d: %s", resp.StatusCode, string(body))
 	}
 
 	var result AITemplateResponse

--- a/pkg/catalog/loader/loader.go
+++ b/pkg/catalog/loader/loader.go
@@ -85,9 +85,6 @@ type Store struct {
 	// NotFoundCallback is called for each not found template
 	// This overrides error handling for not found templates
 	NotFoundCallback func(template string) bool
-
-	// aiTemplatesTempDirectory is the temporary directory used for AI templates
-	aiTemplatesTempDirectory string
 }
 
 // NewConfig returns a new loader config
@@ -186,11 +183,10 @@ func New(cfg *Config) (*Store, error) {
 
 	// Handle AI template generation if prompt is provided
 	if len(cfg.AITemplatePrompt) > 0 {
-		aiTemplates, aiTemplatesTempDirectory, err := getAIGeneratedTemplates(cfg.AITemplatePrompt, cfg.ExecutorOptions.Options)
+		aiTemplates, err := getAIGeneratedTemplates(cfg.AITemplatePrompt, cfg.ExecutorOptions.Options)
 		if err != nil {
 			return nil, err
 		}
-		store.aiTemplatesTempDirectory = aiTemplatesTempDirectory
 		store.finalTemplates = append(store.finalTemplates, aiTemplates...)
 	}
 
@@ -645,13 +641,5 @@ func (s *Store) logErroredTemplates(erred map[string]error) {
 		if s.NotFoundCallback == nil || !s.NotFoundCallback(template) {
 			gologger.Error().Msgf("Could not find template '%s': %s", template, err)
 		}
-	}
-}
-
-// Cleanup cleans up any temporary files created by the store
-func (store *Store) Cleanup() {
-	if store.aiTemplatesTempDirectory != "" {
-		os.RemoveAll(store.aiTemplatesTempDirectory)
-		store.aiTemplatesTempDirectory = ""
 	}
 }

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -42,6 +42,8 @@ type Options struct {
 	Templates goflags.StringSlice
 	// TemplateURLs specifies URLs to a list of templates to use
 	TemplateURLs goflags.StringSlice
+	// AITemplatePrompt specifies prompt to generate template using AI
+	AITemplatePrompt string
 	// RemoteTemplates specifies list of allowed URLs to load remote templates from
 	RemoteTemplateDomainList goflags.StringSlice
 	// 	ExcludedTemplates  specifies the template/templates to exclude


### PR DESCRIPTION
### Feature 

This Adds the integration of ProjectDiscovery's [AI Template generation API](https://cloud.projectdiscovery.io/templates) to nuclei, You must configure the PDCP API Key to use this ( Use the `nuclei -auth` command, enter your API key when prompted. The API Key can be generated for free at https://cloud.projectdiscovery.io ) , templates can be generated on runtime by giving the prompt via the `-ai` flag : 

```
$ nuclei -ai "extract page title" -l target_urls.txt  

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.3.8

		projectdiscovery.io

[INF] Generated template available at: https://cloud.projectdiscovery.io/templates/2sqGIYKynuXMyRXAD8oa4E5d8Ip
[INF] Generated template path: /var/folders/jp/q03dqrms061_9sr8j1qy_6m40000gn/T/nuclei-ai-templates-1292509399/2sqGIYKynuXMyRXAD8oa4E5d8Ip.yaml
[INF] Current nuclei version: v3.3.8 (latest)
[INF] Current nuclei-templates version: v10.1.2 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 52
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 275
[INF] Running httpx on input host
[INF] Found 8 URL from httpx
[extract-page-title] [http] [info] http://fake.uber.com:8080 ["Burp Suite Professional"]
[extract-page-title] [http] [info] http://api.uber.com:8080 ["301 Moved Permanently"]
[extract-page-title] [http] [info] http://health.uber.com:8080 ["301 Moved Permanently"]
[extract-page-title] [http] [info] http://cn.uber.com:8080 ["301 Moved Permanently"]
[extract-page-title] [http] [info] http://cn-staging.uber.com:8080 ["301 Moved Permanently"]
[extract-page-title] [http] [info] http://test-api.uber.com:8080 ["301 Moved Permanently"]
[extract-page-title] [http] [info] http://capability.uber.com:8080 ["301 Moved Permanently"]
[extract-page-title] [http] [info] http://edgetest.uber.com:8080 ["301 Moved Permanently"]
[extract-page-title] [http] [info] http://www.uber.com:8080 ["301 Moved Permanently"]
[extract-page-title] [http] [info] http://uc.uber.com:8080 ["301 Moved Permanently"]
[extract-page-title] [http] [info] http://business.uber.com:8080 ["301 Moved Permanently"]
[extract-page-title] [http] [info] http://docs.uber.com ["302 Moved"]
[extract-page-title] [http] [info] http://mail.uber.com ["301 Moved"]
[extract-page-title] [http] [info] https://api.uber.com ["301 Moved Permanently"]
[extract-page-title] [http] [info] https://account.uber.com ["302 Found"]
[extract-page-title] [http] [info] http://businesses.uber.com:8443 ["400 The plain HTTP request was sent to HTTPS port"]
[extract-page-title] [http] [info] http://groups.uber.com ["302 Moved"]
[extract-page-title] [http] [info] https://accounts.uber.com ["301 Moved Permanently"]
[extract-page-title] [http] [info] https://account-sandbox.uber.com ["302 Found"]
[extract-page-title] [http] [info] https://admin.uber.com ["301 Moved Permanently"]
[extract-page-title] [http] [info] https://advertiser.uber.com ["302 Found"]
[extract-page-title] [http] [info] https://account-staging.uber.com ["302 Found"]
[extract-page-title] [http] [info] https://auth-staging.uber.com ["301 Moved Permanently"]
[extract-page-title] [http] [info] https://auth-test.uber.com ["404 Not Found"]
[extract-page-title] [http] [info] https://auth.uber.com ["301 Moved Permanently"]
[extract-page-title] [http] [info] http://investor.uber.com:8080 ["Attention Required! | Cloudflare"]

```

### If no target is provided then nuclei will display the generated template : 
```
parth@Parths-Laptop nuclei % ./nuclei -ai "detect exposed git config"

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.3.8

                projectdiscovery.io

[INF] Generated template available at: https://cloud.projectdiscovery.io/templates/2sqIllpnwqocKnrQ2Ke8Wd0H3wI
[INF] Template: /var/folders/jp/q03dqrms061_9sr8j1qy_6m40000gn/T/nuclei-ai-templates-60717539/2sqIllpnwqocKnrQ2Ke8Wd0H3wI.yaml

id: git-config-exposed

info:
  name: Exposed Git Config Detection
  author: ProjectDiscoveryAI
  severity: medium
  description: |
        Detects exposed .git/config files on web servers, which may contain sensitive information about the repository.

http:
  - method: GET
    path:
      - "{{BaseURL}}/.git/config"

    matchers-condition: or
    matchers:
      - type: word
        words:
          - "[core]"
          - "repositoryformatversion"

      - type: status
        status:
          - 200

      - type: regex
        regex:
          - "bare = (true|false)"
parth@Parths-Laptop nuclei % 
```

Closes https://github.com/projectdiscovery/nuclei/issues/6046


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a new command-line option that lets users provide an AI prompt to generate and execute scanning templates.
	- Integrated AI-driven template creation to enhance scanning flexibility and effectiveness.
	- Expanded configuration options to include an AI template prompt for enhanced user customization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->