### PR TITLE
fix: auth scanning race condition when using -secret-file (#6592)

### DIFF
--- a/pkg/authprovider/authx/dynamic.go
+++ b/pkg/authprovider/authx/dynamic.go
@@ -3,7 +3,7 @@ package authx
 import (
 	"fmt"
 	"strings"
-	"sync/atomic"
+	"sync"
 
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/replacer"
@@ -30,8 +30,7 @@ type Dynamic struct {
 	Input         string                 `json:"input" yaml:"input"` // (optional) target for the dynamic secret
 	Extracted     map[string]interface{} `json:"-" yaml:"-"`         // extracted values from the dynamic secret
 	fetchCallback LazyFetchSecret        `json:"-" yaml:"-"`
-	fetched       *atomic.Bool           `json:"-" yaml:"-"` // atomic flag to check if the secret has been fetched
-	fetching      *atomic.Bool           `json:"-" yaml:"-"` // atomic flag to prevent recursive fetch calls
+	fetchOnce     sync.Once              `json:"-" yaml:"-"` // ensures fetch happens only once
 	error         error                  `json:"-" yaml:"-"` // error if any
 }
 
@@ -70,8 +69,7 @@ func (d *Dynamic) UnmarshalJSON(data []byte) error {
 
 // Validate validates the dynamic secret
 func (d *Dynamic) Validate() error {
-	d.fetched = &atomic.Bool{}
-	d.fetching = &atomic.Bool{}
+	// fetchOnce is a zero-value sync.Once, no initialization needed
 	if d.TemplatePath == "" {
 		return errkit.New(" template-path is required for dynamic secret")
 	}
@@ -183,14 +181,8 @@ func (d *Dynamic) applyValuesToSecret(secret *Secret) error {
 
 // GetStrategy returns the auth strategies for the dynamic secret
 func (d *Dynamic) GetStrategies() []AuthStrategy {
-	if d.fetched.Load() {
-		if d.error != nil {
-			return nil
-		}
-	} else {
-		// Try to fetch if not already fetched
-		_ = d.Fetch(true)
-	}
+	// Ensure fetch has completed (blocks if another goroutine is fetching)
+	_ = d.Fetch(true)
 
 	if d.error != nil {
 		return nil
@@ -207,23 +199,13 @@ func (d *Dynamic) GetStrategies() []AuthStrategy {
 
 // Fetch fetches the dynamic secret
 // if isFatal is true, it will stop the execution if the secret could not be fetched
+// Uses sync.Once to ensure fetch happens exactly once and concurrent callers wait
 func (d *Dynamic) Fetch(isFatal bool) error {
-	if d.fetched.Load() {
-		return d.error
-	}
-
-	// Try to set fetching flag atomically
-	if !d.fetching.CompareAndSwap(false, true) {
-		// Already fetching, return current error
-		return d.error
-	}
-
-	// We're the only one fetching, call the callback
-	d.error = d.fetchCallback(d)
-
-	// Mark as fetched and clear fetching flag
-	d.fetched.Store(true)
-	d.fetching.Store(false)
+	// sync.Once ensures this runs exactly once, and all concurrent callers
+	// will block until the first call completes
+	d.fetchOnce.Do(func() {
+		d.error = d.fetchCallback(d)
+	})
 
 	if d.error != nil && isFatal {
 		gologger.Fatal().Msgf("Could not fetch dynamic secret: %s\n", d.error)

--- a/pkg/authprovider/authx/dynamic_test.go
+++ b/pkg/authprovider/authx/dynamic_test.go
@@ -1,7 +1,10 @@
 package authx
 
 import (
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -121,5 +124,120 @@ func TestDynamicUnmarshalJSON(t *testing.T) {
 		var d Dynamic
 		err := d.UnmarshalJSON(data)
 		require.NoError(t, err)
+	})
+}
+
+// TestConcurrentFetch tests that concurrent Fetch() calls properly wait
+// for the first fetch to complete, fixing the race condition in issue #6592
+func TestConcurrentFetch(t *testing.T) {
+	t.Run("concurrent-fetch-waits", func(t *testing.T) {
+		var callCount atomic.Int32
+		var fetchStarted atomic.Bool
+
+		d := &Dynamic{
+			TemplatePath: "test-template.yaml",
+			Variables:    []KV{{Key: "test", Value: "value"}},
+			Secret: &Secret{
+				Type:    "BasicAuth",
+				Domains: []string{"example.com"},
+			},
+			Extracted: make(map[string]interface{}),
+		}
+
+		// Set up a callback that simulates a slow authentication fetch
+		d.SetLazyFetchCallback(func(d *Dynamic) error {
+			callCount.Add(1)
+			fetchStarted.Store(true)
+			// Simulate network delay
+			time.Sleep(100 * time.Millisecond)
+			// Set extracted values
+			d.Extracted["token"] = "test-token"
+			return nil
+		})
+
+		const numGoroutines = 10
+		var wg sync.WaitGroup
+		wg.Add(numGoroutines)
+
+		// Start a barrier to ensure all goroutines start at roughly the same time
+		startBarrier := make(chan struct{})
+
+		// Track results from each goroutine
+		errors := make([]error, numGoroutines)
+
+		for i := 0; i < numGoroutines; i++ {
+			go func(idx int) {
+				defer wg.Done()
+				<-startBarrier // Wait for signal to start
+				errors[idx] = d.Fetch(false)
+			}(i)
+		}
+
+		// Release all goroutines at once
+		close(startBarrier)
+
+		// Wait for all to complete
+		wg.Wait()
+
+		// Verify callback was called exactly once
+		require.Equal(t, int32(1), callCount.Load(), "callback should be called exactly once")
+
+		// Verify all goroutines got no error
+		for i, err := range errors {
+			require.NoError(t, err, "goroutine %d should have no error", i)
+		}
+
+		// Verify extracted values are available
+		require.Equal(t, "test-token", d.Extracted["token"])
+	})
+
+	t.Run("get-strategies-waits-for-fetch", func(t *testing.T) {
+		var callCount atomic.Int32
+
+		d := &Dynamic{
+			TemplatePath: "test-template.yaml",
+			Variables:    []KV{{Key: "test", Value: "value"}},
+			Secret: &Secret{
+				Type:     "BasicAuth",
+				Domains:  []string{"example.com"},
+				Username: "user",
+				Password: "pass",
+			},
+			Extracted: make(map[string]interface{}),
+		}
+
+		d.SetLazyFetchCallback(func(d *Dynamic) error {
+			callCount.Add(1)
+			time.Sleep(50 * time.Millisecond)
+			d.Extracted["dummy"] = "value"
+			return nil
+		})
+
+		const numGoroutines = 5
+		var wg sync.WaitGroup
+		wg.Add(numGoroutines)
+
+		startBarrier := make(chan struct{})
+		strategies := make([][]AuthStrategy, numGoroutines)
+
+		for i := 0; i < numGoroutines; i++ {
+			go func(idx int) {
+				defer wg.Done()
+				<-startBarrier
+				strategies[idx] = d.GetStrategies()
+			}(i)
+		}
+
+		close(startBarrier)
+		wg.Wait()
+
+		// Callback should be called exactly once
+		require.Equal(t, int32(1), callCount.Load(), "callback should be called exactly once")
+
+		// All goroutines should get valid strategies
+		for i, strats := range strategies {
+			require.NotNil(t, strats, "goroutine %d should get strategies", i)
+			require.Len(t, strats, 1, "goroutine %d should get 1 strategy", i)
+		}
 	})
 }


### PR DESCRIPTION
/claim #6592

## Summary

This PR fixes the auth scanning race condition reported in issue #6592.

## Problem

When using `-secret-file`, templates started executing before the secret file (authentication) completed, causing unauthenticated requests. This was a regression from the expected behavior in 3.4.7.

## Root Cause

The `Dynamic.Fetch()` method in `pkg/authprovider/authx/dynamic.go` used atomic bools for coordination:

```go
// Original problematic code
if !d.fetching.CompareAndSwap(false, true) {
    // Already fetching, return current error
    return d.error  // BUG: Returns immediately without waiting!
}
```

When multiple goroutines called `Fetch()` concurrently:
1. First caller set `fetching=true` and started the actual auth fetch
2. Other callers saw `fetching=true` and returned `d.error` immediately (which was `nil` at this point)
3. Those callers proceeded with HTTP requests before auth was ready → unauthenticated requests

## Fix

Replace atomic bool flags with `sync.Once` which properly blocks all concurrent callers until the first fetch completes:

```go
func (d *Dynamic) Fetch(isFatal bool) error {
    d.fetchOnce.Do(func() {
        d.error = d.fetchCallback(d)
    })
    // ...
}
```

This ensures:
1. The fetch callback runs exactly once
2. All concurrent callers **wait** until fetch completes  
3. All callers get the correct result after fetch

## Changes

- `pkg/authprovider/authx/dynamic.go`: Replace `atomic.Bool` flags with `sync.Once`
- `pkg/authprovider/authx/dynamic_test.go`: Add comprehensive tests for concurrent fetch behavior

## Testing

- All existing tests pass
- Added new tests that verify:
  - Concurrent `Fetch()` calls wait and callback runs only once
  - Concurrent `GetStrategies()` calls wait for fetch to complete
- Ran with Go race detector - no races detected

## Related

- Fixes #6592
- Related to #6231 (multiple responses issue, addressed by #6449) - this is a different issue (race condition vs multiple responses)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed race conditions in concurrent dynamic secret fetch operations, ensuring all simultaneous requests properly wait for and share the same fetched secrets.

* **Tests**
  * Added comprehensive concurrent access tests for dynamic secret fetching to validate reliability under parallel load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->