### PR TITLE
fix(trackers): add gitlab paginated dup issue search

### DIFF
--- a/cmd/nuclei/issue-tracker-config.yaml
+++ b/cmd/nuclei/issue-tracker-config.yaml
@@ -55,6 +55,12 @@
 #  # these severity labels or tags (does not affect exporters. set those globally)
 #  deny-list:
 #    severity: low
+#  # duplicate-issue-check (optional) flag to enable duplicate tracking issue check
+#  duplicate-issue-check: false
+#  # duplicate-issue-page-size (optional) controls how many issues to fetch per page when searching for duplicates
+#  duplicate-issue-page-size: 100
+#  # duplicate-issue-max-pages (optional) limits how many pages to fetch when searching for duplicates (0 = no limit)
+#  duplicate-issue-max-pages: 0
 #
 # Gitea contains configuration options for a gitea issue tracker
 #gitea:


### PR DESCRIPTION
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->

fix(trackers): add gitlab paginated dup issue search

with configurable limits

This patch fixes duplicate issue detection for
GitLab trackers by implementing paginated search
with configurable page size and max pages. Adds
`duplicate-issue-page-size` and
`duplicate-issue-max-pages` options to the config.

Fixes #6711.

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration options to control pagination when searching for duplicate issues in GitLab.

* **Improvements**
  * Enhanced duplicate issue detection to automatically reopen closed duplicates when logging new results.
  * Refactored duplicate-check workflow to return existing issue details instead of creating duplicates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->