### PR TITLE
fix: prevent nil pointer panic in WAF detector

### DIFF
--- a/pkg/output/stats/waf/waf.go
+++ b/pkg/output/stats/waf/waf.go
@@ -53,8 +53,12 @@ func NewWafDetector() *WafDetector {
 }
 
 func (d *WafDetector) DetectWAF(content string) (string, bool) {
+	if d == nil || d.regexCache == nil {
+		return "", false
+	}
+
 	for id, regex := range d.regexCache {
-		if regex.MatchString(content) {
+		if regex != nil && regex.MatchString(content) {
 			return id, true
 		}
 	}


### PR DESCRIPTION
- Add nil checks for detector and regexCache in DetectWAF()
- Add nil check for individual regex entries before MatchString()
- Add comprehensive unit tests for nil pointer scenarios
- Prevents runtime panic when WAF detector encounters nil pointers during regex matching

## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->


## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of WAF detection to prevent errors when handling uninitialized or partially initialized detectors.

* **Tests**
  * Added tests to ensure WAF detection handles nil pointers safely and does not cause application crashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->