### PR TITLE
feat: http(s) probing optimization

### DIFF
--- a/pkg/utils/http_probe_test.go
+++ b/pkg/utils/http_probe_test.go
@@ -1,0 +1,37 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetermineSchemeOrder(t *testing.T) {
+	type testCase struct {
+		input    string
+		expected []string
+	}
+
+	tests := []testCase{
+		// No port or uncommon ports should return https first
+		{"example.com", []string{"https", "http"}},
+		{"example.com:443", []string{"https", "http"}},
+		{"127.0.0.1", []string{"https", "http"}},
+		{"[fe80::1]:443", []string{"https", "http"}},
+		// Common HTTP ports should return http first
+		{"example.com:80", []string{"http", "https"}},
+		{"example.com:8080", []string{"http", "https"}},
+		{"127.0.0.1:80", []string{"http", "https"}},
+		{"127.0.0.1:8080", []string{"http", "https"}},
+		{"fe80::1", []string{"https", "http"}},
+		{"[fe80::1]:80", []string{"http", "https"}},
+		{"[fe80::1]:8080", []string{"http", "https"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			actual := determineSchemeOrder(tc.input)
+			require.Equal(t, tc.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
## Proposed changes

This PR optimizes HTTP probing. Nuclei tries all ports with HTTPS first; this means twice as many requests have to be made on HTTP (80,8080) ports, making probing slower.

This PR implements `determineSchemeOrder`, which makes performance better on 80 and 8080 ports without making it slower on normal scenarios.

TLDR: This PR cuts all needed probing requests to port 80/8080 to half.

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Smarter URL probing: automatically prioritizes HTTP or HTTPS based on detected ports (typically preferring HTTPS), reducing timeouts and improving connection success.
  * Backward-compatible behavior preserved: continues trying alternatives on errors and returns no result if none succeed; no configuration changes required.

* Tests
  * Added comprehensive tests to validate the new probing order across various URL formats and port scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->