### PR TITLE
fix(fuzz): handles duplicate multipart form field names

### DIFF
--- a/pkg/fuzz/dataformat/multipart.go
+++ b/pkg/fuzz/dataformat/multipart.go
@@ -76,15 +76,28 @@ func (m *MultiPartForm) Encode(data KV) (string, error) {
 			return true
 		}
 
-		// Add field
-		if fw, err = w.CreateFormField(key); err != nil {
-			Itererr = err
-			return false
+		// Handle form field values - can be string or []string for duplicate fields
+		var values []string
+		switch v := value.(type) {
+		case string:
+			values = []string{v}
+		case []string:
+			values = v
+		default:
+			// Fallback: attempt string conversion
+			values = []string{fmt.Sprint(v)}
 		}
 
-		if _, err = fw.Write([]byte(value.(string))); err != nil {
-			Itererr = err
-			return false
+		// Write all values for this field
+		for _, val := range values {
+			if fw, err = w.CreateFormField(key); err != nil {
+				Itererr = err
+				return false
+			}
+			if _, err = fw.Write([]byte(val)); err != nil {
+				Itererr = err
+				return false
+			}
 		}
 		return true
 	})

--- a/pkg/fuzz/dataformat/multipart.go
+++ b/pkg/fuzz/dataformat/multipart.go
@@ -49,10 +49,10 @@ func (m *MultiPartForm) Encode(data KV) (string, error) {
 		var fw io.Writer
 		var err error
 
-		if filesArray, ok := value.([]interface{}); ok {
-			fileMetadata, ok := m.filesMetadata[key]
-			if !ok {
-				Itererr = fmt.Errorf("file metadata not found for key %s", key)
+		if fileMetadata, ok := m.filesMetadata[key]; ok {
+			filesArray, isArray := value.([]any)
+			if !isArray {
+				Itererr = fmt.Errorf("field '%s' is marked as a file but its value is not an array", key)
 				return false
 			}
 

--- a/pkg/fuzz/dataformat/multipart.go
+++ b/pkg/fuzz/dataformat/multipart.go
@@ -84,8 +84,9 @@ func (m *MultiPartForm) Encode(data KV) (string, error) {
 		case []string:
 			values = v
 		case []any:
-			for _, item := range v {
-				values = append(values, fmt.Sprintf("%v", item))
+			values = make([]string, len(v))
+			for i, item := range v {
+				values[i] = fmt.Sprint(item)
 			}
 		default:
 			values = []string{fmt.Sprintf("%v", v)}

--- a/pkg/fuzz/dataformat/multipart.go
+++ b/pkg/fuzz/dataformat/multipart.go
@@ -76,19 +76,21 @@ func (m *MultiPartForm) Encode(data KV) (string, error) {
 			return true
 		}
 
-		// Handle form field values - can be string or []string for duplicate fields
+		// Add field
 		var values []string
 		switch v := value.(type) {
 		case string:
 			values = []string{v}
 		case []string:
 			values = v
+		case []any:
+			for _, item := range v {
+				values = append(values, fmt.Sprintf("%v", item))
+			}
 		default:
-			// Fallback: attempt string conversion
-			values = []string{fmt.Sprint(v)}
+			values = []string{fmt.Sprintf("%v", v)}
 		}
 
-		// Write all values for this field
 		for _, val := range values {
 			if fw, err = w.CreateFormField(key); err != nil {
 				Itererr = err

--- a/pkg/fuzz/dataformat/multipart.go
+++ b/pkg/fuzz/dataformat/multipart.go
@@ -79,6 +79,8 @@ func (m *MultiPartForm) Encode(data KV) (string, error) {
 		// Add field
 		var values []string
 		switch v := value.(type) {
+		case nil:
+			values = []string{""}
 		case string:
 			values = []string{v}
 		case []string:
@@ -86,7 +88,11 @@ func (m *MultiPartForm) Encode(data KV) (string, error) {
 		case []any:
 			values = make([]string, len(v))
 			for i, item := range v {
-				values[i] = fmt.Sprint(item)
+				if item == nil {
+					values[i] = ""
+				} else {
+					values[i] = fmt.Sprint(item)
+				}
 			}
 		default:
 			values = []string{fmt.Sprintf("%v", v)}

--- a/pkg/fuzz/dataformat/multipart_test.go
+++ b/pkg/fuzz/dataformat/multipart_test.go
@@ -1,0 +1,94 @@
+package dataformat
+
+import (
+	"testing"
+
+	mapsutil "github.com/projectdiscovery/utils/maps"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMultiPartFormEncode(t *testing.T) {
+	tests := []struct {
+		name     string
+		fields   map[string]any
+		wantErr  bool
+		contains []string // strings that should appear in encoded output
+	}{
+		{
+			name: "duplicate fields ([]string) - checkbox scenario",
+			fields: map[string]any{
+				"interests": []string{"sports", "music", "reading"},
+				"colors":    []string{"red", "blue"},
+			},
+			contains: []string{"interests", "sports", "music", "reading", "colors", "red", "blue"},
+		},
+		{
+			name: "single string fields - backward compatibility",
+			fields: map[string]any{
+				"username": "john",
+				"email":    "john@example.com",
+			},
+			contains: []string{"username", "john", "email", "john@example.com"},
+		},
+		{
+			name: "mixed types",
+			fields: map[string]any{
+				"string": "text",
+				"array":  []string{"item1", "item2"},
+				"number": 42, // tests fmt.Sprint fallback
+			},
+			contains: []string{"string", "text", "array", "item1", "item2", "number", "42"},
+		},
+		{
+			name: "empty array - should not appear in output",
+			fields: map[string]any{
+				"emptyArray":  []string{},
+				"normalField": "value",
+			},
+			contains: []string{"normalField", "value"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			form := NewMultiPartForm()
+			form.boundary = "----WebKitFormBoundary7MA4YWxkTrZu0gW"
+
+			kv := mapsutil.NewOrderedMap[string, any]()
+			for k, v := range tt.fields {
+				kv.Set(k, v)
+			}
+
+			encoded, err := form.Encode(KVOrderedMap(&kv))
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			for _, expected := range tt.contains {
+				assert.Contains(t, encoded, expected)
+			}
+		})
+	}
+}
+
+func TestMultiPartFormRoundTrip(t *testing.T) {
+	form := NewMultiPartForm()
+	form.boundary = "----WebKitFormBoundary7MA4YWxkTrZu0gW"
+
+	original := mapsutil.NewOrderedMap[string, any]()
+	original.Set("username", "john")
+	original.Set("interests", []string{"sports", "music", "reading"})
+
+	encoded, err := form.Encode(KVOrderedMap(&original))
+	require.NoError(t, err)
+
+	decoded, err := form.Decode(encoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, "john", decoded.Get("username"))
+	assert.ElementsMatch(t, []string{"sports", "music", "reading"}, decoded.Get("interests"))
+}

--- a/pkg/fuzz/dataformat/multipart_test.go
+++ b/pkg/fuzz/dataformat/multipart_test.go
@@ -52,6 +52,12 @@ func TestMultiPartFormEncode(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("Test panicked: %v", r)
+				}
+			}()
+
 			form := NewMultiPartForm()
 			form.boundary = "----WebKitFormBoundary7MA4YWxkTrZu0gW"
 
@@ -71,11 +77,19 @@ func TestMultiPartFormEncode(t *testing.T) {
 			for _, expected := range tt.contains {
 				assert.Contains(t, encoded, expected)
 			}
+
+			t.Logf("Encoded output:\n%s", encoded)
 		})
 	}
 }
 
 func TestMultiPartFormRoundTrip(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("Test panicked: %v", r)
+		}
+	}()
+
 	form := NewMultiPartForm()
 	form.boundary = "----WebKitFormBoundary7MA4YWxkTrZu0gW"
 
@@ -91,4 +105,6 @@ func TestMultiPartFormRoundTrip(t *testing.T) {
 
 	assert.Equal(t, "john", decoded.Get("username"))
 	assert.ElementsMatch(t, []string{"sports", "music", "reading"}, decoded.Get("interests"))
+
+	t.Logf("Encoded output:\n%s", encoded)
 }

--- a/pkg/fuzz/dataformat/multipart_test.go
+++ b/pkg/fuzz/dataformat/multipart_test.go
@@ -42,26 +42,26 @@ func TestMultiPartFormEncode(t *testing.T) {
 			fields: map[string]any{
 				"string":     "text",
 				"array":      []string{"item1", "item2"},
-				"number":     42,                       // tests fmt.Sprint fallback
-				"float":      3.14,                     // tests float conversion
-				"boolean":    true,                     // tests boolean conversion
-				"zero":       0,                        // tests zero value
-				"emptyStr":   "",                       // tests empty string
-				"negative":   -123,                     // tests negative number
-				"nil":        nil,                      // tests nil value
-				"mixedArray": []any{"str", 123, false}, // tests mixed type array
+				"number":     42,                            // tests fmt.Sprint fallback
+				"float":      3.14,                          // tests float conversion
+				"boolean":    true,                          // tests boolean conversion
+				"zero":       0,                             // tests zero value
+				"emptyStr":   "",                            // tests empty string
+				"negative":   -123,                          // tests negative number
+				"nil":        nil,                           // tests nil value
+				"mixedArray": []any{"str", 123, false, nil}, // tests mixed type array
 			},
 			expected: map[string]any{
 				"string":     "text",
 				"array":      []string{"item1", "item2"},
-				"number":     "42",                            // numbers are converted to strings in multipart
-				"float":      "3.14",                          // floats are converted to strings
-				"boolean":    "true",                          // booleans are converted to strings
-				"zero":       "0",                             // zero value converted to string
-				"emptyStr":   "",                              // empty string remains empty
-				"negative":   "-123",                          // negative numbers converted to strings
-				"nil":        "<nil>",                         // nil values converted to "<nil>" string
-				"mixedArray": []string{"str", "123", "false"}, // mixed array converted to string array
+				"number":     "42",                                // numbers are converted to strings in multipart
+				"float":      "3.14",                              // floats are converted to strings
+				"boolean":    "true",                              // booleans are converted to strings
+				"zero":       "0",                                 // zero value converted to string
+				"emptyStr":   "",                                  // empty string remains empty
+				"negative":   "-123",                              // negative numbers converted to strings
+				"nil":        "",                                  // nil values converted to "" string
+				"mixedArray": []string{"str", "123", "false", ""}, // mixed array converted to string array
 			},
 		},
 		{

--- a/pkg/fuzz/dataformat/multipart_test.go
+++ b/pkg/fuzz/dataformat/multipart_test.go
@@ -13,7 +13,7 @@ func TestMultiPartFormEncode(t *testing.T) {
 		name     string
 		fields   map[string]any
 		wantErr  bool
-		contains []string // strings that should appear in encoded output
+		expected map[string]any
 	}{
 		{
 			name: "duplicate fields ([]string) - checkbox scenario",
@@ -21,7 +21,10 @@ func TestMultiPartFormEncode(t *testing.T) {
 				"interests": []string{"sports", "music", "reading"},
 				"colors":    []string{"red", "blue"},
 			},
-			contains: []string{"interests", "sports", "music", "reading", "colors", "red", "blue"},
+			expected: map[string]any{
+				"interests": []string{"sports", "music", "reading"},
+				"colors":    []string{"red", "blue"},
+			},
 		},
 		{
 			name: "single string fields - backward compatibility",
@@ -29,16 +32,37 @@ func TestMultiPartFormEncode(t *testing.T) {
 				"username": "john",
 				"email":    "john@example.com",
 			},
-			contains: []string{"username", "john", "email", "john@example.com"},
+			expected: map[string]any{
+				"username": "john",
+				"email":    "john@example.com",
+			},
 		},
 		{
 			name: "mixed types",
 			fields: map[string]any{
-				"string": "text",
-				"array":  []string{"item1", "item2"},
-				"number": 42, // tests fmt.Sprint fallback
+				"string":     "text",
+				"array":      []string{"item1", "item2"},
+				"number":     42,                       // tests fmt.Sprint fallback
+				"float":      3.14,                     // tests float conversion
+				"boolean":    true,                     // tests boolean conversion
+				"zero":       0,                        // tests zero value
+				"emptyStr":   "",                       // tests empty string
+				"negative":   -123,                     // tests negative number
+				"nil":        nil,                      // tests nil value
+				"mixedArray": []any{"str", 123, false}, // tests mixed type array
 			},
-			contains: []string{"string", "text", "array", "item1", "item2", "number", "42"},
+			expected: map[string]any{
+				"string":     "text",
+				"array":      []string{"item1", "item2"},
+				"number":     "42",                            // numbers are converted to strings in multipart
+				"float":      "3.14",                          // floats are converted to strings
+				"boolean":    "true",                          // booleans are converted to strings
+				"zero":       "0",                             // zero value converted to string
+				"emptyStr":   "",                              // empty string remains empty
+				"negative":   "-123",                          // negative numbers converted to strings
+				"nil":        "<nil>",                         // nil values converted to "<nil>" string
+				"mixedArray": []string{"str", "123", "false"}, // mixed array converted to string array
+			},
 		},
 		{
 			name: "empty array - should not appear in output",
@@ -46,7 +70,10 @@ func TestMultiPartFormEncode(t *testing.T) {
 				"emptyArray":  []string{},
 				"normalField": "value",
 			},
-			contains: []string{"normalField", "value"},
+			expected: map[string]any{
+				"normalField": "value",
+				// emptyArray should not appear in decoded output
+			},
 		},
 	}
 
@@ -74,9 +101,34 @@ func TestMultiPartFormEncode(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			for _, expected := range tt.contains {
-				assert.Contains(t, encoded, expected)
+
+			// Decode the encoded multipart data
+			decoded, err := form.Decode(encoded)
+			require.NoError(t, err)
+
+			// Compare decoded values with expected values
+			for expectedKey, expectedValue := range tt.expected {
+				actualValue := decoded.Get(expectedKey)
+				switch expected := expectedValue.(type) {
+				case []string:
+					actual, ok := actualValue.([]string)
+					require.True(t, ok, "Expected []string for key %s, got %T", expectedKey, actualValue)
+					assert.ElementsMatch(t, expected, actual, "Values mismatch for key %s", expectedKey)
+				case string:
+					actual, ok := actualValue.(string)
+					require.True(t, ok, "Expected string for key %s, got %T", expectedKey, actualValue)
+					assert.Equal(t, expected, actual, "Values mismatch for key %s", expectedKey)
+				default:
+					assert.Equal(t, expected, actualValue, "Values mismatch for key %s", expectedKey)
+				}
 			}
+
+			// Ensure no unexpected keys are present in decoded output
+			decoded.Iterate(func(key string, value any) bool {
+				_, exists := tt.expected[key]
+				assert.True(t, exists, "Unexpected key %s found in decoded output", key)
+				return true
+			})
 
 			t.Logf("Encoded output:\n%s", encoded)
 		})


### PR DESCRIPTION
## Proposed changes

Fixes #6402

also:

* fix incorrectly treated mixed-type field (when file metadata is not found) -- there are missing APIs for this (why? ref: 65437b71e101bfcb77e5ffcc7bbdff51826d4863)
* treats nil value as an empty string

## Proof

```console
$ go test -v -run "^TestMultiPartForm" ./pkg/fuzz/dataformat/
=== RUN   TestMultiPartFormEncode
=== RUN   TestMultiPartFormEncode/duplicate_fields_([]string)_-_checkbox_scenario
    multipart_test.go:137: Encoded output:
        ------WebKitFormBoundary7MA4YWxkTrZu0gW
        Content-Disposition: form-data; name="interests"
        
        sports
        ------WebKitFormBoundary7MA4YWxkTrZu0gW
        Content-Disposition: form-data; name="interests"
        
        music
        ------WebKitFormBoundary7MA4YWxkTrZu0gW
        Content-Disposition: form-data; name="interests"
        
        reading
        ------WebKitFormBoundary7MA4YWxkTrZu0gW
        Content-Disposition: form-data; name="colors"
        
        red
        ------WebKitFormBoundary7MA4YWxkTrZu0gW
        Content-Disposition: form-data; name="colors"
        
        blue
        ------WebKitFormBoundary7MA4YWxkTrZu0gW--
=== RUN   TestMultiPartFormEncode/single_string_fields_-_backward_compatibility
    multipart_test.go:137: Encoded output:
        ------WebKitFormBoundary7MA4YWxkTrZu0gW
        Content-Disposition: form-data; name="username"
        
        john
        ------WebKitFormBoundary7MA4YWxkTrZu0gW
        Content-Disposition: form-data; name="email"
        
        john@example.com
        ------WebKitFormBoundary7MA4YWxkTrZu0gW--
=== RUN   TestMultiPartFormEncode/mixed_types
    multipart_test.go:137: Encoded output:
        ------WebKitFormBoundary7MA4YWxkTrZu0gW
        Content-Disposition: form-data; name="zero"
        
        0
        ------WebKitFormBoundary7MA4YWxkTrZu0gW
        Content-Disposition: form-data; name="emptyStr"
        
        
        ------WebKitFormBoundary7MA4YWxkTrZu0gW
        Content-Disposition: form-data; name="negative"
        
        -123
        ------WebKitFormBoundary7MA4YWxkTrZu0gW
        Content-Disposition: form-data; name="mixedArray"
        
        str
        ------WebKitFormBoundary7MA4YWxkTrZu0gW
        Content-Disposition: form-data; name="mixedArray"
        
        123
        ------WebKitFormBoundary7MA4YWxkTrZu0gW
        Content-Disposition: form-data; name="mixedArray"
        
        false
        ------WebKitFormBoundary7MA4YWxkTrZu0gW
        Content-Disposition: form-data; name="mixedArray"
        
        
        ------WebKitFormBoundary7MA4YWxkTrZu0gW
        Content-Disposition: form-data; name="nil"
        
        
        ------WebKitFormBoundary7MA4YWxkTrZu0gW
        Content-Disposition: form-data; name="string"
        
        text
        ------WebKitFormBoundary7MA4YWxkTrZu0gW
        Content-Disposition: form-data; name="number"
        
        42
        ------WebKitFormBoundary7MA4YWxkTrZu0gW
        Content-Disposition: form-data; name="boolean"
        
        true
        ------WebKitFormBoundary7MA4YWxkTrZu0gW
        Content-Disposition: form-data; name="array"
        
        item1
        ------WebKitFormBoundary7MA4YWxkTrZu0gW
        Content-Disposition: form-data; name="array"
        
        item2
        ------WebKitFormBoundary7MA4YWxkTrZu0gW
        Content-Disposition: form-data; name="float"
        
        3.14
        ------WebKitFormBoundary7MA4YWxkTrZu0gW--
=== RUN   TestMultiPartFormEncode/empty_array_-_should_not_appear_in_output
    multipart_test.go:137: Encoded output:
        ------WebKitFormBoundary7MA4YWxkTrZu0gW
        Content-Disposition: form-data; name="normalField"
        
        value
        ------WebKitFormBoundary7MA4YWxkTrZu0gW--
--- PASS: TestMultiPartFormEncode (0.00s)
    --- PASS: TestMultiPartFormEncode/duplicate_fields_([]string)_-_checkbox_scenario (0.00s)
    --- PASS: TestMultiPartFormEncode/single_string_fields_-_backward_compatibility (0.00s)
    --- PASS: TestMultiPartFormEncode/mixed_types (0.00s)
    --- PASS: TestMultiPartFormEncode/empty_array_-_should_not_appear_in_output (0.00s)
=== RUN   TestMultiPartFormRoundTrip
    multipart_test.go:165: Encoded output:
        ------WebKitFormBoundary7MA4YWxkTrZu0gW
        Content-Disposition: form-data; name="username"
        
        john
        ------WebKitFormBoundary7MA4YWxkTrZu0gW
        Content-Disposition: form-data; name="interests"
        
        sports
        ------WebKitFormBoundary7MA4YWxkTrZu0gW
        Content-Disposition: form-data; name="interests"
        
        music
        ------WebKitFormBoundary7MA4YWxkTrZu0gW
        Content-Disposition: form-data; name="interests"
        
        reading
        ------WebKitFormBoundary7MA4YWxkTrZu0gW--
--- PASS: TestMultiPartFormRoundTrip (0.00s)
=== RUN   TestMultiPartFormFileUpload
--- PASS: TestMultiPartFormFileUpload (0.00s)
PASS
ok  	github.com/projectdiscovery/nuclei/v3/pkg/fuzz/dataformat	0.011s
```


## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Multipart forms now support multiple values per key and robust file-array uploads using provided filenames and content types.
  * Improved field value handling: converts various types to strings consistently; omits empty arrays.

* Bug Fixes
  * Eliminated stray file write after processing arrays.
  * Removed erroneous “metadata not found” errors when file data is present.

* Tests
  * Added comprehensive tests covering encoding/decoding, round-trip validation, and mixed file-plus-field payloads to ensure correct behavior across data types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->