### PR TITLE
chore: update GoReleaser configurations

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -38,9 +38,9 @@ builds:
 #  goarch: [amd64]
 
 archives:
-  - format: zip
+  - formats: [zip]
     id: nuclei
-    builds: [nuclei-cli]
+    ids: [nuclei-cli]
     name_template: '{{ .ProjectName }}_{{ .Version }}_{{ if eq .Os "darwin" }}macOS{{ else }}{{ .Os }}{{ end }}_{{ .Arch }}'
 
 checksum:


### PR DESCRIPTION
## Proposed changes
This small PR updates the GoReleaser configuration to resolve the following warnings which you can find in the [CI logs](https://github.com/projectdiscovery/nuclei/actions/runs/15760454691/job/44427042923#step:4:514): 
```
DEPRECATED: archives.format should not be used anymore, check https://goreleaser.com/deprecations#archivesformat for more info
DEPRECATED: archives.builds should not be used anymore, check https://goreleaser.com/deprecations#archivesbuilds for more info
```

## Checklist

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)