### PR TITLE
fix: always pre-fetch secrets when using -secret-file

### DIFF
--- a/cmd/integration-test/http.go
+++ b/cmd/integration-test/http.go
@@ -90,6 +90,7 @@ var httpTestcases = []TestCaseInfo{
 	{Path: "protocols/http/multi-http-var-sharing.yaml", TestCase: &httpMultiVarSharing{}},
 	{Path: "protocols/http/raw-path-single-slash.yaml", TestCase: &httpRawPathSingleSlash{}},
 	{Path: "protocols/http/raw-unsafe-path-single-slash.yaml", TestCase: &httpRawUnsafePathSingleSlash{}},
+	{Path: "protocols/http/auth-secret-file-test.yaml", TestCase: &httpAuthSecretFile{}},
 }
 
 type httpMultiVarSharing struct{}
@@ -1754,5 +1755,111 @@ func (h *httpRawUnsafePathSingleSlash) Execute(filepath string) error {
 	if actual != expectedPath {
 		return fmt.Errorf("expected: %v\n\nactual: %v", expectedPath, actual)
 	}
+	return nil
+}
+
+type httpAuthSecretFile struct{}
+
+// Execute executes a test case and returns an error if occurred
+func (h *httpAuthSecretFile) Execute(filePath string) error {
+	router := httprouter.New()
+	var requestLog []string
+	var mu sync.Mutex
+
+	router.POST("/login", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+		mu.Lock()
+		requestLog = append(requestLog, "login")
+		mu.Unlock()
+		http.SetCookie(w, &http.Cookie{
+			Name:  "session",
+			Value: "authenticated-session-token",
+			Path:  "/",
+		})
+		_, _ = fmt.Fprint(w, "authenticated")
+	})
+
+	router.GET("/protected", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+		mu.Lock()
+		requestLog = append(requestLog, "protected")
+		mu.Unlock()
+
+		cookie, err := r.Cookie("session")
+		if err != nil || cookie.Value != "authenticated-session-token" {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = fmt.Fprint(w, "unauthorized")
+			return
+		}
+		_, _ = fmt.Fprint(w, "authenticated-data")
+	})
+
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+
+	secretFileContent := fmt.Sprintf(`id: test-auth-secret
+info:
+  name: Test Auth Secret File
+  author: pdteam
+  
+dynamic:
+  - template: protocols/http/auth-secret-file-login.yaml
+    input: %s
+    variables:
+      - key: username
+        value: testuser
+      - key: password
+        value: testpass
+    type: Cookie
+    domains:
+      - %s
+    cookies:
+      - raw: "{{session_cookie}}"
+`, ts.URL, strings.TrimPrefix(ts.URL, "http://"))
+
+	secretFile, err := os.CreateTemp("", "nuclei-secret-*.yaml")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(secretFile.Name())
+
+	if _, err := secretFile.WriteString(secretFileContent); err != nil {
+		return err
+	}
+	secretFile.Close()
+
+	results, err := testutils.RunNucleiBinaryAndGetCombinedOutput(debug, []string{
+		"-t", filePath,
+		"-u", ts.URL,
+		"-sf", secretFile.Name(),
+		"-timeout", "10",
+	})
+	if err != nil {
+		return err
+	}
+
+	if !strings.Contains(results, "auth-secret-file-test") {
+		return fmt.Errorf("expected template to match but it didn't")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(requestLog) < 2 {
+		return fmt.Errorf("expected at least 2 requests, got %d", len(requestLog))
+	}
+	if requestLog[0] != "login" {
+		return fmt.Errorf("expected first request to be login, got %s", requestLog[0])
+	}
+
+	foundProtected := false
+	for _, req := range requestLog {
+		if req == "protected" {
+			foundProtected = true
+			break
+		}
+	}
+	if !foundProtected {
+		return fmt.Errorf("protected endpoint was never called")
+	}
+
 	return nil
 }

--- a/cmd/integration-test/http.go
+++ b/cmd/integration-test/http.go
@@ -1819,12 +1819,14 @@ dynamic:
 	if err != nil {
 		return err
 	}
-	defer os.Remove(secretFile.Name())
+	defer func() { _ = os.Remove(secretFile.Name()) }()
 
 	if _, err := secretFile.WriteString(secretFileContent); err != nil {
 		return err
 	}
-	secretFile.Close()
+	if err := secretFile.Close(); err != nil {
+		return err
+	}
 
 	results, err := testutils.RunNucleiBinaryAndGetCombinedOutput(debug, []string{
 		"-t", filePath,

--- a/integration_tests/protocols/http/auth-secret-file-login.yaml
+++ b/integration_tests/protocols/http/auth-secret-file-login.yaml
@@ -1,0 +1,30 @@
+id: auth-secret-file-login
+
+info:
+  name: Test Auth Login Template
+  author: pdteam
+  severity: info
+  description: Login template for authenticated scanning test
+
+http:
+  - raw:
+      - |
+        POST /login HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+        
+        username={{username}}&password={{password}}
+
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "authenticated"
+
+    extractors:
+      - type: kval
+        part: header
+        kval:
+          - Set-Cookie
+        name: session_cookie
+        internal: true

--- a/integration_tests/protocols/http/auth-secret-file-test.yaml
+++ b/integration_tests/protocols/http/auth-secret-file-test.yaml
@@ -1,4 +1,4 @@
-id: test-auth-secret-file
+id: auth-secret-file-test
 
 info:
   name: Test Authenticated Scan Request

--- a/integration_tests/protocols/http/auth-secret-file-test.yaml
+++ b/integration_tests/protocols/http/auth-secret-file-test.yaml
@@ -1,0 +1,18 @@
+id: test-auth-secret-file
+
+info:
+  name: Test Authenticated Scan Request
+  author: pdteam
+  severity: info
+  description: Template that should use authenticated session
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/protected"
+
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "authenticated-data"

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -681,8 +681,10 @@ func (r *Runner) RunEnumeration() error {
 	// display execution info like version , templates used etc
 	r.displayExecutionInfo(store)
 
-	// prefetch secrets if enabled
-	if executorOpts.AuthProvider != nil && r.options.PreFetchSecrets {
+	// prefetch secrets when auth provider is configured
+	// this ensures that dynamic secrets (from secret-file templates) are fetched
+	// before other templates start executing, preventing unauthenticated requests
+	if executorOpts.AuthProvider != nil {
 		r.Logger.Info().Msgf("Pre-fetching secrets from authprovider[s]")
 		if err := executorOpts.AuthProvider.PreFetchSecrets(); err != nil {
 			return errors.Wrap(err, "could not pre-fetch secrets")


### PR DESCRIPTION
## Proposed changes

Fixes #6592

authenticated scanning started template execution before secret-file authentication completed, causing initial http requests to be unauthenticated.

root cause: `prefetchsecrets()` only ran with the `-ps` flag, so lazy secret fetching caused a race where requests ran before auth completed. (introduced in: #4477)

## Proof

<img width="1648" height="599" alt="image" src="https://github.com/user-attachments/assets/f4531652-cb8e-4596-a7cd-36993cd27c1a" />

<img width="1061" height="774" alt="image" src="https://github.com/user-attachments/assets/3e96127e-c4b7-43b6-8f21-4d4e37f03e40" />

<img width="1078" height="470" alt="image" src="https://github.com/user-attachments/assets/a54aa9e5-2c81-4d7d-ac4b-58e79fc74e94" />

<img width="1169" height="588" alt="image" src="https://github.com/user-attachments/assets/55184486-e590-45de-885a-6cfc2e294dbc" />

## Checklist

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

/claim #6592

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Authentication secret handling now always pre-fetches secrets when an authentication provider is configured, simplifying setup and reducing missed secret retrievals.

* **Tests**
  * Added integration test covering HTTP authentication via secret files, validating login-before-access flow, session handling, request order, and expected output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->