### PR TITLE
Remove the stack trace when the nuclei-ignore file does not exist

### DIFF
--- a/pkg/catalog/config/ignorefile.go
+++ b/pkg/catalog/config/ignorefile.go
@@ -18,6 +18,10 @@ type IgnoreFile struct {
 func ReadIgnoreFile() IgnoreFile {
 	file, err := os.Open(DefaultConfig.GetIgnoreFilePath())
 	if err != nil {
+		if os.IsNotExist(err) {
+			gologger.Error().Msgf("Could not read nuclei-ignore file: %s\n", err)
+			return IgnoreFile{}
+		}
 		gologger.Error().Msgf("Could not read nuclei-ignore file: %s\n%s\n", err, string(debug.Stack()))
 		return IgnoreFile{}
 	}


### PR DESCRIPTION
## Proposed changes

Removed the stack trace when the .nuclei-ignore file didn't exist.

Before:

```
[ERR] Could not read nuclei-ignore file: open /Users/x/Library/Application Support/nuclei/.nuclei-ignore: no such file or directory
goroutine 1 [running]:
runtime/debug.Stack()
        /opt/homebrew/Cellar/go/1.25.0/libexec/src/runtime/debug/stack.go:26 +0x64
github.com/projectdiscovery/nuclei/v3/pkg/catalog/config.ReadIgnoreFile()
        /Users/x/_dev/nuclei/pkg/catalog/config/ignorefile.go:21 +0x90
github.com/projectdiscovery/nuclei/v3/internal/runner.(*Runner).RunEnumeration(0x14000b9b200)
        /Users/x/_dev/nuclei/internal/runner/runner.go:544 +0x2d4
main.main()
        /Users/x/_dev/nuclei/cmd/nuclei/main.go:223 +0x964
...
```

After:

```
[ERR] Could not read nuclei-ignore file: open /Users/x/Library/Application Support/nuclei/.nuclei-ignore: no such file or directory
...
```
## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)