### PR TITLE
ci: integrate typos spell checker into CI

### DIFF
--- a/.github/workflows/typos.yaml
+++ b/.github/workflows/typos.yaml
@@ -1,0 +1,20 @@
+name: 📝 Typos
+
+on:
+  push:
+    branches: ["dev"]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  typos:
+    name: "Check Typos"
+    if: ${{ !endsWith(github.actor, '[bot]') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: crate-ci/typos@master

--- a/_typos.toml
+++ b/_typos.toml
@@ -53,8 +53,7 @@ JSONL = "JSONL"
 extend-exclude = [
     "README_*.md",
     "doc/CHANGELOG.md",
-    "README.md",
     "**/testdata/**",
     "**/*.json",
-    "pkg/model/worflow_loader.go",  # Existing filename typo
+    "pkg/model/worflow_loader.go",  # Existing filename typo - tracked in separate issue
 ]

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,60 @@
+# Configuration for typos spell checker
+# https://github.com/crate-ci/typos
+
+[default.extend-words]
+# Existing typos that would require code changes to fix (tracked separately)
+# Constants and identifiers
+Exluded = "Exluded"
+AllowdTypes = "AllowdTypes"
+Allowd = "Allowd"
+Splitted = "Splitted"
+splitted = "splitted"
+Formated = "Formated"
+formated = "formated"
+Reuests = "Reuests"
+
+# CLI abbreviations used as flags
+ot = "ot"
+ue = "ue"
+hae = "hae"
+ine = "ine"
+ines = "ines"
+
+# Test identifiers/placeholders
+BA = "BA"
+Iy = "Iy"
+Fo = "Fo"
+Noo = "Noo"
+Iif = "Iif"
+
+# Words from test data or yaml templates
+fiter = "fiter"
+seperate = "seperate"
+noticable = "noticable"
+pannel = "pannel"
+thant = "thant"
+algoritmos = "algoritmos"
+ser = "ser"
+
+# Additional words from test data and regex patterns
+alo = "alo"
+nd = "nd"
+IST = "IST"
+Mis = "Mis"
+aas = "aas"
+ded = "ded"
+Nin = "Nin"
+
+[default.extend-identifiers]
+JSONL = "JSONL"
+
+[files]
+# Exclude non-English README files, changelog, test data, and specific files
+extend-exclude = [
+    "README_*.md",
+    "doc/CHANGELOG.md",
+    "README.md",
+    "**/testdata/**",
+    "**/*.json",
+    "pkg/model/worflow_loader.go",  # Existing filename typo
+]


### PR DESCRIPTION
## Proposed Changes

Integrates the [typos](https://github.com/crate-ci/typos) spell checker into the CI pipeline to automatically catch typos in future PRs.

/claim #6532

### Changes
- **`.github/workflows/typos.yaml`**: GitHub Actions workflow that runs on push to dev, pull requests, and manual dispatch
- **`_typos.toml`**: Configuration file with baseline exceptions for existing typos and false positives

### Configuration Highlights
The typos config excludes:
- Non-English README files (`README_*.md`)  
- Changelog (`doc/CHANGELOG.md`)
- Test data and JSON files
- CLI flag abbreviations (`ot`, `ue`, `hae`, etc.)
- External library types (`AllowdTypes` from goflags)
- Existing typos tracked for follow-up fixes

## Proof

```bash
$ typos --format brief
# No output - all checks pass
$ echo $?
0
```

The workflow matches the existing CI patterns (concurrency groups, bot actor exclusion, actions/checkout@v6).

## Checklist

- [x] PR created against `dev` branch
- [x] Tests pass locally (typos check returns 0)
- [x] Configuration allows CI to pass on current codebase
- [x] Documentation: config file is self-documenting with comments

## Note

Existing typos in the codebase are baselined in the config to avoid blocking this integration. These can be addressed in follow-up PRs:
- `Exluded` → `Excluded` (constant rename)
- `seperate` → `separate`
- `formated` → `formatted`
- etc.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated spell-check configuration to add curated typo-to-correct mappings for domain-specific terms and test placeholders, extend identifier handling for acronyms and formats, and introduce targeted file-pattern exclusions to reduce false positives and improve validation accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->