### PR TITLE
ISSUE: 6314 - fixing panic caused by uninitialized colorizer

### DIFF
--- a/lib/config.go
+++ b/lib/config.go
@@ -296,8 +296,8 @@ func WithNetworkConfig(opts NetworkConfig) NucleiSDKOptions {
 		if e.opts.ShouldUseHostError() {
 			maxHostError := opts.MaxHostError
 			if e.opts.TemplateThreads > maxHostError {
-				gologger.Print().Msgf("[%v] The concurrency value is higher than max-host-error", e.executerOpts.Colorizer.BrightYellow("WRN"))
-				gologger.Info().Msgf("Adjusting max-host-error to the concurrency value: %d", e.opts.TemplateThreads)
+				gologger.Warning().Msg(" The concurrency value is higher than max-host-error")
+				gologger.Warning().Msgf("Adjusting max-host-error to the concurrency value: %d", e.opts.TemplateThreads)
 				maxHostError = e.opts.TemplateThreads
 				e.opts.MaxHostError = maxHostError
 			}


### PR DESCRIPTION
Addresses the panic caused by an uninitialized interface field:
https://github.com/projectdiscovery/nuclei/issues/6314

- [X] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved clarity and consistency of warning messages related to concurrency settings in system logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->