### PR TITLE
fix(fuzz): data race in evaluateVarsWithInteractsh

### DIFF
--- a/pkg/fuzz/execute.go
+++ b/pkg/fuzz/execute.go
@@ -3,6 +3,7 @@ package fuzz
 import (
 	"fmt"
 	"io"
+	"maps"
 	"regexp"
 	"strings"
 
@@ -222,6 +223,8 @@ func (rule *Rule) evaluateVars(input string) (string, error) {
 func (rule *Rule) evaluateVarsWithInteractsh(data map[string]interface{}, interactshUrls []string) (map[string]interface{}, []string) {
 	// Check if Interactsh options are configured
 	if rule.options.Interactsh != nil {
+		data = maps.Clone(data)
+
 		interactshUrlsMap := make(map[string]struct{})
 		for _, url := range interactshUrls {
 			interactshUrlsMap[url] = struct{}{}

--- a/pkg/fuzz/execute_race_test.go
+++ b/pkg/fuzz/execute_race_test.go
@@ -1,0 +1,32 @@
+package fuzz
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/interactsh"
+)
+
+func TestEvaluateVarsWithInteractsh_RaceCondition(t *testing.T) {
+	rule := &Rule{}
+	rule.options = &protocols.ExecutorOptions{
+		Interactsh: &interactsh.Client{},
+	}
+
+	sharedData := map[string]interface{}{
+		"var1": "value1",
+		"var2": "{{var1}}_suffix",
+		"var3": "prefix_{{var1}}",
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			rule.evaluateVarsWithInteractsh(sharedData, nil)
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
## Summary

Clone the `data` map before modification in `evaluateVarsWithInteractsh` to prevent race conditions when multiple goroutines call this function concurrently with a shared map.

Closes #6827

## Changes

- Added `maps.Clone(data)` at the beginning of the interactsh processing block
- Added a test case that reproduces the race condition (passes with `-race` flag after fix)

## Before

```
$ go test -race -run TestEvaluateVarsWithInteractsh_RaceCondition ./pkg/fuzz/
WARNING: DATA RACE
Write at 0x00c0006380f0 by goroutine 24:
  github.com/projectdiscovery/nuclei/v3/pkg/fuzz.(*Rule).evaluateVarsWithInteractsh()
      pkg/fuzz/execute.go:252 +0x5d0
...
```

## After

```
$ go test -race -run TestEvaluateVarsWithInteractsh_RaceCondition -count=5 ./pkg/fuzz/
PASS
ok  github.com/projectdiscovery/nuclei/v3/pkg/fuzz  2.421s
```

## Testing

- [x] `go test -race ./pkg/fuzz/...` passes
- [x] `make vet` passes
- [x] `make build` succeeds


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced data integrity and system reliability by preventing unintended modifications to input data during variable evaluation operations, significantly reducing potential side effects on the caller's data and operations

* **Tests**
  * Added comprehensive race condition testing to thoroughly validate and ensure that variable evaluation with Interactsh integration operates safely, correctly, and reliably under concurrent access scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->