### PR TITLE
fix(fuzz): use OrderedMap for path component to ensure deterministic iteration

### DIFF
--- a/pkg/fuzz/component/path.go
+++ b/pkg/fuzz/component/path.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz/dataformat"
 	"github.com/projectdiscovery/retryablehttp-go"
+	mapsutil "github.com/projectdiscovery/utils/maps"
 	urlutil "github.com/projectdiscovery/utils/url"
 )
 
@@ -36,7 +37,9 @@ func (q *Path) Parse(req *retryablehttp.Request) (bool, error) {
 	q.value = NewValue("")
 
 	splitted := strings.Split(req.Path, "/")
-	values := make(map[string]interface{})
+	// Use OrderedMap to preserve iteration order and ensure deterministic fuzzing
+	values := mapsutil.NewOrderedMap[string, any]()
+	segmentIndex := 0
 	for i, segment := range splitted {
 		if segment == "" && i == 0 {
 			// Skip the first empty segment from leading "/"
@@ -47,10 +50,11 @@ func (q *Path) Parse(req *retryablehttp.Request) (bool, error) {
 			continue
 		}
 		// Use 1-based indexing and store individual segments
-		key := strconv.Itoa(len(values) + 1)
-		values[key] = segment
+		segmentIndex++
+		key := strconv.Itoa(segmentIndex)
+		values.Set(key, segment)
 	}
-	q.value.SetParsed(dataformat.KVMap(values), "")
+	q.value.SetParsed(dataformat.KVOrderedMap(&values), "")
 	return true, nil
 }
 
@@ -109,8 +113,12 @@ func (q *Path) Rebuild() (*retryablehttp.Request, error) {
 
 		// Check if we have a replacement for this segment
 		key := strconv.Itoa(segmentIndex)
-		if newValue, exists := q.value.parsed.Map.GetOrDefault(key, "").(string); exists && newValue != "" {
-			rebuiltSegments = append(rebuiltSegments, newValue)
+		if newValue := q.value.parsed.Get(key); newValue != nil {
+			if strValue, ok := newValue.(string); ok && strValue != "" {
+				rebuiltSegments = append(rebuiltSegments, strValue)
+			} else {
+				rebuiltSegments = append(rebuiltSegments, originalSegment)
+			}
 		} else {
 			rebuiltSegments = append(rebuiltSegments, originalSegment)
 		}

--- a/pkg/fuzz/component/path_test.go
+++ b/pkg/fuzz/component/path_test.go
@@ -127,3 +127,46 @@ func TestPathComponent_SQLInjection(t *testing.T) {
 	// Let's also test what the actual URL looks like
 	t.Logf("Full URL: %s", newReq.String())
 }
+
+// TestPathComponent_DeterministicIteration tests that path iteration is deterministic
+// This test verifies the fix for https://github.com/projectdiscovery/nuclei/issues/6398
+// where path-based fuzzing would non-deterministically skip numeric path segments
+// due to random map iteration order in Go.
+func TestPathComponent_DeterministicIteration(t *testing.T) {
+	// Run multiple iterations to verify deterministic behavior
+	// Previously, using regular Go maps would cause random iteration order
+	for run := 0; run < 100; run++ {
+		path := NewPath()
+		req, err := retryablehttp.NewRequest(http.MethodGet, "https://example.com/user/55/profile", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		found, err := path.Parse(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !found {
+			t.Fatal("expected path to be found")
+		}
+
+		// Collect keys and values in iteration order
+		var keys []string
+		var values []string
+		err = path.Iterate(func(key string, value interface{}) error {
+			keys = append(keys, key)
+			values = append(values, value.(string))
+			return nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Verify consistent order: keys should always be 1, 2, 3
+		// and values should always be user, 55, profile in that order
+		expectedKeys := []string{"1", "2", "3"}
+		expectedValues := []string{"user", "55", "profile"}
+
+		require.Equal(t, expectedKeys, keys, "iteration %d: keys should be in consistent order", run)
+		require.Equal(t, expectedValues, values, "iteration %d: values should be in consistent order", run)
+	}
+}


### PR DESCRIPTION
## Summary

This PR fixes issue #6398 where path-based fuzzing would non-deterministically skip numeric path segments (like `/user/55/profile`) due to random map iteration order in Go.

## Problem

The path component used a regular Go map to store path segments:
```go
values := make(map[string]interface{})
```

Go maps have **random iteration order**, which caused the fuzzing to sometimes skip certain path segments during iteration. This was confirmed by @dwisiswant0 who showed that only 3 out of 10 runs would fuzz the numeric `55` segment:

```console
=== Run 3 ===
[INF] Dumped HTTP request for http://127.0.0.1:8082/user/55+OR+True/profile  # <-- only some runs had this
=== Run 7 ===
[INF] Dumped HTTP request for http://127.0.0.1:8082/user/55+OR+True/profile
=== Run 10 ===
[INF] Dumped HTTP request for http://127.0.0.1:8082/user/55+OR+True/profile
```

## Solution

- Use `mapsutil.OrderedMap` instead of `map[string]interface{}` in `Path.Parse()`
- Update `Path.Rebuild()` to use the `KV.Get()` method instead of direct map access
- Add `TestPathComponent_DeterministicIteration` test that verifies consistent ordering across 100 iterations

## Testing

All existing tests pass, plus a new test that specifically verifies deterministic iteration order:

```go
func TestPathComponent_DeterministicIteration(t *testing.T) {
    // Run 100 iterations to verify deterministic behavior
    for run := 0; run < 100; run++ {
        // ... verify keys are always ["1", "2", "3"]
        // ... verify values are always ["user", "55", "profile"]
    }
}
```

/claim #6398

Fixes #6398

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Path component iteration is now deterministic and consistent across repeated runs, improving reliability during fuzzing operations.

* **Tests**
  * Added comprehensive tests to validate deterministic iteration behavior of path components across multiple test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->