### PR TITLE
fix(fuzz): restore proper ErrRuleNotApplicable error handling

### DIFF
--- a/pkg/protocols/http/request_fuzz.go
+++ b/pkg/protocols/http/request_fuzz.go
@@ -168,7 +168,7 @@ func (request *Request) executeAllFuzzingRules(input *contextargs.Context, value
 	}
 
 	if !applicable {
-		return fmt.Errorf("no rule was applicable for this request: %v", input.MetaInput.Input)
+		return fuzz.ErrRuleNotApplicable(fmt.Sprintf("no rule was applicable for this request: %v", input.MetaInput.Input))
 	}
 
 	return nil


### PR DESCRIPTION
Fixes fuzzing regression introduced in commit 6a6fa4d3 where fmt.Errorf was incorrectly used instead of fuzz.ErrRuleNotApplicable.

The issue caused pre-condition filters (like 'method == GET') to fail because the error type detection was broken. This led to legitimate fuzzing targets being incorrectly marked as 'not applicable for fuzzing'.

Changes:
- Restore fuzz.ErrRuleNotApplicable() call in executeAllFuzzingRules()
- Ensures proper error type checking with fuzz.IsErrRuleNotApplicable()
- Fixes path-based SQL injection fuzzing and other fuzz templates

Tested with: integration_tests/fuzz/fuzz-path-sqli.yaml

## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->


## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)