### PR TITLE
fix(authx): wait for secret-file completion before executing template…

### DIFF
--- a/internal/runner/auth_secrets.go
+++ b/internal/runner/auth_secrets.go
@@ -1,0 +1,32 @@
+package runner
+
+import (
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/projectdiscovery/gologger"
+	"github.com/projectdiscovery/nuclei/v3/pkg/authprovider"
+	"github.com/projectdiscovery/nuclei/v3/pkg/types"
+)
+
+// PrefetchAuthSecrets resolves secret-file auth before template execution.
+// - logger is used for start/end/error messages.
+// - provider is the auth provider to prefetch.
+// - options supplies the secret-file list for logging and guard checks.
+func PrefetchAuthSecrets(logger *gologger.Logger, provider authprovider.AuthProvider, options *types.Options) error {
+	if provider == nil || options == nil || len(options.SecretsFile) == 0 {
+		return nil
+	}
+	if logger == nil {
+		logger = gologger.DefaultLogger
+	}
+
+	logger.Info().Msgf("Secret-file auth: prefetch starting for %d file(s)", len(options.SecretsFile))
+	start := time.Now()
+	if err := provider.PreFetchSecrets(); err != nil {
+		logger.Error().Msgf("Secret-file auth: prefetch failed: %s", err)
+		return errors.Wrap(err, "secret-file auth prefetch failed")
+	}
+	logger.Info().Msgf("Secret-file auth: prefetch completed in %s", time.Since(start))
+	return nil
+}

--- a/internal/runner/lazy.go
+++ b/internal/runner/lazy.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
+	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/nuclei/v3/pkg/authprovider/authx"
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog"
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/disk"
@@ -67,11 +69,28 @@ func GetAuthTmplStore(opts *types.Options, catalog catalog.Catalog, execOpts *pr
 // GetLazyAuthFetchCallback returns a lazy fetch callback for auth secrets
 func GetLazyAuthFetchCallback(opts *AuthLazyFetchOptions) authx.LazyFetchSecret {
 	return func(d *authx.Dynamic) error {
+		if opts == nil || opts.TemplateStore == nil {
+			return fmt.Errorf("secret-file auth is not configured")
+		}
+		var logger *gologger.Logger
+		if opts != nil && opts.ExecOpts != nil {
+			logger = opts.ExecOpts.Logger
+		}
+		if logger != nil {
+			logger.Info().Msgf("Secret-file auth: executing template %s", d.TemplatePath)
+		}
+		start := time.Now()
 		tmpls := opts.TemplateStore.LoadTemplates([]string{d.TemplatePath})
 		if len(tmpls) == 0 {
+			if logger != nil {
+				logger.Error().Msgf("Secret-file auth: template %s not found", d.TemplatePath)
+			}
 			return fmt.Errorf("%w for path: %s", disk.ErrNoTemplatesFound, d.TemplatePath)
 		}
 		if len(tmpls) > 1 {
+			if logger != nil {
+				logger.Error().Msgf("Secret-file auth: multiple templates found for %s", d.TemplatePath)
+			}
 			return fmt.Errorf("multiple templates found for path: %s", d.TemplatePath)
 		}
 		data := map[string]interface{}{}
@@ -146,6 +165,13 @@ func GetLazyAuthFetchCallback(opts *AuthLazyFetchOptions) authx.LazyFetchSecret 
 		}
 		// store extracted result in auth context
 		d.Extracted = data
+		if logger != nil {
+			if finalErr != nil {
+				logger.Error().Msgf("Secret-file auth: template %s failed after %s: %s", d.TemplatePath, time.Since(start), finalErr)
+			} else {
+				logger.Info().Msgf("Secret-file auth: template %s completed in %s", d.TemplatePath, time.Since(start))
+			}
+		}
 		if finalErr != nil && opts.OnError != nil {
 			opts.OnError(finalErr)
 		}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -594,6 +594,10 @@ func (r *Runner) RunEnumeration() error {
 			return errors.Wrap(err, "could not create auth provider")
 		}
 		executorOpts.AuthProvider = provider
+		// Ensure authenticated scans do not race with template execution before auth completes.
+		if err := PrefetchAuthSecrets(r.Logger, executorOpts.AuthProvider, r.options); err != nil {
+			return err
+		}
 	}
 
 	if r.options.ShouldUseHostError() {
@@ -681,13 +685,7 @@ func (r *Runner) RunEnumeration() error {
 	// display execution info like version , templates used etc
 	r.displayExecutionInfo(store)
 
-	// prefetch secrets if enabled
-	if executorOpts.AuthProvider != nil && r.options.PreFetchSecrets {
-		r.Logger.Info().Msgf("Pre-fetching secrets from authprovider[s]")
-		if err := executorOpts.AuthProvider.PreFetchSecrets(); err != nil {
-			return errors.Wrap(err, "could not pre-fetch secrets")
-		}
-	}
+	// secret-file auth prefetch is handled before template execution
 
 	// If not explicitly disabled, check if http based protocols
 	// are used, and if inputs are non-http to pre-perform probing

--- a/lib/sdk_private.go
+++ b/lib/sdk_private.go
@@ -223,17 +223,16 @@ func (e *NucleiEngine) init(ctx context.Context) error {
 			return errors.Wrap(err, "could not create auth provider")
 		}
 		e.executerOpts.AuthProvider = provider
+		// Ensure authenticated scans do not race with template execution before auth completes.
+		if err := runner.PrefetchAuthSecrets(e.opts.Logger, e.executerOpts.AuthProvider, e.opts); err != nil {
+			return err
+		}
 	}
 	if e.authprovider != nil {
 		e.executerOpts.AuthProvider = e.authprovider
 	}
 
-	// prefetch secrets
-	if e.executerOpts.AuthProvider != nil && e.opts.PreFetchSecrets {
-		if err := e.executerOpts.AuthProvider.PreFetchSecrets(); err != nil {
-			return errors.Wrap(err, "could not prefetch secrets")
-		}
-	}
+	// secret-file auth prefetch is handled before template execution
 
 	if e.executerOpts.RateLimiter == nil {
 		if e.opts.RateLimitMinute > 0 {

--- a/pkg/authprovider/file_test.go
+++ b/pkg/authprovider/file_test.go
@@ -1,0 +1,60 @@
+package authprovider
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/authprovider/authx"
+)
+
+// TestPrefetchSecretsBeforeAuthApply verifies that prefetch resolves dynamic auth before use.
+// - t is the testing harness instance.
+func TestPrefetchSecretsBeforeAuthApply(t *testing.T) {
+	tempDir := t.TempDir()
+	secretPath := filepath.Join(tempDir, "secret.yaml")
+	secretContent := []byte(`id: test-auth
+info:
+  name: Test Auth
+  author: unit-test
+  severity: info
+dynamic:
+  - template: auth-template.yaml
+    variables:
+      - key: email
+        value: ignored
+    secrets:
+      - type: Header
+        domains:
+          - example.com
+        headers:
+          - key: X-User
+            value: "{{email}}"
+`)
+	require.NoError(t, os.WriteFile(secretPath, secretContent, 0o600))
+
+	var prefetched atomic.Bool
+	callback := func(d *authx.Dynamic) error {
+		d.Extracted = map[string]interface{}{"email": "engbot@example.com"}
+		prefetched.Store(true)
+		return nil
+	}
+
+	provider, err := NewFileAuthProvider(secretPath, callback)
+	require.NoError(t, err)
+	require.NoError(t, provider.PreFetchSecrets())
+	require.True(t, prefetched.Load())
+
+	strategies := provider.LookupAddr("example.com")
+	require.NotEmpty(t, strategies)
+
+	req, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
+	require.NoError(t, err)
+	strategies[0].Apply(req)
+
+	require.Equal(t, "engbot@example.com", req.Header.Get("X-User"))
+}


### PR DESCRIPTION
/claim #6592

## 📌 Title
fix(authx): ensure secret-file authentication completes before template execution

## 🧠 Summary

This pull request fixes a race condition in authenticated scanning when using `-secret-file`.  
Currently, templates begin executing **before** the secret-file authentication finishes, causing early requests to be sent unauthenticated.  
This restores the intended behavior from Nuclei 3.4.7, where the engine waits for login completion before running other templates.

## 🛠 Proposed Changes

- Add synchronization so that template execution waits until the secret-file has fully completed authentication.
- Introduce a mechanism to **pre-fetch and block** until auth data (cookies/session) is available.
- Maintain parallel execution of templates **only after** authentication is complete.
- Keep existing behavior unchanged for non-authenticated scans.

## 🎯 Expected Behavior After Fix

1. The secret-file runs first and completes login.
2. No template is executed until authentication finalizes.
3. Subsequent requests use authenticated session data.
4. No regressions in non-authenticated scans.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced authentication handling by prefetching secrets earlier in the execution workflow for improved reliability and performance.
  * Added detailed logging and performance diagnostics for authentication operations.
  * Strengthened error validation and handling for authentication configuration.

* **Tests**
  * Added comprehensive test coverage for authentication secret prefetching workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->