### PR TITLE
feat(fuzz): enhance `MultiPartForm` with metadata APIs

### DIFF
--- a/pkg/fuzz/dataformat/multipart.go
+++ b/pkg/fuzz/dataformat/multipart.go
@@ -200,11 +200,11 @@ func (m *MultiPartForm) Decode(data string) (KV, error) {
 
 			buffer := new(bytes.Buffer)
 			if _, err := buffer.ReadFrom(file); err != nil {
-				file.Close()
+				_ = file.Close()
 
 				return KV{}, err
 			}
-			file.Close()
+			_ = file.Close()
 
 			fileContents = append(fileContents, buffer.String())
 

--- a/pkg/fuzz/dataformat/multipart.go
+++ b/pkg/fuzz/dataformat/multipart.go
@@ -27,7 +27,29 @@ var (
 
 // NewMultiPartForm returns a new MultiPartForm encoder
 func NewMultiPartForm() *MultiPartForm {
-	return &MultiPartForm{}
+	return &MultiPartForm{
+		filesMetadata: make(map[string]FileMetadata),
+	}
+}
+
+// SetFileMetadata sets the file metadata for a given field name
+func (m *MultiPartForm) SetFileMetadata(fieldName string, metadata FileMetadata) {
+	if m.filesMetadata == nil {
+		m.filesMetadata = make(map[string]FileMetadata)
+	}
+
+	m.filesMetadata[fieldName] = metadata
+}
+
+// GetFileMetadata gets the file metadata for a given field name
+func (m *MultiPartForm) GetFileMetadata(fieldName string) (FileMetadata, bool) {
+	if m.filesMetadata == nil {
+		return FileMetadata{}, false
+	}
+
+	metadata, exists := m.filesMetadata[fieldName]
+
+	return metadata, exists
 }
 
 // IsType returns true if the data is MultiPartForm encoded
@@ -125,16 +147,24 @@ func (m *MultiPartForm) ParseBoundary(contentType string) error {
 	if m.boundary == "" {
 		return fmt.Errorf("no boundary found in the content type")
 	}
+
+	// NOTE(dwisiswant0): boundary cannot exceed 70 characters according to
+	// RFC-2046.
+	if len(m.boundary) > 70 {
+		return fmt.Errorf("boundary exceeds maximum length of 70 characters")
+	}
+
 	return nil
 }
 
 // Decode decodes the data from MultiPartForm format
 func (m *MultiPartForm) Decode(data string) (KV, error) {
+	if m.boundary == "" {
+		return KV{}, fmt.Errorf("boundary not set, call ParseBoundary first")
+	}
+
 	// Create a buffer from the string data
 	b := bytes.NewBufferString(data)
-	// The boundary parameter should be extracted from the Content-Type header of the HTTP request
-	// which is not available in this context, so this is a placeholder for demonstration.
-	// You will need to pass the actual boundary value to this function.
 	r := multipart.NewReader(b, m.boundary)
 
 	form, err := r.ReadForm(32 << 20) // 32MB is the max memory used to parse the form
@@ -153,30 +183,44 @@ func (m *MultiPartForm) Decode(data string) (KV, error) {
 			result.Set(key, values[0])
 		}
 	}
-	m.filesMetadata = make(map[string]FileMetadata)
+
+	if m.filesMetadata == nil {
+		m.filesMetadata = make(map[string]FileMetadata)
+	}
+
 	for key, files := range form.File {
 		fileContents := []interface{}{}
+		var fileMetadataList []FileMetadata
+
 		for _, fileHeader := range files {
 			file, err := fileHeader.Open()
 			if err != nil {
 				return KV{}, err
 			}
-			defer func() {
-				_ = file.Close()
-			}()
 
 			buffer := new(bytes.Buffer)
 			if _, err := buffer.ReadFrom(file); err != nil {
+				file.Close()
+
 				return KV{}, err
 			}
+			file.Close()
+
 			fileContents = append(fileContents, buffer.String())
 
-			m.filesMetadata[key] = FileMetadata{
+			fileMetadataList = append(fileMetadataList, FileMetadata{
 				ContentType: fileHeader.Header.Get("Content-Type"),
 				Filename:    fileHeader.Filename,
-			}
+			})
 		}
+
 		result.Set(key, fileContents)
+
+		// NOTE(dwisiswant0): store the first file's metadata instead of the
+		// last one
+		if len(fileMetadataList) > 0 {
+			m.filesMetadata[key] = fileMetadataList[0]
+		}
 	}
 	return KVOrderedMap(&result), nil
 }


### PR DESCRIPTION
* add `SetFileMetadata`/`GetFileMetadata` APIs for file metadata management.
* implement RFC-2046 boundary validation (max 70 chars).
* add boundary validation in `Decode` method.

* fix `filesMetadata` initialization.
* fix mem leak by removing defer from file reading loop.
* fix file metadata overwriting by storing first file's metadata instead of last.

Closes #6405, #6406

## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->


## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added per-field file metadata support with public getters/setters; preserves the first file’s metadata when multiple files share a field.

- **Bug Fixes**
  - Enforces RFC-compliant maximum boundary length (70 chars).
  - Decoding now requires a set boundary, returning a clear error if missing.
  - Ensures metadata storage is initialized to avoid nil-map issues.
  - Explicitly closes file resources on all success/error paths.

- **Tests**
  - Added tests covering metadata handling, boundary parsing/validation, missing-boundary errors, multi-file decoding, and nil-map behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->