### PR TITLE
feat: add template profile improvements

### DIFF
--- a/cmd/integration-test/profile-loader.go
+++ b/cmd/integration-test/profile-loader.go
@@ -11,6 +11,7 @@ var profileLoaderTestcases = []TestCaseInfo{
 	{Path: "profile-loader/load-with-filename", TestCase: &profileLoaderByRelFile{}},
 	{Path: "profile-loader/load-with-id", TestCase: &profileLoaderById{}},
 	{Path: "profile-loader/basic.yml", TestCase: &customProfileLoader{}},
+	{Path: "profile-loader/extended-profile.yml", TestCase: &extendedProfileLoader{}},
 }
 
 type profileLoaderByRelFile struct{}
@@ -46,6 +47,22 @@ func (h *customProfileLoader) Execute(filepath string) error {
 	results, err := testutils.RunNucleiWithArgsAndGetResults(debug, "-tl", "-tp", filepath)
 	if err != nil {
 		return errkit.Wrap(err, "failed to load template with id")
+	}
+	if len(results) < 1 {
+		return fmt.Errorf("incorrect result: expected more results than %d, got %v", 1, len(results))
+	}
+	return nil
+}
+
+// extendedProfileLoader tests the extended profile format with metadata fields
+// The profile contains id, name, description, purpose, author, version fields
+// which should be ignored by goflags but parsed by the profile loader
+type extendedProfileLoader struct{}
+
+func (h *extendedProfileLoader) Execute(filepath string) error {
+	results, err := testutils.RunNucleiWithArgsAndGetResults(debug, "-tl", "-tp", filepath, "-v")
+	if err != nil {
+		return errkit.Wrap(err, "failed to load extended profile")
 	}
 	if len(results) < 1 {
 		return fmt.Errorf("incorrect result: expected more results than %d, got %v", 1, len(results))

--- a/cmd/integration-test/profile-loader/extended-profile.yml
+++ b/cmd/integration-test/profile-loader/extended-profile.yml
@@ -1,0 +1,18 @@
+# Extended Profile Format Test
+# This profile demonstrates the new template profile improvements:
+# - Profile metadata fields (id, name, description, purpose, author, version)
+# - Embedded secrets configuration
+
+id: extended-profile-test
+name: Extended Profile Test
+description: A test profile demonstrating the extended profile format with metadata and embedded secrets
+purpose: Integration testing for template profile improvements
+author: nuclei-team
+version: "1.0"
+profile-tags:
+  - test
+  - integration
+
+# Standard nuclei options (passed to goflags)
+tags:
+  - kev

--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/http"
 	"github.com/projectdiscovery/nuclei/v3/pkg/templates"
 	"github.com/projectdiscovery/nuclei/v3/pkg/templates/extensions"
+	"github.com/projectdiscovery/nuclei/v3/pkg/templates/profile"
 	"github.com/projectdiscovery/nuclei/v3/pkg/templates/signer"
 	templateTypes "github.com/projectdiscovery/nuclei/v3/pkg/templates/types"
 	"github.com/projectdiscovery/nuclei/v3/pkg/types"
@@ -656,8 +657,49 @@ Additional documentation is available at: https://docs.nuclei.sh/getting-started
 		if !fileutil.FileExists(templateProfile) {
 			options.Logger.Fatal().Msgf("given template profile file '%s' does not exist", templateProfile)
 		}
-		if err := flagSet.MergeConfigFile(templateProfile); err != nil {
-			options.Logger.Fatal().Msgf("Could not read template profile: %s\n", err)
+
+		// Parse profile using the new profile package to handle extended format
+		// This supports metadata fields (id, name, description, purpose, etc.) and embedded secrets
+		loadedProfile, err := profile.LoadProfile(templateProfile)
+		if err != nil {
+			options.Logger.Fatal().Msgf("Could not parse template profile: %s\n", err)
+		}
+
+		// Log profile info if available
+		if loadedProfile.Name != "" {
+			options.Logger.Info().Msgf("Using profile: %s", loadedProfile.Name)
+		}
+		if loadedProfile.Description != "" && options.Verbose {
+			options.Logger.Info().Msgf("Profile description: %s", loadedProfile.Description)
+		}
+
+		// Handle embedded secrets if present
+		if loadedProfile.HasSecrets() {
+			if err := loadedProfile.ValidateSecrets(); err != nil {
+				options.Logger.Fatal().Msgf("Invalid secrets in profile: %s\n", err)
+			}
+			// Store embedded secrets in options for later use by auth provider
+			authxData := loadedProfile.GetAuthx()
+			if authxData != nil {
+				options.EmbeddedSecrets = append(options.EmbeddedSecrets, authxData)
+			}
+			options.Logger.Info().Msgf("Loaded embedded secrets from profile")
+		}
+
+		// Write a temporary config file with only goflags-compatible fields
+		// This excludes profile metadata (id, name, etc.) and embedded secrets
+		if len(loadedProfile.RawConfig) > 0 {
+			tmpDir := os.TempDir()
+			tmpConfigPath, err := loadedProfile.WriteConfigForGoflags(tmpDir)
+			if err != nil {
+				options.Logger.Fatal().Msgf("Could not create temp profile config: %s\n", err)
+			}
+			if tmpConfigPath != "" {
+				defer os.Remove(tmpConfigPath)
+				if err := flagSet.MergeConfigFile(tmpConfigPath); err != nil {
+					options.Logger.Fatal().Msgf("Could not read template profile: %s\n", err)
+				}
+			}
 		}
 	}
 

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -14,6 +14,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/internal/pdcp"
 	"github.com/projectdiscovery/nuclei/v3/internal/server"
 	"github.com/projectdiscovery/nuclei/v3/pkg/authprovider"
+	"github.com/projectdiscovery/nuclei/v3/pkg/authprovider/authx"
 	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz/frequency"
 	"github.com/projectdiscovery/nuclei/v3/pkg/input/provider"
 	"github.com/projectdiscovery/nuclei/v3/pkg/installer"
@@ -576,7 +577,9 @@ func (r *Runner) RunEnumeration() error {
 		executorOpts.ExportReqURLPattern = true
 	}
 
-	if len(r.options.SecretsFile) > 0 && !r.options.Validate {
+	hasSecretsFile := len(r.options.SecretsFile) > 0
+	hasEmbeddedSecrets := len(r.options.EmbeddedSecrets) > 0
+	if (hasSecretsFile || hasEmbeddedSecrets) && !r.options.Validate {
 		// Clone options so GetAuthTmplStore can modify them without affecting the original
 		authOptions := r.options.Copy()
 		authTmplStore, err := GetAuthTmplStore(authOptions, r.catalog, executorOpts)
@@ -588,6 +591,12 @@ func (r *Runner) RunEnumeration() error {
 			TemplateStore: authTmplStore,
 			ExecOpts:      executorOpts,
 		})
+		// Add embedded secrets from profile files
+		for _, embedded := range r.options.EmbeddedSecrets {
+			if authxData, ok := embedded.(*authx.Authx); ok {
+				authOpts.EmbeddedSecrets = append(authOpts.EmbeddedSecrets, authxData)
+			}
+		}
 		// initialize auth provider
 		provider, err := authprovider.NewAuthProvider(authOpts)
 		if err != nil {

--- a/pkg/authprovider/embedded.go
+++ b/pkg/authprovider/embedded.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/nuclei/v3/pkg/authprovider/authx"
 	"github.com/projectdiscovery/utils/errkit"
 	urlutil "github.com/projectdiscovery/utils/url"
@@ -62,6 +63,7 @@ func (f *EmbeddedAuthProvider) init() {
 				}
 				compiled, err := regexp.Compile(domain)
 				if err != nil {
+					gologger.Warning().Msgf("failed to compile domain regex '%s': %v", domain, err)
 					continue
 				}
 
@@ -96,6 +98,7 @@ func (f *EmbeddedAuthProvider) init() {
 				}
 				compiled, err := regexp.Compile(domain)
 				if err != nil {
+					gologger.Warning().Msgf("failed to compile domain regex '%s': %v", domain, err)
 					continue
 				}
 				if ss, ok := f.compiled[compiled]; !ok {

--- a/pkg/authprovider/embedded.go
+++ b/pkg/authprovider/embedded.go
@@ -1,0 +1,192 @@
+package authprovider
+
+import (
+	"net"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/authprovider/authx"
+	"github.com/projectdiscovery/utils/errkit"
+	urlutil "github.com/projectdiscovery/utils/url"
+)
+
+// EmbeddedAuthProvider is an auth provider for embedded auth data
+// it accepts an Authx struct directly and returns its provider
+type EmbeddedAuthProvider struct {
+	store    *authx.Authx
+	compiled map[*regexp.Regexp][]authx.AuthStrategy
+	domains  map[string][]authx.AuthStrategy
+}
+
+// NewEmbeddedAuthProvider creates a new embedded auth provider from Authx data
+func NewEmbeddedAuthProvider(store *authx.Authx, callback authx.LazyFetchSecret) (AuthProvider, error) {
+	if store == nil {
+		return nil, errkit.New("store cannot be nil")
+	}
+	if len(store.Secrets) == 0 && len(store.Dynamic) == 0 {
+		return nil, ErrNoSecrets
+	}
+	if len(store.Dynamic) > 0 && callback == nil {
+		return nil, errkit.New("lazy fetch callback is required for dynamic secrets")
+	}
+	for _, secret := range store.Secrets {
+		if err := secret.Validate(); err != nil {
+			errorErr := errkit.FromError(err)
+			errorErr.Msgf("invalid embedded secret")
+			return nil, errorErr
+		}
+	}
+	for i, dynamic := range store.Dynamic {
+		if err := dynamic.Validate(); err != nil {
+			errorErr := errkit.FromError(err)
+			errorErr.Msgf("invalid embedded dynamic secret")
+			return nil, errorErr
+		}
+		dynamic.SetLazyFetchCallback(callback)
+		store.Dynamic[i] = dynamic
+	}
+	f := &EmbeddedAuthProvider{store: store}
+	f.init()
+	return f, nil
+}
+
+// init initializes the embedded auth provider
+func (f *EmbeddedAuthProvider) init() {
+	for _, _secret := range f.store.Secrets {
+		secret := _secret // allocate copy of pointer
+		if len(secret.DomainsRegex) > 0 {
+			for _, domain := range secret.DomainsRegex {
+				if f.compiled == nil {
+					f.compiled = make(map[*regexp.Regexp][]authx.AuthStrategy)
+				}
+				compiled, err := regexp.Compile(domain)
+				if err != nil {
+					continue
+				}
+
+				if ss, ok := f.compiled[compiled]; ok {
+					f.compiled[compiled] = append(ss, secret.GetStrategy())
+				} else {
+					f.compiled[compiled] = []authx.AuthStrategy{secret.GetStrategy()}
+				}
+			}
+		}
+		for _, domain := range secret.Domains {
+			if f.domains == nil {
+				f.domains = make(map[string][]authx.AuthStrategy)
+			}
+			domain = strings.TrimSpace(domain)
+			domain = strings.TrimSuffix(domain, ":80")
+			domain = strings.TrimSuffix(domain, ":443")
+			if ss, ok := f.domains[domain]; ok {
+				f.domains[domain] = append(ss, secret.GetStrategy())
+			} else {
+				f.domains[domain] = []authx.AuthStrategy{secret.GetStrategy()}
+			}
+		}
+	}
+	for _, dynamic := range f.store.Dynamic {
+		domain, domainsRegex := dynamic.GetDomainAndDomainRegex()
+
+		if len(domainsRegex) > 0 {
+			for _, domain := range domainsRegex {
+				if f.compiled == nil {
+					f.compiled = make(map[*regexp.Regexp][]authx.AuthStrategy)
+				}
+				compiled, err := regexp.Compile(domain)
+				if err != nil {
+					continue
+				}
+				if ss, ok := f.compiled[compiled]; !ok {
+					f.compiled[compiled] = []authx.AuthStrategy{&authx.DynamicAuthStrategy{Dynamic: dynamic}}
+				} else {
+					f.compiled[compiled] = append(ss, &authx.DynamicAuthStrategy{Dynamic: dynamic})
+				}
+			}
+		}
+		for _, domain := range domain {
+			if f.domains == nil {
+				f.domains = make(map[string][]authx.AuthStrategy)
+			}
+			domain = strings.TrimSpace(domain)
+			domain = strings.TrimSuffix(domain, ":80")
+			domain = strings.TrimSuffix(domain, ":443")
+
+			if ss, ok := f.domains[domain]; !ok {
+				f.domains[domain] = []authx.AuthStrategy{&authx.DynamicAuthStrategy{Dynamic: dynamic}}
+			} else {
+				f.domains[domain] = append(ss, &authx.DynamicAuthStrategy{Dynamic: dynamic})
+			}
+		}
+	}
+}
+
+// LookupAddr looks up a given domain/address and returns appropriate auth strategy
+func (f *EmbeddedAuthProvider) LookupAddr(addr string) []authx.AuthStrategy {
+	var strategies []authx.AuthStrategy
+
+	if strings.Contains(addr, ":") {
+		// default normalization for host:port
+		host, port, err := net.SplitHostPort(addr)
+		if err == nil && (port == "80" || port == "443") {
+			addr = host
+		}
+	}
+	for domain, strategy := range f.domains {
+		if strings.EqualFold(domain, addr) {
+			strategies = append(strategies, strategy...)
+		}
+	}
+	for compiled, strategy := range f.compiled {
+		if compiled.MatchString(addr) {
+			strategies = append(strategies, strategy...)
+		}
+	}
+
+	return strategies
+}
+
+// LookupURL looks up a given URL and returns appropriate auth strategy
+func (f *EmbeddedAuthProvider) LookupURL(u *url.URL) []authx.AuthStrategy {
+	return f.LookupAddr(u.Host)
+}
+
+// LookupURLX looks up a given URL and returns appropriate auth strategy
+func (f *EmbeddedAuthProvider) LookupURLX(u *urlutil.URL) []authx.AuthStrategy {
+	return f.LookupAddr(u.Host)
+}
+
+// GetTemplatePaths returns the template path for the auth provider
+func (f *EmbeddedAuthProvider) GetTemplatePaths() []string {
+	res := []string{}
+	for _, dynamic := range f.store.Dynamic {
+		if dynamic.TemplatePath != "" {
+			res = append(res, dynamic.TemplatePath)
+		}
+	}
+	return res
+}
+
+// PreFetchSecrets pre-fetches the secrets from the auth provider
+func (f *EmbeddedAuthProvider) PreFetchSecrets() error {
+	for _, ss := range f.domains {
+		for _, s := range ss {
+			if val, ok := s.(*authx.DynamicAuthStrategy); ok {
+				if err := val.Dynamic.Fetch(false); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	for _, ss := range f.compiled {
+		for _, s := range ss {
+			if val, ok := s.(*authx.DynamicAuthStrategy); ok {
+				if err := val.Dynamic.Fetch(false); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/authprovider/embedded_test.go
+++ b/pkg/authprovider/embedded_test.go
@@ -1,0 +1,126 @@
+package authprovider
+
+import (
+	"testing"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/authprovider/authx"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewEmbeddedAuthProvider(t *testing.T) {
+	store := &authx.Authx{
+		ID: "test-secrets",
+		Info: authx.AuthFileInfo{
+			Name:   "Test Secrets",
+			Author: "test",
+		},
+		Secrets: []authx.Secret{
+			{
+				Type:    "Header",
+				Domains: []string{"example.com"},
+				Headers: []authx.KV{
+					{Key: "X-API-Key", Value: "test-key"},
+				},
+			},
+		},
+	}
+
+	provider, err := NewEmbeddedAuthProvider(store, nil)
+	require.NoError(t, err)
+	require.NotNil(t, provider)
+}
+
+func TestEmbeddedAuthProviderLookupAddr(t *testing.T) {
+	store := &authx.Authx{
+		ID: "test-secrets",
+		Secrets: []authx.Secret{
+			{
+				Type:    "Header",
+				Domains: []string{"example.com", "api.example.com"},
+				Headers: []authx.KV{
+					{Key: "X-API-Key", Value: "test-key"},
+				},
+			},
+		},
+	}
+
+	provider, err := NewEmbeddedAuthProvider(store, nil)
+	require.NoError(t, err)
+
+	// Test exact domain match
+	strategies := provider.LookupAddr("example.com")
+	require.Len(t, strategies, 1)
+
+	// Test domain with port normalization
+	strategies = provider.LookupAddr("example.com:443")
+	require.Len(t, strategies, 1)
+
+	// Test non-matching domain
+	strategies = provider.LookupAddr("other.com")
+	require.Len(t, strategies, 0)
+}
+
+func TestEmbeddedAuthProviderWithRegex(t *testing.T) {
+	store := &authx.Authx{
+		ID: "test-secrets",
+		Secrets: []authx.Secret{
+			{
+				Type:         "Header",
+				DomainsRegex: []string{`.*\.example\.com`},
+				Headers: []authx.KV{
+					{Key: "X-API-Key", Value: "test-key"},
+				},
+			},
+		},
+	}
+
+	provider, err := NewEmbeddedAuthProvider(store, nil)
+	require.NoError(t, err)
+
+	// Test regex match
+	strategies := provider.LookupAddr("api.example.com")
+	require.Len(t, strategies, 1)
+
+	strategies = provider.LookupAddr("sub.example.com")
+	require.Len(t, strategies, 1)
+
+	// Test non-matching domain
+	strategies = provider.LookupAddr("example.org")
+	require.Len(t, strategies, 0)
+}
+
+func TestEmbeddedAuthProviderNoSecrets(t *testing.T) {
+	store := &authx.Authx{
+		ID: "test-secrets",
+	}
+
+	_, err := NewEmbeddedAuthProvider(store, nil)
+	require.Error(t, err)
+	require.Equal(t, ErrNoSecrets, err)
+}
+
+func TestEmbeddedAuthProviderNilStore(t *testing.T) {
+	_, err := NewEmbeddedAuthProvider(nil, nil)
+	require.Error(t, err)
+}
+
+func TestEmbeddedAuthProviderGetTemplatePaths(t *testing.T) {
+	store := &authx.Authx{
+		ID: "test-secrets",
+		Secrets: []authx.Secret{
+			{
+				Type:    "Header",
+				Domains: []string{"example.com"},
+				Headers: []authx.KV{
+					{Key: "X-API-Key", Value: "test-key"},
+				},
+			},
+		},
+	}
+
+	provider, err := NewEmbeddedAuthProvider(store, nil)
+	require.NoError(t, err)
+
+	paths := provider.GetTemplatePaths()
+	require.Empty(t, paths)
+}

--- a/pkg/authprovider/interface.go
+++ b/pkg/authprovider/interface.go
@@ -41,6 +41,8 @@ type AuthProvider interface {
 type AuthProviderOptions struct {
 	// File based auth provider options
 	SecretsFiles []string
+	// EmbeddedSecrets contains secrets embedded directly in config/profile files
+	EmbeddedSecrets []*authx.Authx
 	// LazyFetchSecret is a callback for lazy fetching of dynamic secrets
 	LazyFetchSecret authx.LazyFetchSecret
 }
@@ -50,6 +52,14 @@ func NewAuthProvider(options *AuthProviderOptions) (AuthProvider, error) {
 	var providers []AuthProvider
 	for _, file := range options.SecretsFiles {
 		provider, err := NewFileAuthProvider(file, options.LazyFetchSecret)
+		if err != nil {
+			return nil, err
+		}
+		providers = append(providers, provider)
+	}
+	// Add providers for embedded secrets
+	for _, embedded := range options.EmbeddedSecrets {
+		provider, err := NewEmbeddedAuthProvider(embedded, options.LazyFetchSecret)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/templates/profile/profile.go
+++ b/pkg/templates/profile/profile.go
@@ -64,10 +64,19 @@ func (p *Profile) HasSecrets() bool {
 }
 
 // GetAuthx returns the embedded secrets as an Authx struct
+// Creates defensive copies of slices to prevent unexpected mutations
 func (p *Profile) GetAuthx() *authx.Authx {
 	if !p.HasSecrets() {
 		return nil
 	}
+
+	// Create defensive copies of slices to prevent mutations
+	staticCopy := make([]authx.Secret, len(p.Secrets.Static))
+	copy(staticCopy, p.Secrets.Static)
+
+	dynamicCopy := make([]authx.Dynamic, len(p.Secrets.Dynamic))
+	copy(dynamicCopy, p.Secrets.Dynamic)
+
 	return &authx.Authx{
 		ID: p.ID,
 		Info: authx.AuthFileInfo{
@@ -75,8 +84,8 @@ func (p *Profile) GetAuthx() *authx.Authx {
 			Description: p.Description,
 			Author:      p.Author,
 		},
-		Secrets: p.Secrets.Static,
-		Dynamic: p.Secrets.Dynamic,
+		Secrets: staticCopy,
+		Dynamic: dynamicCopy,
 	}
 }
 

--- a/pkg/templates/profile/profile.go
+++ b/pkg/templates/profile/profile.go
@@ -1,0 +1,173 @@
+package profile
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/authprovider/authx"
+	"github.com/projectdiscovery/utils/errkit"
+	"github.com/projectdiscovery/utils/generic"
+	"gopkg.in/yaml.v3"
+)
+
+// Profile represents a nuclei template profile configuration
+// It extends the standard config format with metadata and embedded secrets
+type Profile struct {
+	// Profile metadata fields (ignored by goflags but useful for documentation)
+	ID          string         `yaml:"id,omitempty" json:"id,omitempty"`
+	Name        string         `yaml:"name,omitempty" json:"name,omitempty"`
+	Description string         `yaml:"description,omitempty" json:"description,omitempty"`
+	Purpose     string         `yaml:"purpose,omitempty" json:"purpose,omitempty"`
+	Author      string         `yaml:"author,omitempty" json:"author,omitempty"`
+	Version     string         `yaml:"version,omitempty" json:"version,omitempty"`
+	Tags        []string       `yaml:"profile-tags,omitempty" json:"profile-tags,omitempty"`
+	Secrets     *SecretsConfig `yaml:"secrets,omitempty" json:"secrets,omitempty"`
+
+	// RawConfig holds all other fields that are passed to goflags
+	RawConfig map[string]interface{} `yaml:"-" json:"-"`
+}
+
+// SecretsConfig holds embedded secrets configuration
+type SecretsConfig struct {
+	Static  []authx.Secret  `yaml:"static,omitempty" json:"static,omitempty"`
+	Dynamic []authx.Dynamic `yaml:"dynamic,omitempty" json:"dynamic,omitempty"`
+}
+
+// Info returns the profile information
+type Info struct {
+	ID          string
+	Name        string
+	Description string
+	Purpose     string
+	Author      string
+	Version     string
+	Tags        []string
+}
+
+// GetInfo returns the profile metadata info
+func (p *Profile) GetInfo() Info {
+	return Info{
+		ID:          p.ID,
+		Name:        p.Name,
+		Description: p.Description,
+		Purpose:     p.Purpose,
+		Author:      p.Author,
+		Version:     p.Version,
+		Tags:        p.Tags,
+	}
+}
+
+// HasSecrets returns true if the profile has embedded secrets
+func (p *Profile) HasSecrets() bool {
+	return p.Secrets != nil && (len(p.Secrets.Static) > 0 || len(p.Secrets.Dynamic) > 0)
+}
+
+// GetAuthx returns the embedded secrets as an Authx struct
+func (p *Profile) GetAuthx() *authx.Authx {
+	if !p.HasSecrets() {
+		return nil
+	}
+	return &authx.Authx{
+		ID: p.ID,
+		Info: authx.AuthFileInfo{
+			Name:        p.Name,
+			Description: p.Description,
+			Author:      p.Author,
+		},
+		Secrets: p.Secrets.Static,
+		Dynamic: p.Secrets.Dynamic,
+	}
+}
+
+// LoadProfile loads a profile from a file
+func LoadProfile(filePath string) (*Profile, error) {
+	ext := filepath.Ext(filePath)
+	if !generic.EqualsAny(ext, ".yml", ".yaml") {
+		return nil, errkit.New("invalid file extension: supported extensions are .yml and .yaml got %s", ext)
+	}
+
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, errkit.Wrap(err, "failed to read profile file")
+	}
+
+	return ParseProfile(data)
+}
+
+// ParseProfile parses profile data from bytes
+func ParseProfile(data []byte) (*Profile, error) {
+	var profile Profile
+
+	// First parse all fields into a map to preserve unknown fields for goflags
+	var rawData map[string]interface{}
+	if err := yaml.Unmarshal(data, &rawData); err != nil {
+		return nil, errkit.Wrap(err, "failed to parse profile yaml")
+	}
+
+	// Parse the known profile fields
+	if err := yaml.Unmarshal(data, &profile); err != nil {
+		return nil, errkit.Wrap(err, "failed to parse profile")
+	}
+
+	// Store raw config for passing to goflags (excludes profile-specific fields)
+	profile.RawConfig = make(map[string]interface{})
+	excludedKeys := map[string]bool{
+		"id": true, "name": true, "description": true, "purpose": true,
+		"author": true, "version": true, "profile-tags": true, "secrets": true,
+	}
+
+	for key, value := range rawData {
+		if !excludedKeys[key] {
+			profile.RawConfig[key] = value
+		}
+	}
+
+	return &profile, nil
+}
+
+// WriteConfigForGoflags writes a temporary config file containing only
+// the goflags-compatible fields (excludes profile metadata and secrets)
+func (p *Profile) WriteConfigForGoflags(tmpDir string) (string, error) {
+	if len(p.RawConfig) == 0 {
+		return "", nil
+	}
+
+	data, err := yaml.Marshal(p.RawConfig)
+	if err != nil {
+		return "", errkit.Wrap(err, "failed to marshal profile config")
+	}
+
+	tmpFile, err := os.CreateTemp(tmpDir, "nuclei-profile-*.yaml")
+	if err != nil {
+		return "", errkit.Wrap(err, "failed to create temp profile file")
+	}
+	defer tmpFile.Close()
+
+	if _, err := tmpFile.Write(data); err != nil {
+		return "", errkit.Wrap(err, "failed to write temp profile file")
+	}
+
+	return tmpFile.Name(), nil
+}
+
+// ValidateSecrets validates the embedded secrets configuration
+func (p *Profile) ValidateSecrets() error {
+	if !p.HasSecrets() {
+		return nil
+	}
+
+	for i, secret := range p.Secrets.Static {
+		if err := secret.Validate(); err != nil {
+			return errkit.Wrap(err, fmt.Sprintf("invalid static secret at index %d", i))
+		}
+	}
+
+	for i, dynamic := range p.Secrets.Dynamic {
+		if err := dynamic.Validate(); err != nil {
+			return errkit.Wrap(err, fmt.Sprintf("invalid dynamic secret at index %d", i))
+		}
+	}
+
+	return nil
+}

--- a/pkg/templates/profile/profile_test.go
+++ b/pkg/templates/profile/profile_test.go
@@ -1,0 +1,274 @@
+package profile
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseProfile(t *testing.T) {
+	tests := []struct {
+		name        string
+		content     string
+		wantID      string
+		wantName    string
+		wantDesc    string
+		wantPurpose string
+		wantAuthor  string
+		wantTags    int
+		wantRawKeys []string
+		wantErr     bool
+	}{
+		{
+			name: "basic profile with metadata",
+			content: `id: test-profile
+name: Test Profile
+description: A test profile
+purpose: Testing
+author: test-author
+version: "1.0"
+tags:
+  - kev
+  - cve`,
+			wantID:      "test-profile",
+			wantName:    "Test Profile",
+			wantDesc:    "A test profile",
+			wantPurpose: "Testing",
+			wantAuthor:  "test-author",
+			wantRawKeys: []string{"tags"},
+			wantErr:     false,
+		},
+		{
+			name: "profile without metadata",
+			content: `tags:
+  - kev
+severity:
+  - critical`,
+			wantRawKeys: []string{"tags", "severity"},
+			wantErr:     false,
+		},
+		{
+			name: "profile with profile-tags",
+			content: `id: test-profile
+profile-tags:
+  - internal
+  - test
+tags:
+  - kev`,
+			wantID:      "test-profile",
+			wantTags:    2,
+			wantRawKeys: []string{"tags"},
+			wantErr:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			profile, err := ParseProfile([]byte(tt.content))
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, profile)
+
+			if tt.wantID != "" {
+				require.Equal(t, tt.wantID, profile.ID)
+			}
+			if tt.wantName != "" {
+				require.Equal(t, tt.wantName, profile.Name)
+			}
+			if tt.wantDesc != "" {
+				require.Equal(t, tt.wantDesc, profile.Description)
+			}
+			if tt.wantPurpose != "" {
+				require.Equal(t, tt.wantPurpose, profile.Purpose)
+			}
+			if tt.wantAuthor != "" {
+				require.Equal(t, tt.wantAuthor, profile.Author)
+			}
+			if tt.wantTags > 0 {
+				require.Len(t, profile.Tags, tt.wantTags)
+			}
+
+			for _, key := range tt.wantRawKeys {
+				_, ok := profile.RawConfig[key]
+				require.True(t, ok, "expected key %s in RawConfig", key)
+			}
+		})
+	}
+}
+
+func TestProfileWithEmbeddedSecrets(t *testing.T) {
+	content := `id: test-profile
+name: Test Profile with Secrets
+description: A test profile with embedded secrets
+secrets:
+  static:
+    - type: Header
+      domains:
+        - example.com
+      headers:
+        - key: X-API-Key
+          value: test-api-key
+    - type: BasicAuth
+      domains:
+        - api.example.com
+      username: admin
+      password: password123
+tags:
+  - kev`
+
+	profile, err := ParseProfile([]byte(content))
+	require.NoError(t, err)
+	require.NotNil(t, profile)
+
+	require.True(t, profile.HasSecrets())
+	require.NotNil(t, profile.Secrets)
+	require.Len(t, profile.Secrets.Static, 2)
+
+	// Verify first secret (Header auth)
+	require.Equal(t, "Header", profile.Secrets.Static[0].Type)
+	require.Equal(t, []string{"example.com"}, profile.Secrets.Static[0].Domains)
+	require.Len(t, profile.Secrets.Static[0].Headers, 1)
+	require.Equal(t, "X-API-Key", profile.Secrets.Static[0].Headers[0].Key)
+
+	// Verify second secret (BasicAuth)
+	require.Equal(t, "BasicAuth", profile.Secrets.Static[1].Type)
+	require.Equal(t, "admin", profile.Secrets.Static[1].Username)
+
+	// Verify GetAuthx
+	authx := profile.GetAuthx()
+	require.NotNil(t, authx)
+	require.Equal(t, "test-profile", authx.ID)
+	require.Len(t, authx.Secrets, 2)
+}
+
+func TestProfileWithoutSecrets(t *testing.T) {
+	content := `id: test-profile
+name: Test Profile
+tags:
+  - kev`
+
+	profile, err := ParseProfile([]byte(content))
+	require.NoError(t, err)
+	require.NotNil(t, profile)
+
+	require.False(t, profile.HasSecrets())
+	require.Nil(t, profile.GetAuthx())
+}
+
+func TestProfileGetInfo(t *testing.T) {
+	content := `id: test-profile
+name: Test Profile
+description: A test description
+purpose: Testing
+author: test-author
+version: "1.0"
+profile-tags:
+  - tag1
+  - tag2`
+
+	profile, err := ParseProfile([]byte(content))
+	require.NoError(t, err)
+
+	info := profile.GetInfo()
+	require.Equal(t, "test-profile", info.ID)
+	require.Equal(t, "Test Profile", info.Name)
+	require.Equal(t, "A test description", info.Description)
+	require.Equal(t, "Testing", info.Purpose)
+	require.Equal(t, "test-author", info.Author)
+	require.Equal(t, "1.0", info.Version)
+	require.Len(t, info.Tags, 2)
+}
+
+func TestWriteConfigForGoflags(t *testing.T) {
+	content := `id: test-profile
+name: Test Profile
+description: A test description
+tags:
+  - kev
+concurrency: 10`
+
+	profile, err := ParseProfile([]byte(content))
+	require.NoError(t, err)
+
+	tmpDir := t.TempDir()
+	configPath, err := profile.WriteConfigForGoflags(tmpDir)
+	require.NoError(t, err)
+	require.NotEmpty(t, configPath)
+
+	// Verify file was created and contains only goflags-compatible fields
+	data, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+
+	dataStr := string(data)
+	require.Contains(t, dataStr, "tags")
+	require.Contains(t, dataStr, "concurrency")
+	require.NotContains(t, dataStr, "id:")
+	require.NotContains(t, dataStr, "name:")
+	require.NotContains(t, dataStr, "description:")
+
+	// Clean up
+	os.Remove(configPath)
+}
+
+func TestLoadProfileFromFile(t *testing.T) {
+	content := `id: test-profile
+name: Test Profile
+tags:
+  - kev`
+
+	tmpDir := t.TempDir()
+	profilePath := filepath.Join(tmpDir, "test-profile.yaml")
+	err := os.WriteFile(profilePath, []byte(content), 0644)
+	require.NoError(t, err)
+
+	profile, err := LoadProfile(profilePath)
+	require.NoError(t, err)
+	require.NotNil(t, profile)
+	require.Equal(t, "test-profile", profile.ID)
+}
+
+func TestLoadProfileInvalidExtension(t *testing.T) {
+	tmpDir := t.TempDir()
+	profilePath := filepath.Join(tmpDir, "test-profile.json")
+	err := os.WriteFile(profilePath, []byte(`{"id": "test"}`), 0644)
+	require.NoError(t, err)
+
+	_, err = LoadProfile(profilePath)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid file extension")
+}
+
+func TestValidateSecrets(t *testing.T) {
+	// Valid secrets
+	validContent := `id: test
+secrets:
+  static:
+    - type: Header
+      domains:
+        - example.com
+      headers:
+        - key: X-API-Key
+          value: test`
+
+	profile, err := ParseProfile([]byte(validContent))
+	require.NoError(t, err)
+	require.NoError(t, profile.ValidateSecrets())
+
+	// Invalid secrets (missing domains)
+	invalidContent := `id: test
+secrets:
+  static:
+    - type: Header
+      headers:
+        - key: X-API-Key
+          value: test`
+
+	profile, err = ParseProfile([]byte(invalidContent))
+	require.NoError(t, err)
+	require.Error(t, profile.ValidateSecrets())
+}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -420,6 +420,8 @@ type Options struct {
 	JsConcurrency int
 	// SecretsFile is file containing secrets for nuclei
 	SecretsFile goflags.StringSlice
+	// EmbeddedSecrets contains secrets embedded directly in profile files
+	EmbeddedSecrets []interface{}
 	// PreFetchSecrets pre-fetches the secrets from the auth provider
 	PreFetchSecrets bool
 	// FormatUseRequiredOnly only uses required fields when generating requests
@@ -665,6 +667,7 @@ func (options *Options) Copy() *Options {
 		TeamID:                         options.TeamID,
 		JsConcurrency:                  options.JsConcurrency,
 		SecretsFile:                    options.SecretsFile,
+		EmbeddedSecrets:                options.EmbeddedSecrets,
 		PreFetchSecrets:                options.PreFetchSecrets,
 		FormatUseRequiredOnly:          options.FormatUseRequiredOnly,
 		SkipFormatValidation:           options.SkipFormatValidation,


### PR DESCRIPTION
## Proposed changes

This PR implements the **Template Profile Improvements** feature that allows users to maintain a single, comprehensive config file for nuclei scans.

### Features Implemented:

**1. Profile Metadata Fields**
- Added support for metadata fields: `id`, `name`, `description`, `purpose`, `author`, `version`, `profile-tags`
- These fields are parsed and displayed but not passed to goflags (won't cause errors)
- Profile name and description are shown during scan startup

**2. Embedded Secrets Configuration**
- Added `secrets` key support directly in profile files
- Supports both `static` and `dynamic` secrets:
  - Static: Header, BasicAuth, Cookie, BearerToken, Query authentication
  - Dynamic: Template-based secret fetching with variables
- Secrets are automatically loaded and used by the auth provider

### Example Profile Format:
```yaml
name: projectdiscovery-scan
purpose: Config File for Scanning
description: single config file for scanning specific targets

type:
  - http
  - dns
  - ssl

exclude-tags:
  - dos
  - fuzz

concurrency: 5
timeout: 30

secrets:
  static:
    - type: Header
      domains:
        - api.projectdiscovery.io
      headers:
        - key: x-pdcp-key
          value: <api-key-here>
  dynamic:
    - template: custom-oauth-flow.yaml
      variables:
        - key: username
          value: pdteam
      type: Cookie
      domains:
        - api.projectdiscovery.io
```
<img width="1894" height="1079" alt="image" src="https://github.com/user-attachments/assets/8ae6ff78-2333-4f2e-897e-c4f1a3796cbd" />

### Proof

**1. Profile with metadata fields:**
<img width="1917" height="870" alt="Screenshot From 2026-02-04 19-34-05" src="https://github.com/user-attachments/assets/bc9dae9f-6037-408f-a9fc-04910080e240" />


**2. Profile with embedded secrets:**
<img width="1920" height="620" alt="image" src="https://github.com/user-attachments/assets/fce251cf-45db-4eaf-94bb-94a1b474d971" />



**3. Unit tests passing:**
<img width="1771" height="556" alt="image" src="https://github.com/user-attachments/assets/5387f1d6-4796-47ed-bca1-02b3d78583a6" />

<img width="1745" height="656" alt="image" src="https://github.com/user-attachments/assets/f6d16669-c88d-4ba6-8970-f68f0b3376c4" />


## Checklist

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)


Fixes #5567

/claim #5567



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for extended profile configurations with metadata (ID, name, description, purpose, author, version, tags).
  * Ability to embed authentication secrets inside profiles and use them during authentication setup, including prefetch and templated secret support.
  * Profiles can expose auxiliary config for integration with existing flag/config flows; verbose profile info logging added.

* **Tests**
  * Added comprehensive tests for profile parsing, validation, and embedded authentication provider behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->