### PR TITLE
fix: body loss on retries/redirects in remaining paths

### DIFF
--- a/pkg/fuzz/component/body.go
+++ b/pkg/fuzz/component/body.go
@@ -11,7 +11,6 @@ import (
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz/dataformat"
 	"github.com/projectdiscovery/retryablehttp-go"
-	readerutil "github.com/projectdiscovery/utils/reader"
 )
 
 // Body is a component for a request body
@@ -132,12 +131,10 @@ func (b *Body) Rebuild() (*retryablehttp.Request, error) {
 		return nil, errors.Wrap(err, "could not encode body")
 	}
 	cloned := b.req.Clone(context.Background())
-	reusableReader, err := readerutil.NewReusableReadCloser(encoded)
+	err = cloned.SetBodyString(encoded)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not create reusable reader")
+		return nil, errors.Wrap(err, "could not set body")
 	}
-	cloned.Body = reusableReader
-	cloned.ContentLength = int64(len(encoded))
 	cloned.Header.Set("Content-Length", strconv.Itoa(len(encoded)))
 	return cloned, nil
 }

--- a/pkg/protocols/http/request.go
+++ b/pkg/protocols/http/request.go
@@ -691,7 +691,7 @@ func (request *Request) executeRequest(input *contextargs.Context, generatedRequ
 			}
 			if err == nil {
 				// update the request body with the reusable reader
-				generatedRequest.request.Body = newReqBody
+				generatedRequest.request.SetBodyReader(newReqBody)
 				// get content length
 				length, _ := io.Copy(io.Discard, newReqBody)
 				generatedRequest.request.ContentLength = length


### PR DESCRIPTION
## Proposed changes

fix: body loss on retries/redirects in remaining paths

Continue the fix from #6666 by converting
remaining direct Body assignments to use setter
methods:

* pkg/fuzz/component/body.go:139: use
  `SetBodyReader()` in transfer-encoding path.
* pkg/protocols/http/request.go:694: use
  `SetBodyString()` in fuzz component `Rebuild()`.

Fixes #6692.

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal request body handling for more reliable content management and consistent Content-Length behavior.
* **Bug Fixes**
  * Clarified error reporting when setting request bodies, reducing failures related to body updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->