### PR TITLE
Added datestamp to output files

### DIFF
--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -549,8 +549,8 @@ func (w *StandardWriter) WriteStoreDebugData(host, templateID, eventType string,
 		if len(templateID) > 100 {
 			templateID = templateID[:97] + "..."
 		}
-
-		filename := sanitizeFileName(fmt.Sprintf("%s_%s", host, templateID))
+		ts := time.Now().Format("20060102")
+		filename := sanitizeFileName(fmt.Sprintf("%s_%s_%s", ts, host, templateID))
 		subFolder := filepath.Join(w.storeResponseDir, sanitizeFileName(eventType))
 		if !fileutil.FolderExists(subFolder) {
 			_ = fileutil.CreateFolder(subFolder)


### PR DESCRIPTION
## Proposed changes

Minimal change, just adds a date to files output. Helps with easy log rotation for scheduled scans. This could be expanded as a toggle-able option, with options to include full timestamps, rather than just date.

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Debug data files now include the current date as a prefix in their filenames, improving organization and chronological sorting.
  * Storage location and write behavior remain unchanged, ensuring compatibility while making it easier to identify files from different sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->