### PR TITLE
Javascript Multi-Port Support

### DIFF
--- a/cmd/nuclei/ssh.yaml
+++ b/cmd/nuclei/ssh.yaml
@@ -1,0 +1,31 @@
+id: ssh-auth-methods
+
+info:
+  name: SSH Auth Methods - Detection
+  author: Ice3man543
+  severity: info
+  description: |
+    SSH (Secure Shell) authentication modes are methods used to verify the identity of users and ensure secure access to remote systems. Common SSH authentication modes include password-based authentication, which relies on a secret passphrase, and public key authentication, which uses cryptographic keys for a more secure and convenient login process. Additionally, multi-factor authentication (MFA) can be employed to enhance security by requiring users to provide multiple forms of authentication, such as a password and a one-time code.
+  reference:
+    - https://nmap.org/nsedoc/scripts/ssh-auth-methods.html
+  metadata:
+    max-request: 1
+    shodan-query: product:"OpenSSH"
+  tags: js,detect,ssh,enum,network
+
+javascript:
+  - pre-condition: |
+      isPortOpen(Host,Port);
+    code: |
+      var m = require("nuclei/ssh");
+      var c = m.SSHClient();
+      var response = c.ConnectSSHInfoMode(Host, Port);
+      Export(response);
+    args:
+      Host: "{{Host}}"
+      Port: "222,2222,22"
+
+    extractors:
+      - type: json
+        json:
+          - '.UserAuth'

--- a/cmd/nuclei/ssh.yaml
+++ b/cmd/nuclei/ssh.yaml
@@ -23,7 +23,7 @@ javascript:
       Export(response);
     args:
       Host: "{{Host}}"
-      Port: "222,2222,22"
+      Port: "222,22"
 
     extractors:
       - type: json


### PR DESCRIPTION
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->
Added support for multiple ports in the Nuclei engine for JavaScript templates

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

./nuclei -u 127.0.0.1 -t ssh.yaml

Sample Template 
```

id: ssh-auth-methods

info:
  name: SSH Auth Methods - Detection
  author: Ice3man543
  severity: info
  description: |
    SSH (Secure Shell) authentication modes are methods used to verify the identity of users and ensure secure access to remote systems. Common SSH authentication modes include password-based authentication, which relies on a secret passphrase, and public key authentication, which uses cryptographic keys for a more secure and convenient login process. Additionally, multi-factor authentication (MFA) can be employed to enhance security by requiring users to provide multiple forms of authentication, such as a password and a one-time code.
  reference:
    - https://nmap.org/nsedoc/scripts/ssh-auth-methods.html
  metadata:
    max-request: 1
    shodan-query: product:"OpenSSH"
  tags: js,detect,ssh,enum,network

javascript:
  - pre-condition: |
      isPortOpen(Host,Port);
    code: |
      var m = require("nuclei/ssh");
      var c = m.SSHClient();
      var response = c.ConnectSSHInfoMode(Host, Port);
      Export(response);
    args:
      Host: "{{Host}}"
      Port: "222,22",2244

    extractors:
      - type: json
        json:
          - '.UserAuth'


```
