### PR TITLE
fix: populate req_url_pattern before event creation

### DIFF
--- a/pkg/protocols/http/operators.go
+++ b/pkg/protocols/http/operators.go
@@ -173,6 +173,12 @@ func (request *Request) MakeResultEventItem(wrapped *output.InternalWrappedEvent
 	if value, ok := wrapped.InternalEvent["analyzer_details"]; ok {
 		analyzerDetails = value.(string)
 	}
+	var reqURLPattern string
+	if request.options.ExportReqURLPattern {
+		if value, ok := wrapped.InternalEvent[ReqURLPatternKey]; ok {
+			reqURLPattern = types.ToString(value)
+		}
+	}
 	data := &output.ResultEvent{
 		TemplateID:       types.ToString(wrapped.InternalEvent["template-id"]),
 		TemplatePath:     types.ToString(wrapped.InternalEvent["template-path"]),
@@ -197,6 +203,7 @@ func (request *Request) MakeResultEventItem(wrapped *output.InternalWrappedEvent
 		TemplateEncoded:  request.options.EncodeTemplate(),
 		Error:            types.ToString(wrapped.InternalEvent["error"]),
 		AnalyzerDetails:  analyzerDetails,
+		ReqURLPattern:    reqURLPattern,
 	}
 	return data
 }


### PR DESCRIPTION
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->
Populate the req_url_pattern in internalEvent to fix timing issue causing interactsh events to miss this causing wrong vulnhash calculation 

Example:

```
d3t35d0ngn4503g699909td9q7j9jboit.oast.site'","matcher-status":true,"req_url_pattern":"/models?url=http%3a//{{interactsh-url}}"}
```

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured request URL pattern handling to improve result processing efficiency. The ReqURLPattern field is now properly exposed in result events when the export option is enabled, with optimized population logic during operator execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->