### PR TITLE
fix: race condition of the lastmatcherevent

### DIFF
--- a/pkg/tmplexec/exec.go
+++ b/pkg/tmplexec/exec.go
@@ -215,8 +215,10 @@ func (e *TemplateExecuter) Execute(ctx *scan.ScanContext) (bool, error) {
 
 	if lastMatcherEvent != nil {
 		lastMatcherEvent.Lock()
+		defer lastMatcherEvent.Unlock()
+
 		lastMatcherEvent.InternalEvent["error"] = getErrorCause(ctx.GenerateErrorMessage())
-		lastMatcherEvent.Unlock()
+
 		writeFailureCallback(lastMatcherEvent, e.options.Options.MatcherStatus)
 	}
 


### PR DESCRIPTION
## Proposed changes

This PR fixes a race condition that causes the "sync: Unlock of unlocked RWMutex" panic in the template executor. reported in this issue https://github.com/projectdiscovery/nuclei/issues/6062

Problem
The issue occurs in pkg/tmplexec/exec.go where a lastMatcherEvent is modified and then passed to writeFailureCallback. Multiple goroutines can access this event simultaneously, leading to a race condition where one goroutine tries to unlock a mutex that was never locked or was already unlocked by another goroutine.


Solution
Improve the locking mechanism with a proper defer pattern to ensure the mutex is always unlocked after being locked:
```
if lastMatcherEvent != nil {
    lastMatcherEvent.Lock()
    _defer lastMatcherEvent.Unlock()_

    lastMatcherEvent.InternalEvent["error"] = getErrorCause(ctx.GenerateErrorMessage())

    writeFailureCallback(lastMatcherEvent, e.options.Options.MatcherStatus)

}
```

i tried multiple solution but this one seems simple and make sure resrouce is unlocked per thread.   

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)