### PR TITLE
Fix ingress template in helm chart

### DIFF
--- a/helm/templates/interactsh-ingress.yaml
+++ b/helm/templates/interactsh-ingress.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.interactsh.ingress.enabled -}}
 {{- $fullName := include "nuclei.fullname" . -}}
-{{- $svcPort := .Values.service.port -}}
+{{- $svcPort := .Values.interactsh.service.port -}}
+{{- $svcName := .Values.interactsh.service.name -}}
 {{- if and .Values.interactsh.ingress.className (not (semverCompare ">=1.20-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.interactsh.ingress.annotations "kubernetes.io/ingress.class") }}
   {{- $_ := set .Values.interactsh.ingress.annotations "kubernetes.io/ingress.class" .Values.interactsh.ingress.className}}
@@ -49,11 +50,11 @@ spec:
             backend:
               {{- if semverCompare ">=1.20-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
-                name: {{ $fullName }}
+                name: {{ $svcName }}
                 port:
                   number: {{ $svcPort }}
               {{- else }}
-              serviceName: {{ $fullName }}
+              serviceName: {{ $svcName }}
               servicePort: {{ $svcPort }}
               {{- end }}
           {{- end }}


### PR DESCRIPTION
## Proposed changes

There is wrong service name and service port in ingress object of Helm template, which is broken if enabled ingress


## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)