### PR TITLE
Address race conditions in http.Request and MemGuardian

### DIFF
--- a/pkg/protocols/common/protocolstate/memguardian.go
+++ b/pkg/protocols/common/protocolstate/memguardian.go
@@ -16,9 +16,12 @@ var (
 	MaxBytesBufferAllocOnLowMemory = env.GetEnvOrDefault("MEMGUARDIAN_ALLOC", 0)
 	memTimer                       *time.Ticker
 	cancelFunc                     context.CancelFunc
+	muGlobalChange                 sync.Mutex
 )
 
 func StartActiveMemGuardian(ctx context.Context) {
+	muGlobalChange.Lock()
+	defer muGlobalChange.Unlock()
 	if memguardian.DefaultMemGuardian == nil || memTimer != nil {
 		return
 	}
@@ -42,6 +45,9 @@ func StartActiveMemGuardian(ctx context.Context) {
 }
 
 func StopActiveMemGuardian() {
+	muGlobalChange.Lock()
+	defer muGlobalChange.Unlock()
+
 	if memguardian.DefaultMemGuardian == nil {
 		return
 	}
@@ -72,8 +78,6 @@ func GuardThreadsOrDefault(current int) int {
 
 	return 1
 }
-
-var muGlobalChange sync.Mutex
 
 // Global setting
 func GlobalGuardBytesBufferAlloc() error {

--- a/pkg/protocols/http/utils.go
+++ b/pkg/protocols/http/utils.go
@@ -12,7 +12,8 @@ import (
 // dump creates a dump of the http request in form of a byte slice
 func dump(req *generatedRequest, reqURL string) ([]byte, error) {
 	if req.request != nil {
-		bin, err := req.request.Dump()
+		// Use a clone to avoid a race condition with the http transport
+		bin, err := req.request.Clone(req.request.Context()).Dump()
 		if err != nil {
 			return nil, errorutil.NewWithErr(err).WithTag("http").Msgf("could not dump request: %v", req.request.String())
 		}


### PR DESCRIPTION
## Proposed changes

This PR addresses two sets of race conditions:
 - An active HTTP scan could race against the dump/curl functions (same engine)
 - A global race in MemGuardian (concurrent engines)

Example traces:

*HTTP*

```
==================
WARNING: DATA RACE
Write at 0x00c020e49580 by goroutine 1527061:
  github.com/projectdiscovery/nuclei/v3/pkg/protocols/http.(*Request).executeRequest()
      project/nuclei/pkg/protocols/http/request.go:869 +0x7170
  github.com/projectdiscovery/nuclei/v3/pkg/protocols/http.(*Request).ExecuteWithResults.func1()
      project/nuclei/pkg/protocols/http/request.go:508 +0xa04
  github.com/projectdiscovery/nuclei/v3/pkg/protocols/http.(*Request).ExecuteWithResults()
      project/nuclei/pkg/protocols/http/request.go:585 +0x786
  github.com/projectdiscovery/nuclei/v3/pkg/tmplexec/generic.(*Generic).ExecuteWithResults()
      project/nuclei/pkg/tmplexec/generic/exec.go:61 +0x595
  github.com/projectdiscovery/nuclei/v3/pkg/tmplexec.(*TemplateExecuter).Execute()
      project/nuclei/pkg/tmplexec/exec.go:216 +0x876
  github.com/projectdiscovery/nuclei/v3/pkg/core.(*Engine).executeTemplateWithTargets.func2.1()
      project/nuclei/pkg/core/executors.go:138 +0x415
  github.com/projectdiscovery/nuclei/v3/pkg/core.(*Engine).executeTemplateWithTargets.func2.gowrap1()
      project/nuclei/pkg/core/executors.go:145 +0x61

Previous read at 0x00c020e49580 by goroutine 1605854:
  net/http.newTransferWriter()
      /root/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.5.linux-amd64/src/net/http/transfer.go:93 +0x3b3
  net/http.(*Request).write()
      /root/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.5.linux-amd64/src/net/http/request.go:706 +0x1011
  net/http.(*persistConn).writeLoop()
      /root/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.5.linux-amd64/src/net/http/transport.go:2593 +0x364
  net/http.(*Transport).dialConn.gowrap3()
      /root/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.5.linux-amd64/src/net/http/transport.go:1945 +0x33

Goroutine 1527061 (running) created at:
  github.com/projectdiscovery/nuclei/v3/pkg/core.(*Engine).executeTemplateWithTargets.func2()
      project/nuclei/pkg/core/executors.go:114 +0xd6a
  github.com/projectdiscovery/nuclei/v3/pkg/input/provider.(*SimpleInputProvider).Iterate()
      project/nuclei/pkg/input/provider/simple.go:38 +0x8a
  github.com/projectdiscovery/nuclei/v3/pkg/core.(*Engine).executeTemplateWithTargets()
      project/nuclei/pkg/core/executors.go:79 +0x85b
  github.com/projectdiscovery/nuclei/v3/pkg/core.(*Engine).executeTemplateSpray.func1()
      project/nuclei/pkg/core/execute_options.go:137 +0x10a
  github.com/projectdiscovery/nuclei/v3/pkg/core.(*Engine).executeTemplateSpray.gowrap2()
      project/nuclei/pkg/core/execute_options.go:138 +0x41

Goroutine 1605854 (running) created at:
  net/http.(*Transport).dialConn()
      /root/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.5.linux-amd64/src/net/http/transport.go:1945 +0x2dd9
  net/http.(*Transport).dialConnFor()
      /root/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.5.linux-amd64/src/net/http/transport.go:1615 +0x11d
  net/http.(*Transport).startDialConnForLocked.func1()
      /root/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.5.linux-amd64/src/net/http/transport.go:1597 +0x3c
==================
```

*MemGuardian*
```
==================
WARNING: DATA RACE
Read at 0x0000111e4aa8 by goroutine 795469:
  github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate.StartActiveMemGuardian()
      project/nuclei/pkg/protocols/common/protocolstate/memguardian.go:22 +0x47
  github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate.initDialers()
      project/nuclei/pkg/protocols/common/protocolstate/state.go:201 +0x17c8
  github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate.Init()
      project/nuclei/pkg/protocols/common/protocolstate/state.go:61 +0xb1
  github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolinit.Init()
      project/nuclei/pkg/protocols/common/protocolinit/init.go:17 +0x2e
  github.com/projectdiscovery/nuclei/v3/lib.(*NucleiEngine).init()
      project/nuclei/lib/sdk_private.go:120 +0x5b8
  github.com/projectdiscovery/nuclei/v3/lib.NewNucleiEngineCtx()
      project/nuclei/lib/sdk.go:326 +0x4b6
  github.com/runZeroInc/platform/runzero.(*Scanner).vulnScanTechDetectionHTTP()
      /home/runzero/platform/runzero/scanner_vscan.go:1257 +0x1ef9
  github.com/runZeroInc/platform/runzero.(*TCPPortScanner).httpAnalyzeActive()
      /home/runzero/platform/runzero/tcp_http_analyze_active.go:310 +0x766e
  github.com/runZeroInc/platform/runzero.(*TCPPortScanner).httpProcessResponse()
      /home/runzero/platform/runzero/tcp_http.go:1115 +0x1dc4
  github.com/runZeroInc/platform/runzero.(*TCPPortScanner).httpParseRaw()
      /home/runzero/platform/runzero/tcp_http.go:504 +0x97e
  github.com/runZeroInc/platform/runzero.(*TCPPortScanner).ProcessResponse()
      /home/runzero/platform/runzero/tcp.go:2666 +0x70d2
  github.com/runZeroInc/platform/runzero.(*TCPPortScanner).ActiveFingerprint()
      /home/runzero/platform/runzero/tcp.go:3598 +0x3e54
  github.com/runZeroInc/platform/runzero.(*TCPPortScanner).GatherInformation()
      /home/runzero/platform/runzero/tcp.go:3180 +0x22b6
  github.com/runZeroInc/platform/runzero.(*TCPPortScanner).ProcessTarget()
      /home/runzero/platform/runzero/tcp.go:961 +0x7c4
  github.com/runZeroInc/platform/runzero.(*TCPPortScanner).ProcessSingleTarget.func2()
      /home/runzero/platform/runzero/tcp.go:650 +0x204

Previous write at 0x0000111e4aa8 by goroutine 795470:
  github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate.StartActiveMemGuardian()
      project/nuclei/pkg/protocols/common/protocolstate/memguardian.go:26 +0x85
  github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate.initDialers()
      project/nuclei/pkg/protocols/common/protocolstate/state.go:201 +0x17c8
  github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate.Init()
      project/nuclei/pkg/protocols/common/protocolstate/state.go:61 +0xb1
  github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolinit.Init()
      project/nuclei/pkg/protocols/common/protocolinit/init.go:17 +0x2e
  github.com/projectdiscovery/nuclei/v3/lib.(*NucleiEngine).init()
      project/nuclei/lib/sdk_private.go:120 +0x5b8
  github.com/projectdiscovery/nuclei/v3/lib.NewNucleiEngineCtx()
      project/nuclei/lib/sdk.go:326 +0x4b6
  github.com/runZeroInc/platform/runzero.(*Scanner).vulnScanTechDetectionHTTP()
      /home/runzero/platform/runzero/scanner_vscan.go:1257 +0x1ef9
  github.com/runZeroInc/platform/runzero.(*TCPPortScanner).httpAnalyzeActive()
      /home/runzero/platform/runzero/tcp_http_analyze_active.go:310 +0x766e
  github.com/runZeroInc/platform/runzero.(*TCPPortScanner).httpProcessResponse()
      /home/runzero/platform/runzero/tcp_http.go:1115 +0x1dc4
  github.com/runZeroInc/platform/runzero.(*TCPPortScanner).httpParseRaw()
      /home/runzero/platform/runzero/tcp_http.go:504 +0x97e
  github.com/runZeroInc/platform/runzero.(*TCPPortScanner).ProcessResponse()
      /home/runzero/platform/runzero/tcp.go:2666 +0x70d2
  github.com/runZeroInc/platform/runzero.(*TCPPortScanner).ActiveFingerprint()
      /home/runzero/platform/runzero/tcp.go:3598 +0x3e54
  github.com/runZeroInc/platform/runzero.(*TCPPortScanner).GatherInformation()
      /home/runzero/platform/runzero/tcp.go:3180 +0x22b6
  github.com/runZeroInc/platform/runzero.(*TCPPortScanner).ProcessTarget()
      /home/runzero/platform/runzero/tcp.go:961 +0x7c4
  github.com/runZeroInc/platform/runzero.(*TCPPortScanner).ProcessSingleTarget.func2()
      /home/runzero/platform/runzero/tcp.go:650 +0x204

Goroutine 795469 (running) created at:
  github.com/runZeroInc/platform/runzero.(*TCPPortScanner).ProcessSingleTarget()
      /home/runzero/platform/runzero/tcp.go:642 +0x512
  github.com/runZeroInc/platform/runzero.(*TCPPortScanner).ProcessTargets()
      /home/runzero/platform/runzero/tcp.go:596 +0x1e4
  github.com/runZeroInc/platform/runzero.NewTCPPortScanner.gowrap1()
      /home/runzero/platform/runzero/tcp.go:218 +0x33

Goroutine 795470 (running) created at:
  github.com/runZeroInc/platform/runzero.(*TCPPortScanner).ProcessSingleTarget()
      /home/runzero/platform/runzero/tcp.go:642 +0x512
  github.com/runZeroInc/platform/runzero.(*TCPPortScanner).ProcessTargets()
      /home/runzero/platform/runzero/tcp.go:596 +0x1e4
  github.com/runZeroInc/platform/runzero.NewTCPPortScanner.gowrap1()
      /home/runzero/platform/runzero/tcp.go:218 +0x33
==================
```

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread safety and reliability when handling HTTP requests, reducing the risk of race conditions during request processing and logging.
* **Chores**
  * Enhanced internal synchronization mechanisms for memory management processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->