### PR TITLE
fix: improve headless engine startup and shutdown

### DIFF
--- a/pkg/protocols/headless/engine/engine.go
+++ b/pkg/protocols/headless/engine/engine.go
@@ -15,16 +15,15 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/types"
 	fileutil "github.com/projectdiscovery/utils/file"
 	osutils "github.com/projectdiscovery/utils/os"
-	processutil "github.com/projectdiscovery/utils/process"
 )
 
 // Browser is a browser structure for nuclei headless module
 type Browser struct {
-	customAgent  string
-	tempDir      string
-	previousPIDs map[int32]struct{} // track already running PIDs
-	engine       *rod.Browser
-	options      *types.Options
+	customAgent string
+	tempDir     string
+	engine      *rod.Browser
+	options     *types.Options
+	launcher    *launcher.Launcher
 	// use getHTTPClient to get the http client
 	httpClient     *http.Client
 	httpClientOnce *sync.Once
@@ -36,7 +35,6 @@ func New(options *types.Options) (*Browser, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "could not create temporary directory")
 	}
-	previousPIDs := processutil.FindProcesses(processutil.IsChromeProcess)
 
 	chromeLauncher := launcher.New().
 		Leakless(false).
@@ -110,8 +108,8 @@ func New(options *types.Options) (*Browser, error) {
 		engine:         browser,
 		options:        options,
 		httpClientOnce: &sync.Once{},
+		launcher:       chromeLauncher,
 	}
-	engine.previousPIDs = previousPIDs
 	return engine, nil
 }
 
@@ -143,6 +141,6 @@ func (b *Browser) getHTTPClient() (*http.Client, error) {
 // Close closes the browser engine
 func (b *Browser) Close() {
 	b.engine.Close()
+	b.launcher.Kill()
 	os.RemoveAll(b.tempDir)
-	processutil.CloseProcesses(processutil.IsChromeProcess, b.previousPIDs)
 }


### PR DESCRIPTION
Fixes #6221

## Proposed changes

Instead of enumerating all chrome processes to determine which ones need to be killed on shutdown, use the launcher.Kill() method to terminate the process that was launched for this browser instance.

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)