### PR TITLE
fix(fuzz): use OrderedMap for path segments to ensure deterministic iteration

### DIFF
--- a/pkg/fuzz/component/path.go
+++ b/pkg/fuzz/component/path.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz/dataformat"
 	"github.com/projectdiscovery/retryablehttp-go"
+	mapsutil "github.com/projectdiscovery/utils/maps"
 	urlutil "github.com/projectdiscovery/utils/url"
 )
 
@@ -36,7 +37,8 @@ func (q *Path) Parse(req *retryablehttp.Request) (bool, error) {
 	q.value = NewValue("")
 
 	splitted := strings.Split(req.Path, "/")
-	values := make(map[string]interface{})
+	values := mapsutil.NewOrderedMap[string, any]()
+	segmentIndex := 1
 	for i, segment := range splitted {
 		if segment == "" && i == 0 {
 			// Skip the first empty segment from leading "/"
@@ -47,10 +49,11 @@ func (q *Path) Parse(req *retryablehttp.Request) (bool, error) {
 			continue
 		}
 		// Use 1-based indexing and store individual segments
-		key := strconv.Itoa(len(values) + 1)
-		values[key] = segment
+		key := strconv.Itoa(segmentIndex)
+		values.Set(key, segment)
+		segmentIndex++
 	}
-	q.value.SetParsed(dataformat.KVMap(values), "")
+	q.value.SetParsed(dataformat.KVOrderedMap(&values), "")
 	return true, nil
 }
 
@@ -109,8 +112,12 @@ func (q *Path) Rebuild() (*retryablehttp.Request, error) {
 
 		// Check if we have a replacement for this segment
 		key := strconv.Itoa(segmentIndex)
-		if newValue, exists := q.value.parsed.Map.GetOrDefault(key, "").(string); exists && newValue != "" {
-			rebuiltSegments = append(rebuiltSegments, newValue)
+		if newValue := q.value.parsed.Get(key); newValue != nil {
+			if newValueStr, ok := newValue.(string); ok && newValueStr != "" {
+				rebuiltSegments = append(rebuiltSegments, newValueStr)
+			} else {
+				rebuiltSegments = append(rebuiltSegments, originalSegment)
+			}
 		} else {
 			rebuiltSegments = append(rebuiltSegments, originalSegment)
 		}

--- a/pkg/fuzz/component/path.go
+++ b/pkg/fuzz/component/path.go
@@ -30,8 +30,10 @@ func (q *Path) Name() string {
 	return RequestPathComponent
 }
 
-// Parse parses the component and returns the
-// parsed component
+// Parse parses the URL path component from the HTTP request and extracts individual path segments
+// into a deterministically ordered map with 1-based numeric keys. It handles leading slashes and
+// empty segments correctly, ensuring consistent iteration order for fuzzing operations.
+// Returns true if parsing was successful, along with any error encountered.
 func (q *Path) Parse(req *retryablehttp.Request) (bool, error) {
 	q.req = req
 	q.value = NewValue("")
@@ -87,8 +89,10 @@ func (q *Path) Delete(key string) error {
 	return nil
 }
 
-// Rebuild returns a new request with the
-// component rebuilt
+// Rebuild constructs a new HTTP request with modified path segments based on values set during fuzzing.
+// It preserves the original path structure while replacing segments that were modified via SetValue().
+// The method handles URL encoding/decoding to avoid double-encoding issues and maintains proper path formatting.
+// Returns a cloned request with the rebuilt path, or an error if reconstruction fails.
 func (q *Path) Rebuild() (*retryablehttp.Request, error) {
 	// Get the original path segments
 	originalSplitted := strings.Split(q.req.Path, "/")

--- a/pkg/fuzz/component/path_test.go
+++ b/pkg/fuzz/component/path_test.go
@@ -127,3 +127,33 @@ func TestPathComponent_SQLInjection(t *testing.T) {
 	// Let's also test what the actual URL looks like
 	t.Logf("Full URL: %s", newReq.String())
 }
+
+func TestPathComponent_DeterministicIteration(t *testing.T) {
+	// Run the test 100 times to catch non-deterministic behavior
+	for iteration := 0; iteration < 100; iteration++ {
+		path := NewPath()
+		req, err := retryablehttp.NewRequest(http.MethodGet, "https://example.com/user/55/profile", nil)
+		require.NoError(t, err)
+
+		found, err := path.Parse(req)
+		require.NoError(t, err)
+		require.True(t, found)
+
+		var keys []string
+		var values []string
+
+		err = path.Iterate(func(key string, value interface{}) error {
+			keys = append(keys, key)
+			values = append(values, value.(string))
+			return nil
+		})
+		require.NoError(t, err)
+
+		// Keys and values should always be in the same order
+		expectedKeys := []string{"1", "2", "3"}
+		expectedValues := []string{"user", "55", "profile"}
+
+		require.Equal(t, expectedKeys, keys, "iteration %d: keys should be deterministic", iteration)
+		require.Equal(t, expectedValues, values, "iteration %d: values should be deterministic", iteration)
+	}
+}

--- a/pkg/fuzz/component/path_test.go
+++ b/pkg/fuzz/component/path_test.go
@@ -128,6 +128,10 @@ func TestPathComponent_SQLInjection(t *testing.T) {
 	t.Logf("Full URL: %s", newReq.String())
 }
 
+// TestPathComponent_DeterministicIteration verifies that path segment iteration order is deterministic
+// by running 100 iterations and ensuring keys and values are always returned in the same order.
+// This test validates the fix that replaced standard maps with OrderedMap to ensure consistent
+// fuzzing behavior across multiple executions.
 func TestPathComponent_DeterministicIteration(t *testing.T) {
 	// Run the test 100 times to catch non-deterministic behavior
 	for iteration := 0; iteration < 100; iteration++ {


### PR DESCRIPTION
/claim #6398

## Proposed Changes

Fix non-deterministic path-based fuzzing that causes numeric path segments to be randomly skipped.

### Root Cause

The `Path.Parse()` method used a plain Go `map[string]interface{}` to store parsed path segments. Since Go maps have non-deterministic iteration order, the fuzzing engine would randomly skip path segments during iteration, particularly numeric ones like `/user/55/profile`.

### Fix

- Replace the plain map with `mapsutil.OrderedMap` in `Path.Parse()`, matching the pattern already used by the `Cookie` component
- Update `Path.Rebuild()` to use the `KV.Get()` accessor instead of directly accessing the `.Map` field (which would be nil when using OrderedMap)
- Add a deterministic iteration regression test that runs 100 iterations to verify order stability

### Proof of Fix

#### Test Results

All existing tests pass, plus new regression test verifies deterministic iteration:

```
=== RUN   TestPathComponent_SQLInjection
    path_test.go:97: Original path: /user/55/profile
    path_test.go:101: Key: 1, Value: user
    path_test.go:101: Key: 2, Value: 55
    path_test.go:101: Key: 3, Value: profile
    path_test.go:120: Modified path: /user/55 OR True/profile
    path_test.go:128: Full URL: https://example.com/user/55 OR True/profile
--- PASS: TestPathComponent_SQLInjection (0.00s)
=== RUN   TestPathComponent_DeterministicIteration
--- PASS: TestPathComponent_DeterministicIteration (0.00s)
PASS
ok      github.com/projectdiscovery/nuclei/v3/pkg/fuzz/component       0.177s
```

**Key observations:**
- The iteration order is now **consistently deterministic** (Key: 1, 2, 3) across all test runs
- The numeric segment `55` is **correctly included** in iteration (Key: 2, Value: 55)
- Path fuzzing now works correctly: `/user/55 OR True/profile`
- The `TestPathComponent_DeterministicIteration` test runs 100 iterations to verify no randomness

#### Before vs After Comparison

**Before (dev branch with plain map):**
```
[VER] [path-based-sqli] Sent HTTP request to http://127.0.0.1:8082/blog/post%20OR%20True?postId=3
[VER] [path-based-sqli] Sent HTTP request to http://127.0.0.1:8082/user%20OR%20True/55/profile
[VER] [path-based-sqli] Sent HTTP request to http://127.0.0.1:8082/user/55/profile
[VER] [path-based-sqli] Sent HTTP request to http://127.0.0.1:8082/user/55/profile%20OR%20True
```
**Issue:** The numeric segment `55` is NOT fuzzed (missing `/user/55%20OR%20True/profile` request).

**After (with OrderedMap fix):**
```
[VER] [path-based-sqli] Sent HTTP request to http://127.0.0.1:8082/blog/post%20OR%20True?postId=3
[VER] [path-based-sqli] Sent HTTP request to http://127.0.0.1:8082/user%20OR%20True/55/profile
[VER] [path-based-sqli] Sent HTTP request to http://127.0.0.1:8082/user/55%20OR%20True/profile
[VER] [path-based-sqli] Sent HTTP request to http://127.0.0.1:8082/user/55/profile%20OR%20True
```
**Fixed:** All path segments are now consistently fuzzed, including the numeric `55` (see the `/user/55%20OR%20True/profile` request).

### Technical Details

The fix uses `mapsutil.OrderedMap` which maintains insertion order, ensuring:
1. Path segments are always iterated in the same order (left to right)
2. No segments are skipped during fuzzing
3. Consistent behavior across all runs
4. Matches the pattern already used successfully in the `Cookie` component

## Checklist

- [x] PR created against the `dev` branch
- [x] All checks passed (`go build ./...`, `go vet ./pkg/fuzz/...`, `go test ./pkg/fuzz/...`)
- [x] Tests added that prove the fix is effective
- [x] Minimal, focused change (2 files, 43 insertions, 6 deletions)
- [x] Proof of fix provided with test output and before/after comparison

Fixes #6398

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deterministic ordering for path components during parsing and iteration.

* **Bug Fixes**
  * Improved path segment replacement to preserve original segments when replacements are missing, empty, or non-string.
  * Rebuilt path now performs URL decoding to avoid double-encoding and returns a cloned request with the reconstructed path.

* **Tests**
  * Added test verifying consistent iteration order of path components across multiple runs.

* **Documentation**
  * Expanded comments describing ordering, encoding/decoding, and reconstruction behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
