### PR TITLE
fix: handle duplicate field names in multipart form encoding

### DIFF
--- a/pkg/fuzz/dataformat/multipart.go
+++ b/pkg/fuzz/dataformat/multipart.go
@@ -76,15 +76,28 @@ func (m *MultiPartForm) Encode(data KV) (string, error) {
 			return true
 		}
 
-		// Add field
-		if fw, err = w.CreateFormField(key); err != nil {
-			Itererr = err
-			return false
+		// Handle form field values - can be string or []string for duplicate fields
+		var values []string
+		switch v := value.(type) {
+		case string:
+			values = []string{v}
+		case []string:
+			values = v
+		default:
+			// Fallback: attempt string conversion
+			values = []string{fmt.Sprint(v)}
 		}
 
-		if _, err = fw.Write([]byte(value.(string))); err != nil {
-			Itererr = err
-			return false
+		// Write all values for this field
+		for _, val := range values {
+			if fw, err = w.CreateFormField(key); err != nil {
+				Itererr = err
+				return false
+			}
+			if _, err = fw.Write([]byte(val)); err != nil {
+				Itererr = err
+				return false
+			}
 		}
 		return true
 	})

--- a/pkg/fuzz/dataformat/multipart.go
+++ b/pkg/fuzz/dataformat/multipart.go
@@ -83,6 +83,12 @@ func (m *MultiPartForm) Encode(data KV) (string, error) {
 			values = []string{v}
 		case []string:
 			values = v
+		case []any:
+			// Handle []any by converting each element to string
+			values = make([]string, len(v))
+			for i, elem := range v {
+				values[i] = fmt.Sprint(elem)
+			}
 		default:
 			// Fallback: attempt string conversion
 			values = []string{fmt.Sprint(v)}

--- a/pkg/fuzz/dataformat/multipart_test.go
+++ b/pkg/fuzz/dataformat/multipart_test.go
@@ -1,0 +1,94 @@
+package dataformat
+
+import (
+	"testing"
+
+	mapsutil "github.com/projectdiscovery/utils/maps"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMultiPartFormEncode(t *testing.T) {
+	tests := []struct {
+		name     string
+		fields   map[string]any
+		wantErr  bool
+		contains []string // strings that should appear in encoded output
+	}{
+		{
+			name: "duplicate fields ([]string) - checkbox scenario",
+			fields: map[string]any{
+				"interests": []string{"sports", "music", "reading"},
+				"colors":    []string{"red", "blue"},
+			},
+			contains: []string{"interests", "sports", "music", "reading", "colors", "red", "blue"},
+		},
+		{
+			name: "single string fields - backward compatibility",
+			fields: map[string]any{
+				"username": "john",
+				"email":    "john@example.com",
+			},
+			contains: []string{"username", "john", "email", "john@example.com"},
+		},
+		{
+			name: "mixed types",
+			fields: map[string]any{
+				"string": "text",
+				"array":  []string{"item1", "item2"},
+				"number": 42, // tests fmt.Sprint fallback
+			},
+			contains: []string{"string", "text", "array", "item1", "item2", "number", "42"},
+		},
+		{
+			name: "empty array - should not appear in output",
+			fields: map[string]any{
+				"emptyArray":  []string{},
+				"normalField": "value",
+			},
+			contains: []string{"normalField", "value"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			form := NewMultiPartForm()
+			form.boundary = "----WebKitFormBoundary7MA4YWxkTrZu0gW"
+
+			kv := mapsutil.NewOrderedMap[string, any]()
+			for k, v := range tt.fields {
+				kv.Set(k, v)
+			}
+
+			encoded, err := form.Encode(KVOrderedMap(&kv))
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			for _, expected := range tt.contains {
+				assert.Contains(t, encoded, expected)
+			}
+		})
+	}
+}
+
+func TestMultiPartFormRoundTrip(t *testing.T) {
+	form := NewMultiPartForm()
+	form.boundary = "----WebKitFormBoundary7MA4YWxkTrZu0gW"
+
+	original := mapsutil.NewOrderedMap[string, any]()
+	original.Set("username", "john")
+	original.Set("interests", []string{"sports", "music", "reading"})
+
+	encoded, err := form.Encode(KVOrderedMap(&original))
+	require.NoError(t, err)
+
+	decoded, err := form.Decode(encoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, "john", decoded.Get("username"))
+	assert.ElementsMatch(t, []string{"sports", "music", "reading"}, decoded.Get("interests"))
+}


### PR DESCRIPTION
## Proposed changes

Fix panic when encoding multipart forms with duplicate field names during DAST fuzzing.

**Problem**: The fuzzing module would panic with "interface conversion: interface {} is []string, not string" when processing forms with duplicate field names (common in checkboxes and multi-select elements).

**Root Cause**:
- `Decode` method correctly stores duplicate fields as `[]string`
- `Encode` method incorrectly assumes all values are `string` type
- Results in type assertion failure causing panic

**Solution**:
1. Added type-safe handling in `MultiPartForm.Encode()` to process both `string` and `[]string` values
2. Refactored code to reduce duplication
3. Added comprehensive tests including real-world checkbox use cases

Fixes #6401

## Checklist

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Multipart form encoding now supports multiple values per field (duplicate keys), normalizes various value types to strings, preserves file attachment behavior, and improves per-value error handling.

- **Tests**
  - Added tests validating multi-value fields, single-value backward compatibility, mixed-type handling, omission of empty arrays, and full encode/decode round-trip with deterministic ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->