### PR TITLE
fix: suppress warn code flag not found & excludes known misc dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,8 +147,6 @@ template-validate: build
 template-validate:
 	./bin/nuclei -ut
 	./bin/nuclei -validate \
-		-et .github/ \
-		-et helpers/payloads/ \
 		-et http/technologies \
 		-t dns \
 		-t ssl \
@@ -157,7 +155,5 @@ template-validate:
 		-ept code
 	./bin/nuclei -validate \
 		-w workflows \
-		-et .github/ \
-		-et helpers/payloads/ \
 		-et http/technologies \
 		-ept code

--- a/pkg/catalog/config/template.go
+++ b/pkg/catalog/config/template.go
@@ -12,7 +12,10 @@ import (
 	stringsutil "github.com/projectdiscovery/utils/strings"
 )
 
-var knownConfigFiles = []string{"cves.json", "contributors.json", "TEMPLATES-STATS.json"}
+var (
+	knownConfigFiles     = []string{"cves.json", "contributors.json", "TEMPLATES-STATS.json"}
+	knownMiscDirectories = []string{".git/", ".github/", "helpers/"}
+)
 
 // TemplateFormat
 type TemplateFormat uint8
@@ -47,6 +50,11 @@ func IsTemplate(filename string) bool {
 	if stringsutil.ContainsAny(filename, knownConfigFiles...) {
 		return false
 	}
+
+	if stringsutil.ContainsAny(filename, knownMiscDirectories...) {
+		return false
+	}
+
 	return stringsutil.EqualFoldAny(filepath.Ext(filename), GetSupportTemplateFileExtensions()...)
 }
 

--- a/pkg/catalog/config/template.go
+++ b/pkg/catalog/config/template.go
@@ -26,11 +26,16 @@ const (
 	Unknown
 )
 
-// GetKnownConfigFiles returns known config files
+// GetKnownConfigFiles returns known config files.
 func GetKnownConfigFiles() []string {
 	return knownConfigFiles
 }
 
+// GetKnownMiscDirectories returns known misc directories with trailing slashes.
+//
+// The trailing slash ensures that directory matching is explicit and avoids
+// falsely match files with similar names (e.g. "helpers" matching
+// "some-helpers.yaml"), since [IsTemplate] checks against normalized full paths.
 func GetKnownMiscDirectories() []string {
 	trailedSlashDirs := make([]string, 0, len(knownMiscDirectories))
 	for _, dir := range knownMiscDirectories {
@@ -61,6 +66,7 @@ func GetSupportTemplateFileExtensions() []string {
 // IsTemplate returns true if the file is a template based on its path.
 // It used by goflags and other places to filter out non-template files.
 func IsTemplate(fpath string) bool {
+	fpath = filepath.FromSlash(fpath)
 	fname := filepath.Base(fpath)
 	fext := strings.ToLower(filepath.Ext(fpath))
 

--- a/pkg/catalog/config/template.go
+++ b/pkg/catalog/config/template.go
@@ -14,7 +14,7 @@ import (
 
 var (
 	knownConfigFiles     = []string{"cves.json", "contributors.json", "TEMPLATES-STATS.json"}
-	knownMiscDirectories = []string{".git/", ".github/", "helpers/"}
+	knownMiscDirectories = []string{".git", ".github", "helpers"}
 )
 
 // TemplateFormat
@@ -25,6 +25,20 @@ const (
 	JSON
 	Unknown
 )
+
+// GetKnownConfigFiles returns known config files
+func GetKnownConfigFiles() []string {
+	return knownConfigFiles
+}
+
+func GetKnownMiscDirectories() []string {
+	trailedSlashDirs := make([]string, 0, len(knownMiscDirectories))
+	for _, dir := range knownMiscDirectories {
+		trailedSlashDirs = append(trailedSlashDirs, dir+string(os.PathSeparator))
+	}
+
+	return trailedSlashDirs
+}
 
 // GetTemplateFormatFromExt returns template format
 func GetTemplateFormatFromExt(filePath string) TemplateFormat {
@@ -44,18 +58,21 @@ func GetSupportTemplateFileExtensions() []string {
 	return []string{extensions.YAML, extensions.JSON}
 }
 
-// IsTemplate is a callback function used by goflags to decide if given file should be read
-// if it is not a nuclei-template file only then file is read
-func IsTemplate(filename string) bool {
-	if stringsutil.ContainsAny(filename, knownConfigFiles...) {
+// IsTemplate returns true if the file is a template based on its path.
+// It used by goflags and other places to filter out non-template files.
+func IsTemplate(fpath string) bool {
+	fname := filepath.Base(fpath)
+	fext := strings.ToLower(filepath.Ext(fpath))
+
+	if stringsutil.ContainsAny(fname, GetKnownConfigFiles()...) {
 		return false
 	}
 
-	if stringsutil.ContainsAny(filename, knownMiscDirectories...) {
+	if stringsutil.ContainsAny(fpath, GetKnownMiscDirectories()...) {
 		return false
 	}
 
-	return stringsutil.EqualFoldAny(filepath.Ext(filename), GetSupportTemplateFileExtensions()...)
+	return stringsutil.EqualFoldAny(fext, GetSupportTemplateFileExtensions()...)
 }
 
 type template struct {

--- a/pkg/catalog/disk/find.go
+++ b/pkg/catalog/disk/find.go
@@ -257,7 +257,7 @@ func (c *DiskCatalog) findDirectoryMatches(absPath string, processed map[string]
 				if err != nil {
 					return nil
 				}
-				if !d.IsDir() && config.GetTemplateFormatFromExt(path) != config.Unknown {
+				if !d.IsDir() && config.IsTemplate(path) {
 					if _, ok := processed[path]; !ok {
 						results = append(results, path)
 						processed[path] = struct{}{}
@@ -281,7 +281,7 @@ func (c *DiskCatalog) findDirectoryMatches(absPath string, processed map[string]
 				if err != nil {
 					return nil
 				}
-				if !d.IsDir() && config.GetTemplateFormatFromExt(path) != config.Unknown {
+				if !d.IsDir() && config.IsTemplate(path) {
 					if _, ok := processed[path]; !ok {
 						results = append(results, path)
 						processed[path] = struct{}{}

--- a/pkg/templates/workflows.go
+++ b/pkg/templates/workflows.go
@@ -94,7 +94,14 @@ func parseWorkflowTemplate(workflow *workflows.WorkflowTemplate, preprocessor Pr
 
 		if len(template.RequestsCode) > 0 {
 			if !options.Options.EnableCodeTemplates {
-				gologger.Warning().Msgf("`-code` flag not found, skipping code template from workflow: %v\n", path)
+				// NOTE(dwisiswant0): It is safe to continue here during
+				// validation mode, because the template has already been parsed
+				// and syntax-validated by templates.Parse() above. It only
+				// prevents adding to workflow's executer list and suppresses
+				// warning messages.
+				if !options.Options.Validate {
+					gologger.Warning().Msgf("`-code` flag not found, skipping code template from workflow: %v\n", path)
+				}
 				continue
 			} else if !template.Verified {
 				// unverfied code templates are not allowed in workflows


### PR DESCRIPTION
## Proposed changes

Addresses:

* #6499
* #6498

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Improved template detection by evaluating full paths and excluding known config files and misc directories, reducing false positives.
  - Suppressed noisy warnings about missing code flags when running in validation mode.

- Chores
  - Broadened validation scope to include paths previously skipped (e.g., .github and helper payloads).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->