### PR TITLE
fix(offlinehttp): Replace "-" in headers with "_" for DSL variables

### DIFF
--- a/pkg/protocols/offlinehttp/operators.go
+++ b/pkg/protocols/offlinehttp/operators.go
@@ -109,7 +109,7 @@ func (request *Request) responseToDSLMap(resp *http.Response, host, matched, raw
 		data[strings.ToLower(cookie.Name)] = cookie.Value
 	}
 	for k, v := range resp.Header {
-		k = strings.ToLower(strings.TrimSpace(k))
+		k = strings.ToLower(strings.ReplaceAll(strings.TrimSpace(k), "-", "_"))
 		data[k] = strings.Join(v, " ")
 	}
 

--- a/pkg/protocols/offlinehttp/operators_test.go
+++ b/pkg/protocols/offlinehttp/operators_test.go
@@ -134,7 +134,7 @@ func TestHTTPOperatorExtract(t *testing.T) {
 	event := request.responseToDSLMap(resp, host, matched, exampleRawRequest, exampleRawResponse, exampleResponseBody, exampleResponseHeader, 1*time.Second, map[string]interface{}{})
 	require.Len(t, event, 14, "could not get correct number of items in dsl map")
 	require.Equal(t, exampleRawResponse, event["response"], "could not get correct resp")
-	require.Equal(t, "Test-Response", event["test-header"], "could not get correct resp for header")
+	require.Equal(t, "Test-Response", event["test_header"], "could not get correct resp for header")
 
 	t.Run("extract", func(t *testing.T) {
 		extractor := &extractors.Extractor{
@@ -153,7 +153,7 @@ func TestHTTPOperatorExtract(t *testing.T) {
 	t.Run("kval", func(t *testing.T) {
 		extractor := &extractors.Extractor{
 			Type: extractors.ExtractorTypeHolder{ExtractorType: extractors.KValExtractor},
-			KVal: []string{"test-header"},
+			KVal: []string{"test_header"},
 			Part: "header",
 		}
 		err = extractor.CompileExtractors()


### PR DESCRIPTION
## Proposed changes

This fix the bug mentioned in https://github.com/projectdiscovery/nuclei/issues/6362
The change makes the passive mode handles header the same as active mode here:
https://github.com/projectdiscovery/nuclei/blob/91adfeb91c2e8fe1e077dd5f36c045442c18009c/pkg/protocols/http/operators.go#L117

I didn't add test or documentation since this should be a small bug fix.

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved normalization of HTTP response header keys by replacing hyphens with underscores, in addition to trimming whitespace and converting to lowercase. This may change the appearance of header keys in outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->