### PR TITLE
hotfix(javascript): restore exec for templates w/o `Port` arg

### DIFF
--- a/cmd/integration-test/javascript.go
+++ b/cmd/integration-test/javascript.go
@@ -18,6 +18,7 @@ var jsTestcases = []TestCaseInfo{
 	{Path: "protocols/javascript/oracle-auth-test.yaml", TestCase: &javascriptOracleAuthTest{}, DisableOn: func() bool { return osutils.IsWindows() || osutils.IsOSX() }},
 	{Path: "protocols/javascript/vnc-pass-brute.yaml", TestCase: &javascriptVncPassBrute{}},
 	{Path: "protocols/javascript/multi-ports.yaml", TestCase: &javascriptMultiPortsSSH{}},
+	{Path: "protocols/javascript/no-port-args.yaml", TestCase: &javascriptNoPortArgs{}},
 }
 
 var (
@@ -173,6 +174,16 @@ type javascriptMultiPortsSSH struct{}
 func (j *javascriptMultiPortsSSH) Execute(filePath string) error {
 	// use scanme.sh as target to ensure we match on the 2nd default port 22
 	results, err := testutils.RunNucleiTemplateAndGetResults(filePath, "scanme.sh", debug)
+	if err != nil {
+		return err
+	}
+	return expectResultsCount(results, 1)
+}
+
+type javascriptNoPortArgs struct{}
+
+func (j *javascriptNoPortArgs) Execute(filePath string) error {
+	results, err := testutils.RunNucleiTemplateAndGetResults(filePath, "yo.dawg", debug)
 	if err != nil {
 		return err
 	}

--- a/integration_tests/protocols/javascript/no-port-args.yaml
+++ b/integration_tests/protocols/javascript/no-port-args.yaml
@@ -1,0 +1,23 @@
+id: javascript-no-port-args
+
+info:
+  name: JavaScript Template Without Port Args
+  author: dwisiswant0
+  severity: info
+  description: |
+    Test backwards compatibility for JavaScript templates without Port in args.
+    Templates should execute even when Port arg is not explicitly specified.
+
+javascript:
+  - code: |
+      // Simple JavaScript code that does not require Port
+      let result = "executed";
+      Export(result);
+
+    args:
+      TestArg: "test-value"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - success == true

--- a/pkg/protocols/javascript/js.go
+++ b/pkg/protocols/javascript/js.go
@@ -287,6 +287,9 @@ func (request *Request) GetID() string {
 func (request *Request) ExecuteWithResults(target *contextargs.Context, dynamicValues, previous output.InternalEvent, callback protocols.OutputEventCallback) error {
 	// Get default port(s) if specified in template
 	ports := request.getPorts()
+	if len(ports) == 0 {
+		return request.executeWithResults("", target, dynamicValues, previous, callback)
+	}
 
 	var errs []error
 


### PR DESCRIPTION
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->

Restore backwards compat for JavaScript protocol
templates that omit the `Port` argument.
Regression was introduced in f4f2e9f2, which
removed the fallback for empty `Port` in
`(*Request).ExecuteWithResults`, causing templates
without `Port` to be silently skipped.

Now, if no `Port` is specified, the engine
executes the JavaScript block using the target
URL's port.

Fixes #6708.


### Proof

```console
$ ./bin/nuclei -duc -u yo.dawg -t integration_tests/protocols/javascript/no-port-args.yaml -debug

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.6.1

		projectdiscovery.io

[INF] Current nuclei version: v3.6.1 (unknown) - remove '-duc' flag to enable update checks
[INF] Current nuclei-templates version: v10.3.5 (unknown) - remove '-duc' flag to enable update checks
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 0
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[DBG] [javascript-no-port-args] Dumped Javascript request for yo.dawg:
Variables:
 map[string]interface {}:2 {
  "Port": "",
  "TestArg": "test-value",
} address=yo.dawg
[DBG]  [javascript-no-port-args] Javascript Code:

	// Simple JavaScript code that does not require Port
	let result = "executed";
	Export(result);

[DBG] [javascript-no-port-args] Dumped Javascript response for yo.dawg:
map[string]interface {}:2 {
  "response": "executed",
  "success": "true",
} address=yo.dawg
[javascript-no-port-args:dsl-1] [javascript] [info] yo.dawg
[INF] Scan completed in 1.043825879s. 1 matches found.
```

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * JavaScript protocol now properly handles cases where no ports are defined, executing a request with an empty port instead of skipping execution.

* **Tests**
  * Added integration test coverage for no-port-args scenario.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->