### PR TITLE
fix secrets lookup logic

### DIFF
--- a/pkg/authprovider/file.go
+++ b/pkg/authprovider/file.go
@@ -122,6 +122,8 @@ func (f *FileAuthProvider) init() {
 
 // LookupAddr looks up a given domain/address and returns appropriate auth strategy
 func (f *FileAuthProvider) LookupAddr(addr string) []authx.AuthStrategy {
+	var strategies []authx.AuthStrategy
+
 	if strings.Contains(addr, ":") {
 		// default normalization for host:port
 		host, port, err := net.SplitHostPort(addr)
@@ -131,15 +133,16 @@ func (f *FileAuthProvider) LookupAddr(addr string) []authx.AuthStrategy {
 	}
 	for domain, strategy := range f.domains {
 		if strings.EqualFold(domain, addr) {
-			return strategy
+			strategies = append(strategies, strategy...)
 		}
 	}
 	for compiled, strategy := range f.compiled {
 		if compiled.MatchString(addr) {
-			return strategy
+			strategies = append(strategies, strategy...)
 		}
 	}
-	return nil
+
+	return strategies
 }
 
 // LookupURL looks up a given URL and returns appropriate auth strategy

--- a/pkg/authprovider/multi.go
+++ b/pkg/authprovider/multi.go
@@ -22,7 +22,7 @@ func NewMultiAuthProvider(providers ...AuthProvider) AuthProvider {
 func (m *MultiAuthProvider) LookupAddr(host string) []authx.AuthStrategy {
 	for _, provider := range m.Providers {
 		strategy := provider.LookupAddr(host)
-		if strategy != nil {
+		if len(strategy) > 0 {
 			return strategy
 		}
 	}


### PR DESCRIPTION
## Proposed changes

Closes https://github.com/projectdiscovery/nuclei/issues/5498

```console
$ cat secrets.yaml 
static:
  - type: cookie
    domains-regex:
      - php.vulnerabletarget.com
    cookies:
      - key: SESSIONID
        value: f9a9a185-1e05-41c7-98f3-432de6b114b0

  - type: header
    domains:
      - php.vulnerabletarget.com
    headers:
      - key: secretkey
        value: 33626665393961652d623633652d346639382d393366362d663532343935653336376438

  - type: cookie
    domains-regex:
      - asp.vulnerabletarget.com
    cookies:
      - key: SESSIONID
        value: c9190916-1b97-401d-a223-492894deff9e

  - type: header
    domains:
      - asp.vulnerabletarget.com
    headers:
      - key: secretkey
        value: 33343063656665352d616130352d346537622d616338322d306337346339353635326466


$ cat config.yaml
list: 'target.list'

templates:  'test_template.yaml'

prefetch-secrets: true
secret-file: 'secrets.yaml'


debug-req: true

bulk-size: 50
cloud-upload: false
concurrency: 50
disable-update-check: true
no-interactsh: true
no-max-host-error: true
rate-limit: 500
stats: true
timeout: 5
uncover: false
update-templates: false


$ go run . --config config.yaml

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.3.9

                projectdiscovery.io

[WRN] The concurrency value is higher than max-host-error
[INF] Adjusting max-host-error to the concurrency value: 50
[INF] Current nuclei version: v3.3.9 (outdated)
[INF] Current nuclei-templates version: v10.1.2 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 52
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 2
[INF] Pre-fetching secrets from authprovider[s]
[INF] [test] Dumped HTTP request for http://php.vulnerabletarget.com/api/order/plaintext

POST /api/order/plaintext HTTP/1.1
Host: php.vulnerabletarget.com
User-Agent: Mozilla/5.0 (X11; Linux i686) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36
Connection: close
Content-Length: 0
Cookie: SESSIONID=f9a9a185-1e05-41c7-98f3-432de6b114b0
Secretkey: 33626665393961652d623633652d346639382d393366362d663532343935653336376438
Accept-Encoding: gzip

[INF] [test] Dumped HTTP request for http://asp.vulnerabletarget.com/api/order/plaintext

POST /api/order/plaintext HTTP/1.1
Host: asp.vulnerabletarget.com
User-Agent: Mozilla/5.0 (Fedora; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36
Connection: close
Content-Length: 0
Cookie: SESSIONID=c9190916-1b97-401d-a223-492894deff9e
Secretkey: 33343063656665352d616130352d346537622d616338322d306337346339353635326466
Accept-Encoding: gzip

[INF] No results found. Better luck next time!
[0:00:01] | Templates: 1 | Hosts: 2 | RPS: 1 | Matched: 0 | Errors: 0 | Requests: 2/2 (100%)
```

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced the authentication lookup process to now consider all applicable strategies, ensuring more comprehensive results for varied scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->