### PR TITLE
fix(loader): avoid panic when dialers are missing

### DIFF
--- a/internal/runner/lazy.go
+++ b/internal/runner/lazy.go
@@ -67,7 +67,10 @@ func GetAuthTmplStore(opts *types.Options, catalog catalog.Catalog, execOpts *pr
 // GetLazyAuthFetchCallback returns a lazy fetch callback for auth secrets
 func GetLazyAuthFetchCallback(opts *AuthLazyFetchOptions) authx.LazyFetchSecret {
 	return func(d *authx.Dynamic) error {
-		tmpls := opts.TemplateStore.LoadTemplates([]string{d.TemplatePath})
+		tmpls, err := opts.TemplateStore.LoadTemplates([]string{d.TemplatePath})
+		if err != nil {
+			return err
+		}
 		if len(tmpls) == 0 {
 			return fmt.Errorf("%w for path: %s", disk.ErrNoTemplatesFound, d.TemplatePath)
 		}
@@ -140,9 +143,9 @@ func GetLazyAuthFetchCallback(opts *AuthLazyFetchOptions) authx.LazyFetchSecret 
 			// log result of template in result file/screen
 			_ = writer.WriteResult(e, opts.ExecOpts.Output, opts.ExecOpts.Progress, opts.ExecOpts.IssuesClient)
 		}
-		_, err := tmpl.Executer.ExecuteWithResults(ctx)
-		if err != nil {
-			finalErr = err
+		_, execErr := tmpl.Executer.ExecuteWithResults(ctx)
+		if execErr != nil {
+			finalErr = execErr
 		}
 		// store extracted result in auth context
 		d.Extracted = data

--- a/pkg/catalog/loader/loader.go
+++ b/pkg/catalog/loader/loader.go
@@ -334,8 +334,18 @@ func (store *Store) RegisterPreprocessor(preprocessor templates.Preprocessor) {
 // Load loads all the templates from a store, performs filtering and returns
 // the complete compiled templates for a nuclei execution configuration.
 func (store *Store) Load() {
-	store.templates = store.LoadTemplates(store.finalTemplates)
-	store.workflows = store.LoadWorkflows(store.finalWorkflows)
+	templates, err := store.LoadTemplates(store.finalTemplates)
+	if err != nil {
+		store.config.ExecutorOptions.Logger.Error().Msgf("could not load templates: %s", err)
+	} else {
+		store.templates = templates
+	}
+	workflows, err := store.LoadWorkflows(store.finalWorkflows)
+	if err != nil {
+		store.config.ExecutorOptions.Logger.Error().Msgf("could not load workflows: %s", err)
+	} else {
+		store.workflows = workflows
+	}
 }
 
 var templateIDPathMap map[string]string
@@ -637,12 +647,12 @@ func isParsingError(store *Store, message string, template string, err error) bo
 }
 
 // LoadTemplates takes a list of templates and returns paths for them
-func (store *Store) LoadTemplates(templatesList []string) []*templates.Template {
+func (store *Store) LoadTemplates(templatesList []string) ([]*templates.Template, error) {
 	return store.LoadTemplatesWithTags(templatesList, nil)
 }
 
 // LoadWorkflows takes a list of workflows and returns paths for them
-func (store *Store) LoadWorkflows(workflowsList []string) []*templates.Template {
+func (store *Store) LoadWorkflows(workflowsList []string) ([]*templates.Template, error) {
 	includedWorkflows, errs := store.config.Catalog.GetTemplatesPath(workflowsList)
 	store.logErroredTemplates(errs)
 
@@ -663,12 +673,12 @@ func (store *Store) LoadWorkflows(workflowsList []string) []*templates.Template 
 		}
 	}
 
-	return loadedWorkflows
+	return loadedWorkflows, nil
 }
 
 // LoadTemplatesWithTags takes a list of templates and extra tags
 // returning templates that match.
-func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) []*templates.Template {
+func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) ([]*templates.Template, error) {
 	defer store.saveMetadataIndexOnce()
 
 	indexFilter := store.indexFilter
@@ -720,20 +730,11 @@ func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) []*templ
 		// Dialers might be uninitialized in non-scanning flows (e.g. template listing/display)
 		// and should not crash the process.
 		if err := protocolstate.Init(typesOpts); err != nil {
-			store.config.ExecutorOptions.Logger.Error().Msgf(
-				"could not initialize dialers for executionId %s: %s",
-				typesOpts.ExecutionId,
-				err,
-			)
-		} else {
-			dialers = protocolstate.GetDialersWithId(typesOpts.ExecutionId)
+			return nil, fmt.Errorf("dialers for executionId %s could not be initialized: %w", typesOpts.ExecutionId, err)
 		}
+		dialers = protocolstate.GetDialersWithId(typesOpts.ExecutionId)
 		if dialers == nil {
-			store.config.ExecutorOptions.Logger.Error().Msgf(
-				"dialers with executionId %s not found",
-				typesOpts.ExecutionId,
-			)
-			return loadedTemplates.Slice
+			return nil, fmt.Errorf("dialers with executionId %s not found", typesOpts.ExecutionId)
 		}
 	}
 
@@ -869,7 +870,7 @@ func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) []*templ
 		return loadedTemplates.Slice[i].Path < loadedTemplates.Slice[j].Path
 	})
 
-	return loadedTemplates.Slice
+	return loadedTemplates.Slice, nil
 }
 
 // IsHTTPBasedProtocolUsed returns true if http/headless protocol is being used for

--- a/pkg/catalog/loader/loader.go
+++ b/pkg/catalog/loader/loader.go
@@ -717,7 +717,24 @@ func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) []*templ
 
 	dialers := protocolstate.GetDialersWithId(typesOpts.ExecutionId)
 	if dialers == nil {
-		panic("dialers with executionId " + typesOpts.ExecutionId + " not found")
+		// Dialers might be uninitialized in non-scanning flows (e.g. template listing/display)
+		// and should not crash the process.
+		if err := protocolstate.Init(typesOpts); err != nil {
+			store.config.ExecutorOptions.Logger.Error().Msgf(
+				"could not initialize dialers for executionId %s: %s",
+				typesOpts.ExecutionId,
+				err,
+			)
+		} else {
+			dialers = protocolstate.GetDialersWithId(typesOpts.ExecutionId)
+		}
+		if dialers == nil {
+			store.config.ExecutorOptions.Logger.Error().Msgf(
+				"dialers with executionId %s not found",
+				typesOpts.ExecutionId,
+			)
+			return loadedTemplates.Slice
+		}
 	}
 
 	for _, templatePath := range includedTemplates {

--- a/pkg/catalog/loader/loader_bench_test.go
+++ b/pkg/catalog/loader/loader_bench_test.go
@@ -71,7 +71,7 @@ func BenchmarkLoadTemplates(b *testing.B) {
 		b.ReportAllocs()
 
 		for b.Loop() {
-			_ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
+			_, _ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
 		}
 	})
 
@@ -89,7 +89,7 @@ func BenchmarkLoadTemplates(b *testing.B) {
 		b.ReportAllocs()
 
 		for b.Loop() {
-			_ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
+			_, _ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
 		}
 	})
 
@@ -107,7 +107,7 @@ func BenchmarkLoadTemplates(b *testing.B) {
 		b.ReportAllocs()
 
 		for b.Loop() {
-			_ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
+			_, _ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
 		}
 	})
 
@@ -125,7 +125,7 @@ func BenchmarkLoadTemplates(b *testing.B) {
 		b.ReportAllocs()
 
 		for b.Loop() {
-			_ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
+			_, _ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
 		}
 	})
 
@@ -143,7 +143,7 @@ func BenchmarkLoadTemplates(b *testing.B) {
 		b.ReportAllocs()
 
 		for b.Loop() {
-			_ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
+			_, _ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
 		}
 	})
 
@@ -161,7 +161,7 @@ func BenchmarkLoadTemplates(b *testing.B) {
 		b.ReportAllocs()
 
 		for b.Loop() {
-			_ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
+			_, _ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
 		}
 	})
 
@@ -181,7 +181,7 @@ func BenchmarkLoadTemplates(b *testing.B) {
 		b.ReportAllocs()
 
 		for b.Loop() {
-			_ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
+			_, _ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
 		}
 	})
 }

--- a/pkg/protocols/common/automaticscan/util.go
+++ b/pkg/protocols/common/automaticscan/util.go
@@ -37,7 +37,10 @@ func getTemplateDirs(opts Options) ([]string, error) {
 
 // LoadTemplatesWithTags loads and returns templates with given tags
 func LoadTemplatesWithTags(opts Options, templateDirs []string, tags []string, logInfo bool) ([]*templates.Template, error) {
-	finalTemplates := opts.Store.LoadTemplatesWithTags(templateDirs, tags)
+	finalTemplates, err := opts.Store.LoadTemplatesWithTags(templateDirs, tags)
+	if err != nil {
+		return nil, err
+	}
 	if len(finalTemplates) == 0 {
 		return nil, errors.New("could not find any templates with tech tag")
 	}


### PR DESCRIPTION
Fixes #6674
/claim #6674

## What
Template loader panics when dialers are not initialized for a given executionId. This can happen in non-scanning flows (template listing/display, lazy auth loading, auto tech detection) and should not crash the process.

## Change
- Replace the panic with error-based flow: attempt to initialize dialers via `protocolstate.Init(options)`
- If dialers are still unavailable, return a descriptive error so callers can handle it
- Update lazy auth + auto tech detection callers to propagate/handle the error

## Proof
Local tests:
- `go test ./pkg/catalog/loader`
- `go test ./internal/runner`
- `go test ./pkg/protocols/common/automaticscan`

(full terminal output attached in PR comments)

## Checklist
- [x] PR targets `dev`
- [ ] All checks passed (some workflows are pending maintainer approval)
- [x] Includes /claim tag for Algora


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling in template and workflow loading operations to gracefully manage failures with proper error messages instead of causing application crashes, enhancing stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->