### PR TITLE
fix(authx): JSON unmarshalling for Dynamic auth type

### DIFF
--- a/pkg/authprovider/authx/dynamic.go
+++ b/pkg/authprovider/authx/dynamic.go
@@ -52,14 +52,15 @@ func (d *Dynamic) GetDomainAndDomainRegex() ([]string, []string) {
 }
 
 func (d *Dynamic) UnmarshalJSON(data []byte) error {
-	if err := json.Unmarshal(data, &d); err != nil {
+	// Use an alias type (auxiliary) to avoid a recursive call in this method.
+	type Alias Dynamic
+
+	// If d.Secret was nil, json.Unmarshal will allocate a new Secret object
+	// and populate it from the top level JSON fields.
+	if err := json.Unmarshal(data, (*Alias)(d)); err != nil {
 		return err
 	}
-	var s Secret
-	if err := json.Unmarshal(data, &s); err != nil {
-		return err
-	}
-	d.Secret = &s
+
 	return nil
 }
 

--- a/pkg/authprovider/authx/dynamic.go
+++ b/pkg/authprovider/authx/dynamic.go
@@ -52,6 +52,10 @@ func (d *Dynamic) GetDomainAndDomainRegex() ([]string, []string) {
 }
 
 func (d *Dynamic) UnmarshalJSON(data []byte) error {
+	if d == nil {
+		return errorutil.New("cannot unmarshal into nil Dynamic struct")
+	}
+
 	// Use an alias type (auxiliary) to avoid a recursive call in this method.
 	type Alias Dynamic
 

--- a/pkg/authprovider/authx/dynamic_test.go
+++ b/pkg/authprovider/authx/dynamic_test.go
@@ -1,0 +1,125 @@
+package authx
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDynamicUnmarshalJSON(t *testing.T) {
+	t.Run("basic-unmarshal", func(t *testing.T) {
+		data := []byte(`{
+			"template": "test-template.yaml",
+			"variables": [
+				{
+					"key": "username",
+					"value": "testuser"
+				}
+			],
+			"secrets": [
+				{
+					"type": "BasicAuth",
+					"domains": ["example.com"],
+					"username": "user1",
+					"password": "pass1"
+				}
+			],
+			"type": "BasicAuth",
+			"domains": ["test.com"],
+			"username": "testuser",
+			"password": "testpass"
+		}`)
+
+		var d Dynamic
+		err := d.UnmarshalJSON(data)
+		require.NoError(t, err)
+
+		// Secret
+		require.NotNil(t, d.Secret)
+		require.Equal(t, "BasicAuth", d.Secret.Type)
+		require.Equal(t, []string{"test.com"}, d.Secret.Domains)
+		require.Equal(t, "testuser", d.Secret.Username)
+		require.Equal(t, "testpass", d.Secret.Password)
+
+		// Dynamic fields
+		require.Equal(t, "test-template.yaml", d.TemplatePath)
+		require.Len(t, d.Variables, 1)
+		require.Equal(t, "username", d.Variables[0].Key)
+		require.Equal(t, "testuser", d.Variables[0].Value)
+		require.Len(t, d.Secrets, 1)
+		require.Equal(t, "BasicAuth", d.Secrets[0].Type)
+		require.Equal(t, []string{"example.com"}, d.Secrets[0].Domains)
+		require.Equal(t, "user1", d.Secrets[0].Username)
+		require.Equal(t, "pass1", d.Secrets[0].Password)
+	})
+
+	t.Run("complex-unmarshal", func(t *testing.T) {
+		data := []byte(`{
+			"template": "test-template.yaml",
+			"variables": [
+				{
+					"key": "token",
+					"value": "Bearer xyz"
+				}
+			],
+			"secrets": [
+				{
+					"type": "CookiesAuth",
+					"domains": ["example.com"],
+					"cookies": [
+						{
+							"key": "session",
+							"value": "abc123"
+						}
+					]
+				}
+			],
+			"type": "HeadersAuth",
+			"domains": ["api.test.com"],
+			"headers": [
+				{
+					"key": "X-API-Key",
+					"value": "secret-key"
+				}
+			]
+		}`)
+
+		var d Dynamic
+		err := d.UnmarshalJSON(data)
+		require.NoError(t, err)
+
+		// Secret
+		require.NotNil(t, d.Secret)
+		require.Equal(t, "HeadersAuth", d.Secret.Type)
+		require.Equal(t, []string{"api.test.com"}, d.Secret.Domains)
+		require.Len(t, d.Secret.Headers, 1)
+		require.Equal(t, "X-API-Key", d.Secret.Headers[0].Key)
+		require.Equal(t, "secret-key", d.Secret.Headers[0].Value)
+
+		// Dynamic fields
+		require.Equal(t, "test-template.yaml", d.TemplatePath)
+		require.Len(t, d.Variables, 1)
+		require.Equal(t, "token", d.Variables[0].Key)
+		require.Equal(t, "Bearer xyz", d.Variables[0].Value)
+		require.Len(t, d.Secrets, 1)
+		require.Equal(t, "CookiesAuth", d.Secrets[0].Type)
+		require.Equal(t, []string{"example.com"}, d.Secrets[0].Domains)
+		require.Len(t, d.Secrets[0].Cookies, 1)
+		require.Equal(t, "session", d.Secrets[0].Cookies[0].Key)
+		require.Equal(t, "abc123", d.Secrets[0].Cookies[0].Value)
+	})
+
+	t.Run("invalid-json", func(t *testing.T) {
+		data := []byte(`{invalid json}`)
+		var d Dynamic
+		err := d.UnmarshalJSON(data)
+		require.Error(t, err)
+	})
+
+	t.Run("empty-json", func(t *testing.T) {
+		data := []byte(`{}`)
+		var d Dynamic
+		err := d.UnmarshalJSON(data)
+		require.NoError(t, err)
+	})
+}


### PR DESCRIPTION
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->

Correcting the `UnmarshalJSON` method to properly
unmarshal JSON, particularlyaddressing the
population of the embedded `Secret` field. This
was achieved by using a type alias to avoid
recursive calls and rely on default unmarshalling
behavior.

Fixes #6267

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced JSON handling for dynamic authentication providers to prevent errors when processing data.

- **Tests**
  - Added thorough tests to ensure accurate processing of diverse JSON inputs, including valid, complex, invalid, and empty cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->