### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/cmd/integration-test/http.go
+++ b/cmd/integration-test/http.go
@@ -829,10 +829,7 @@ func (h *httpPaths) Execute(filepath string) error {
 	}
 
 	if len(expected) > len(actual) {
-		actualValuesIndex := len(actual) - 1
-		if actualValuesIndex < 0 {
-			actualValuesIndex = 0
-		}
+		actualValuesIndex := max(len(actual)-1, 0)
 		return fmt.Errorf("missing values : %v", expected[actualValuesIndex:])
 	} else if len(expected) < len(actual) {
 		return fmt.Errorf("unexpected values : %v", actual[len(expected)-1:])

--- a/pkg/protocols/http/request.go
+++ b/pkg/protocols/http/request.go
@@ -336,11 +336,8 @@ func (request *Request) executeTurboHTTP(input *contextargs.Context, dynamicValu
 	pipeClient := rawhttp.NewPipelineClient(pipeOptions)
 
 	// defaultMaxWorkers should be a sufficient value to keep queues always full
-	maxWorkers := defaultMaxWorkers
 	// in case the queue is bigger increase the workers
-	if pipeOptions.MaxPendingRequests > maxWorkers {
-		maxWorkers = pipeOptions.MaxPendingRequests
-	}
+	maxWorkers := max(pipeOptions.MaxPendingRequests, defaultMaxWorkers)
 
 	// Stop-at-first-match logic while executing requests
 	// parallely using threads


### PR DESCRIPTION
## Proposed changes

In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)