### PR TITLE
feat: enable TLS session cache for client pool

### DIFF
--- a/pkg/protocols/headless/engine/http_client.go
+++ b/pkg/protocols/headless/engine/http_client.go
@@ -29,6 +29,7 @@ func newHttpClient(options *types.Options) (*http.Client, error) {
 		Renegotiation:      tls.RenegotiateOnceAsClient,
 		InsecureSkipVerify: true,
 		MinVersion:         tls.VersionTLS10,
+		ClientSessionCache: tls.NewLRUClientSessionCache(1024),
 	}
 
 	if options.SNI != "" {

--- a/pkg/protocols/http/httpclientpool/clientpool.go
+++ b/pkg/protocols/http/httpclientpool/clientpool.go
@@ -248,6 +248,7 @@ func wrappedGet(options *types.Options, configuration *Configuration) (*retryabl
 		Renegotiation:      tls.RenegotiateOnceAsClient,
 		InsecureSkipVerify: true,
 		MinVersion:         tls.VersionTLS10,
+		ClientSessionCache: tls.NewLRUClientSessionCache(1024),
 	}
 
 	if options.SNI != "" {


### PR DESCRIPTION
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->

feat: enable TLS session cache for client pool

This patch enables TLS session resumption by
setting a shared LRU session cache
(`ClientSessionCache`) in all HTTP client TLS
configs. This reduces handshake overhead and CPU
usage for repeated conns to the same host,
improving throughput and efficiency in
clusterbomb/pitchfork modes.

This applied to HTTP-request-based and headless-
request-based protocols.

No runtime/compatibility impact.

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced TLS client session caching in HTTP clients for improved connection performance and efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->