### PR TITLE
fix(headless): fixed memory leak issue during page initialization

### DIFF
--- a/pkg/protocols/headless/engine/page.go
+++ b/pkg/protocols/headless/engine/page.go
@@ -218,7 +218,7 @@ func (i *Instance) Run(ctx *contextargs.Context, actions []*Action, payloads map
 		}
 	}
 
-	successfulPageCreation = true // avoid closing the page in case of success in defered function
+	successfulPageCreation = true // avoid closing the page in case of success in deferred function
 	return data, createdPage, nil
 }
 


### PR DESCRIPTION
The fix covering the following issue of headless processing: 

In case of failure on any step of `Run` method after browser page init (like navigation error) original version of code caused pages (sometimes just blank) opened and such _zombie_ pages consume RAM. On some sites with headless enabled it causes OOM on my machine (chromium instances consumed > 40 Gb) making this mode unusable. _After the fix 8 Gb was enough to scan target sites._

I suppose it's a **critical** issue of the headless implementation for production use.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented resource leaks by ensuring pages are reliably closed when errors occur during initialization.
  * Improved cleanup logic so partially created pages are cleaned up on failure, reducing stale resources.
  * Enhances overall stability and memory/resource management during page creation and startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->