### PR TITLE
Update README.md with new required go version

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Browse the full Nuclei [**`documentation here`**](https://docs.projectdiscovery.
 
 ### Installation
 
-`nuclei` requires **go1.22** to install successfully. Run the following command to get the repo:
+`nuclei` requires **go1.23** to install successfully. Run the following command to get the repo:
 
 ```sh
 go install -v github.com/projectdiscovery/nuclei/v3/cmd/nuclei@latest


### PR DESCRIPTION
## Proposed changes

latest version of nuclei requires 1.23 , README updated accordingly.

Following error is received with go 1.22 
```
2.023 go: github.com/projectdiscovery/nuclei/v3/cmd/nuclei@latest: github.com/projectdiscovery/nuclei/v3@v3.4.3 requires go >= 1.23.0 (running go 1.22.2; GOTOOLCHAIN=local)
```

