### PR TITLE
fix(flow): global state collision and leakage

### DIFF
--- a/cmd/nuclei/main_benchmark_test.go
+++ b/cmd/nuclei/main_benchmark_test.go
@@ -117,12 +117,12 @@ func runEnumBenchmark(b *testing.B, options *types.Options) {
 
 func BenchmarkRunEnumeration(b *testing.B) {
 	// Default case: run enumeration with default options == all nuclei-templates
-	// b.Run("Default", func(b *testing.B) {
-	// 	options := getDefaultOptions()
-	// 	options.Targets = []string{targetURL}
+	b.Run("Default", func(b *testing.B) {
+		options := getDefaultOptions()
+		options.Targets = []string{targetURL}
 
-	// 	runEnumBenchmark(b, options)
-	// })
+		runEnumBenchmark(b, options)
+	})
 
 	// Case: https://github.com/projectdiscovery/nuclei/pull/6258
 	b.Run("Multiproto", func(b *testing.B) {
@@ -131,5 +131,54 @@ func BenchmarkRunEnumeration(b *testing.B) {
 		options.Templates = []string{"./cmd/nuclei/testdata/benchmark/multiproto/"}
 
 		runEnumBenchmark(b, options)
+	})
+
+	// Case: https://github.com/projectdiscovery/nuclei/issues/6263
+	b.Run("Flow", func(b *testing.B) {
+		options := getDefaultOptions()
+		options.Targets = []string{
+			"https://google.com",
+			"https://youtube.com",
+			"https://facebook.com",
+			"https://baidu.com",
+			"https://wikipedia.org",
+			"https://qq.com",
+			"https://taobao.com",
+			"https://yahoo.com",
+			"https://tmall.com",
+			"https://amazon.com",
+			"https://twitter.com",
+			"https://sohu.com",
+			"https://live.com",
+			"https://jd.com",
+			"https://vk.com",
+			"https://instagram.com",
+			"https://sina.com.cn",
+			"https://weibo.com",
+			"https://reddit.com",
+			"https://login.tmall.com",
+			"https://360.cn",
+			"https://yandex.ru",
+			"https://linkedin.com",
+			"https://blogspot.com",
+			"https://netflix.com",
+			"https://twitch.tv",
+			"https://whatsapp.com",
+			"https://yahoo.co.jp",
+			"https://csdn.net",
+			"https://wordcamp.org",
+		}
+
+		b.Run("Local-Scoping", func(b *testing.B) {
+			options.Templates = []string{"./cmd/nuclei/testdata/benchmark/flow/wordpress-readme-local-scoping.yaml"}
+
+			runEnumBenchmark(b, options)
+		})
+
+		b.Run("Namespacing", func(b *testing.B) {
+			options.Templates = []string{"./cmd/nuclei/testdata/benchmark/flow/wordpress-readme-namespacing.yaml"}
+
+			runEnumBenchmark(b, options)
+		})
 	})
 }

--- a/cmd/nuclei/testdata/benchmark/flow/wordpress-readme-local-scoping.yaml
+++ b/cmd/nuclei/testdata/benchmark/flow/wordpress-readme-local-scoping.yaml
@@ -1,0 +1,56 @@
+id: wordpress_readme-scoping
+
+info:
+  name: WordPress readme detection
+  author: nisay759
+  severity: info
+  tags: readme,wordpress,themes,plugins
+
+flow: |
+  // get imports from website's root
+  http(1);
+
+  let uniq = Dedupe();
+
+  // get unique webroot of each import
+  for (let path of iterate(template["imports"])) {
+    let pathArray = path.split("/");
+    let rootIdx = pathArray.indexOf("wp-content") + 3;
+    let finalUrl = pathArray.slice(0, rootIdx).join("/");
+    uniq.Add(finalUrl);
+  }
+
+  // for each import, look for readme
+  for (let url of iterate(uniq.Values())) {
+    set("target", url);
+    http(2);
+  }
+
+http:
+  # http(1) - Query web root and extract themes/plugins imports
+  - method: GET
+    redirects: true
+    path:
+      - "{{BaseURL}}"
+
+    extractors:
+      - type: xpath
+        name: "imports"
+        internal: true
+        xpath:
+          - "/html/*/script/@src[contains(.,'wp-content/plugins/')]"
+          - "/html/*/script/@src[contains(.,'wp-content/themes/')]"
+          - "/html/*/style/@src[contains(.,'wp-content/themes/')]"
+          - "/html/*/img/@src[contains(.,'wp-content/themes/')]"
+
+  # http(2) - Given a theme/plugin "target", look for Readme file
+  - method: GET
+    path:
+      - "{{target}}/README.md"
+      - "{{target}}/README.txt"
+
+    stop-at-first-match: true
+    matchers:
+      - type: status
+        status:
+          - 200

--- a/cmd/nuclei/testdata/benchmark/flow/wordpress-readme-namespacing.yaml
+++ b/cmd/nuclei/testdata/benchmark/flow/wordpress-readme-namespacing.yaml
@@ -1,0 +1,56 @@
+id: wordpress_readme-namespacing
+
+info:
+  name: WordPress readme detection
+  author: nisay759
+  severity: info
+  tags: readme,wordpress,themes,plugins
+
+flow: |
+  // get imports from website's root
+  http(1);
+
+  template["{{BaseURL}}_results"] = Dedupe();
+
+  // get unique webroot of each import
+  for (let path of iterate(template["imports"])) {
+    let pathArray = path.split("/");
+    let rootIdx = pathArray.indexOf("wp-content") + 3;
+    let finalUrl = pathArray.slice(0, rootIdx).join("/");
+    template["{{BaseURL}}_results"].Add(finalUrl);
+  }
+
+  // for each import, look for readme
+  for (let url of iterate(template["{{BaseURL}}_results"].Values())) {
+    set("target", url);
+    http(2);
+  }
+
+http:
+  # http(1) - Query web root and extract themes/plugins imports
+  - method: GET
+    redirects: true
+    path:
+      - "{{BaseURL}}"
+
+    extractors:
+      - type: xpath
+        name: "imports"
+        internal: true
+        xpath:
+          - "/html/*/script/@src[contains(.,'wp-content/plugins/')]"
+          - "/html/*/script/@src[contains(.,'wp-content/themes/')]"
+          - "/html/*/style/@src[contains(.,'wp-content/themes/')]"
+          - "/html/*/img/@src[contains(.,'wp-content/themes/')]"
+
+  # http(2) - Given a theme/plugin "target", look for Readme file
+  - method: GET
+    path:
+      - "{{target}}/README.md"
+      - "{{target}}/README.txt"
+
+    stop-at-first-match: true
+    matchers:
+      - type: status
+        status:
+          - 200

--- a/pkg/tmplexec/flow/vm_benchmark_test.go
+++ b/pkg/tmplexec/flow/vm_benchmark_test.go
@@ -1,0 +1,19 @@
+package flow_test
+
+import (
+	"testing"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/tmplexec/flow"
+	"github.com/projectdiscovery/nuclei/v3/pkg/types"
+)
+
+func BenchmarkGetJSRuntime(b *testing.B) {
+	opts := types.DefaultOptions()
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		runtime := flow.GetJSRuntime(opts)
+		flow.PutJSRuntime(runtime)
+	}
+}


### PR DESCRIPTION
## Proposed changes

Fixes #6263

## Benchmark

### Local Scoping v. Namespacing

> [!NOTE]
> Local scoping == clean state (this patch).
> Namespacing == runtime shared/reuse (old / prior to this PR/patch).
>
> Local scoping:
> ```js
> // ...
> let uniq = Dedupe();
> // ...
> for (let path of iterate(template["imports"])) {
>   // ...
>   uniq.Add(finalUrl);
> }
> // ...
> for (let url of iterate(uniq.Values())) {
>   // ...
> }
> ```
>
> Namespacing:
> ```js
> template["{{BaseURL}}_results"] = Dedupe();
> // ...
> for (let path of iterate(template["imports"])) {
>   // ...
>   template["{{BaseURL}}_results"].Add(finalUrl);
> }
> // ...
> for (let url of iterate(template["{{BaseURL}}_results"].Values())) {
>   // ...
> }
> ```

old (runtime shared/reuse):

```console
$ go test -benchmem -run=^$ -bench ^BenchmarkGetJSRuntime$ ./pkg/tmplexec/flow
goos: linux
goarch: amd64
pkg: github.com/projectdiscovery/nuclei/v3/pkg/tmplexec/flow
cpu: 11th Gen Intel(R) Core(TM) i9-11900H @ 2.50GHz
BenchmarkGetJSRuntime-16    	14630804	        80.35 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/projectdiscovery/nuclei/v3/pkg/tmplexec/flow	1.386s
```

patch (clean state):

```console
$ go test -benchmem -run=^$ -bench ^BenchmarkGetJSRuntime$ ./pkg/tmplexec/flow
goos: linux
goarch: amd64
pkg: github.com/projectdiscovery/nuclei/v3/pkg/tmplexec/flow
cpu: 11th Gen Intel(R) Core(TM) i9-11900H @ 2.50GHz
BenchmarkGetJSRuntime-16    	  143451	      8376 ns/op	    8552 B/op	      66 allocs/op
PASS
ok  	github.com/projectdiscovery/nuclei/v3/pkg/tmplexec/flow	1.396s
```

benchstat:

```console
$ benchstat namespacing.txt local-scoping.txt
goos: linux
goarch: amd64
pkg: github.com/projectdiscovery/nuclei/v3/cmd/nuclei
cpu: 11th Gen Intel(R) Core(TM) i9-11900H @ 2.50GHz
                       │ namespacing.txt │       local-scoping.txt       │
                       │     sec/op      │   sec/op     vs base          │
RunEnumeration/Flow-16       17.70 ± 33%   19.13 ± 25%  ~ (p=0.912 n=10)

                       │ namespacing.txt │       local-scoping.txt        │
                       │      B/op       │     B/op      vs base          │
RunEnumeration/Flow-16     73.31Mi ± 20%   70.11Mi ± 6%  ~ (p=0.052 n=10)

                       │ namespacing.txt │       local-scoping.txt       │
                       │    allocs/op    │  allocs/op   vs base          │
RunEnumeration/Flow-16      251.4k ± 16%   245.5k ± 5%  ~ (p=0.739 n=10)
```

Strange that the benchstat results show **_no statistically significant difference_** between the two approaches on a real-world task.

### Steps to Test

```console
$ gh pr checkout <this_pr_num>
$ make build-test
$ go test -benchmem -run=^$ -bench ^BenchmarkGetJSRuntime$ ./pkg/tmplexec/flow | tee BenchmarkGetJSRuntime-patch.txt # patch (clean state)
$ ./bin/nuclei.test -test.run - -test.bench="^BenchmarkRunEnumeration/Flow/Local-Scoping$" -test.benchmem -test.count=10 ./cmd/nuclei/ | tee local-scoping.txt # patch (clean state)
$ git revert b8631c52
$ make build-test
$ go test -benchmem -run=^$ -bench ^BenchmarkGetJSRuntime$ ./pkg/tmplexec/flow | tee BenchmarkGetJSRuntime-old.txt # runtime shared/reuse
$ ./bin/nuclei.test -test.run - -test.bench="^BenchmarkRunEnumeration/Flow/Namespacing$" -test.benchmem -test.count=10 ./cmd/nuclei/ | tee namespacing.txt # runtime shared/reuse
$ sed -i -e 's|/Local-Scoping||g' -e 's|/Namespacing||g' local-scoping.txt namespacing.txt 
```

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new benchmark tests to improve coverage for multi-target and template-based flow scenarios.
  * Introduced a benchmark to measure JavaScript runtime creation and release performance.

* **Refactor**
  * Changed JavaScript runtime handling to create a new runtime instance for each use, eliminating pooling and reuse.

* **Bug Fixes**
  * Ensured that updates to the template context during protocol execution are accurately reflected in the JavaScript runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->