### PR TITLE
fix headless template loading logic when `-dast` option is enabled

### DIFF
--- a/pkg/catalog/loader/loader.go
+++ b/pkg/catalog/loader/loader.go
@@ -580,7 +580,14 @@ func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) []*templ
 						// check if the template is a DAST template
 						// also allow global matchers template to be loaded
 						if parsed.IsFuzzing() || parsed.Options.GlobalMatchers != nil && parsed.Options.GlobalMatchers.HasMatchers() {
-							loadTemplate(parsed)
+							if len(parsed.RequestsHeadless) > 0 && !store.config.ExecutorOptions.Options.Headless {
+								stats.Increment(templates.ExcludedHeadlessTmplStats)
+								if config.DefaultConfig.LogAllEvents {
+									store.logger.Print().Msgf("[%v] Headless flag is required for headless template '%s'.\n", aurora.Yellow("WRN").String(), templatePath)
+								}
+							} else {
+								loadTemplate(parsed)
+							}
 						}
 					} else if len(parsed.RequestsHeadless) > 0 && !store.config.ExecutorOptions.Options.Headless {
 						// donot include headless template in final list if headless flag is not set


### PR DESCRIPTION
## Proposed changes

closes https://github.com/projectdiscovery/nuclei/issues/6494

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

• New Features
  • Adds clear warnings when headless-only templates are skipped outside headless mode.
  • Tracks metrics for templates excluded due to headless requirements.

• Bug Fixes
  • Prevents unintended loading of headless-only templates when headless mode is not enabled, even if they match global/fuzzing conditions.
  • Evaluates headless-related conditions earlier to ensure correct template loading behavior.
  • Maintains existing behavior for non-headless templates while improving accuracy of load decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->