### PR TITLE
fix context leak in flow

### DIFF
--- a/pkg/js/compiler/compiler_test.go
+++ b/pkg/js/compiler/compiler_test.go
@@ -21,7 +21,7 @@ func TestNewCompilerConsoleDebug(t *testing.T) {
 	})
 
 	compiler := New()
-	p, err := WrapScriptNCompile("console.log('hello world');", false)
+	p, err := SourceAutoMode("console.log('hello world');", false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/protocols/code/code.go
+++ b/pkg/protocols/code/code.go
@@ -130,7 +130,7 @@ func (request *Request) Compile(options *protocols.ExecutorOptions) error {
 
 	// compile pre-condition if any
 	if request.PreCondition != "" {
-		preConditionCompiled, err := compiler.WrapScriptNCompile(request.PreCondition, false)
+		preConditionCompiled, err := compiler.SourceAutoMode(request.PreCondition, false)
 		if err != nil {
 			return errorutil.NewWithTag(request.TemplateID, "could not compile pre-condition: %s", err)
 		}

--- a/pkg/protocols/javascript/js.go
+++ b/pkg/protocols/javascript/js.go
@@ -215,7 +215,7 @@ func (request *Request) Compile(options *protocols.ExecutorOptions) error {
 		// proceed with whatever args we have
 		args.Args, _ = request.evaluateArgs(allVars, options, true)
 
-		initCompiled, err := compiler.WrapScriptNCompile(request.Init, false)
+		initCompiled, err := compiler.SourceAutoMode(request.Init, false)
 		if err != nil {
 			return errorutil.NewWithTag(request.TemplateID, "could not compile init code: %s", err)
 		}
@@ -236,7 +236,7 @@ func (request *Request) Compile(options *protocols.ExecutorOptions) error {
 
 	// compile pre-condition if any
 	if request.PreCondition != "" {
-		preConditionCompiled, err := compiler.WrapScriptNCompile(request.PreCondition, false)
+		preConditionCompiled, err := compiler.SourceAutoMode(request.PreCondition, false)
 		if err != nil {
 			return errorutil.NewWithTag(request.TemplateID, "could not compile pre-condition: %s", err)
 		}
@@ -245,7 +245,7 @@ func (request *Request) Compile(options *protocols.ExecutorOptions) error {
 
 	// compile actual source code
 	if request.Code != "" {
-		scriptCompiled, err := compiler.WrapScriptNCompile(request.Code, false)
+		scriptCompiled, err := compiler.SourceAutoMode(request.Code, false)
 		if err != nil {
 			return errorutil.NewWithTag(request.TemplateID, "could not compile javascript code: %s", err)
 		}

--- a/pkg/tmplexec/exec.go
+++ b/pkg/tmplexec/exec.go
@@ -43,7 +43,7 @@ func NewTemplateExecuter(requests []protocols.Request, options *protocols.Execut
 		// we use a dummy input here because goal of flow executor at this point is to just check
 		// syntax and other things are correct before proceeding to actual execution
 		// during execution new instance of flow will be created as it is tightly coupled with lot of executor options
-		p, err := compiler.WrapScriptNCompile(options.Flow, false)
+		p, err := compiler.SourceAutoMode(options.Flow, false)
 		if err != nil {
 			return nil, fmt.Errorf("could not compile flow: %s", err)
 		}

--- a/pkg/tmplexec/flow/flow_executor.go
+++ b/pkg/tmplexec/flow/flow_executor.go
@@ -8,6 +8,7 @@ import (
 	"sync/atomic"
 
 	"github.com/dop251/goja"
+	"github.com/projectdiscovery/nuclei/v3/pkg/js/compiler"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/generators"
 	"github.com/projectdiscovery/nuclei/v3/pkg/scan"
@@ -195,7 +196,13 @@ func (f *FlowExecutor) ExecuteWithResults(ctx *scan.ScanContext) error {
 
 	// get a new runtime from pool
 	runtime := GetJSRuntime(f.options.Options)
-	defer PutJSRuntime(runtime) // put runtime back to pool
+	defer func() {
+		// whether to reuse or not depends on the whether script modifies
+		// global scope or not,
+		if compiler.CanRunAsIIFE(f.options.Flow) {
+			PutJSRuntime(runtime)
+		}
+	}()
 	defer func() {
 		// remove set builtin
 		_ = runtime.GlobalObject().Delete("set")

--- a/pkg/tmplexec/flow/flow_executor.go
+++ b/pkg/tmplexec/flow/flow_executor.go
@@ -199,9 +199,7 @@ func (f *FlowExecutor) ExecuteWithResults(ctx *scan.ScanContext) error {
 	defer func() {
 		// whether to reuse or not depends on the whether script modifies
 		// global scope or not,
-		if compiler.CanRunAsIIFE(f.options.Flow) {
-			PutJSRuntime(runtime)
-		}
+		PutJSRuntime(runtime, compiler.CanRunAsIIFE(f.options.Flow))
 	}()
 	defer func() {
 		// remove set builtin

--- a/pkg/tmplexec/flow/vm.go
+++ b/pkg/tmplexec/flow/vm.go
@@ -35,7 +35,7 @@ func GetJSRuntime(opts *types.Options) *goja.Runtime {
 		if opts.JsConcurrency < 100 {
 			opts.JsConcurrency = 100
 		}
-		sizedgojapool, _ = sizedpool.New[*goja.Runtime](
+		sizedgojapool, _ = sizedpool.New(
 			sizedpool.WithPool[*goja.Runtime](gojapool),
 			sizedpool.WithSize[*goja.Runtime](int64(opts.JsConcurrency)),
 		)
@@ -45,8 +45,12 @@ func GetJSRuntime(opts *types.Options) *goja.Runtime {
 }
 
 // PutJSRuntime returns a JS runtime to pool
-func PutJSRuntime(runtime *goja.Runtime) {
-	sizedgojapool.Put(runtime)
+func PutJSRuntime(runtime *goja.Runtime, reuse bool) {
+	if reuse {
+		sizedgojapool.Put(runtime)
+	} else {
+		sizedgojapool.Put(gojapool.Get().(*goja.Runtime))
+	}
 }
 
 func registerBuiltins(runtime *goja.Runtime) {


### PR DESCRIPTION
## Description

- this is based on pr #6281 
- the original cause is that vm is being reused and since shadowing is not supported , previous instances of objects are used in different scan contexts for the same template
- the root cause was divereged implementation of javascript protocol vs flow , where in javascript protocol the IIFE (vm reuse mode) was conditional but that was not implemented in flow which lead to issue
- in #6263 we tried to remove the vm reuse completely but in this pr we make that conditional and consistent with javascript protocol
- and to avoid confusion renamed WrapScriptNCompile methods to more appropriate IIFEMode and AutoMode
- closes #6281 