### PR TITLE
No changes message for github custom template update to INF from ERR for better logging

### DIFF
--- a/pkg/external/customtemplates/github.go
+++ b/pkg/external/customtemplates/github.go
@@ -53,7 +53,11 @@ func (customTemplate *customTemplateGitHubRepo) Update(ctx context.Context) {
 	}
 	err := customTemplate.pullChanges(clonePath, customTemplate.githubToken)
 	if err != nil {
-		gologger.Error().Msgf("%s", err)
+		if strings.Contains(err.Error(), "already up-to-date") {
+			gologger.Info().Msgf("%s", err)
+		} else {
+			gologger.Error().Msgf("%s", err)
+		}
 	} else {
 		gologger.Info().Msgf("Repo %s/%s successfully pulled the changes.\n", customTemplate.owner, customTemplate.reponame)
 	}


### PR DESCRIPTION
## Proposed changes

No changes message for github custom template update can be **`[INF]`** instead of **`[ERR]`** for better logging

> <img width="1920" height="1017" alt="better logging" src="https://github.com/user-attachments/assets/8c1d391c-5d5f-4bcc-8b76-7da161f5c8de" />


## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)