### PR TITLE
ci: integrate typos spell checker into CI pipeline

### DIFF
--- a/.github/workflows/typos.yaml
+++ b/.github/workflows/typos.yaml
@@ -1,0 +1,27 @@
+name: Typos Check
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+  pull_request:
+    branches:
+      - main
+      - dev
+
+permissions:
+  contents: read
+
+jobs:
+  typos:
+    name: Check for typos
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Check spelling with typos
+        uses: crate-ci/typos@master
+        with:
+          config: .typos.toml

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,30 @@
+# Configuration for typos spell checker
+# https://github.com/crate-ci/typos
+
+[files]
+extend-exclude = [
+    "*.min.js",
+    "*.min.css",
+    "vendor/",
+    "go.sum",
+    "go.mod",
+    "*.pb.go",
+    "testdata/",
+    "*.svg",
+]
+
+[default]
+extend-ignore-re = [
+    # Ignore base64 encoded strings
+    "[A-Za-z0-9+/]{40,}={0,2}",
+    # Ignore hex strings
+    "[0-9a-fA-F]{32,}",
+    # Ignore URLs
+    "https?://[^\\s]+",
+]
+
+[default.extend-words]
+# Project-specific words to ignore
+hto = "hto"
+numer = "numer"
+requestor = "requestor"


### PR DESCRIPTION
## Description

This PR integrates the [typos](https://github.com/crate-ci/typos) spell checker into the CI pipeline as requested in #6532.

## Changes

- Add `.github/workflows/typos.yaml` - GitHub Action workflow for running typos
- Add `.typos.toml` - Configuration file with appropriate exclusions for the project

## Configuration

The typos action will run on:
- Push to `main`/`dev` branches  
- Pull requests to `main`/`dev` branches

The config excludes:
- Vendor directories
- Generated files (`*.pb.go`, `go.sum`)
- Test data
- Base64/hex strings and URLs (via regex)

## References

- typos GitHub Action docs: https://github.com/crate-ci/typos/blob/master/docs/github-action.md
- Related PR: https://github.com/projectdiscovery/nuclei/pull/6521

Fixes #6532

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added spell-checking configuration to enhance code quality standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->