### PR TITLE
fix: default offlinehttp extractor without part to body like requests

### DIFF
--- a/pkg/protocols/offlinehttp/operators.go
+++ b/pkg/protocols/offlinehttp/operators.go
@@ -77,6 +77,9 @@ func (request *Request) Extract(data map[string]interface{}, extractor *extracto
 
 // getMatchPart returns the match part honoring "all" matchers + others.
 func getMatchPart(part string, data output.InternalEvent) (string, bool) {
+	if part == "" {
+		part = "body"
+	}
 	if part == "header" {
 		part = "all_headers"
 	}


### PR DESCRIPTION
## Proposed changes

pkg/protocols/http/operators.go:84 defaults extractors without explicit part to use the body. For offlinehttp/passive no default part is used, so the extractor is not executed at all.


## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved data matching reliability by automatically applying a default value when an empty input is encountered, preventing potential errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->