### PR TITLE
fix(lib): scans didn't stop on ctx cancellation

### DIFF
--- a/lib/sdk_test.go
+++ b/lib/sdk_test.go
@@ -1,0 +1,37 @@
+package nuclei_test
+
+import (
+	"context"
+	"log"
+	"testing"
+	"time"
+
+	nuclei "github.com/projectdiscovery/nuclei/v3/lib"
+	"github.com/stretchr/testify/require"
+)
+
+func TestContextCancelNucleiEngine(t *testing.T) {
+	// create nuclei engine with options
+	ctx, cancel := context.WithCancel(context.Background())
+	ne, err := nuclei.NewNucleiEngineCtx(ctx,
+		nuclei.WithTemplateFilters(nuclei.TemplateFilters{Tags: []string{"oast"}}),
+		nuclei.EnableStatsWithOpts(nuclei.StatsOptions{MetricServerPort: 6064}),
+	)
+	require.NoError(t, err, "could not create nuclei engine")
+
+	go func() {
+		time.Sleep(time.Second * 2)
+		cancel()
+		log.Println("Test: context cancelled")
+	}()
+
+	// load targets and optionally probe non http/https targets
+	ne.LoadTargets([]string{"http://honey.scanme.sh"}, false)
+	// when callback is nil it nuclei will print JSON output to stdout
+	err = ne.ExecuteWithCallback(nil)
+	if err != nil {
+		// we expect a context cancellation error
+		require.ErrorIs(t, err, context.Canceled, "was expecting context cancellation error")
+	}
+	defer ne.Close()
+}


### PR DESCRIPTION
## Proposed changes

* add a `ctx` field to `NucleiEngine` struct to store the context.
* use stored context (respect) from `NucleiEngine` instance in `ExecuteWithCallback` method.
* update `ExecuteCallbackWithCtx` method to make `ExecuteScanWithOpts` run in a goroutine and wait for either:
  * the scan to complete, or
  * the context to be canceled.



Fixes #6298

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)