### PR TITLE
Fix(headless): Variables are now available into headless template

### DIFF
--- a/pkg/protocols/headless/request.go
+++ b/pkg/protocols/headless/request.go
@@ -54,10 +54,11 @@ func (request *Request) ExecuteWithResults(input *contextargs.Context, metadata,
 	optionVars := generators.BuildPayloadFromOptions(request.options.Options)
 	// add templatecontext variables to varMap
 	if request.options.HasTemplateCtx(input.MetaInput) {
-		vars = generators.MergeMaps(vars, metadata, optionVars, request.options.GetTemplateCtx(input.MetaInput).GetAll())
+		vars = generators.MergeMaps(vars, request.options.GetTemplateCtx(input.MetaInput).GetAll())
 	}
+
 	variablesMap := request.options.Variables.Evaluate(vars)
-	vars = generators.MergeMaps(vars, variablesMap, request.options.Constants)
+	vars = generators.MergeMaps(vars, metadata, optionVars, variablesMap, request.options.Constants)
 
 	// check for operator matches by wrapping callback
 	gotmatches := false
@@ -188,12 +189,19 @@ func (request *Request) executeRequestWithPayloads(input *contextargs.Context, p
 	outputEvent := request.responseToDSLMap(responseBody, header, statusCode, reqBuilder.String(), input.MetaInput.Input, navigatedURL, page.DumpHistory())
 	// add response fields to template context and merge templatectx variables to output event
 	request.options.AddTemplateVars(input.MetaInput, request.Type(), request.ID, outputEvent)
+
+	gologger.Info().Msgf("foo1 : %s", outputEvent["foo"])
+
 	if request.options.HasTemplateCtx(input.MetaInput) {
 		outputEvent = generators.MergeMaps(outputEvent, request.options.GetTemplateCtx(input.MetaInput).GetAll())
+		gologger.Info().Msgf("foo2 : %s", outputEvent["foo"])
+
 	}
 
 	maps.Copy(outputEvent, out)
 	maps.Copy(outputEvent, payloads)
+
+	gologger.Info().Msgf("foo3 : %s", outputEvent["foo"])
 
 	var event *output.InternalWrappedEvent
 	if len(page.InteractshURLs) == 0 {

--- a/pkg/protocols/headless/request.go
+++ b/pkg/protocols/headless/request.go
@@ -119,8 +119,8 @@ func (request *Request) executeRequestWithPayloads(input *contextargs.Context, p
 		return errors.Wrap(err, errCouldNotGetHtmlElement)
 	}
 	defer func() {
-         _ = instance.Close()
-       }()
+		_ = instance.Close()
+	}()
 
 	instance.SetInteractsh(request.options.Interactsh)
 
@@ -189,19 +189,12 @@ func (request *Request) executeRequestWithPayloads(input *contextargs.Context, p
 	outputEvent := request.responseToDSLMap(responseBody, header, statusCode, reqBuilder.String(), input.MetaInput.Input, navigatedURL, page.DumpHistory())
 	// add response fields to template context and merge templatectx variables to output event
 	request.options.AddTemplateVars(input.MetaInput, request.Type(), request.ID, outputEvent)
-
-	gologger.Info().Msgf("foo1 : %s", outputEvent["foo"])
-
 	if request.options.HasTemplateCtx(input.MetaInput) {
 		outputEvent = generators.MergeMaps(outputEvent, request.options.GetTemplateCtx(input.MetaInput).GetAll())
-		gologger.Info().Msgf("foo2 : %s", outputEvent["foo"])
-
 	}
 
 	maps.Copy(outputEvent, out)
 	maps.Copy(outputEvent, payloads)
-
-	gologger.Info().Msgf("foo3 : %s", outputEvent["foo"])
 
 	var event *output.InternalWrappedEvent
 	if len(page.InteractshURLs) == 0 {


### PR DESCRIPTION
## Proposed changes

Modify variables merge maps in headless requests to avoid loss of information (such as metadata, variables, constants, etc.). Sometimes, the headless template has no template context. But we need to keep information about variables.
## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)