### PR TITLE
fix(trackers): paginate gitea to find all issues when searching for duplicates

### DIFF
--- a/cmd/nuclei/issue-tracker-config.yaml
+++ b/cmd/nuclei/issue-tracker-config.yaml
@@ -81,6 +81,10 @@
 #    severity: low
 #  # duplicate-issue-check (optional) flag to enable duplicate tracking issue check
 #  duplicate-issue-check: false
+#  # duplicate-issue-page-size (optional) controls how many issues to fetch per page when searching for duplicates
+#  duplicate-issue-page-size: 100
+#  # duplicate-issue-max-pages (optional) limits how many pages to fetch when searching for duplicates (0 = no limit)
+#  duplicate-issue-max-pages: 0
 #
 # Jira contains configuration options for Jira issue tracker
 #jira:
@@ -118,10 +122,10 @@
 # status-not: Closed
 #  # Customfield supports name, id and freeform. name and id are to be used when the custom field is a dropdown.
 #  # freeform can be used if the custom field is just a text entry
-#  # Variables can be used to pull various pieces of data from the finding itself. 
+#  # Variables can be used to pull various pieces of data from the finding itself.
 #  # Supported variables: $CVSSMetrics, $CVEID, $CWEID, $Host, $Severity, $CVSSScore, $Name
 # custom-fields:
-#  customfield_00001: 
+#  customfield_00001:
 #    name: "Nuclei"
 #  customfield_00002:
 #    freeform: $CVSSMetrics


### PR DESCRIPTION
## Proposed changes

When searching for duplicates, issue API responses are paginated. Because the reporting integration does not paginate results, older issues are skipped and logged as a duplicate.

Fixes #6706.

## Checklist

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved issue lookup from Gitea repositories to iterate through paginated results for more reliable matching.
  * Added configurable paging controls (page size and max pages) with an early-exit when limits are reached, preserving existing error behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->