### PR TITLE
fix(authx): wait for in-flight dynamic secret fetch

### DIFF
--- a/pkg/authprovider/authx/dynamic.go
+++ b/pkg/authprovider/authx/dynamic.go
@@ -3,6 +3,7 @@ package authx
 import (
 	"fmt"
 	"strings"
+	"sync"
 	"sync/atomic"
 
 	"github.com/projectdiscovery/gologger"
@@ -33,6 +34,8 @@ type Dynamic struct {
 	fetched       *atomic.Bool           `json:"-" yaml:"-"` // atomic flag to check if the secret has been fetched
 	fetching      *atomic.Bool           `json:"-" yaml:"-"` // atomic flag to prevent recursive fetch calls
 	error         error                  `json:"-" yaml:"-"` // error if any
+	fetchMu       sync.Mutex             `json:"-" yaml:"-"`
+	fetchCond     *sync.Cond             `json:"-" yaml:"-"`
 }
 
 func (d *Dynamic) GetDomainAndDomainRegex() ([]string, []string) {
@@ -72,6 +75,7 @@ func (d *Dynamic) UnmarshalJSON(data []byte) error {
 func (d *Dynamic) Validate() error {
 	d.fetched = &atomic.Bool{}
 	d.fetching = &atomic.Bool{}
+	d.initFetchSync()
 	if d.TemplatePath == "" {
 		return errkit.New(" template-path is required for dynamic secret")
 	}
@@ -92,6 +96,12 @@ func (d *Dynamic) Validate() error {
 		}
 	}
 	return nil
+}
+
+func (d *Dynamic) initFetchSync() {
+	if d.fetchCond == nil {
+		d.fetchCond = sync.NewCond(&d.fetchMu)
+	}
 }
 
 // SetLazyFetchCallback sets the lazy fetch callback for the dynamic secret
@@ -208,22 +218,35 @@ func (d *Dynamic) GetStrategies() []AuthStrategy {
 // Fetch fetches the dynamic secret
 // if isFatal is true, it will stop the execution if the secret could not be fetched
 func (d *Dynamic) Fetch(isFatal bool) error {
+	d.initFetchSync()
 	if d.fetched.Load() {
 		return d.error
 	}
 
-	// Try to set fetching flag atomically
-	if !d.fetching.CompareAndSwap(false, true) {
-		// Already fetching, return current error
+	d.fetchMu.Lock()
+	if d.fetched.Load() {
+		d.fetchMu.Unlock()
 		return d.error
 	}
+	if d.fetching.Load() {
+		for d.fetching.Load() && !d.fetched.Load() {
+			d.fetchCond.Wait()
+		}
+		d.fetchMu.Unlock()
+		return d.error
+	}
+	d.fetching.Store(true)
+	d.fetchMu.Unlock()
 
 	// We're the only one fetching, call the callback
 	d.error = d.fetchCallback(d)
 
-	// Mark as fetched and clear fetching flag
+	// Mark as fetched and clear fetching flag, then wake any waiters
+	d.fetchMu.Lock()
 	d.fetched.Store(true)
 	d.fetching.Store(false)
+	d.fetchCond.Broadcast()
+	d.fetchMu.Unlock()
 
 	if d.error != nil && isFatal {
 		gologger.Fatal().Msgf("Could not fetch dynamic secret: %s\n", d.error)

--- a/pkg/authprovider/authx/dynamic_test.go
+++ b/pkg/authprovider/authx/dynamic_test.go
@@ -2,6 +2,7 @@ package authx
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -122,4 +123,46 @@ func TestDynamicUnmarshalJSON(t *testing.T) {
 		err := d.UnmarshalJSON(data)
 		require.NoError(t, err)
 	})
+}
+
+func TestDynamicFetchWaitsForInFlight(t *testing.T) {
+	d := &Dynamic{
+		TemplatePath: "test-template.yaml",
+		Variables: []KV{
+			{Key: "username", Value: "testuser"},
+		},
+	}
+	require.NoError(t, d.Validate())
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	d.SetLazyFetchCallback(func(d *Dynamic) error {
+		close(started)
+		<-release
+		d.Extracted = map[string]interface{}{"token": "abc123"}
+		return nil
+	})
+
+	done1 := make(chan error, 1)
+	go func() {
+		done1 <- d.Fetch(false)
+	}()
+
+	<-started
+
+	done2 := make(chan error, 1)
+	go func() {
+		done2 <- d.Fetch(false)
+	}()
+
+	select {
+	case err := <-done2:
+		require.NoError(t, err)
+		t.Fatalf("expected second fetch to wait for in-flight fetch")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(release)
+	require.NoError(t, <-done1)
+	require.NoError(t, <-done2)
 }

--- a/proof_6592_authx.txt
+++ b/proof_6592_authx.txt
@@ -1,0 +1,4 @@
+=== RUN   TestDynamicFetchWaitsForInFlight
+--- PASS: TestDynamicFetchWaitsForInFlight (0.05s)
+PASS
+ok  	github.com/projectdiscovery/nuclei/v3/pkg/authprovider/authx	3.560s


### PR DESCRIPTION
Fixes #6592
/claim #6592

## What
Dynamic secrets (loaded from `-secret-file`) can be fetched lazily while templates execute concurrently. When multiple requests trigger a dynamic secret fetch at the same time, callers can observe an in-flight fetch and proceed before it completes, which results in templates running without the expected authenticated context.

## Change
- Make `Dynamic.Fetch` wait for an in-flight fetch to finish instead of returning early.
- Add a deterministic concurrency unit test covering the in-flight wait behavior.

## Proof
```bash
GOCACHE=/tmp/nuclei-gocache go test ./pkg/authprovider/authx -run TestDynamicFetchWaitsForInFlight -count=1 -v
```
Output attached in `proof_6592_authx.txt`.

/claim #6592


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization mechanism for concurrent dynamic secret fetching operations to ensure reliable coordination when multiple requests access the same dynamic secrets simultaneously, preventing potential race conditions.

* **Tests**
  * Added test coverage to verify that concurrent secret fetch operations properly synchronize and complete successfully without conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->