### PR TITLE
fix: Add support for .yml extension in template parsing

### DIFF
--- a/pkg/catalog/config/template.go
+++ b/pkg/catalog/config/template.go
@@ -30,7 +30,7 @@ func GetTemplateFormatFromExt(filePath string) TemplateFormat {
 	switch fileExt {
 	case extensions.JSON:
 		return JSON
-	case extensions.YAML:
+	case extensions.YAML, extensions.YML:
 		return YAML
 	default:
 		return Unknown
@@ -39,7 +39,7 @@ func GetTemplateFormatFromExt(filePath string) TemplateFormat {
 
 // GetSupportTemplateFileExtensions returns all supported template file extensions
 func GetSupportTemplateFileExtensions() []string {
-	return []string{extensions.YAML, extensions.JSON}
+	return []string{extensions.YAML, extensions.YML, extensions.JSON}
 }
 
 // IsTemplate is a callback function used by goflags to decide if given file should be read


### PR DESCRIPTION
## Proposed changes

This PR fixes a bug where files with the `.yml` extension were not recognized as valid YAML templates, causing errors like:
```sh
[ERR] Could not find template 'id: test-template': could not find file: open /path/to/templates/id: test-template: no such file or directory
```
The issue occurred because `extensions.YML` was not included in the `GetTemplateFormatFromExt` function in `pkg/catalog/config/template.go`. As a result, `.yml` files were treated as invalid, leading Nuclei to misinterpret their content as template IDs or file paths.

This change:
- Adds `extensions.YML` to the `GetTemplateFormatFromExt` switch case, ensuring both `.yaml` and `.yml` are recognized as valid YAML template extensions.
- Updates `GetSupportTemplateFileExtensions` to include `.yml` for consistency in template filtering.

Since `.yml` and `.yaml` are synonymous extensions for YAML files, this fix aligns Nuclei with user expectations and improves compatibility with common YAML file naming conventions.
## Checklist

- Verified in a Docker container and host system with a `.yml` template (e.g., `test.yml`), confirming that both `.yml` and `.yaml` are now parsed correctly:
```yml
---
id: test-template
info:
  name: Test Template
  author: test
  severity: info
requests:
  - method: GET
    path:
      - "{{Host}}"
```
**Related**:
- Issue: Closes #6213
- PR: #4133 (Partially addresses the issue by adding an info message when `.yml` is misinterpreted as a template list, but does not enable `.yml` parsing. This PR provides a complete fix)

**Anything else?**
- If there is a PR with this problem, just close this PR. 🐰
---
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)