### PR TITLE
add strict probe option for httpx

### DIFF
--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -434,6 +434,7 @@ on extensive configurability, massive extensibility and ease of use.`)
 		}),
 		flagSet.DurationVarP(&options.InputReadTimeout, "input-read-timeout", "irt", time.Duration(3*time.Minute), "timeout on input read"),
 		flagSet.BoolVarP(&options.DisableHTTPProbe, "no-httpx", "nh", false, "disable httpx probing for non-url input"),
+		flagSet.BoolVarP(&options.StrictProbe, "strict-probe", "sp", false, "stop scanning when httpx probe returns 0 URLs (no fallback to raw input)"),
 		flagSet.BoolVar(&options.DisableStdin, "no-stdin", false, "disable stdin processing"),
 	)
 

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -701,9 +701,13 @@ func (r *Runner) RunEnumeration() error {
 	// are used, and if inputs are non-http to pre-perform probing
 	// of urls and storing them for execution.
 	if !r.options.DisableHTTPProbe && loader.IsHTTPBasedProtocolUsed(store) && r.isInputNonHTTP() {
-		inputHelpers, err := r.initializeTemplatesHTTPInput()
+		inputHelpers, urlCount, err := r.initializeTemplatesHTTPInput()
 		if err != nil {
 			return errors.Wrap(err, "could not probe http input")
+		}
+		if r.options.StrictProbe && urlCount == 0 {
+			r.Logger.Info().Msgf("Strict probe mode: No URLs found from httpx probe, skipping scan")
+			return nil
 		}
 		executorOpts.InputHelper.InputsHTTP = inputHelpers
 	}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -201,6 +201,8 @@ type Options struct {
 	DebugResponse bool
 	// DisableHTTPProbe disables http probing feature of input normalization
 	DisableHTTPProbe bool
+	// StrictProbe stops scanning when httpx probe returns 0 URLs (no fallback to raw input)
+	StrictProbe bool
 	// LeaveDefaultPorts skips normalization of default ports
 	LeaveDefaultPorts bool
 	// AutomaticScan enables automatic tech based template execution


### PR DESCRIPTION
## Proposed changes

closes https://github.com/projectdiscovery/nuclei/issues/6651

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added `--strict-probe` (`-sp`) CLI flag to enforce strict HTTP probe mode. When enabled, scanning stops if the HTTP probe returns zero URLs, preventing fallback to raw input.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->