### PR TITLE
Refactor to use reflect.TypeFor

### DIFF
--- a/pkg/js/gojs/gojs.go
+++ b/pkg/js/gojs/gojs.go
@@ -59,7 +59,7 @@ func wrapModuleFunc(runtime *goja.Runtime, fn interface{}) interface{} {
 	}
 
 	// Only wrap if first parameter is context.Context
-	if fnType.NumIn() == 0 || fnType.In(0) != reflect.TypeOf((*context.Context)(nil)).Elem() {
+	if fnType.NumIn() == 0 || fnType.In(0) != reflect.TypeFor[context.Context]() {
 		return fn // Return original function unchanged if it doesn't have context.Context as first arg
 	}
 

--- a/pkg/js/gojs/set.go
+++ b/pkg/js/gojs/set.go
@@ -34,7 +34,7 @@ func wrapWithContext(runtime *goja.Runtime, fn interface{}) interface{} {
 	}
 
 	// Only wrap if first parameter is context.Context
-	if fnType.NumIn() == 0 || fnType.In(0) != reflect.TypeOf((*context.Context)(nil)).Elem() {
+	if fnType.NumIn() == 0 || fnType.In(0) != reflect.TypeFor[context.Context]() {
 		return fn // Return original function unchanged if it doesn't have context.Context as first arg
 	}
 


### PR DESCRIPTION
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->

**why you might use `reflect.TypeFor` instead of `reflect.TypeOf` in Go**.

---

### **Background**
In Go, the `reflect` package provides two similar-looking functions:

- **`reflect.TypeOf(x)`**  
  Takes a value `x` and returns its `reflect.Type`.  
  Example:  
  ```go
  t := reflect.TypeOf(123) // type: int
  ```

- **`reflect.TypeFor[T]()`** *(introduced in Go 1.22)*  
  A generic function that returns the `reflect.Type` for a type parameter `T` **without needing a value**.  
  Example:  
  ```go
  t := reflect.TypeFor[int]() // type: int
  ```

---

### **Why use `reflect.TypeFor` instead of `reflect.TypeOf`?**

1. **No value needed**  
   - `reflect.TypeOf` requires an actual value at runtime.  
     If you only know the type (not a value), you have to create a dummy value:
     ```go
     t := reflect.TypeOf((*MyStruct)(nil)).Elem()
     ```
   - `reflect.TypeFor` works directly with the type parameter:
     ```go
     t := reflect.TypeFor[MyStruct]()
     ```
     This is cleaner and avoids allocating or creating dummy values.

2. **Compile-time type safety**  
   - With `reflect.TypeOf`, the type is determined from a runtime value, so mistakes may only show up at runtime.
   - With `reflect.TypeFor`, the type is determined at compile time from the generic type parameter, so it’s safer and clearer.

3. **Better for generic code**  
   - In generic functions, you often have a type parameter `T` but no value of type `T`.  
     `reflect.TypeOf` can’t be used without creating a zero value:
     ```go
     func PrintType[T any]() {
         var zero T
         fmt.Println(reflect.TypeOf(zero))
     }
     ```
     With `reflect.TypeFor`, you can simply do:
     ```go
     func PrintType[T any]() {
         fmt.Println(reflect.TypeFor[T]())
     }
     ```

4. **Avoids unnecessary allocations**  
   - Creating a dummy value for `reflect.TypeOf` may allocate memory (especially for composite types).  
   - `reflect.TypeFor` avoids this overhead entirely.

---

### **Summary Table**

| Feature                  | `reflect.TypeOf`                  | `reflect.TypeFor` (Go 1.22+) |
|--------------------------|------------------------------------|------------------------------|
| Requires a value         | ✅ Yes                             | ❌ No                        |
| Works without allocation | ❌ Sometimes allocates             | ✅ Yes                       |
| Compile-time type safety | ❌ Runtime only                    | ✅ Compile-time              |
| Good for generics        | ❌ Needs zero value                | ✅ Directly works            |

---

✅ **Recommendation:**  
Use `reflect.TypeFor` when:
- You know the type at compile time (especially in generic code).
- You don’t have or don’t want to create a value.
- You want cleaner, safer, and allocation-free code.

Use `reflect.TypeOf` when:
- You already have a value and want its type at runtime.

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal handling of context-aware function wrapping to use a unified type lookup, improving consistency across modules.
  * No changes to public APIs, configuration, or usage.
  * Behavior remains unchanged; functions continue to receive context as before where applicable.
  * No performance impact expected.
  * This update is internal-only with no user-visible differences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->