### PR TITLE
fix(utils): santize host when target has host port

### DIFF
--- a/pkg/protocols/utils/fields_test.go
+++ b/pkg/protocols/utils/fields_test.go
@@ -1,0 +1,138 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetJsonFieldsFromURL_HostPortExtraction(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		input        string
+		expectedHost string
+		expectedPort string
+	}{
+		{
+			name:         "URL with scheme and port",
+			input:        "http://example.com:8080/path",
+			expectedHost: "example.com",
+			expectedPort: "8080",
+		},
+		{
+			name:         "URL with scheme no port",
+			input:        "https://example.com/path",
+			expectedHost: "example.com",
+			expectedPort: "443",
+		},
+		{
+			name:         "host:port without scheme",
+			input:        "example.com:8080",
+			expectedHost: "example.com",
+			expectedPort: "8080",
+		},
+		{
+			name:         "host:port with standard HTTPS port",
+			input:        "example.com:443",
+			expectedHost: "example.com",
+			expectedPort: "443",
+		},
+		{
+			name:         "IPv4 with port",
+			input:        "192.168.1.1:8080",
+			expectedHost: "192.168.1.1",
+			expectedPort: "8080",
+		},
+		{
+			name:         "IPv6 with port",
+			input:        "[2001:db8::1]:8080",
+			expectedHost: "2001:db8::1",
+			expectedPort: "8080",
+		},
+		{
+			name:         "localhost with port",
+			input:        "localhost:3000",
+			expectedHost: "localhost",
+			expectedPort: "3000",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			fields := GetJsonFieldsFromURL(tt.input)
+
+			assert.Equal(t, tt.expectedHost, fields.Host)
+			assert.Equal(t, tt.expectedPort, fields.Port)
+		})
+	}
+}
+
+func TestExtractHostPort(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		host         string
+		port         string
+		expectedHost string
+		expectedPort string
+	}{
+		{
+			name:         "host without port",
+			host:         "example.com",
+			port:         "",
+			expectedHost: "example.com",
+			expectedPort: "",
+		},
+		{
+			name:         "host with port",
+			host:         "example.com:8080",
+			port:         "",
+			expectedHost: "example.com",
+			expectedPort: "8080",
+		},
+		{
+			name:         "port already set",
+			host:         "example.com:8080",
+			port:         "443",
+			expectedHost: "example.com",
+			expectedPort: "443",
+		},
+		{
+			name:         "IPv6 with port",
+			host:         "[::1]:8080",
+			port:         "",
+			expectedHost: "::1",
+			expectedPort: "8080",
+		},
+		{
+			name:         "IPv6 without port",
+			host:         "[::1]",
+			port:         "",
+			expectedHost: "::1",
+			expectedPort: "",
+		},
+		{
+			name:         "IPv4 with port",
+			host:         "192.168.1.1:8080",
+			port:         "",
+			expectedHost: "192.168.1.1",
+			expectedPort: "8080",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			host, port := extractHostPort(tt.host, tt.port)
+
+			assert.Equal(t, tt.expectedHost, host)
+			assert.Equal(t, tt.expectedPort, port)
+		})
+	}
+}


### PR DESCRIPTION
closes #6758 
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->

### Proof

<!-- How has this been tested? Please describe the tests that you ran to verify your changes. -->

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced host and port extraction normalization to improve handling of IPv6 addresses and various host formats.

* **Tests**
  * Added comprehensive test coverage for URL host/port extraction logic across various scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->