### PR TITLE
fix(docs): wrong command example

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ nuclei -target https://example.com
 Nuclei can handle bulk scanning by providing a list of targets. You can use a file containing multiple URLs.
 
 ```sh
-nuclei -targets urls.txt
+nuclei -list urls.txt
 ```
 
 ### Network scan


### PR DESCRIPTION
## Proposed changes

Hey, just a simple documentation fix, the command to scan multiple hosts from a file should be `-list` instead of `-targets`

## Checklist

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Revised the bulk scanning command instructions. Users should now specify multiple URLs using the new `-list` option instead of the previous `-targets` option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->