### PR TITLE
ci: apply free-disk-space on tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -39,6 +39,15 @@ jobs:
       - uses: actions/checkout@v6
       - uses: projectdiscovery/actions/setup/go@v1
       - uses: projectdiscovery/actions/cache/go-rod-browser@v1
+      - uses: projectdiscovery/actions/free-disk-space@v1
+        with:
+          llvm: 'false'
+          php: 'false'
+          mongodb: 'false'
+          mysql: 'false'
+          misc-packages: 'false'
+          docker-images: 'false'
+          tools-cache: 'false'
       - run: make vet
       - run: make build
       - run: make test


### PR DESCRIPTION
## Proposed changes

Tbh have no idea why this ends up being OS-specific. It kinda started happening after GitHub pinned `ubuntu-latest` to `ubuntu-24.04`, which has become significantly more bloated, but that’s just me guessing, still needs proper checking.
More context: could also be from the Go tools cache(?) (~3 GiB rn). Not sure if it keeps growing, but AFAIK, it shouldn’t since the cache is based on the `go.sum` hash. I'm confused lmao.

re: https://github.com/projectdiscovery/nuclei/actions/runs/19766522640/job/56640731129?pr=6629

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)