### PR TITLE
Fix incorrect usage of os.MkdirTemp pattern and redundant redefinition of defaultOpts

### DIFF
--- a/cmd/tmc/main.go
+++ b/cmd/tmc/main.go
@@ -132,7 +132,7 @@ func main() {
 }
 
 func process(opts options) error {
-	tempDir, err := os.MkdirTemp("", "nuclei-nvd-%s")
+	tempDir, err := os.MkdirTemp("", "nuclei-nvd")
 	if err != nil {
 		return err
 	}

--- a/cmd/tmc/main.go
+++ b/cmd/tmc/main.go
@@ -65,7 +65,6 @@ func init() {
 		allTagsRegex = append(allTagsRegex, re)
 	}
 
-	defaultOpts := types.DefaultOptions()
 	// need to set headless to true for headless templates
 	defaultOpts.Headless = true
 	defaultOpts.EnableCodeTemplates = true


### PR DESCRIPTION
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->
This pull request addresses two key issues:

1- Fix incorrect usage of `os.MkdirTemp` pattern:

  * The previous code used an incorrect pattern for directory naming `("nuclei-nvd-%s")` in the `os.MkdirTemp` function call, which caused issues due to Go's lack of support for string interpolation in this context.

  * The pattern has been corrected to "nuclei-nvd", ensuring proper naming conventions for temporary directories.

2- Fix redundant redefinition of `defaultOpts` in `init() function`:

  * The redundant redefinition of the `defaultOpts` variable inside the `init() function` has been removed.

  * The global `defaultOpts` variable is now directly modified within the `init() function` to avoid confusion and prevent unexpected behavior from hiding the global variable.

These changes ensure proper temporary directory creation and eliminate the potential for bugs caused by variable redefinition.

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue with temporary directory creation to ensure compatibility and prevent errors.
  - Resolved a variable shadowing problem to maintain consistent configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->