### PR TITLE
fix: auth scanning race condition when using -secret-file (#6592)

### DIFF
--- a/pkg/authprovider/authx/dynamic.go
+++ b/pkg/authprovider/authx/dynamic.go
@@ -3,7 +3,7 @@ package authx
 import (
 	"fmt"
 	"strings"
-	"sync/atomic"
+	"sync"
 
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/replacer"
@@ -30,8 +30,7 @@ type Dynamic struct {
 	Input         string                 `json:"input" yaml:"input"` // (optional) target for the dynamic secret
 	Extracted     map[string]interface{} `json:"-" yaml:"-"`         // extracted values from the dynamic secret
 	fetchCallback LazyFetchSecret        `json:"-" yaml:"-"`
-	fetched       *atomic.Bool           `json:"-" yaml:"-"` // atomic flag to check if the secret has been fetched
-	fetching      *atomic.Bool           `json:"-" yaml:"-"` // atomic flag to prevent recursive fetch calls
+	fetchOnce     sync.Once              `json:"-" yaml:"-"` // ensures fetch runs exactly once and blocks concurrent callers
 	error         error                  `json:"-" yaml:"-"` // error if any
 }
 
@@ -70,8 +69,7 @@ func (d *Dynamic) UnmarshalJSON(data []byte) error {
 
 // Validate validates the dynamic secret
 func (d *Dynamic) Validate() error {
-	d.fetched = &atomic.Bool{}
-	d.fetching = &atomic.Bool{}
+	// fetchOnce is a zero-value sync.Once, no initialization needed
 	if d.TemplatePath == "" {
 		return errkit.New(" template-path is required for dynamic secret")
 	}
@@ -181,16 +179,11 @@ func (d *Dynamic) applyValuesToSecret(secret *Secret) error {
 	return nil
 }
 
-// GetStrategy returns the auth strategies for the dynamic secret
+// GetStrategies returns the auth strategies for the dynamic secret
 func (d *Dynamic) GetStrategies() []AuthStrategy {
-	if d.fetched.Load() {
-		if d.error != nil {
-			return nil
-		}
-	} else {
-		// Try to fetch if not already fetched
-		_ = d.Fetch(true)
-	}
+	// Ensure fetch is complete before returning strategies
+	// sync.Once guarantees all callers wait for the first fetch to complete
+	_ = d.Fetch(true)
 
 	if d.error != nil {
 		return nil
@@ -207,23 +200,19 @@ func (d *Dynamic) GetStrategies() []AuthStrategy {
 
 // Fetch fetches the dynamic secret
 // if isFatal is true, it will stop the execution if the secret could not be fetched
+// sync.Once ensures:
+// 1. The fetch callback runs exactly once
+// 2. All concurrent callers block until the first fetch completes
+// 3. All callers get the same result after fetch
 func (d *Dynamic) Fetch(isFatal bool) error {
-	if d.fetched.Load() {
-		return d.error
-	}
-
-	// Try to set fetching flag atomically
-	if !d.fetching.CompareAndSwap(false, true) {
-		// Already fetching, return current error
-		return d.error
-	}
-
-	// We're the only one fetching, call the callback
-	d.error = d.fetchCallback(d)
-
-	// Mark as fetched and clear fetching flag
-	d.fetched.Store(true)
-	d.fetching.Store(false)
+	d.fetchOnce.Do(func() {
+		// Guard against nil callback to prevent panic
+		if d.fetchCallback == nil {
+			d.error = fmt.Errorf("fetch callback not set for dynamic secret")
+			return
+		}
+		d.error = d.fetchCallback(d)
+	})
 
 	if d.error != nil && isFatal {
 		gologger.Fatal().Msgf("Could not fetch dynamic secret: %s\n", d.error)

--- a/pkg/authprovider/authx/dynamic_test.go
+++ b/pkg/authprovider/authx/dynamic_test.go
@@ -1,7 +1,10 @@
 package authx
 
 import (
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -121,5 +124,160 @@ func TestDynamicUnmarshalJSON(t *testing.T) {
 		var d Dynamic
 		err := d.UnmarshalJSON(data)
 		require.NoError(t, err)
+	})
+}
+
+// TestConcurrentFetch tests that concurrent Fetch calls properly wait for the
+// first fetch to complete and all receive the same result. This test verifies
+// the fix for issue #6592 where templates started executing before authentication
+// completed due to a race condition with atomic bool flags.
+func TestConcurrentFetch(t *testing.T) {
+	t.Run("concurrent-fetch-waits-for-completion", func(t *testing.T) {
+		var callCount atomic.Int32
+
+		d := &Dynamic{
+			TemplatePath: "test.yaml",
+			Variables:    []KV{{Key: "test", Value: "value"}},
+			Extracted:    make(map[string]interface{}),
+		}
+
+		// Set up a callback that simulates network delay
+		d.SetLazyFetchCallback(func(d *Dynamic) error {
+			callCount.Add(1)
+			// Simulate authentication network delay
+			time.Sleep(100 * time.Millisecond)
+			d.Extracted["token"] = "test-token"
+			return nil
+		})
+
+		const numGoroutines = 10
+		var wg sync.WaitGroup
+		wg.Add(numGoroutines)
+
+		// Use a barrier to ensure all goroutines start at approximately the same time
+		barrier := make(chan struct{})
+
+		errors := make([]error, numGoroutines)
+
+		for i := 0; i < numGoroutines; i++ {
+			go func(idx int) {
+				defer wg.Done()
+				<-barrier // Wait for barrier
+				errors[idx] = d.Fetch(false)
+			}(i)
+		}
+
+		// Release all goroutines at once
+		close(barrier)
+
+		// Wait for all goroutines to complete
+		wg.Wait()
+
+		// Verify callback was called exactly once
+		require.Equal(t, int32(1), callCount.Load(), "fetch callback should be called exactly once")
+
+		// Verify all goroutines got no error
+		for i, err := range errors {
+			require.NoError(t, err, "goroutine %d should not have error", i)
+		}
+
+		// Verify extracted values are available
+		require.Equal(t, "test-token", d.Extracted["token"])
+	})
+
+	t.Run("concurrent-get-strategies-waits-for-fetch", func(t *testing.T) {
+		var callCount atomic.Int32
+
+		d := &Dynamic{
+			Secret: &Secret{
+				Type:     "BasicAuth",
+				Domains:  []string{"example.com"},
+				Username: "{{username}}",
+				Password: "{{password}}",
+			},
+			TemplatePath: "test.yaml",
+			Variables:    []KV{{Key: "test", Value: "value"}},
+			Extracted:    make(map[string]interface{}),
+		}
+
+		d.SetLazyFetchCallback(func(d *Dynamic) error {
+			callCount.Add(1)
+			// Simulate authentication network delay
+			time.Sleep(100 * time.Millisecond)
+			d.Extracted["username"] = "testuser"
+			d.Extracted["password"] = "testpass"
+			return nil
+		})
+
+		const numGoroutines = 10
+		var wg sync.WaitGroup
+		wg.Add(numGoroutines)
+
+		barrier := make(chan struct{})
+		strategies := make([][]AuthStrategy, numGoroutines)
+
+		for i := 0; i < numGoroutines; i++ {
+			go func(idx int) {
+				defer wg.Done()
+				<-barrier
+				strategies[idx] = d.GetStrategies()
+			}(i)
+		}
+
+		close(barrier)
+		wg.Wait()
+
+		// Verify callback was called exactly once
+		require.Equal(t, int32(1), callCount.Load(), "fetch callback should be called exactly once")
+
+		// Verify all goroutines got valid strategies
+		for i, s := range strategies {
+			require.NotNil(t, s, "goroutine %d should have strategies", i)
+			require.Len(t, s, 1, "goroutine %d should have 1 strategy", i)
+		}
+
+		// Verify the secret was properly populated
+		require.Equal(t, "testuser", d.Secret.Username)
+		require.Equal(t, "testpass", d.Secret.Password)
+	})
+
+	t.Run("fetch-with-nil-callback-returns-error", func(t *testing.T) {
+		d := &Dynamic{
+			TemplatePath: "test.yaml",
+			Variables:    []KV{{Key: "test", Value: "value"}},
+		}
+		// Don't set callback
+
+		err := d.Fetch(false)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "fetch callback not set")
+	})
+
+	t.Run("fetch-error-is-cached", func(t *testing.T) {
+		var callCount atomic.Int32
+
+		d := &Dynamic{
+			TemplatePath: "test.yaml",
+			Variables:    []KV{{Key: "test", Value: "value"}},
+			Extracted:    make(map[string]interface{}),
+		}
+
+		d.SetLazyFetchCallback(func(d *Dynamic) error {
+			callCount.Add(1)
+			// Return empty extracted to trigger error
+			return nil // This will cause "no extracted values found" error
+		})
+
+		// First call should get error
+		err1 := d.Fetch(false)
+		require.Error(t, err1)
+
+		// Second call should return same cached error without calling callback again
+		err2 := d.Fetch(false)
+		require.Error(t, err2)
+		require.Equal(t, err1, err2)
+
+		// Callback should only be called once
+		require.Equal(t, int32(1), callCount.Load())
 	})
 }

--- a/pkg/authprovider/authx/file.go
+++ b/pkg/authprovider/authx/file.go
@@ -227,6 +227,9 @@ func GetTemplatePathsFromSecretFile(file string) ([]string, error) {
 	}
 	var paths []string
 	for _, dynamic := range auth.Dynamic {
+		if dynamic == nil {
+			continue
+		}
 		paths = append(paths, dynamic.TemplatePath)
 	}
 	return paths, nil

--- a/pkg/authprovider/authx/file.go
+++ b/pkg/authprovider/authx/file.go
@@ -40,7 +40,7 @@ type Authx struct {
 	ID      string       `json:"id" yaml:"id"`
 	Info    AuthFileInfo `json:"info" yaml:"info"`
 	Secrets []Secret     `json:"static" yaml:"static"`
-	Dynamic []Dynamic    `json:"dynamic" yaml:"dynamic"`
+	Dynamic []*Dynamic    `json:"dynamic" yaml:"dynamic"`
 }
 
 type AuthFileInfo struct {

--- a/pkg/authprovider/authx/strategy.go
+++ b/pkg/authprovider/authx/strategy.go
@@ -19,7 +19,7 @@ type AuthStrategy interface {
 // it implements the AuthStrategy interface
 type DynamicAuthStrategy struct {
 	// Dynamic is the dynamic secret to use
-	Dynamic Dynamic
+	Dynamic *Dynamic
 }
 
 // Apply applies the strategy to the request

--- a/pkg/authprovider/authx/strategy.go
+++ b/pkg/authprovider/authx/strategy.go
@@ -39,7 +39,13 @@ func (d *DynamicAuthStrategy) Apply(req *http.Request) {
 // ApplyOnRR applies the strategy to the retryable request
 func (d *DynamicAuthStrategy) ApplyOnRR(req *retryablehttp.Request) {
 	strategy := d.Dynamic.GetStrategies()
+	if strategy == nil {
+		return
+	}
 	for _, s := range strategy {
+		if s == nil {
+			continue
+		}
 		s.ApplyOnRR(req)
 	}
 }


### PR DESCRIPTION
## Proposed changes

Fixes #6592

When using `-secret-file` for authenticated scanning, templates started executing before the authentication completed, causing initial HTTP requests to be sent as unauthenticated. This is a race condition introduced in 3.4.8.

### Root Cause

The `Dynamic.Fetch()` method in `pkg/authprovider/authx/dynamic.go` used atomic bool flags (`fetched`/`fetching`) for synchronization. The problem is that `atomic.Bool` with `CompareAndSwap` doesn't block concurrent callers - when multiple goroutines call `Fetch()` concurrently:

1. First caller sets `fetching=true` and starts the actual auth fetch
2. Other callers see `fetching=true` and return immediately with `d.error` (which is still `nil`)
3. Those callers proceed with HTTP requests before auth is ready → **unauthenticated requests**

### Solution

Replace atomic bool flags with `sync.Once` which properly blocks all concurrent callers until the first fetch completes:

```go
func (d *Dynamic) Fetch(isFatal bool) error {
    d.fetchOnce.Do(func() {
        if d.fetchCallback == nil {
            d.error = fmt.Errorf("fetch callback not set for dynamic secret")
            return
        }
        d.error = d.fetchCallback(d)
    })
    // All callers wait here until Do() completes
    // ...
}
```

This ensures:
1. The fetch callback runs exactly once
2. All concurrent callers **block** until the first fetch completes
3. All callers get the correct result after fetch

### Changes

- `pkg/authprovider/authx/dynamic.go`: Replace `atomic.Bool` flags with `sync.Once`
- `pkg/authprovider/authx/dynamic_test.go`: Add comprehensive concurrency tests

## Proof

### Before (with atomic.Bool - race condition)
```
Time T1: Goroutine1 calls Fetch() → fetching=true, starts login
Time T2: Goroutine2,3,4 call Fetch() → see fetching=true
Time T3: Goroutine2,3,4 return IMMEDIATELY with d.error=nil  ← BUG!
Time T4: Templates execute WITHOUT authentication
Time T5: Goroutine1 completes login → TOO LATE
```

### After (with sync.Once - proper blocking)
```
Time T1: Goroutine1 calls Fetch() → enters Do(), starts login
Time T2: Goroutine2,3,4 call Fetch() → BLOCK waiting for Do() to complete
Time T3: Goroutine1 completes login
Time T4: Goroutine2,3,4 unblock with correct result
Time T5: All templates execute WITH authentication
```

### Concurrency Test Results
The new tests verify:
- `TestConcurrentFetch/concurrent-fetch-waits-for-completion`: 10 goroutines call Fetch() simultaneously, callback runs exactly once
- `TestConcurrentFetch/concurrent-get-strategies-waits-for-fetch`: 10 goroutines call GetStrategies() simultaneously, all receive valid strategies
- `TestConcurrentFetch/fetch-with-nil-callback-returns-error`: Nil callback guard works
- `TestConcurrentFetch/fetch-error-is-cached`: Errors are properly cached

```bash
go test -race -v ./pkg/authprovider/authx/...
# All tests pass with race detector enabled
```

## Checklist

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

/claim #6592

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved concurrent authentication fetching to run exactly once, consistently cache errors, and avoid race conditions.
  * Safer handling of dynamic authentication entries to skip nil values and prevent nil-related failures.

* **Tests**
  * Added comprehensive concurrency tests validating single-fetch behavior, error caching, and consistent availability of strategies and secrets under parallel access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->