### PR TITLE
fix(fuzz): use OrderedMap for path components to ensure deterministic iteration

### DIFF
--- a/pkg/fuzz/component/path.go
+++ b/pkg/fuzz/component/path.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz/dataformat"
 	"github.com/projectdiscovery/retryablehttp-go"
+	mapsutil "github.com/projectdiscovery/utils/maps"
 	urlutil "github.com/projectdiscovery/utils/url"
 )
 
@@ -36,7 +37,7 @@ func (q *Path) Parse(req *retryablehttp.Request) (bool, error) {
 	q.value = NewValue("")
 
 	splitted := strings.Split(req.Path, "/")
-	values := make(map[string]interface{})
+	values := mapsutil.NewOrderedMap[string, any]()
 	for i, segment := range splitted {
 		if segment == "" && i == 0 {
 			// Skip the first empty segment from leading "/"
@@ -47,10 +48,10 @@ func (q *Path) Parse(req *retryablehttp.Request) (bool, error) {
 			continue
 		}
 		// Use 1-based indexing and store individual segments
-		key := strconv.Itoa(len(values) + 1)
-		values[key] = segment
+		key := strconv.Itoa(values.Len() + 1)
+		values.Set(key, segment)
 	}
-	q.value.SetParsed(dataformat.KVMap(values), "")
+	q.value.SetParsed(dataformat.KVOrderedMap(&values), "")
 	return true, nil
 }
 
@@ -109,8 +110,12 @@ func (q *Path) Rebuild() (*retryablehttp.Request, error) {
 
 		// Check if we have a replacement for this segment
 		key := strconv.Itoa(segmentIndex)
-		if newValue, exists := q.value.parsed.Map.GetOrDefault(key, "").(string); exists && newValue != "" {
-			rebuiltSegments = append(rebuiltSegments, newValue)
+		if val := q.value.parsed.Get(key); val != nil {
+			if newValue, ok := val.(string); ok && newValue != "" {
+				rebuiltSegments = append(rebuiltSegments, newValue)
+			} else {
+				rebuiltSegments = append(rebuiltSegments, originalSegment)
+			}
 		} else {
 			rebuiltSegments = append(rebuiltSegments, originalSegment)
 		}

--- a/pkg/fuzz/component/path_test.go
+++ b/pkg/fuzz/component/path_test.go
@@ -80,6 +80,36 @@ func TestURLComponent_NestedPaths(t *testing.T) {
 	}
 }
 
+func TestPathComponent_DeterministicIteration(t *testing.T) {
+	// Regression test for https://github.com/projectdiscovery/nuclei/issues/6398
+	// Path iteration must be deterministic to ensure all path segments are fuzzed
+	for run := 0; run < 100; run++ {
+		path := NewPath()
+		req, err := retryablehttp.NewRequest(http.MethodGet, "https://example.com/user/55/profile", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		found, err := path.Parse(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !found {
+			t.Fatal("expected path to be found")
+		}
+
+		var keys []string
+		var vals []string
+		_ = path.Iterate(func(key string, value interface{}) error {
+			keys = append(keys, key)
+			vals = append(vals, value.(string))
+			return nil
+		})
+
+		require.Equal(t, []string{"1", "2", "3"}, keys, "run %d: keys must be in insertion order", run)
+		require.Equal(t, []string{"user", "55", "profile"}, vals, "run %d: values must be in insertion order", run)
+	}
+}
+
 func TestPathComponent_SQLInjection(t *testing.T) {
 	path := NewPath()
 	req, err := retryablehttp.NewRequest(http.MethodGet, "https://example.com/user/55/profile", nil)


### PR DESCRIPTION
## Proposed Changes

Fix non-deterministic path-based fuzzing that causes numeric path segments to be randomly skipped.

### Root Cause

The `Path.Parse()` method used a plain Go `map[string]interface{}` to store parsed path segments. Since Go maps have non-deterministic iteration order, the fuzzing engine would randomly skip path segments during iteration, particularly numeric ones like `/user/55/profile`.

### Fix

- Replace the plain map with `mapsutil.OrderedMap` in `Path.Parse()`, matching the pattern already used by the `Cookie` component
- Update `Path.Rebuild()` to use the `KV.Get()` accessor instead of directly accessing the `.Map` field (which would be nil when using OrderedMap)
- Add a deterministic iteration regression test that runs 100 iterations to verify order stability

### Proof

All existing tests pass, plus new regression test:

```
=== RUN   TestURLComponent
--- PASS: TestURLComponent (0.00s)
=== RUN   TestURLComponent_NestedPaths
    path_test.go:64: Key: 1, Value: user
    path_test.go:64: Key: 2, Value: 753
    path_test.go:64: Key: 3, Value: profile
--- PASS: TestURLComponent_NestedPaths (0.00s)
=== RUN   TestPathComponent_DeterministicIteration
--- PASS: TestPathComponent_DeterministicIteration (0.00s)
=== RUN   TestPathComponent_SQLInjection
    path_test.go:127: Original path: /user/55/profile
    path_test.go:131: Key: 1, Value: user
    path_test.go:131: Key: 2, Value: 55
    path_test.go:131: Key: 3, Value: profile
    path_test.go:150: Modified path: /user/55 OR True/profile
--- PASS: TestPathComponent_SQLInjection (0.00s)
```

### Checklist

- [x] PR created against the correct branch (`dev`)
- [x] All checks passed (`go build ./...`, `go vet ./...`, `go test ./pkg/fuzz/...`)
- [x] Tests added that prove the fix is effective
- [x] Minimal, focused change (2 files, 41 insertions, 6 deletions)

Fixes #6398

/claim #6398

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path segment processing to maintain consistent ordering across operations.
  * Added fallback logic to preserve original segments when replacements are unavailable or invalid.

* **Tests**
  * Added test to verify deterministic iteration of path segments, ensuring consistent and predictable behavior across repeated executions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->