### PR TITLE
fix(http): resolve timeout config issues

### DIFF
--- a/pkg/protocols/http/httpclientpool/clientpool.go
+++ b/pkg/protocols/http/httpclientpool/clientpool.go
@@ -214,6 +214,10 @@ func wrappedGet(options *types.Options, configuration *Configuration) (*retryabl
 
 	retryableHttpOptions.RetryWaitMax = 10 * time.Second
 	retryableHttpOptions.RetryMax = options.Retries
+	retryableHttpOptions.Timeout = time.Duration(options.Timeout) * time.Second
+	if configuration.ResponseHeaderTimeout > 0 && configuration.ResponseHeaderTimeout > retryableHttpOptions.Timeout {
+		retryableHttpOptions.Timeout = configuration.ResponseHeaderTimeout
+	}
 	redirectFlow := configuration.RedirectFlow
 	maxRedirects := configuration.MaxRedirects
 
@@ -261,6 +265,11 @@ func wrappedGet(options *types.Options, configuration *Configuration) (*retryabl
 	if configuration.ResponseHeaderTimeout != 0 {
 		responseHeaderTimeout = configuration.ResponseHeaderTimeout
 	}
+
+	if responseHeaderTimeout < retryableHttpOptions.Timeout {
+		responseHeaderTimeout = retryableHttpOptions.Timeout
+	}
+
 	if configuration.Connection != nil && configuration.Connection.CustomMaxTimeout > 0 {
 		responseHeaderTimeout = configuration.Connection.CustomMaxTimeout
 	}

--- a/pkg/protocols/http/request.go
+++ b/pkg/protocols/http/request.go
@@ -825,6 +825,7 @@ func (request *Request) executeRequest(input *contextargs.Context, generatedRequ
 					connConfiguration := request.connConfiguration.Clone()
 					modifiedConfig = connConfiguration
 				}
+
 				modifiedConfig.ResponseHeaderTimeout = updatedTimeout.Timeout
 			}
 

--- a/pkg/protocols/http/request_annotations_test.go
+++ b/pkg/protocols/http/request_annotations_test.go
@@ -4,11 +4,25 @@ import (
 	"context"
 	"net/http"
 	"testing"
+	"time"
 
+	"github.com/projectdiscovery/gologger"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/http/httpclientpool"
+	"github.com/projectdiscovery/nuclei/v3/pkg/testutils"
 	"github.com/projectdiscovery/retryablehttp-go"
 	"github.com/stretchr/testify/require"
 )
+
+func getExecuterOptions(t *testing.T) *protocols.ExecutorOptions {
+	t.Helper()
+
+	options := testutils.DefaultOptions.Copy()
+	options.Logger = &gologger.Logger{}
+	testutils.Init(options)
+
+	return testutils.NewMockExecuterOptions(options, nil)
+}
 
 func TestRequestParseAnnotationsSNI(t *testing.T) {
 	t.Run("compliant-SNI-value", func(t *testing.T) {
@@ -44,6 +58,7 @@ func TestRequestParseAnnotationsSNI(t *testing.T) {
 func TestRequestParseAnnotationsTimeout(t *testing.T) {
 	t.Run("positive", func(t *testing.T) {
 		request := &Request{
+			options:           getExecuterOptions(t),
 			connConfiguration: &httpclientpool.Configuration{NoTimeout: true},
 		}
 		rawRequest := `@timeout: 2s
@@ -56,12 +71,91 @@ func TestRequestParseAnnotationsTimeout(t *testing.T) {
 		overrides, modified := request.parseAnnotations(rawRequest, httpReq)
 		require.NotNil(t, overrides.cancelFunc, "could not initialize valid cancel function")
 		require.True(t, modified, "could not get correct modified value")
-		_, deadlined := overrides.request.Context().Deadline()
+
+		// Verify context has deadline
+		deadline, deadlined := overrides.request.Context().Deadline()
 		require.True(t, deadlined, "could not get set request deadline")
+
+		// Verify the timeout value is stored in context
+		customTimeout, ok := overrides.request.Context().Value(httpclientpool.WithCustomTimeout{}).(httpclientpool.WithCustomTimeout)
+		require.True(t, ok, "custom timeout not found in context")
+		require.Equal(t, 2*time.Second, customTimeout.Timeout, "timeout value mismatch")
+
+		// Verify deadline is approximately 2 seconds from now
+		expectedDeadline := time.Now().Add(2 * time.Second)
+		require.WithinDuration(t, expectedDeadline, deadline, 100*time.Millisecond, "deadline not set correctly")
+	})
+
+	t.Run("large-timeout", func(t *testing.T) {
+		request := &Request{
+			options:           getExecuterOptions(t),
+			connConfiguration: &httpclientpool.Configuration{NoTimeout: true},
+		}
+
+		// Request a timeout of 10 minutes - should be capped at 5 minutes
+		rawRequest := `@timeout: 10m
+		GET / HTTP/1.1
+		Host: {{Hostname}}`
+
+		httpReq, err := retryablehttp.NewRequest(http.MethodGet, "https://example.com", nil)
+		require.Nil(t, err, "could not create http request")
+
+		overrides, modified := request.parseAnnotations(rawRequest, httpReq)
+		require.NotNil(t, overrides.cancelFunc, "could not initialize valid cancel function")
+		require.True(t, modified, "could not get correct modified value")
+
+		// Verify context has deadline
+		deadline, deadlined := overrides.request.Context().Deadline()
+		require.True(t, deadlined, "could not get set request deadline")
+
+		// Verify the timeout was capped at 5 minutes (not 10 minutes)
+		customTimeout, ok := overrides.request.Context().Value(httpclientpool.WithCustomTimeout{}).(httpclientpool.WithCustomTimeout)
+		require.True(t, ok, "custom timeout not found in context")
+
+		require.Equal(t, 5*time.Minute, customTimeout.Timeout, "timeout should be capped at 5 minutes")
+		require.Less(t, customTimeout.Timeout, 10*time.Minute, "timeout should be less than requested 10 minutes")
+
+		// Verify deadline matches the capped timeout
+		expectedDeadline := time.Now().Add(5 * time.Minute)
+		require.WithinDuration(t, expectedDeadline, deadline, 100*time.Millisecond, "deadline not set to capped timeout")
+	})
+
+	t.Run("below-cap-timeout", func(t *testing.T) {
+		request := &Request{
+			options:           getExecuterOptions(t),
+			connConfiguration: &httpclientpool.Configuration{NoTimeout: true},
+		}
+
+		// Request a timeout of 2 minutes - should be allowed (below 5 minute cap)
+		rawRequest := `@timeout: 2m
+		GET / HTTP/1.1
+		Host: {{Hostname}}`
+
+		httpReq, err := retryablehttp.NewRequest(http.MethodGet, "https://example.com", nil)
+		require.Nil(t, err, "could not create http request")
+
+		overrides, modified := request.parseAnnotations(rawRequest, httpReq)
+		require.NotNil(t, overrides.cancelFunc, "could not initialize valid cancel function")
+		require.True(t, modified, "could not get correct modified value")
+
+		// Verify context has deadline
+		deadline, deadlined := overrides.request.Context().Deadline()
+		require.True(t, deadlined, "could not get set request deadline")
+
+		// Verify the timeout is NOT capped - should be 2 minutes
+		customTimeout, ok := overrides.request.Context().Value(httpclientpool.WithCustomTimeout{}).(httpclientpool.WithCustomTimeout)
+		require.True(t, ok, "custom timeout not found in context")
+
+		require.Equal(t, 2*time.Minute, customTimeout.Timeout, "timeout should be the requested 2 minutes")
+
+		// Verify deadline matches the requested timeout
+		expectedDeadline := time.Now().Add(2 * time.Minute)
+		require.WithinDuration(t, expectedDeadline, deadline, 100*time.Millisecond, "deadline not set to requested timeout")
 	})
 
 	t.Run("negative", func(t *testing.T) {
 		request := &Request{
+			options:           getExecuterOptions(t),
 			connConfiguration: &httpclientpool.Configuration{},
 		}
 		rawRequest := `GET / HTTP/1.1

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -742,11 +742,11 @@ func (tv *Timeouts) ApplyDefaults() {
 	if tv.TcpReadTimeout == 0 {
 		tv.TcpReadTimeout = 5 * time.Second
 	}
-	if tv.HttpResponseHeaderTimeout == 0 {
-		tv.HttpResponseHeaderTimeout = 10 * time.Second
-	}
 	if tv.HttpTimeout == 0 {
 		tv.HttpTimeout = 3 * tv.DialTimeout
+	}
+	if tv.HttpResponseHeaderTimeout < tv.HttpTimeout {
+		tv.HttpResponseHeaderTimeout = tv.HttpTimeout
 	}
 	if tv.JsCompilerExecutionTimeout == 0 {
 		tv.JsCompilerExecutionTimeout = 2 * tv.DialTimeout


### PR DESCRIPTION
## Proposed changes

    fix(http): resolve timeout config issues
    
    across multiple layers
    
    Fixes timeout configuration conflicts where HTTP
    requests would timeout prematurely despite
    configured values in `@timeout` annotations or
    `-timeout` flags.
    
    RCA:
    * `retryablehttp` pkg overriding with default
      30s timeout.
    * Custom timeouts not propagating to
      `retryablehttp` layer.
    * Multiple timeout layers not sync properly.
    
    Changes:
    * Propagate custom timeouts from `@timeout`
      annotations to `retryablehttp` layer.
    * Adjust 5-minute maximum cap to prevent DoS via
      extremely large timeouts.
    * Ensure `retryableHttpOptions.Timeout` respects
      `ResponseHeaderTimeout`.
    * Add comprehensive tests for timeout capping
      behavior.
    
    This allows templates to override global timeout
    via `@timeout` annotations while preventing abuse
    thru unreasonably large timeout values.
    
    Fixes #6560.


### Proof

**Templates**:

* debug-timeout-issue.yaml
  ```yaml
  id: debug-timeout-issue
  
  info:
    name: Debug Timeout Issue — debug extended timeout
    author: Maoz Zadok
    severity: info
    tags: debug,timeout
  
  variables:
    time_to_sleep: "61"
    request_timeout: "300s"
  
  http:
    - raw:
        - |
          @timeout: {{request_timeout}}
          GET /?time_to_sleep={{time_to_sleep}} HTTP/1.1
          Host: {{Hostname}}
          X-Requested-With: curl
          Accept: application/json
      matchers:
        - type: status
          status: [200]
      extractors:
        - type: dsl
          name: scan_data
          part: body
          dsl:
            - body
  ```
* debug-timeout-issue-2.yaml
  ```yaml
  id: debug-timeout-issue-2
  
  info:
    name: Debug Timeout Issue 2 — debug extended timeout
    author: Maoz Zadok
    severity: info
    tags: debug,timeout
  
  variables:
    time_to_sleep_2: "25"
    request_timeout: "300s"
  
  http:
    - raw:
        - |
          GET /?time_to_sleep={{time_to_sleep_2}} HTTP/1.1
          Host: {{Hostname}}
          X-Requested-With: curl
          Accept: application/json
      matchers:
        - type: status
          status: [200]
      extractors:
        - type: dsl
          name: scan_data
          part: body
          dsl:
            - body
  ```

**Usage**:

```console
$ time ./bin/nuclei -silent -t debug-template-issue.yaml -t debug-template-issue-2.yaml -var time_to_sleep=30 -u https://sleep.skymaster.io/ --timeout 70
[debug-timeout-issue-2:scan_data] [http] [info] https://sleep.skymaster.io/?time_to_sleep=25 ["{\n  "args": {\n    "time_to_sleep": "25"\n  },\n  "data": null,\n  "form": {},\n  "headers": {\n    "Accept": "application/json",\n    "Accept-Encoding": "gzip",\n    "Forwarded": "for=\\"[2404:8000:1016:a2d:61c1:7ef3:4fdc:3e43]\\";proto=https",\n    "Host": "sleep.skymaster.io",\n    "Traceparent": "00-da5670c8b650410813076d491865564a-a6daa532bd006592-00",\n    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36",\n    "X-Cloud-Trace-Context": "da5670c8b650410813076d491865564a/12023103792556828050",\n    "X-Forwarded-For": "2404:8000:1016:a2d:61c1:7ef3:4fdc:3e43",\n    "X-Forwarded-Proto": "https",\n    "X-Requested-With": "curl"\n  },\n  "json": null,\n  "method": "GET",\n  "path": "/",\n  "remote_addr": "169.254.169.126",\n  "time_slept": 25.0,\n  "url": "http://sleep.skymaster.io/?time_to_sleep=25"\n}"]
[debug-timeout-issue:scan_data] [http] [info] https://sleep.skymaster.io/?time_to_sleep=30 ["{\n  "args": {\n    "time_to_sleep": "30"\n  },\n  "data": null,\n  "form": {},\n  "headers": {\n    "Accept": "application/json",\n    "Accept-Encoding": "gzip",\n    "Forwarded": "for=\\"[2404:8000:1016:a2d:61c1:7ef3:4fdc:3e43]\\";proto=https",\n    "Host": "sleep.skymaster.io",\n    "Traceparent": "00-2ce9e24b62506a7d2900098b95254ae1-23880069822af813-01",\n    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:140.0) Gecko/20100101 Firefox/140.6",\n    "X-Cloud-Trace-Context": "2ce9e24b62506a7d2900098b95254ae1/2560296841315547155;o=1",\n    "X-Forwarded-For": "2404:8000:1016:a2d:61c1:7ef3:4fdc:3e43",\n    "X-Forwarded-Proto": "https",\n    "X-Requested-With": "curl"\n  },\n  "json": null,\n  "method": "GET",\n  "path": "/",\n  "remote_addr": "169.254.169.126",\n  "time_slept": 30.0,\n  "url": "http://sleep.skymaster.io/?time_to_sleep=30"\n}"]

real	0m31.785s
user	0m0.185s
sys	0m0.075s
```

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced timeout configuration logic to ensure response header timeouts are properly aligned with HTTP timeouts, preventing misalignment scenarios.

* **New Features**
  * Updated @timeout annotation maximum cap from 2 minutes to 5 minutes.

* **Tests**
  * Added test coverage for timeout annotation parsing, including verification of cap enforcement and deadline calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->