### PR TITLE
fix(charts): fixed out of bounds read

### DIFF
--- a/pkg/scan/charts/echarts.go
+++ b/pkg/scan/charts/echarts.go
@@ -172,16 +172,22 @@ func (s *ScanEventsCharts) topSlowTemplates(c echo.Context) *charts.Kline {
 		return data[i].end-data[i].start > data[j].end-data[j].start
 	})
 
+	// Ensure we don't try to access more elements than available
+	limit := TopK
+	if len(data) < TopK {
+		limit = len(data)
+	}
+
 	x := make([]string, 0)
 	y := make([]opts.KlineData, 0)
-	for _, event := range data[:TopK] {
+	for _, event := range data[:limit] {
 		x = append(x, event.ID)
 		y = append(y, event.KlineData)
 	}
 
 	kline.SetXAxis(x).AddSeries("templates", y)
 	kline.SetGlobalOptions(
-		charts.WithTitleOpts(opts.Title{Title: fmt.Sprintf("Nuclei: Top %v Slow Templates", TopK)}),
+		charts.WithTitleOpts(opts.Title{Title: fmt.Sprintf("Nuclei: Top %v Slow Templates", limit)}),
 		charts.WithXAxisOpts(opts.XAxis{
 			Type:      "category",
 			Show:      opts.Bool(true),


### PR DESCRIPTION
Fixed panic during statistics report generation in case of small amount of templates loaded. Before fix the following issue takes place:

> [+] Scan Info
> 
> Name: nuclei-stats
> Target Count: 20
> Template Count: 35
> Template Concurrency: 25
> Payload Concurrency: 25
> Retries: 1
> Total Events: 1400
> panic: runtime error: slice bounds out of range [:50] with capacity 35
> 
> goroutine 1 [running]:
> github.com/projectdiscovery/nuclei/v3/pkg/scan/charts.(*ScanEventsCharts).topSlowTemplates(0xc000504de0, {0x1?, 0x0?})
> github.com/projectdiscovery/nuclei/v3/pkg/scan/charts/echarts.go:177 +0x14f1
> github.com/projectdiscovery/nuclei/v3/pkg/scan/charts.(*ScanEventsCharts).allCharts(0xc000504de0, {0x0, 0x0})
> github.com/projectdiscovery/nuclei/v3/pkg/scan/charts/echarts.go:45 +0xa5
> github.com/projectdiscovery/nuclei/v3/pkg/scan/charts.(*ScanEventsCharts).GenerateHTML(0xc000504de0?, {0x7ffef77c9ffa, 0x26})
> github.com/projectdiscovery/nuclei/v3/pkg/scan/charts/echarts.go:28 +0x37
> main.main()
> ./main.go:33 +0x1f4

To reproduce the issue 2 steps are required:
1.  run nuclei with less than 50 templates loaded and statistics enabled (_build-stats_)
2. generate an html report using _scan-charts_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of chart display when fewer data points are available than the display limit. The chart now gracefully displays the actual number of items available.
  * Updated chart titles to accurately reflect the actual count of data points displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->