### PR TITLE
ci: add typos check workflow

### DIFF
--- a/.github/workflows/typos.yaml
+++ b/.github/workflows/typos.yaml
@@ -1,0 +1,15 @@
+name: Typos Check
+
+on:
+  push:
+    branches: ["dev"]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  typos:
+    name: Spell Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: crate-ci/typos@v1.43.0


### PR DESCRIPTION
## Summary
Fixes #6532 - adds automated typo checking to CI

## Changes
- Add `.github/workflows/typos.yaml` using crate-ci/typos@v1.43.0
- Runs on push to dev, all PRs, and manual dispatch

## Notes
If the action finds existing typos or false positives, I can add a `_typos.toml` config file.

/claim #6532