### PR TITLE
refactor: replace panic with proper error handling in template loader

### DIFF
--- a/internal/runner/lazy.go
+++ b/internal/runner/lazy.go
@@ -67,7 +67,10 @@ func GetAuthTmplStore(opts *types.Options, catalog catalog.Catalog, execOpts *pr
 // GetLazyAuthFetchCallback returns a lazy fetch callback for auth secrets
 func GetLazyAuthFetchCallback(opts *AuthLazyFetchOptions) authx.LazyFetchSecret {
 	return func(d *authx.Dynamic) error {
-		tmpls := opts.TemplateStore.LoadTemplates([]string{d.TemplatePath})
+		tmpls, err := opts.TemplateStore.LoadTemplates([]string{d.TemplatePath})
+		if err != nil {
+			return fmt.Errorf("could not load templates: %w", err)
+		}
 		if len(tmpls) == 0 {
 			return fmt.Errorf("%w for path: %s", disk.ErrNoTemplatesFound, d.TemplatePath)
 		}
@@ -140,9 +143,9 @@ func GetLazyAuthFetchCallback(opts *AuthLazyFetchOptions) authx.LazyFetchSecret 
 			// log result of template in result file/screen
 			_ = writer.WriteResult(e, opts.ExecOpts.Output, opts.ExecOpts.Progress, opts.ExecOpts.IssuesClient)
 		}
-		_, err := tmpl.Executer.ExecuteWithResults(ctx)
-		if err != nil {
-			finalErr = err
+		_, execErr := tmpl.Executer.ExecuteWithResults(ctx)
+		if execErr != nil {
+			finalErr = execErr
 		}
 		// store extracted result in auth context
 		d.Extracted = data

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -660,7 +660,9 @@ func (r *Runner) RunEnumeration() error {
 		}
 		return nil // exit
 	}
-	store.Load()
+	if err := store.Load(); err != nil {
+		return err
+	}
 	// TODO: remove below functions after v3 or update warning messages
 	templates.PrintDeprecatedProtocolNameMsgIfApplicable(r.options.Silent, r.options.Verbose)
 

--- a/internal/server/nuclei_sdk.go
+++ b/internal/server/nuclei_sdk.go
@@ -125,7 +125,9 @@ func newNucleiExecutor(opts *NucleiExecutorOptions) (*nucleiExecutor, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "Could not create loader options.")
 	}
-	store.Load()
+	if err := store.Load(); err != nil {
+		return nil, errors.Wrap(err, "Could not load templates.")
+	}
 
 	return &nucleiExecutor{
 		engine:       executorEngine,

--- a/lib/multi.go
+++ b/lib/multi.go
@@ -150,7 +150,9 @@ func (e *ThreadSafeNucleiEngine) ExecuteNucleiWithOptsCtx(ctx context.Context, t
 	if err != nil {
 		return errkit.Wrapf(err, "Could not create loader client: %s", err)
 	}
-	store.Load()
+	if err := store.Load(); err != nil {
+		return errkit.Wrapf(err, "Could not load templates: %s", err)
+	}
 
 	inputProvider := provider.NewSimpleInputProviderWithUrls(e.eng.opts.ExecutionId, targets...)
 

--- a/lib/sdk.go
+++ b/lib/sdk.go
@@ -110,7 +110,9 @@ func (e *NucleiEngine) LoadAllTemplates() error {
 	if err != nil {
 		return errkit.Wrapf(err, "Could not create loader client: %s", err)
 	}
-	e.store.Load()
+	if err := e.store.Load(); err != nil {
+		return errkit.Wrapf(err, "Could not load templates: %s", err)
+	}
 	e.templatesLoaded = true
 	return nil
 }

--- a/pkg/catalog/loader/loader.go
+++ b/pkg/catalog/loader/loader.go
@@ -333,9 +333,14 @@ func (store *Store) RegisterPreprocessor(preprocessor templates.Preprocessor) {
 
 // Load loads all the templates from a store, performs filtering and returns
 // the complete compiled templates for a nuclei execution configuration.
-func (store *Store) Load() {
-	store.templates = store.LoadTemplates(store.finalTemplates)
+func (store *Store) Load() error {
+	var err error
+	store.templates, err = store.LoadTemplates(store.finalTemplates)
+	if err != nil {
+		return fmt.Errorf("could not load templates: %w", err)
+	}
 	store.workflows = store.LoadWorkflows(store.finalWorkflows)
+	return nil
 }
 
 var templateIDPathMap map[string]string
@@ -637,7 +642,7 @@ func isParsingError(store *Store, message string, template string, err error) bo
 }
 
 // LoadTemplates takes a list of templates and returns paths for them
-func (store *Store) LoadTemplates(templatesList []string) []*templates.Template {
+func (store *Store) LoadTemplates(templatesList []string) ([]*templates.Template, error) {
 	return store.LoadTemplatesWithTags(templatesList, nil)
 }
 
@@ -668,7 +673,7 @@ func (store *Store) LoadWorkflows(workflowsList []string) []*templates.Template 
 
 // LoadTemplatesWithTags takes a list of templates and extra tags
 // returning templates that match.
-func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) []*templates.Template {
+func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) ([]*templates.Template, error) {
 	defer store.saveMetadataIndexOnce()
 
 	indexFilter := store.indexFilter
@@ -708,7 +713,7 @@ func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) []*templ
 
 	wgLoadTemplates, errWg := syncutil.New(syncutil.WithSize(concurrency))
 	if errWg != nil {
-		panic("could not create wait group")
+		return nil, fmt.Errorf("could not create wait group: %w", errWg)
 	}
 
 	if typesOpts.ExecutionId == "" {
@@ -717,7 +722,7 @@ func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) []*templ
 
 	dialers := protocolstate.GetDialersWithId(typesOpts.ExecutionId)
 	if dialers == nil {
-		panic("dialers with executionId " + typesOpts.ExecutionId + " not found")
+		return nil, fmt.Errorf("dialers with executionId %s not found", typesOpts.ExecutionId)
 	}
 
 	for _, templatePath := range includedTemplates {
@@ -852,7 +857,7 @@ func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) []*templ
 		return loadedTemplates.Slice[i].Path < loadedTemplates.Slice[j].Path
 	})
 
-	return loadedTemplates.Slice
+	return loadedTemplates.Slice, nil
 }
 
 // IsHTTPBasedProtocolUsed returns true if http/headless protocol is being used for

--- a/pkg/catalog/loader/loader_bench_test.go
+++ b/pkg/catalog/loader/loader_bench_test.go
@@ -71,7 +71,7 @@ func BenchmarkLoadTemplates(b *testing.B) {
 		b.ReportAllocs()
 
 		for b.Loop() {
-			_ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
+			_, _ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
 		}
 	})
 
@@ -89,7 +89,7 @@ func BenchmarkLoadTemplates(b *testing.B) {
 		b.ReportAllocs()
 
 		for b.Loop() {
-			_ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
+			_, _ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
 		}
 	})
 
@@ -107,7 +107,7 @@ func BenchmarkLoadTemplates(b *testing.B) {
 		b.ReportAllocs()
 
 		for b.Loop() {
-			_ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
+			_, _ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
 		}
 	})
 
@@ -125,7 +125,7 @@ func BenchmarkLoadTemplates(b *testing.B) {
 		b.ReportAllocs()
 
 		for b.Loop() {
-			_ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
+			_, _ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
 		}
 	})
 
@@ -143,7 +143,7 @@ func BenchmarkLoadTemplates(b *testing.B) {
 		b.ReportAllocs()
 
 		for b.Loop() {
-			_ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
+			_, _ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
 		}
 	})
 
@@ -161,7 +161,7 @@ func BenchmarkLoadTemplates(b *testing.B) {
 		b.ReportAllocs()
 
 		for b.Loop() {
-			_ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
+			_, _ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
 		}
 	})
 
@@ -181,7 +181,7 @@ func BenchmarkLoadTemplates(b *testing.B) {
 		b.ReportAllocs()
 
 		for b.Loop() {
-			_ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
+			_, _ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
 		}
 	})
 }

--- a/pkg/catalog/loader/loader_test.go
+++ b/pkg/catalog/loader/loader_test.go
@@ -4,8 +4,10 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/config"
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/disk"
+	"github.com/projectdiscovery/nuclei/v3/pkg/testutils"
 	"github.com/stretchr/testify/require"
 )
 
@@ -100,4 +102,39 @@ func TestRemoteTemplates(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestLoadTemplatesWithMissingDialers verifies that LoadTemplatesWithTags returns
+// an error instead of panicking when dialers are not initialized for the given
+// execution ID. This is a regression test for issue #6674.
+func TestLoadTemplatesWithMissingDialers(t *testing.T) {
+	catalog := disk.NewCatalog("")
+
+	// Create options with a unique execution ID that has no dialers registered
+	options := testutils.DefaultOptions.Copy()
+	options.ExecutionId = "non-existent-execution-id-for-testing"
+	options.Logger = &gologger.Logger{}
+
+	// Create executor options with proper initialization
+	executerOpts := testutils.NewMockExecuterOptions(options, nil)
+
+	// Create a store with the options - include logger in Config
+	store, err := New(&Config{
+		Templates:       []string{"test-template.yaml"},
+		Catalog:         catalog,
+		ExecutorOptions: executerOpts,
+		Logger:          options.Logger,
+	})
+	require.Nil(t, err, "could not create store")
+
+	// Attempt to load templates - this should return an error, not panic
+	templates, err := store.LoadTemplatesWithTags([]string{"."}, nil)
+
+	// Verify we got an error (not a panic)
+	require.NotNil(t, err, "expected error when dialers are missing")
+	require.Nil(t, templates, "expected nil templates when error occurs")
+
+	// Verify the error message contains the expected text
+	require.Contains(t, err.Error(), "not found", "error should mention dialers not found")
+	require.Contains(t, err.Error(), "non-existent-execution-id-for-testing", "error should contain the execution ID")
 }

--- a/pkg/protocols/common/automaticscan/util.go
+++ b/pkg/protocols/common/automaticscan/util.go
@@ -37,7 +37,10 @@ func getTemplateDirs(opts Options) ([]string, error) {
 
 // LoadTemplatesWithTags loads and returns templates with given tags
 func LoadTemplatesWithTags(opts Options, templateDirs []string, tags []string, logInfo bool) ([]*templates.Template, error) {
-	finalTemplates := opts.Store.LoadTemplatesWithTags(templateDirs, tags)
+	finalTemplates, err := opts.Store.LoadTemplatesWithTags(templateDirs, tags)
+	if err != nil {
+		return nil, err
+	}
 	if len(finalTemplates) == 0 {
 		return nil, errors.New("could not find any templates with tech tag")
 	}


### PR DESCRIPTION
This PR refactors the template loader to replace `panic` calls with proper error handling when dialers are missing or not initialized. This ensures the application remains stable and allows callers to handle failures gracefully instead of crashing the process.

Fixes #6674

## Proposed changes
- Replaced `panic` calls with `fmt.Errorf` in `pkg/catalog/loader/loader.go` when `protocolstate.GetDialersWithId` returns nil.
- Updated function signatures for `LoadTemplatesWithTags`, `LoadTemplates`, and `Load` to return `error` types.
- Propagated and handled errors across all impacted call sites:
    - `runner.go`, `lazy.go`, `sdk.go`, `multi.go`, `nuclei_sdk.go`, and `util.go`.
- Updated `loader_bench_test.go` to support new multi-value return signatures.
- Improved overall system resilience by following the codebase pattern of returning errors for recoverable states.

### Proof
- **Regression Test:** Added `TestLoadTemplatesWithMissingDialers` in `pkg/catalog/loader/loader_test.go` to verify that a missing execution ID returns a proper error instead of panicking.
- **Unit Tests:** Ran `go test -v ./pkg/catalog/loader/...` and all 7 tests (including the new one) passed successfully.
- **Build & Lint:** Verified the entire project compiles without errors using `go build ./...` and passed `go vet`.

## Checklist
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Template loading failures are now properly reported with clear error messages instead of being silently ignored.
  * Enhanced validation ensures template operations fail gracefully when templates cannot be found or configured incorrectly.

* **Tests**
  * Added regression test for template loading error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->