### PR TITLE
fix(release): update Docker image templates

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -48,10 +48,10 @@ checksum:
 
 dockers:
   - image_templates:
-      - "{{ .ProjectName }}:{{ .Tag }}"
-      - "{{ .ProjectName }}:v{{ .Major }}.{{ .Minor }}"
-      - "{{ .ProjectName }}:v{{ .Major }}"
-      - "{{ .ProjectName }}:latest"
+      - "projectdiscovery/{{ .ProjectName }}:{{ .Tag }}"
+      - "projectdiscovery/{{ .ProjectName }}:v{{ .Major }}.{{ .Minor }}"
+      - "projectdiscovery/{{ .ProjectName }}:v{{ .Major }}"
+      - "projectdiscovery/{{ .ProjectName }}:latest"
     dockerfile: Dockerfile.goreleaser
     use: buildx
     build_flag_templates:


### PR DESCRIPTION
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->

Assets are not released when publishing Docker images fails (fail-fast) due to misconfigured image templates in the GoReleaser configuration.

Fixes #6118

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)