### PR TITLE
fix(multiproto): set prev events only for protocols with op results

### DIFF
--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -121,6 +121,12 @@ func (iwe *InternalWrappedEvent) CloneShallow() *InternalWrappedEvent {
 	}
 }
 
+// HasOperatorResult checks if the event has an operator result from template
+// execution.
+// It returns true if OperatorsResult is not nil, indicating that operators like
+// matchers or extractors have produced a result during template execution.
+// Operators are conditions specified in templates that determine if a target is
+// vulnerable or matches certain criteria.
 func (iwe *InternalWrappedEvent) HasOperatorResult() bool {
 	iwe.RLock()
 	defer iwe.RUnlock()
@@ -128,6 +134,11 @@ func (iwe *InternalWrappedEvent) HasOperatorResult() bool {
 	return iwe.OperatorsResult != nil
 }
 
+// HasResults checks if the event has any results from the scan execution.
+// It returns true if there are one or more items in the Results slice. Results
+// represent findings or matches from the template execution against a target.
+// Each result contains details like matched data, extracted information, and
+// metadata about the finding.
 func (iwe *InternalWrappedEvent) HasResults() bool {
 	iwe.RLock()
 	defer iwe.RUnlock()

--- a/pkg/tmplexec/multiproto/multi.go
+++ b/pkg/tmplexec/multiproto/multi.go
@@ -91,7 +91,12 @@ func (m *MultiProtocol) ExecuteWithResults(ctx *scan.ScanContext) error {
 			}
 
 			ID := req.GetID()
-			if ID != "" {
+			// NOTE(dwisiswant0): For multi-protocol templates, we only want to
+			// set the internal event if the event has operator (matchers or
+			// extractors) results, this is to avoid setting empty internal
+			// events which can happen if the protocol does not have any
+			// operators or if the operators do not produce any results.
+			if ID != "" && event.HasOperatorResult() {
 				builder := &strings.Builder{}
 				for k, v := range event.InternalEvent {
 					builder.WriteString(ID)


### PR DESCRIPTION
## Proposed changes

Fixes #6253

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of internal events to prevent empty events from being set when no operator results are present. This ensures more accurate reporting of scan findings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->