### PR TITLE
add setDialer function to TCP protocol

### DIFF
--- a/pkg/protocols/network/network.go
+++ b/pkg/protocols/network/network.go
@@ -259,3 +259,7 @@ func (request *Request) Compile(options *protocols.ExecutorOptions) error {
 func (request *Request) Requests() int {
 	return len(request.Address)
 }
+
+func (request *Request) SetDialer(dialer *fastdialer.Dialer) {
+	request.dialer = dialer
+}


### PR DESCRIPTION
- add ability to override setDialer function for tcp
- socks proxy is not used incase of tcp protocol
- TCP uses global tcp dialer shared, we need template request level ability to set dialer

## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->


## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)