### PR TITLE
fix(headless): data race when reading page history

### DIFF
--- a/pkg/protocols/headless/engine/page.go
+++ b/pkg/protocols/headless/engine/page.go
@@ -207,9 +207,16 @@ func (i *Instance) Run(ctx *contextargs.Context, actions []*Action, payloads map
 
 	// The first item of history data will contain the very first request from the browser
 	// we assume it's the one matching the initial URL
-	if len(createdPage.History) > 0 {
-		firstItem := createdPage.History[0]
-		if resp, err := http.ReadResponse(bufio.NewReader(strings.NewReader(firstItem.RawResponse)), nil); err == nil {
+	createdPage.mutex.RLock()
+	var firstHistoryItem HistoryData
+	hasHistory := len(createdPage.History) > 0
+	if hasHistory {
+		firstHistoryItem = createdPage.History[0]
+	}
+	createdPage.mutex.RUnlock()
+
+	if hasHistory {
+		if resp, err := http.ReadResponse(bufio.NewReader(strings.NewReader(firstHistoryItem.RawResponse)), nil); err == nil {
 			data["header"] = utils.HeadersToString(resp.Header)
 			data["status_code"] = fmt.Sprint(resp.StatusCode)
 			defer func() {


### PR DESCRIPTION
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->

fix(headless): data race when reading page history

The `(*Page).HistoryData` was being read w/o
holding the mutex lock after
`(*Page).ExecuteActions()` returns, while the
background hijack goroutine could still be writing
to it via `(*Page).addToHistory()`.

Copy the first history item by value while holding
RLock to avoid racing with concurrent append ops.

Fixes #6686.

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved page history handling to ensure reliable access and prevent potential data inconsistencies that could affect application stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->