### PR TITLE
ci: run typos check on all pushes

### DIFF
--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -3,8 +3,6 @@ name: Typos
 on:
   pull_request:
   push:
-    branches:
-      - dev
 
 permissions:
   contents: read

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -1,0 +1,23 @@
+name: Typos
+
+on:
+  pull_request:
+  push:
+    branches:
+      - dev
+
+permissions:
+  contents: read
+
+env:
+  CLICOLOR: 1
+
+jobs:
+  typos:
+    name: Spell Check with Typos
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Spell check
+        uses: crate-ci/typos@v1.42.0


### PR DESCRIPTION
/claim #6532

## Summary
Run `typos` CI check on both `push` and `pull_request` events, so the check always runs for PRs and branch pushes.

## Proof
- Workflow file updated: `.github/workflows/typos.yml`
- Local diff:

```bash
git show --stat
```
