### PR TITLE
fix: fallback use addr hostname as SNI for TLS socks proxied connection

### DIFF
--- a/pkg/protocols/http/httpclientpool/clientpool.go
+++ b/pkg/protocols/http/httpclientpool/clientpool.go
@@ -307,6 +307,14 @@ func wrappedGet(options *types.Options, configuration *Configuration) (*retryabl
 			if err != nil {
 				return nil, err
 			}
+			if tlsConfig.ServerName == "" {
+				// addr should be in form of host:port already set from canonicalAddr
+				host, _, err := net.SplitHostPort(addr)
+				if err != nil {
+					return nil, err
+				}
+				tlsConfig.ServerName = host
+			}
 			return tls.Client(conn, tlsConfig), nil
 		}
 	}


### PR DESCRIPTION
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->
Should fixes #6211. Nuclei scan with -proxy set to a socks5 proxy server produce `tls: unrecognized name` / `tls: handshake failure`. Not all hosts encounter this issue, but I found that most websites behind cloudflare have this tls issue. 

The fixes is simply fallback to use hostname from `addr` string as `ServerName` (sni) for TLS Config.

<details><summary>Before</summary>

```
$ ./bin/nuclei -p socks5://127.0.0.1:1080 -u https://myipv4.addr.tools -t ~/nuclei-templates/http/technologies/tech-detect.yaml -duc  -debug
                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.4.3

                projectdiscovery.io

[INF] Current nuclei version: v3.4.3 (unknown) - remove '-duc' flag to enable update checks
[INF] Current nuclei-templates version: v10.2.1 (unknown) - remove '-duc' flag to enable update checks
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 42
[INF] Templates loaded for current scan: 1
[INF] Executing 1 signed templates from projectdiscovery/nuclei-templates
[INF] Targets loaded for current scan: 1
[INF] [tech-detect] Dumped HTTP request for https://myipv4.addr.tools

GET / HTTP/1.1
Host: myipv4.addr.tools
User-Agent: Mozilla/5.0 (Debian; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36
Connection: close
Accept: */*
Accept-Language: en
Accept-Encoding: gzip

[WRN] [tech-detect] Could not execute request for https://myipv4.addr.tools: cause="tls: unrecognized name" chain="got err while executing https://myipv4.addr.tools"
[INF] Scan completed in 2.405888417s. No results found.
```

</details> 

<details><summary>After</summary>

```
$ ./bin/nuclei -p socks5://127.0.0.1:1080 -u https://myipv4.addr.tools -t ~/nuclei-templates/http/technologies/tech-detect.yaml -duc  -debug

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.4.3

                projectdiscovery.io

[INF] Current nuclei version: v3.4.3 (unknown) - remove '-duc' flag to enable update checks
[INF] Current nuclei-templates version: v10.2.1 (unknown) - remove '-duc' flag to enable update checks
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 42
[INF] Templates loaded for current scan: 1
[INF] Executing 1 signed templates from projectdiscovery/nuclei-templates
[INF] Targets loaded for current scan: 1
[INF] [tech-detect] Dumped HTTP request for https://myipv4.addr.tools

GET / HTTP/1.1
Host: myipv4.addr.tools
User-Agent: Mozilla/5.0 (Mac OS X 13_2) AppleWebKit/537.36 (KHTML, like Gecko) Edge/117.0 Safari/537.36
Connection: close
Accept: */*
Accept-Language: en
Accept-Encoding: gzip

[DBG] [tech-detect] Dumped HTTP response https://myipv4.addr.tools

HTTP/1.1 200 OK
Connection: close
Content-Length: 12
Access-Control-Allow-Origin: *
Alt-Svc: h3=":443"; ma=2592000
Cache-Control: no-store
Content-Type: text/plain
Date: Wed, 14 May 2025 02:17:38 GMT
Server: nginx

XX.XX.XX.XX
[tech-detect:nginx] [http] [info] https://myipv4.addr.tools
[INF] Scan completed in 1.003708s. 1 matches found.
```

</details> 

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved TLS connection handling when using a SOCKS proxy by ensuring the server name is correctly set, enhancing connection reliability and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->