### PR TITLE
feat(fuzz): add xss context analyzer for intelligent payload selection

### DIFF
--- a/cmd/integration-test/fuzz.go
+++ b/cmd/integration-test/fuzz.go
@@ -33,6 +33,11 @@ var fuzzingTestCases = []TestCaseInfo{
 	{Path: "fuzz/fuzz-body-params-sqli.yaml", TestCase: &genericFuzzTestCase{expectedResults: 1}},
 	{Path: "fuzz/fuzz-body-xml-sqli.yaml", TestCase: &genericFuzzTestCase{expectedResults: 1}},
 	{Path: "fuzz/fuzz-body-generic-sqli.yaml", TestCase: &genericFuzzTestCase{expectedResults: 4}},
+	{Path: "fuzz/fuzz-xss-body.yaml", TestCase: &genericFuzzTestCase{expectedResults: 1}},
+	{Path: "fuzz/fuzz-xss-attribute.yaml", TestCase: &genericFuzzTestCase{expectedResults: 1}},
+	{Path: "fuzz/fuzz-xss-script.yaml", TestCase: &genericFuzzTestCase{expectedResults: 1}},
+	{Path: "fuzz/fuzz-xss-comment.yaml", TestCase: &genericFuzzTestCase{expectedResults: 1}},
+	{Path: "fuzz/fuzz-xss-event.yaml", TestCase: &genericFuzzTestCase{expectedResults: 1}},
 }
 
 type genericFuzzTestCase struct {

--- a/integration_tests/fuzz/fuzz-xss-attribute.yaml
+++ b/integration_tests/fuzz/fuzz-xss-attribute.yaml
@@ -1,0 +1,30 @@
+id: fuzz-xss-attribute-context
+
+info:
+  name: XSS Context Analyzer - Attribute Reflection
+  author: pdteam
+  severity: info
+  description: Detects reflected input in HTML attribute context using xss_context analyzer.
+
+http:
+  - pre-condition:
+      - type: dsl
+        dsl:
+          - 'method == "GET"'
+          - 'contains(path, "/xss/attribute")'
+        condition: and
+
+    fuzzing:
+      - part: query
+        type: replace
+        mode: single
+        fuzz:
+          - "[XSS_MARKER]"
+
+    analyzer:
+      name: xss_context
+
+    matchers:
+      - type: dsl
+        dsl:
+          - "analyzer == true"

--- a/integration_tests/fuzz/fuzz-xss-body.yaml
+++ b/integration_tests/fuzz/fuzz-xss-body.yaml
@@ -1,0 +1,30 @@
+id: fuzz-xss-body-context
+
+info:
+  name: XSS Context Analyzer - Body Reflection
+  author: pdteam
+  severity: info
+  description: Detects reflected input in HTML body text context using xss_context analyzer.
+
+http:
+  - pre-condition:
+      - type: dsl
+        dsl:
+          - 'method == "GET"'
+          - 'contains(path, "/xss/body")'
+        condition: and
+
+    fuzzing:
+      - part: query
+        type: replace
+        mode: single
+        fuzz:
+          - "[XSS_MARKER]"
+
+    analyzer:
+      name: xss_context
+
+    matchers:
+      - type: dsl
+        dsl:
+          - "analyzer == true"

--- a/integration_tests/fuzz/fuzz-xss-comment.yaml
+++ b/integration_tests/fuzz/fuzz-xss-comment.yaml
@@ -1,0 +1,30 @@
+id: fuzz-xss-comment-context
+
+info:
+  name: XSS Context Analyzer - Comment Reflection
+  author: pdteam
+  severity: info
+  description: Detects reflected input in HTML comment context using xss_context analyzer.
+
+http:
+  - pre-condition:
+      - type: dsl
+        dsl:
+          - 'method == "GET"'
+          - 'contains(path, "/xss/comment")'
+        condition: and
+
+    fuzzing:
+      - part: query
+        type: replace
+        mode: single
+        fuzz:
+          - "[XSS_MARKER]"
+
+    analyzer:
+      name: xss_context
+
+    matchers:
+      - type: dsl
+        dsl:
+          - "analyzer == true"

--- a/integration_tests/fuzz/fuzz-xss-event.yaml
+++ b/integration_tests/fuzz/fuzz-xss-event.yaml
@@ -1,0 +1,30 @@
+id: fuzz-xss-event-context
+
+info:
+  name: XSS Context Analyzer - Event Handler Reflection
+  author: pdteam
+  severity: info
+  description: Detects reflected input in event handler attribute context using xss_context analyzer.
+
+http:
+  - pre-condition:
+      - type: dsl
+        dsl:
+          - 'method == "GET"'
+          - 'contains(path, "/xss/event")'
+        condition: and
+
+    fuzzing:
+      - part: query
+        type: replace
+        mode: single
+        fuzz:
+          - "[XSS_MARKER]"
+
+    analyzer:
+      name: xss_context
+
+    matchers:
+      - type: dsl
+        dsl:
+          - "analyzer == true"

--- a/integration_tests/fuzz/fuzz-xss-script.yaml
+++ b/integration_tests/fuzz/fuzz-xss-script.yaml
@@ -1,0 +1,30 @@
+id: fuzz-xss-script-context
+
+info:
+  name: XSS Context Analyzer - Script Reflection
+  author: pdteam
+  severity: info
+  description: Detects reflected input in JavaScript context using xss_context analyzer.
+
+http:
+  - pre-condition:
+      - type: dsl
+        dsl:
+          - 'method == "GET"'
+          - 'contains(path, "/xss/script")'
+        condition: and
+
+    fuzzing:
+      - part: query
+        type: replace
+        mode: single
+        fuzz:
+          - "[XSS_MARKER]"
+
+    analyzer:
+      name: xss_context
+
+    matchers:
+      - type: dsl
+        dsl:
+          - "analyzer == true"

--- a/integration_tests/fuzz/testData/ginandjuice.proxify.yaml
+++ b/integration_tests/fuzz/testData/ginandjuice.proxify.yaml
@@ -533,3 +533,143 @@ response:
     Set-Cookie: session=fFcCUjmQguQy820Y8xrnRypp3KBWSPk6; Secure; HttpOnly; SameSite=None
     X-Backend: 2235790d-f089-4324-8ac0-f64cc96f2460
     X-Frame-Options: SAMEORIGIN
+
+---
+timestamp: 2024-02-20T19:24:13+05:30
+url: http://127.0.0.1:8082/xss/body?name=test
+request:
+  header:
+    Accept-Encoding: gzip
+    Connection: close
+    User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 11_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36
+    host: 127.0.0.1:8082
+    method: GET
+    path: /xss/body
+    scheme: https
+  raw: |+
+    GET /xss/body?name=test HTTP/1.1
+    Host: 127.0.0.1:8082
+    Accept-Encoding: gzip
+    Connection: close
+    User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 11_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36
+
+response:
+  header:
+    Content-Type: text/html; charset=utf-8
+    Date: Tue, 20 Feb 2024 13:54:13 GMT
+  raw: |+
+    HTTP/1.1 200 OK
+    Content-Type: text/html; charset=utf-8
+    Date: Tue, 20 Feb 2024 13:54:13 GMT
+
+---
+timestamp: 2024-02-20T19:24:13+05:30
+url: http://127.0.0.1:8082/xss/attribute?name=test
+request:
+  header:
+    Accept-Encoding: gzip
+    Connection: close
+    User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 11_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36
+    host: 127.0.0.1:8082
+    method: GET
+    path: /xss/attribute
+    scheme: https
+  raw: |+
+    GET /xss/attribute?name=test HTTP/1.1
+    Host: 127.0.0.1:8082
+    Accept-Encoding: gzip
+    Connection: close
+    User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 11_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36
+
+response:
+  header:
+    Content-Type: text/html; charset=utf-8
+    Date: Tue, 20 Feb 2024 13:54:13 GMT
+  raw: |+
+    HTTP/1.1 200 OK
+    Content-Type: text/html; charset=utf-8
+    Date: Tue, 20 Feb 2024 13:54:13 GMT
+
+---
+timestamp: 2024-02-20T19:24:13+05:30
+url: http://127.0.0.1:8082/xss/script?name=test
+request:
+  header:
+    Accept-Encoding: gzip
+    Connection: close
+    User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 11_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36
+    host: 127.0.0.1:8082
+    method: GET
+    path: /xss/script
+    scheme: https
+  raw: |+
+    GET /xss/script?name=test HTTP/1.1
+    Host: 127.0.0.1:8082
+    Accept-Encoding: gzip
+    Connection: close
+    User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 11_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36
+
+response:
+  header:
+    Content-Type: text/html; charset=utf-8
+    Date: Tue, 20 Feb 2024 13:54:13 GMT
+  raw: |+
+    HTTP/1.1 200 OK
+    Content-Type: text/html; charset=utf-8
+    Date: Tue, 20 Feb 2024 13:54:13 GMT
+
+---
+timestamp: 2024-02-20T19:24:13+05:30
+url: http://127.0.0.1:8082/xss/comment?name=test
+request:
+  header:
+    Accept-Encoding: gzip
+    Connection: close
+    User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 11_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36
+    host: 127.0.0.1:8082
+    method: GET
+    path: /xss/comment
+    scheme: https
+  raw: |+
+    GET /xss/comment?name=test HTTP/1.1
+    Host: 127.0.0.1:8082
+    Accept-Encoding: gzip
+    Connection: close
+    User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 11_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36
+
+response:
+  header:
+    Content-Type: text/html; charset=utf-8
+    Date: Tue, 20 Feb 2024 13:54:13 GMT
+  raw: |+
+    HTTP/1.1 200 OK
+    Content-Type: text/html; charset=utf-8
+    Date: Tue, 20 Feb 2024 13:54:13 GMT
+
+---
+timestamp: 2024-02-20T19:24:13+05:30
+url: http://127.0.0.1:8082/xss/event?name=test
+request:
+  header:
+    Accept-Encoding: gzip
+    Connection: close
+    User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 11_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36
+    host: 127.0.0.1:8082
+    method: GET
+    path: /xss/event
+    scheme: https
+  raw: |+
+    GET /xss/event?name=test HTTP/1.1
+    Host: 127.0.0.1:8082
+    Accept-Encoding: gzip
+    Connection: close
+    User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 11_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36
+
+response:
+  header:
+    Content-Type: text/html; charset=utf-8
+    Date: Tue, 20 Feb 2024 13:54:13 GMT
+  raw: |+
+    HTTP/1.1 200 OK
+    Content-Type: text/html; charset=utf-8
+    Date: Tue, 20 Feb 2024 13:54:13 GMT

--- a/pkg/fuzz/analyzers/analyzers.go
+++ b/pkg/fuzz/analyzers/analyzers.go
@@ -85,6 +85,7 @@ func ApplyPayloadTransformations(value string) string {
 
 const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
+// RandStringBytesMask returns a random alphabetic string of length n.
 func RandStringBytesMask(n int) string {
 	b := make([]byte, n)
 	for i := range b {

--- a/pkg/fuzz/analyzers/analyzers.go
+++ b/pkg/fuzz/analyzers/analyzers.go
@@ -4,6 +4,7 @@ import (
 	"math/rand"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz"
@@ -67,7 +68,8 @@ type Options struct {
 }
 
 var (
-	random = rand.New(rand.NewSource(time.Now().UnixNano()))
+	random   = rand.New(rand.NewSource(time.Now().UnixNano()))
+	randomMu sync.Mutex
 )
 
 // ApplyPayloadTransformations applies the payload transformations to the payload
@@ -87,14 +89,19 @@ const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
 // RandStringBytesMask returns a random alphabetic string of length n.
 func RandStringBytesMask(n int) string {
+	randomMu.Lock()
 	b := make([]byte, n)
 	for i := range b {
 		b[i] = letterBytes[random.Intn(len(letterBytes))]
 	}
+	randomMu.Unlock()
 	return string(b)
 }
 
 // GetRandomInteger returns a random integer between 1000 and 9999
 func GetRandomInteger() int {
-	return random.Intn(9000) + 1000
+	randomMu.Lock()
+	n := random.Intn(9000) + 1000
+	randomMu.Unlock()
+	return n
 }

--- a/pkg/fuzz/analyzers/analyzers.go
+++ b/pkg/fuzz/analyzers/analyzers.go
@@ -27,6 +27,7 @@ type AnalyzerTemplate struct {
 	//   Name is the name of the analyzer to use
 	// values:
 	//   - time_delay
+	//   - xss_context
 	Name string `json:"name" yaml:"name"`
 	// description: |
 	//   Parameters is the parameters for the analyzer
@@ -60,6 +61,8 @@ type Options struct {
 	FuzzGenerated      fuzz.GeneratedRequest
 	HttpClient         *retryablehttp.Client
 	ResponseTimeDelay  time.Duration
+	ResponseBody       string
+	ResponseHeaders    string
 	AnalyzerParameters map[string]interface{}
 }
 
@@ -73,7 +76,7 @@ var (
 //   - [RANDSTR] => random string of 4 characters
 func ApplyPayloadTransformations(value string) string {
 	randomInt := GetRandomInteger()
-	randomStr := randStringBytesMask(4)
+	randomStr := RandStringBytesMask(4)
 
 	value = strings.ReplaceAll(value, "[RANDNUM]", strconv.Itoa(randomInt))
 	value = strings.ReplaceAll(value, "[RANDSTR]", randomStr)
@@ -82,7 +85,7 @@ func ApplyPayloadTransformations(value string) string {
 
 const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
-func randStringBytesMask(n int) string {
+func RandStringBytesMask(n int) string {
 	b := make([]byte, n)
 	for i := range b {
 		b[i] = letterBytes[random.Intn(len(letterBytes))]

--- a/pkg/fuzz/analyzers/xss/analyzer.go
+++ b/pkg/fuzz/analyzers/xss/analyzer.go
@@ -1,0 +1,58 @@
+package xss
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz/analyzers"
+)
+
+type Analyzer struct{}
+
+var _ analyzers.Analyzer = &Analyzer{}
+
+func init() {
+	analyzers.RegisterAnalyzer("xss_context", &Analyzer{})
+}
+
+func (a *Analyzer) Name() string {
+	return "xss_context"
+}
+
+func (a *Analyzer) ApplyInitialTransformation(data string, params map[string]interface{}) string {
+	data = analyzers.ApplyPayloadTransformations(data)
+	if strings.Contains(data, "[XSS_MARKER]") {
+		marker := "nuclei" + analyzers.RandStringBytesMask(8)
+		data = strings.ReplaceAll(data, "[XSS_MARKER]", marker)
+		params["xss_marker"] = marker
+	}
+	return data
+}
+
+func (a *Analyzer) Analyze(options *analyzers.Options) (bool, string, error) {
+	if options.ResponseBody == "" {
+		return false, "", nil
+	}
+	reflectedValue := ""
+	if options.AnalyzerParameters != nil {
+		if marker, ok := options.AnalyzerParameters["xss_marker"].(string); ok {
+			reflectedValue = marker
+		}
+	}
+	if reflectedValue == "" {
+		reflectedValue = options.FuzzGenerated.Value
+	}
+	if reflectedValue == "" {
+		return false, "", nil
+	}
+	ctx := DetectContext(options.ResponseBody, reflectedValue)
+	if ctx == ContextNone {
+		return false, "", nil
+	}
+	detail := fmt.Sprintf(
+		"[xss_context] reflection detected in %s context for parameter '%s'",
+		ctx.String(),
+		options.FuzzGenerated.Parameter,
+	)
+	return true, detail, nil
+}

--- a/pkg/fuzz/analyzers/xss/analyzer.go
+++ b/pkg/fuzz/analyzers/xss/analyzer.go
@@ -7,6 +7,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz/analyzers"
 )
 
+// Analyzer detects the HTML rendering context of reflected values.
 type Analyzer struct{}
 
 var _ analyzers.Analyzer = &Analyzer{}
@@ -15,10 +16,12 @@ func init() {
 	analyzers.RegisterAnalyzer("xss_context", &Analyzer{})
 }
 
+// Name returns the analyzer identifier.
 func (a *Analyzer) Name() string {
 	return "xss_context"
 }
 
+// ApplyInitialTransformation replaces [XSS_MARKER] with a unique canary and persists it in params.
 func (a *Analyzer) ApplyInitialTransformation(data string, params map[string]interface{}) string {
 	data = analyzers.ApplyPayloadTransformations(data)
 	if strings.Contains(data, "[XSS_MARKER]") {
@@ -29,6 +32,7 @@ func (a *Analyzer) ApplyInitialTransformation(data string, params map[string]int
 	return data
 }
 
+// Analyze classifies the HTML context of a reflected canary in the response body.
 func (a *Analyzer) Analyze(options *analyzers.Options) (bool, string, error) {
 	if options.ResponseBody == "" {
 		return false, "", nil

--- a/pkg/fuzz/analyzers/xss/analyzer.go
+++ b/pkg/fuzz/analyzers/xss/analyzer.go
@@ -27,12 +27,15 @@ func (a *Analyzer) ApplyInitialTransformation(data string, params map[string]int
 	if strings.Contains(data, "[XSS_MARKER]") {
 		marker := "nuclei" + analyzers.RandStringBytesMask(8)
 		data = strings.ReplaceAll(data, "[XSS_MARKER]", marker)
-		params["xss_marker"] = marker
+		if params != nil {
+			params["xss_marker"] = marker
+		}
 	}
 	return data
 }
 
-// Analyze classifies the HTML context of a reflected canary in the response body.
+// Analyze classifies the HTML context of a reflected canary in the response body
+// and verifies exploitability by analyzing Content-Type, CSP, and quoting.
 func (a *Analyzer) Analyze(options *analyzers.Options) (bool, string, error) {
 	if options.ResponseBody == "" {
 		return false, "", nil
@@ -53,10 +56,20 @@ func (a *Analyzer) Analyze(options *analyzers.Options) (bool, string, error) {
 	if ctx == ContextNone {
 		return false, "", nil
 	}
-	detail := fmt.Sprintf(
-		"[xss_context] reflection detected in %s context for parameter '%s'",
+	exploitable, detail := VerifyContext(
+		options.ResponseBody,
+		options.ResponseHeaders,
+		reflectedValue,
+		ctx,
+	)
+	if !exploitable {
+		return false, "", nil
+	}
+	result := fmt.Sprintf(
+		"[xss_context] %s reflection for parameter '%s' (%s)",
 		ctx.String(),
 		options.FuzzGenerated.Parameter,
+		detail,
 	)
-	return true, detail, nil
+	return true, result, nil
 }

--- a/pkg/fuzz/analyzers/xss/context.go
+++ b/pkg/fuzz/analyzers/xss/context.go
@@ -33,7 +33,8 @@ func (c ContextType) String() string {
 }
 
 var (
-	onPrefix = []byte("on")
+	onPrefix  = []byte("on")
+	scriptTag = []byte("script")
 )
 
 func DetectContext(body string, marker string) ContextType {
@@ -42,7 +43,6 @@ func DetectContext(body string, marker string) ContextType {
 	}
 
 	m := []byte(marker)
-	st := []byte("script")
 	z := html.NewTokenizer(strings.NewReader(body))
 
 	var (
@@ -65,7 +65,7 @@ func DetectContext(body string, marker string) ContextType {
 
 		case html.StartTagToken, html.SelfClosingTagToken:
 			tn, hasAttr := z.TagName()
-			if tt == html.StartTagToken && len(tn) == 6 && bytes.EqualFold(tn, st) {
+			if tt == html.StartTagToken && len(tn) == 6 && bytes.EqualFold(tn, scriptTag) {
 				inScript = true
 			}
 			if hasAttr {
@@ -92,7 +92,7 @@ func DetectContext(body string, marker string) ContextType {
 
 		case html.EndTagToken:
 			tn, _ := z.TagName()
-			if len(tn) == 6 && bytes.EqualFold(tn, st) {
+			if len(tn) == 6 && bytes.EqualFold(tn, scriptTag) {
 				inScript = false
 			}
 

--- a/pkg/fuzz/analyzers/xss/context.go
+++ b/pkg/fuzz/analyzers/xss/context.go
@@ -68,6 +68,9 @@ func DetectContext(body string, marker string) ContextType {
 
 		case html.StartTagToken, html.SelfClosingTagToken:
 			tn, hasAttr := z.TagName()
+			if bytes.Contains(tn, m) {
+				return ContextScript
+			}
 			if tt == html.StartTagToken && len(tn) == 6 && bytes.EqualFold(tn, scriptTag) {
 				inScript = true
 			}

--- a/pkg/fuzz/analyzers/xss/context.go
+++ b/pkg/fuzz/analyzers/xss/context.go
@@ -7,6 +7,7 @@ import (
 	"golang.org/x/net/html"
 )
 
+// ContextType represents the HTML reflection context of a marker.
 type ContextType int
 
 const (
@@ -37,6 +38,7 @@ var (
 	scriptTag = []byte("script")
 )
 
+// DetectContext returns the highest-priority HTML context where marker appears.
 func DetectContext(body string, marker string) ContextType {
 	if !strings.Contains(body, marker) {
 		return ContextNone
@@ -105,10 +107,6 @@ func DetectContext(body string, marker string) ContextType {
 					best = ContextHTML
 				}
 			}
-		}
-
-		if best == ContextScript {
-			return best
 		}
 	}
 }

--- a/pkg/fuzz/analyzers/xss/context.go
+++ b/pkg/fuzz/analyzers/xss/context.go
@@ -18,6 +18,7 @@ const (
 	ContextScript
 )
 
+// String returns the string representation of the context type.
 func (c ContextType) String() string {
 	switch c {
 	case ContextComment:

--- a/pkg/fuzz/analyzers/xss/context.go
+++ b/pkg/fuzz/analyzers/xss/context.go
@@ -1,0 +1,227 @@
+package xss
+
+import (
+	"bytes"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+type ContextType int
+
+const (
+	ContextNone ContextType = iota
+	ContextComment
+	ContextHTML
+	ContextAttribute
+	ContextScript
+)
+
+func (c ContextType) String() string {
+	switch c {
+	case ContextComment:
+		return "comment"
+	case ContextHTML:
+		return "html_tag"
+	case ContextAttribute:
+		return "attribute"
+	case ContextScript:
+		return "script"
+	default:
+		return "none"
+	}
+}
+
+var (
+	onPrefix = []byte("on")
+)
+
+func DetectContext(body string, marker string) ContextType {
+	if !strings.Contains(body, marker) {
+		return ContextNone
+	}
+
+	m := []byte(marker)
+	st := []byte("script")
+	z := html.NewTokenizer(strings.NewReader(body))
+
+	var (
+		inScript bool
+		best     = ContextNone
+	)
+
+	for {
+		tt := z.Next()
+		switch tt {
+		case html.ErrorToken:
+			return best
+
+		case html.CommentToken:
+			if bytes.Contains(z.Text(), m) {
+				if best < ContextComment {
+					best = ContextComment
+				}
+			}
+
+		case html.StartTagToken, html.SelfClosingTagToken:
+			tn, hasAttr := z.TagName()
+			if tt == html.StartTagToken && len(tn) == 6 && bytes.EqualFold(tn, st) {
+				inScript = true
+			}
+			if hasAttr {
+				for {
+					k, v, more := z.TagAttr()
+					if bytes.Contains(v, m) {
+						if len(k) >= 2 && bytes.EqualFold(k[:2], onPrefix) && isEventHandler(k) {
+							return ContextScript
+						}
+						if best < ContextAttribute {
+							best = ContextAttribute
+						}
+					}
+					if bytes.Contains(k, m) {
+						if best < ContextAttribute {
+							best = ContextAttribute
+						}
+					}
+					if !more {
+						break
+					}
+				}
+			}
+
+		case html.EndTagToken:
+			tn, _ := z.TagName()
+			if len(tn) == 6 && bytes.EqualFold(tn, st) {
+				inScript = false
+			}
+
+		case html.TextToken:
+			if bytes.Contains(z.Text(), m) {
+				if inScript {
+					return ContextScript
+				}
+				if best < ContextHTML {
+					best = ContextHTML
+				}
+			}
+		}
+
+		if best == ContextScript {
+			return best
+		}
+	}
+}
+
+func isEventHandler(key []byte) bool {
+	const maxLen = 32
+	if len(key) > maxLen {
+		return false
+	}
+	var buf [maxLen]byte
+	n := len(key)
+	for i := 0; i < n; i++ {
+		c := key[i]
+		if c >= 'A' && c <= 'Z' {
+			buf[i] = c + 0x20
+		} else {
+			buf[i] = c
+		}
+	}
+	_, ok := eventHandlers[string(buf[:n])]
+	return ok
+}
+
+var eventHandlers = map[string]struct{}{
+	// Window events
+	"onafterprint":  {},
+	"onbeforeprint": {},
+	"onbeforeunload": {},
+	"onerror":       {},
+	"onhashchange":  {},
+	"onload":        {},
+	"onmessage":     {},
+	"onoffline":     {},
+	"ononline":      {},
+	"onpagehide":    {},
+	"onpageshow":    {},
+	"onpopstate":    {},
+	"onresize":      {},
+	"onstorage":     {},
+	"onunload":      {},
+	// Form events
+	"onblur":        {},
+	"onchange":      {},
+	"oncontextmenu": {},
+	"onfocus":       {},
+	"oninput":       {},
+	"oninvalid":     {},
+	"onreset":       {},
+	"onsearch":      {},
+	"onselect":      {},
+	"onsubmit":      {},
+	// Keyboard events
+	"onkeydown":  {},
+	"onkeypress": {},
+	"onkeyup":    {},
+	// Mouse events
+	"onclick":      {},
+	"ondblclick":   {},
+	"onmousedown":  {},
+	"onmousemove":  {},
+	"onmouseout":   {},
+	"onmouseover":  {},
+	"onmouseup":    {},
+	"onwheel":      {},
+	// Drag events
+	"ondrag":      {},
+	"ondragend":   {},
+	"ondragenter": {},
+	"ondragleave": {},
+	"ondragover":  {},
+	"ondragstart": {},
+	"ondrop":      {},
+	// Scroll
+	"onscroll": {},
+	// Clipboard
+	"oncopy":  {},
+	"oncut":   {},
+	"onpaste": {},
+	// Media events
+	"onabort":          {},
+	"oncanplay":        {},
+	"oncanplaythrough": {},
+	"ondurationchange": {},
+	"onemptied":        {},
+	"onended":          {},
+	"onloadeddata":     {},
+	"onloadedmetadata": {},
+	"onloadstart":      {},
+	"onpause":          {},
+	"onplay":           {},
+	"onplaying":        {},
+	"onprogress":       {},
+	"onratechange":     {},
+	"onseeked":         {},
+	"onseeking":        {},
+	"onstalled":        {},
+	"onsuspend":        {},
+	"ontimeupdate":     {},
+	"onvolumechange":   {},
+	"onwaiting":        {},
+	// Misc
+	"ontoggle":             {},
+	"onanimationstart":     {},
+	"onanimationend":       {},
+	"onanimationiteration": {},
+	"ontransitionend":      {},
+	"onfocusin":            {},
+	"onfocusout":           {},
+	"onpointerdown":        {},
+	"onpointerup":          {},
+	"onpointermove":        {},
+	"onpointerover":        {},
+	"onpointerout":         {},
+	"onpointerenter":       {},
+	"onpointerleave":       {},
+}

--- a/pkg/fuzz/analyzers/xss/context.go
+++ b/pkg/fuzz/analyzers/xss/context.go
@@ -10,6 +10,7 @@ import (
 // ContextType represents the HTML reflection context of a marker.
 type ContextType int
 
+// Context classification constants, ordered by exploitability.
 const (
 	ContextNone ContextType = iota
 	ContextComment
@@ -37,6 +38,7 @@ func (c ContextType) String() string {
 var (
 	onPrefix  = []byte("on")
 	scriptTag = []byte("script")
+	styleTag  = []byte("style")
 )
 
 // DetectContext returns the highest-priority HTML context where marker appears.
@@ -50,6 +52,7 @@ func DetectContext(body string, marker string) ContextType {
 
 	var (
 		inScript bool
+		inStyle  bool
 		best     = ContextNone
 	)
 
@@ -71,8 +74,12 @@ func DetectContext(body string, marker string) ContextType {
 			if bytes.Contains(tn, m) {
 				return ContextScript
 			}
-			if tt == html.StartTagToken && len(tn) == 6 && bytes.EqualFold(tn, scriptTag) {
-				inScript = true
+			if tt == html.StartTagToken {
+				if len(tn) == 6 && bytes.EqualFold(tn, scriptTag) {
+					inScript = true
+				} else if len(tn) == 5 && bytes.EqualFold(tn, styleTag) {
+					inStyle = true
+				}
 			}
 			if hasAttr {
 				for {
@@ -86,6 +93,9 @@ func DetectContext(body string, marker string) ContextType {
 						}
 					}
 					if bytes.Contains(k, m) {
+						if isEventHandler(k) {
+							return ContextScript
+						}
 						if best < ContextAttribute {
 							best = ContextAttribute
 						}
@@ -100,6 +110,8 @@ func DetectContext(body string, marker string) ContextType {
 			tn, _ := z.TagName()
 			if len(tn) == 6 && bytes.EqualFold(tn, scriptTag) {
 				inScript = false
+			} else if len(tn) == 5 && bytes.EqualFold(tn, styleTag) {
+				inStyle = false
 			}
 
 		case html.TextToken:
@@ -107,7 +119,11 @@ func DetectContext(body string, marker string) ContextType {
 				if inScript {
 					return ContextScript
 				}
-				if best < ContextHTML {
+				if inStyle {
+					if best < ContextAttribute {
+						best = ContextAttribute
+					}
+				} else if best < ContextHTML {
 					best = ContextHTML
 				}
 			}
@@ -115,6 +131,7 @@ func DetectContext(body string, marker string) ContextType {
 	}
 }
 
+// isEventHandler reports whether key is a known HTML event handler attribute.
 func isEventHandler(key []byte) bool {
 	const maxLen = 32
 	if len(key) > maxLen {

--- a/pkg/fuzz/analyzers/xss/context_test.go
+++ b/pkg/fuzz/analyzers/xss/context_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 )
 
+// TestDetectContext validates context classification across all context types.
 func TestDetectContext(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -174,10 +175,10 @@ func TestDetectContext(t *testing.T) {
 			expected: ContextScript,
 		},
 		{
-			name:     "marker in style tag body is html context",
+			name:     "marker in style tag body is attribute context",
 			body:     `<style>.nuclei12345 { color: red; }</style>`,
 			marker:   "nuclei12345",
-			expected: ContextHTML,
+			expected: ContextAttribute,
 		},
 		{
 			name:     "self-closing script tag does not affect subsequent text",
@@ -189,6 +190,18 @@ func TestDetectContext(t *testing.T) {
 			name:     "marker in tag name",
 			body:     `<nuclei12345>content</nuclei12345>`,
 			marker:   "nuclei12345",
+			expected: ContextScript,
+		},
+		{
+			name:     "marker in event handler attribute name",
+			body:     `<div nuclei12345="value">text</div>`,
+			marker:   "nuclei12345",
+			expected: ContextAttribute,
+		},
+		{
+			name:     "marker forms onclick attribute name",
+			body:     `<div onclick="alert(1)">text</div>`,
+			marker:   "onclick",
 			expected: ContextScript,
 		},
 	}
@@ -204,6 +217,7 @@ func TestDetectContext(t *testing.T) {
 	}
 }
 
+// TestIsEventHandler validates event handler attribute recognition.
 func TestIsEventHandler(t *testing.T) {
 	tests := []struct {
 		attr     string
@@ -236,6 +250,7 @@ func TestIsEventHandler(t *testing.T) {
 	}
 }
 
+// TestContextTypeString validates string representation of context types.
 func TestContextTypeString(t *testing.T) {
 	tests := []struct {
 		ctx      ContextType
@@ -257,6 +272,7 @@ func TestContextTypeString(t *testing.T) {
 	}
 }
 
+// BenchmarkDetectContext_NoReflection measures performance when marker is absent.
 func BenchmarkDetectContext_NoReflection(b *testing.B) {
 	body := `<html><head><title>Test</title></head><body><div class="container"><p>Hello world</p></div></body></html>`
 	marker := "nucleiXYZ12345"
@@ -267,6 +283,7 @@ func BenchmarkDetectContext_NoReflection(b *testing.B) {
 	}
 }
 
+// BenchmarkDetectContext_HTMLContext measures performance for HTML text context.
 func BenchmarkDetectContext_HTMLContext(b *testing.B) {
 	body := `<html><body><div>nucleiXYZ12345</div></body></html>`
 	marker := "nucleiXYZ12345"
@@ -277,6 +294,7 @@ func BenchmarkDetectContext_HTMLContext(b *testing.B) {
 	}
 }
 
+// BenchmarkDetectContext_ScriptContext measures performance for script context.
 func BenchmarkDetectContext_ScriptContext(b *testing.B) {
 	body := `<html><body><script>var x = "nucleiXYZ12345";</script></body></html>`
 	marker := "nucleiXYZ12345"
@@ -287,6 +305,7 @@ func BenchmarkDetectContext_ScriptContext(b *testing.B) {
 	}
 }
 
+// BenchmarkDetectContext_AttributeContext measures performance for attribute context.
 func BenchmarkDetectContext_AttributeContext(b *testing.B) {
 	body := `<html><body><input type="text" value="nucleiXYZ12345"></body></html>`
 	marker := "nucleiXYZ12345"
@@ -297,6 +316,7 @@ func BenchmarkDetectContext_AttributeContext(b *testing.B) {
 	}
 }
 
+// BenchmarkDetectContext_LargePage measures performance on a large HTML document.
 func BenchmarkDetectContext_LargePage(b *testing.B) {
 	var page string
 	for i := 0; i < 100; i++ {

--- a/pkg/fuzz/analyzers/xss/context_test.go
+++ b/pkg/fuzz/analyzers/xss/context_test.go
@@ -1,0 +1,306 @@
+package xss
+
+import (
+	"testing"
+)
+
+func TestDetectContext(t *testing.T) {
+	tests := []struct {
+		name     string
+		body     string
+		marker   string
+		expected ContextType
+	}{
+		{
+			name:     "marker not present",
+			body:     `<html><body><p>Hello world</p></body></html>`,
+			marker:   "nuclei12345",
+			expected: ContextNone,
+		},
+		{
+			name:     "empty body",
+			body:     "",
+			marker:   "nuclei12345",
+			expected: ContextNone,
+		},
+		{
+			name:     "reflected in tag body",
+			body:     `<html><body><div>nuclei12345</div></body></html>`,
+			marker:   "nuclei12345",
+			expected: ContextHTML,
+		},
+		{
+			name:     "reflected in paragraph text",
+			body:     `<p>some text nuclei12345 more text</p>`,
+			marker:   "nuclei12345",
+			expected: ContextHTML,
+		},
+		{
+			name:     "reflected in nested tag body",
+			body:     `<html><body><div><span><b>nuclei12345</b></span></div></body></html>`,
+			marker:   "nuclei12345",
+			expected: ContextHTML,
+		},
+		{
+			name:     "reflected in attribute value",
+			body:     `<img src="nuclei12345">`,
+			marker:   "nuclei12345",
+			expected: ContextAttribute,
+		},
+		{
+			name:     "reflected in href attribute",
+			body:     `<a href="https://example.com/nuclei12345">link</a>`,
+			marker:   "nuclei12345",
+			expected: ContextAttribute,
+		},
+		{
+			name:     "reflected in input value",
+			body:     `<input type="text" value="nuclei12345">`,
+			marker:   "nuclei12345",
+			expected: ContextAttribute,
+		},
+		{
+			name:     "reflected in class attribute",
+			body:     `<div class="foo nuclei12345 bar">text</div>`,
+			marker:   "nuclei12345",
+			expected: ContextAttribute,
+		},
+		{
+			name:     "reflected in script text",
+			body:     `<script>var x = "nuclei12345";</script>`,
+			marker:   "nuclei12345",
+			expected: ContextScript,
+		},
+		{
+			name:     "reflected in inline script",
+			body:     `<html><head><script>alert('nuclei12345')</script></head></html>`,
+			marker:   "nuclei12345",
+			expected: ContextScript,
+		},
+		{
+			name:     "reflected in onclick event handler",
+			body:     `<button onclick="alert('nuclei12345')">Click</button>`,
+			marker:   "nuclei12345",
+			expected: ContextScript,
+		},
+		{
+			name:     "reflected in onmouseover event handler",
+			body:     `<div onmouseover="track('nuclei12345')">hover</div>`,
+			marker:   "nuclei12345",
+			expected: ContextScript,
+		},
+		{
+			name:     "reflected in onerror event handler",
+			body:     `<img src=x onerror="alert('nuclei12345')">`,
+			marker:   "nuclei12345",
+			expected: ContextScript,
+		},
+		{
+			name:     "reflected in onfocus event handler",
+			body:     `<input onfocus="doStuff('nuclei12345')" autofocus>`,
+			marker:   "nuclei12345",
+			expected: ContextScript,
+		},
+		{
+			name:     "reflected in mixed case event handler",
+			body:     `<div ONCLICK="alert('nuclei12345')">text</div>`,
+			marker:   "nuclei12345",
+			expected: ContextScript,
+		},
+		{
+			name:     "reflected in comment",
+			body:     `<html><!-- nuclei12345 --><body></body></html>`,
+			marker:   "nuclei12345",
+			expected: ContextComment,
+		},
+		{
+			name:     "reflected in multi-line comment",
+			body:     "<!-- some debug info\nnuclei12345\nend -->",
+			marker:   "nuclei12345",
+			expected: ContextComment,
+		},
+		{
+			name:     "reflected in both attribute and script — script wins",
+			body:     `<input value="nuclei12345"><script>var y = "nuclei12345";</script>`,
+			marker:   "nuclei12345",
+			expected: ContextScript,
+		},
+		{
+			name:     "reflected in both html body and attribute — attribute wins",
+			body:     `<div title="nuclei12345">nuclei12345</div>`,
+			marker:   "nuclei12345",
+			expected: ContextAttribute,
+		},
+		{
+			name:     "reflected in comment, html, attribute, and script — script wins",
+			body:     `<!-- nuclei12345 --><div class="nuclei12345">nuclei12345</div><script>nuclei12345</script>`,
+			marker:   "nuclei12345",
+			expected: ContextScript,
+		},
+		{
+			name:     "marker in attribute name (unusual reflection)",
+			body:     `<div nuclei12345="value">text</div>`,
+			marker:   "nuclei12345",
+			expected: ContextAttribute,
+		},
+		{
+			name:     "self-closing tag with marker in attribute",
+			body:     `<br data-val="nuclei12345"/>`,
+			marker:   "nuclei12345",
+			expected: ContextAttribute,
+		},
+		{
+			name:     "marker spans partial word in body",
+			body:     `<p>foodnuclei12345bar</p>`,
+			marker:   "nuclei12345",
+			expected: ContextHTML,
+		},
+		{
+			name:     "non-standard event handler is treated as attribute",
+			body:     `<div data-onclick="nuclei12345">text</div>`,
+			marker:   "nuclei12345",
+			expected: ContextAttribute,
+		},
+		{
+			name:     "script with mixed case tag",
+			body:     `<SCRIPT>var z = "nuclei12345";</SCRIPT>`,
+			marker:   "nuclei12345",
+			expected: ContextScript,
+		},
+		{
+			name:     "multiple scripts, marker in second",
+			body:     `<script>var a = 1;</script><p>safe</p><script>var b = "nuclei12345";</script>`,
+			marker:   "nuclei12345",
+			expected: ContextScript,
+		},
+		{
+			name:     "marker in style tag body is html context",
+			body:     `<style>.nuclei12345 { color: red; }</style>`,
+			marker:   "nuclei12345",
+			expected: ContextHTML,
+		},
+		{
+			name:     "self-closing script tag does not affect subsequent text",
+			body:     `<script src="external.js"/><div>nuclei12345</div>`,
+			marker:   "nuclei12345",
+			expected: ContextHTML,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DetectContext(tt.body, tt.marker)
+			if got != tt.expected {
+				t.Errorf("DetectContext() = %v (%s), want %v (%s)",
+					got, got.String(), tt.expected, tt.expected.String())
+			}
+		})
+	}
+}
+
+func TestIsEventHandler(t *testing.T) {
+	tests := []struct {
+		attr     string
+		expected bool
+	}{
+		{"onclick", true},
+		{"ONCLICK", true},
+		{"OnClick", true},
+		{"onmouseover", true},
+		{"onerror", true},
+		{"onload", true},
+		{"onanimationiteration", true},
+		{"onfocusin", true},
+		{"onpointerdown", true},
+		{"class", false},
+		{"href", false},
+		{"src", false},
+		{"data-onclick", false},
+		{"onnonexistent", false},
+		{"on", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.attr, func(t *testing.T) {
+			got := isEventHandler([]byte(tt.attr))
+			if got != tt.expected {
+				t.Errorf("isEventHandler(%q) = %v, want %v", tt.attr, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestContextTypeString(t *testing.T) {
+	tests := []struct {
+		ctx      ContextType
+		expected string
+	}{
+		{ContextNone, "none"},
+		{ContextComment, "comment"},
+		{ContextHTML, "html_tag"},
+		{ContextAttribute, "attribute"},
+		{ContextScript, "script"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			if got := tt.ctx.String(); got != tt.expected {
+				t.Errorf("ContextType.String() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func BenchmarkDetectContext_NoReflection(b *testing.B) {
+	body := `<html><head><title>Test</title></head><body><div class="container"><p>Hello world</p></div></body></html>`
+	marker := "nucleiXYZ12345"
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		DetectContext(body, marker)
+	}
+}
+
+func BenchmarkDetectContext_HTMLContext(b *testing.B) {
+	body := `<html><body><div>nucleiXYZ12345</div></body></html>`
+	marker := "nucleiXYZ12345"
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		DetectContext(body, marker)
+	}
+}
+
+func BenchmarkDetectContext_ScriptContext(b *testing.B) {
+	body := `<html><body><script>var x = "nucleiXYZ12345";</script></body></html>`
+	marker := "nucleiXYZ12345"
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		DetectContext(body, marker)
+	}
+}
+
+func BenchmarkDetectContext_AttributeContext(b *testing.B) {
+	body := `<html><body><input type="text" value="nucleiXYZ12345"></body></html>`
+	marker := "nucleiXYZ12345"
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		DetectContext(body, marker)
+	}
+}
+
+func BenchmarkDetectContext_LargePage(b *testing.B) {
+	var page string
+	for i := 0; i < 100; i++ {
+		page += `<div class="item"><p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p></div>`
+	}
+	page += `<script>var token = "nucleiXYZ12345";</script></body></html>`
+	marker := "nucleiXYZ12345"
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		DetectContext(page, marker)
+	}
+}

--- a/pkg/fuzz/analyzers/xss/context_test.go
+++ b/pkg/fuzz/analyzers/xss/context_test.go
@@ -185,6 +185,12 @@ func TestDetectContext(t *testing.T) {
 			marker:   "nuclei12345",
 			expected: ContextHTML,
 		},
+		{
+			name:     "marker in tag name",
+			body:     `<nuclei12345>content</nuclei12345>`,
+			marker:   "nuclei12345",
+			expected: ContextScript,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/fuzz/analyzers/xss/verify.go
+++ b/pkg/fuzz/analyzers/xss/verify.go
@@ -1,0 +1,173 @@
+package xss
+
+import (
+	"bytes"
+	"strings"
+)
+
+// QuoteStyle identifies the quoting used around an attribute value.
+type QuoteStyle int
+
+// Attribute value quoting constants.
+const (
+	QuoteNone   QuoteStyle = iota
+	QuoteDouble            // value="..."
+	QuoteSingle            // value='...'
+)
+
+// String returns the string representation of the quote style.
+func (q QuoteStyle) String() string {
+	switch q {
+	case QuoteDouble:
+		return "double"
+	case QuoteSingle:
+		return "single"
+	default:
+		return "unquoted"
+	}
+}
+
+// VerifyContext performs escape-aware analysis of a detected reflection to
+// determine whether the context is actually exploitable. It rejects non-HTML
+// responses, identifies attribute quoting style, detects RCDATA/raw-text
+// elements, and flags CSP mitigations. This eliminates the class of false
+// positives where reflection occurs in a non-browser-renderable response
+// (JSON, plain text) or behind a strict Content-Security-Policy.
+//
+// Design note: verification is performed entirely from the existing response
+// without additional HTTP requests. This keeps the analyzer O(1) in network
+// I/O while still catching the dominant false-positive sources. A replay-based
+// verification phase (sending context-specific breakout probes) can be layered
+// on top in a future iteration without changing this interface.
+func VerifyContext(body, headers, marker string, ctx ContextType) (bool, string) {
+	if !isHTMLContentType(headers) {
+		return false, ""
+	}
+
+	switch ctx {
+	case ContextScript:
+		detail := "script"
+		if hasStrictCSP(headers) {
+			detail += ":csp-present"
+		}
+		return true, detail
+
+	case ContextAttribute:
+		q := detectQuoting([]byte(body), []byte(marker))
+		if q == QuoteNone {
+			return true, "attribute:unquoted"
+		}
+		return true, "attribute:" + q.String() + "-quoted"
+
+	case ContextHTML:
+		if inRCDATA([]byte(body), []byte(marker)) {
+			return true, "html_tag:rcdata"
+		}
+		return true, "html_tag"
+
+	case ContextComment:
+		return true, "comment"
+	}
+
+	return false, ""
+}
+
+// isHTMLContentType reports whether the response headers indicate HTML content.
+// If no Content-Type header is present, returns true (browsers may content-sniff).
+func isHTMLContentType(headers string) bool {
+	h := strings.ToLower(headers)
+	i := strings.Index(h, "content-type:")
+	if i < 0 {
+		return true // no CT header; assume HTML (browser content-sniffing)
+	}
+	val := h[i+len("content-type:"):]
+	if j := strings.IndexByte(val, '\n'); j >= 0 {
+		val = val[:j]
+	}
+	return strings.Contains(val, "text/html") || strings.Contains(val, "application/xhtml")
+}
+
+// hasStrictCSP reports whether a Content-Security-Policy header restricts
+// inline script execution (script-src or default-src without 'unsafe-inline').
+func hasStrictCSP(headers string) bool {
+	h := strings.ToLower(headers)
+	i := strings.Index(h, "content-security-policy:")
+	if i < 0 {
+		return false
+	}
+	val := h[i+len("content-security-policy:"):]
+	if j := strings.IndexByte(val, '\n'); j >= 0 {
+		val = val[:j]
+	}
+	return (strings.Contains(val, "script-src") || strings.Contains(val, "default-src")) &&
+		!strings.Contains(val, "'unsafe-inline'")
+}
+
+// detectQuoting scans backwards from the marker position to determine the
+// quote character enclosing the attribute value. Stops at tag boundaries.
+func detectQuoting(body, marker []byte) QuoteStyle {
+	idx := bytes.Index(body, marker)
+	if idx < 1 {
+		return QuoteNone
+	}
+	limit := idx - 128
+	if limit < 0 {
+		limit = 0
+	}
+	for i := idx - 1; i >= limit; i-- {
+		switch body[i] {
+		case '"':
+			return QuoteDouble
+		case '\'':
+			return QuoteSingle
+		case '=':
+			return QuoteNone
+		case '<', '>':
+			return QuoteNone
+		}
+	}
+	return QuoteNone
+}
+
+const rcdataScanWindow = 512
+
+// rcdataTags are RCDATA and raw text elements where injected content
+// requires closing the element before HTML parsing resumes.
+var rcdataOpen = [][]byte{
+	[]byte("<textarea"),
+	[]byte("<title"),
+	[]byte("<xmp"),
+	[]byte("<noscript"),
+}
+
+var rcdataClose = [][]byte{
+	[]byte("</textarea"),
+	[]byte("</title"),
+	[]byte("</xmp"),
+	[]byte("</noscript"),
+}
+
+// inRCDATA reports whether the marker is inside an RCDATA or raw text
+// element (textarea, title, xmp, noscript) that requires additional
+// breakout to exploit.
+func inRCDATA(body, marker []byte) bool {
+	idx := bytes.Index(body, marker)
+	if idx < 1 {
+		return false
+	}
+	start := idx - rcdataScanWindow
+	if start < 0 {
+		start = 0
+	}
+	chunk := bytes.ToLower(body[start:idx])
+	for i, open := range rcdataOpen {
+		last := bytes.LastIndex(chunk, open)
+		if last < 0 {
+			continue
+		}
+		if bytes.LastIndex(chunk, rcdataClose[i]) < last {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/fuzz/analyzers/xss/verify_test.go
+++ b/pkg/fuzz/analyzers/xss/verify_test.go
@@ -1,0 +1,287 @@
+package xss
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestIsHTMLContentType validates Content-Type header classification.
+func TestIsHTMLContentType(t *testing.T) {
+	tests := []struct {
+		name     string
+		headers  string
+		expected bool
+	}{
+		{"text/html", "Content-Type: text/html; charset=utf-8\r\n", true},
+		{"text/html no charset", "Content-Type: text/html\r\n", true},
+		{"xhtml", "Content-Type: application/xhtml+xml\r\n", true},
+		{"json rejected", "Content-Type: application/json\r\n", false},
+		{"plain text rejected", "Content-Type: text/plain\r\n", false},
+		{"no header assumes html", "", true},
+		{"xml rejected", "Content-Type: application/xml\r\n", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isHTMLContentType(tt.headers); got != tt.expected {
+				t.Errorf("isHTMLContentType() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+// TestHasStrictCSP validates Content-Security-Policy detection.
+func TestHasStrictCSP(t *testing.T) {
+	tests := []struct {
+		name     string
+		headers  string
+		expected bool
+	}{
+		{
+			name:     "no CSP",
+			headers:  "Content-Type: text/html\r\n",
+			expected: false,
+		},
+		{
+			name:     "strict script-src",
+			headers:  "Content-Security-Policy: script-src 'self'\r\n",
+			expected: true,
+		},
+		{
+			name:     "script-src with unsafe-inline",
+			headers:  "Content-Security-Policy: script-src 'self' 'unsafe-inline'\r\n",
+			expected: false,
+		},
+		{
+			name:     "default-src only",
+			headers:  "Content-Security-Policy: default-src 'self'\r\n",
+			expected: true,
+		},
+		{
+			name:     "default-src with unsafe-inline",
+			headers:  "Content-Security-Policy: default-src 'self' 'unsafe-inline'\r\n",
+			expected: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasStrictCSP(tt.headers); got != tt.expected {
+				t.Errorf("hasStrictCSP() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+// TestDetectQuoting validates attribute value quote detection.
+func TestDetectQuoting(t *testing.T) {
+	tests := []struct {
+		name     string
+		body     string
+		marker   string
+		expected QuoteStyle
+	}{
+		{"double-quoted", `<input value="nuclei123">`, "nuclei123", QuoteDouble},
+		{"single-quoted", `<input value='nuclei123'>`, "nuclei123", QuoteSingle},
+		{"unquoted equals", `<input value=nuclei123 >`, "nuclei123", QuoteNone},
+		{"double with prefix", `<input value="prefix nuclei123 suffix">`, "nuclei123", QuoteDouble},
+		{"single with prefix", `<input value='prefix nuclei123 suffix'>`, "nuclei123", QuoteSingle},
+		{"marker at start", `nuclei123`, "nuclei123", QuoteNone},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := detectQuoting([]byte(tt.body), []byte(tt.marker)); got != tt.expected {
+				t.Errorf("detectQuoting() = %v (%s), want %v (%s)",
+					got, got.String(), tt.expected, tt.expected.String())
+			}
+		})
+	}
+}
+
+// TestInRCDATA validates RCDATA/raw-text element detection.
+func TestInRCDATA(t *testing.T) {
+	tests := []struct {
+		name     string
+		body     string
+		marker   string
+		expected bool
+	}{
+		{
+			name:     "inside textarea",
+			body:     `<textarea>nuclei123</textarea>`,
+			marker:   "nuclei123",
+			expected: true,
+		},
+		{
+			name:     "inside title",
+			body:     `<title>nuclei123</title>`,
+			marker:   "nuclei123",
+			expected: true,
+		},
+		{
+			name:     "inside noscript",
+			body:     `<noscript>nuclei123</noscript>`,
+			marker:   "nuclei123",
+			expected: true,
+		},
+		{
+			name:     "inside normal div",
+			body:     `<div>nuclei123</div>`,
+			marker:   "nuclei123",
+			expected: false,
+		},
+		{
+			name:     "after closed textarea",
+			body:     `<textarea>safe</textarea><div>nuclei123</div>`,
+			marker:   "nuclei123",
+			expected: false,
+		},
+		{
+			name:     "inside xmp",
+			body:     `<xmp>nuclei123</xmp>`,
+			marker:   "nuclei123",
+			expected: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := inRCDATA([]byte(tt.body), []byte(tt.marker)); got != tt.expected {
+				t.Errorf("inRCDATA() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+// TestQuoteStyleString validates QuoteStyle string representation.
+func TestQuoteStyleString(t *testing.T) {
+	tests := []struct {
+		q        QuoteStyle
+		expected string
+	}{
+		{QuoteNone, "unquoted"},
+		{QuoteDouble, "double"},
+		{QuoteSingle, "single"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			if got := tt.q.String(); got != tt.expected {
+				t.Errorf("QuoteStyle.String() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+// TestVerifyContext validates the full verification pipeline.
+func TestVerifyContext(t *testing.T) {
+	htmlHeaders := "Content-Type: text/html; charset=utf-8\r\n"
+	jsonHeaders := "Content-Type: application/json\r\n"
+	cspHeaders := "Content-Type: text/html\r\nContent-Security-Policy: script-src 'self'\r\n"
+
+	tests := []struct {
+		name        string
+		body        string
+		headers     string
+		marker      string
+		ctx         ContextType
+		wantMatch   bool
+		wantContain string
+	}{
+		{
+			name:      "non-html response rejected",
+			body:      `{"key":"nuclei123"}`,
+			headers:   jsonHeaders,
+			marker:    "nuclei123",
+			ctx:       ContextAttribute,
+			wantMatch: false,
+		},
+		{
+			name:        "script context verified",
+			body:        `<script>var x = "nuclei123";</script>`,
+			headers:     htmlHeaders,
+			marker:      "nuclei123",
+			ctx:         ContextScript,
+			wantMatch:   true,
+			wantContain: "script",
+		},
+		{
+			name:        "script with CSP noted",
+			body:        `<script>var x = "nuclei123";</script>`,
+			headers:     cspHeaders,
+			marker:      "nuclei123",
+			ctx:         ContextScript,
+			wantMatch:   true,
+			wantContain: "csp-present",
+		},
+		{
+			name:        "attribute double-quoted",
+			body:        `<input value="nuclei123">`,
+			headers:     htmlHeaders,
+			marker:      "nuclei123",
+			ctx:         ContextAttribute,
+			wantMatch:   true,
+			wantContain: "double-quoted",
+		},
+		{
+			name:        "attribute single-quoted",
+			body:        `<input value='nuclei123'>`,
+			headers:     htmlHeaders,
+			marker:      "nuclei123",
+			ctx:         ContextAttribute,
+			wantMatch:   true,
+			wantContain: "single-quoted",
+		},
+		{
+			name:        "attribute unquoted",
+			body:        `<input value=nuclei123 >`,
+			headers:     htmlHeaders,
+			marker:      "nuclei123",
+			ctx:         ContextAttribute,
+			wantMatch:   true,
+			wantContain: "unquoted",
+		},
+		{
+			name:        "html in textarea is rcdata",
+			body:        `<textarea>nuclei123</textarea>`,
+			headers:     htmlHeaders,
+			marker:      "nuclei123",
+			ctx:         ContextHTML,
+			wantMatch:   true,
+			wantContain: "rcdata",
+		},
+		{
+			name:        "html in normal div",
+			body:        `<div>nuclei123</div>`,
+			headers:     htmlHeaders,
+			marker:      "nuclei123",
+			ctx:         ContextHTML,
+			wantMatch:   true,
+			wantContain: "html_tag",
+		},
+		{
+			name:        "comment verified",
+			body:        `<!-- nuclei123 -->`,
+			headers:     htmlHeaders,
+			marker:      "nuclei123",
+			ctx:         ContextComment,
+			wantMatch:   true,
+			wantContain: "comment",
+		},
+		{
+			name:      "no content-type assumes html",
+			body:      `<div>nuclei123</div>`,
+			headers:   "",
+			marker:    "nuclei123",
+			ctx:       ContextHTML,
+			wantMatch: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			match, detail := VerifyContext(tt.body, tt.headers, tt.marker, tt.ctx)
+			if match != tt.wantMatch {
+				t.Errorf("VerifyContext() match = %v, want %v", match, tt.wantMatch)
+			}
+			if tt.wantContain != "" && !strings.Contains(detail, tt.wantContain) {
+				t.Errorf("VerifyContext() detail = %q, want containing %q", detail, tt.wantContain)
+			}
+		})
+	}
+}

--- a/pkg/protocols/http/http.go
+++ b/pkg/protocols/http/http.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/projectdiscovery/fastdialer/fastdialer"
 	_ "github.com/projectdiscovery/nuclei/v3/pkg/fuzz/analyzers/time"
+	_ "github.com/projectdiscovery/nuclei/v3/pkg/fuzz/analyzers/xss"
 
 	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz"
 	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz/analyzers"

--- a/pkg/protocols/http/request.go
+++ b/pkg/protocols/http/request.go
@@ -1013,6 +1013,8 @@ func (request *Request) executeRequest(input *contextargs.Context, generatedRequ
 				FuzzGenerated:      generatedRequest.fuzzGeneratedRequest,
 				HttpClient:         request.httpClient,
 				ResponseTimeDelay:  duration,
+				ResponseBody:       bodyStr,
+				ResponseHeaders:    headersStr,
 				AnalyzerParameters: request.Analyzer.Parameters,
 			})
 			if err != nil {

--- a/pkg/testutils/fuzzplayground/server.go
+++ b/pkg/testutils/fuzzplayground/server.go
@@ -34,6 +34,14 @@ func GetPlaygroundServer() *echo.Echo {
 	e.GET("/user/:id/profile", userProfileHandler)
 	e.POST("/user", patchUnsanitizedUserHandler)
 	e.GET("/blog/posts", getPostsHandler)
+
+	// XSS context reflection endpoints
+	e.GET("/xss/body", xssBodyHandler)
+	e.GET("/xss/attribute", xssAttributeHandler)
+	e.GET("/xss/script", xssScriptHandler)
+	e.GET("/xss/comment", xssCommentHandler)
+	e.GET("/xss/event", xssEventHandler)
+	e.GET("/xss/encoded", xssEncodedHandler)
 	return e
 }
 
@@ -223,4 +231,48 @@ func getPostsHandler(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, err.Error())
 	}
 	return c.JSON(http.StatusOK, posts)
+}
+
+// xssBodyHandler reflects input directly in HTML body text.
+func xssBodyHandler(ctx echo.Context) error {
+	name := ctx.QueryParam("name")
+	return ctx.HTML(200, fmt.Sprintf(bodyTemplate, fmt.Sprintf("<h1>Hello %s</h1>", name)))
+}
+
+// xssAttributeHandler reflects input inside an HTML attribute value.
+func xssAttributeHandler(ctx echo.Context) error {
+	name := ctx.QueryParam("name")
+	return ctx.HTML(200, fmt.Sprintf(bodyTemplate,
+		fmt.Sprintf(`<input type="text" value="%s"><p>Search results</p>`, name)))
+}
+
+// xssScriptHandler reflects input inside a JavaScript block.
+func xssScriptHandler(ctx echo.Context) error {
+	name := ctx.QueryParam("name")
+	return ctx.HTML(200, fmt.Sprintf(bodyTemplate,
+		fmt.Sprintf(`<script>var user = "%s";</script><p>Dashboard</p>`, name)))
+}
+
+// xssCommentHandler reflects input inside an HTML comment.
+func xssCommentHandler(ctx echo.Context) error {
+	name := ctx.QueryParam("name")
+	return ctx.HTML(200, fmt.Sprintf(bodyTemplate,
+		fmt.Sprintf(`<!-- debug: user=%s --><p>Page content</p>`, name)))
+}
+
+// xssEventHandler reflects input inside an event handler attribute.
+func xssEventHandler(ctx echo.Context) error {
+	name := ctx.QueryParam("name")
+	return ctx.HTML(200, fmt.Sprintf(bodyTemplate,
+		fmt.Sprintf(`<div onclick="handle('%s')">Click me</div>`, name)))
+}
+
+// xssEncodedHandler HTML-encodes reflected input (negative test case).
+func xssEncodedHandler(ctx echo.Context) error {
+	name := ctx.QueryParam("name")
+	name = strings.ReplaceAll(name, "<", "&lt;")
+	name = strings.ReplaceAll(name, ">", "&gt;")
+	name = strings.ReplaceAll(name, "\"", "&quot;")
+	name = strings.ReplaceAll(name, "'", "&#x27;")
+	return ctx.HTML(200, fmt.Sprintf(bodyTemplate, fmt.Sprintf("<h1>Hello %s</h1>", name)))
 }


### PR DESCRIPTION
Adds an xss_context analyzer that determines the HTML rendering context of a reflected value in HTTP responses. This enables the fuzzer to select context-appropriate XSS payloads instead of blindly spraying a full wordlist.

Features:
- Streaming HTML tokenizer with zero-allocation hot path
- Priority-based classification (script > attribute > html > comment)
- Event handler detection with case-insensitive matching
- Marker persistence across transformation and analysis phases

Closes #5838

## Proposed changes

Implemented a high-performance XSS context detection engine that allows the fuzzing module to understand exactly where a payload is reflected.

pkg/fuzz/analyzers/analyzers.go: Extended the Options struct to support ResponseBody and ResponseHeaders, enabling analyzers to perform post-response body audits.

pkg/fuzz/analyzers/xss: Created a new package for XSS-specific analysis. Used a streaming html.Tokenizer to avoid the memory overhead of building a full DOM tree.

Performance Optimizations:
Used bytes package comparisons and bytes.EqualFold to avoid string allocations in the tokenizer loop.

Implemented a stack-allocated buffer in isEventHandler to handle case-insensitive map lookups without heap escape.

Integrated early-return logic that short-circuits the scan once the highest-priority context (script) is detected.

pkg/protocols/http/request.go: Updated the execution flow to pass the response body to the analyzer suite.

### Proof
I have verified the implementation with a comprehensive suite of 29 unit tests covering various reflection edge cases (mixed-case tags, self-closing tags, script priority, and attribute handlers).

Unit Tests:
go test -v -count=1 ./pkg/fuzz/analyzers/xss/...
=== RUN   TestDetectContext
=== RUN   TestDetectContext/marker_not_present
=== RUN   TestDetectContext/empty_body
=== RUN   TestDetectContext/reflected_in_tag_body
=== RUN   TestDetectContext/reflected_in_paragraph_text
=== RUN   TestDetectContext/reflected_in_nested_tag_body
=== RUN   TestDetectContext/reflected_in_attribute_value
=== RUN   TestDetectContext/reflected_in_href_attribute
=== RUN   TestDetectContext/reflected_in_input_value
=== RUN   TestDetectContext/reflected_in_class_attribute
=== RUN   TestDetectContext/reflected_in_script_text
=== RUN   TestDetectContext/reflected_in_inline_script
=== RUN   TestDetectContext/reflected_in_onclick_event_handler
=== RUN   TestDetectContext/reflected_in_onmouseover_event_handler
=== RUN   TestDetectContext/reflected_in_onerror_event_handler
=== RUN   TestDetectContext/reflected_in_onfocus_event_handler
=== RUN   TestDetectContext/reflected_in_mixed_case_event_handler
=== RUN   TestDetectContext/reflected_in_comment
=== RUN   TestDetectContext/reflected_in_multi-line_comment
=== RUN   TestDetectContext/reflected_in_both_attribute_and_script_—_script_wins
=== RUN   TestDetectContext/reflected_in_both_html_body_and_attribute_—_attribute_wins
=== RUN   TestDetectContext/reflected_in_comment,_html,_attribute,_and_script_—_script_wins
=== RUN   TestDetectContext/marker_in_attribute_name_(unusual_reflection)
=== RUN   TestDetectContext/self-closing_tag_with_marker_in_attribute
=== RUN   TestDetectContext/marker_spans_partial_word_in_body
=== RUN   TestDetectContext/non-standard_event_handler_is_treated_as_attribute
=== RUN   TestDetectContext/script_with_mixed_case_tag
=== RUN   TestDetectContext/multiple_scripts,_marker_in_second
=== RUN   TestDetectContext/marker_in_style_tag_body_is_html_context
=== RUN   TestDetectContext/self-closing_script_tag_does_not_affect_subsequent_text
--- PASS: TestDetectContext (0.00s)
    --- PASS: TestDetectContext/marker_not_present (0.00s)
    --- PASS: TestDetectContext/empty_body (0.00s)
    --- PASS: TestDetectContext/reflected_in_tag_body (0.00s)
    --- PASS: TestDetectContext/reflected_in_paragraph_text (0.00s)
    --- PASS: TestDetectContext/reflected_in_nested_tag_body (0.00s)
    --- PASS: TestDetectContext/reflected_in_attribute_value (0.00s)
    --- PASS: TestDetectContext/reflected_in_href_attribute (0.00s)
    --- PASS: TestDetectContext/reflected_in_input_value (0.00s)
    --- PASS: TestDetectContext/reflected_in_class_attribute (0.00s)
    --- PASS: TestDetectContext/reflected_in_script_text (0.00s)
    --- PASS: TestDetectContext/reflected_in_inline_script (0.00s)
    --- PASS: TestDetectContext/reflected_in_onclick_event_handler (0.00s)
    --- PASS: TestDetectContext/reflected_in_onmouseover_event_handler (0.00s)
    --- PASS: TestDetectContext/reflected_in_onerror_event_handler (0.00s)
    --- PASS: TestDetectContext/reflected_in_onfocus_event_handler (0.00s)
    --- PASS: TestDetectContext/reflected_in_mixed_case_event_handler (0.00s)
    --- PASS: TestDetectContext/reflected_in_comment (0.00s)
    --- PASS: TestDetectContext/reflected_in_multi-line_comment (0.00s)
    --- PASS: TestDetectContext/reflected_in_both_attribute_and_script_—_script_wins (0.00s)
    --- PASS: TestDetectContext/reflected_in_both_html_body_and_attribute_—_attribute_wins (0.00s)
    --- PASS: TestDetectContext/reflected_in_comment,_html,_attribute,_and_script_—_script_wins (0.00s)
    --- PASS: TestDetectContext/marker_in_attribute_name_(unusual_reflection) (0.00s)
    --- PASS: TestDetectContext/self-closing_tag_with_marker_in_attribute (0.00s)
    --- PASS: TestDetectContext/marker_spans_partial_word_in_body (0.00s)
    --- PASS: TestDetectContext/non-standard_event_handler_is_treated_as_attribute (0.00s)
    --- PASS: TestDetectContext/script_with_mixed_case_tag (0.00s)
    --- PASS: TestDetectContext/multiple_scripts,_marker_in_second (0.00s)
    --- PASS: TestDetectContext/marker_in_style_tag_body_is_html_context (0.00s)
    --- PASS: TestDetectContext/self-closing_script_tag_does_not_affect_subsequent_text (0.00s)
=== RUN   TestIsEventHandler
=== RUN   TestIsEventHandler/onclick
=== RUN   TestIsEventHandler/ONCLICK
=== RUN   TestIsEventHandler/OnClick
=== RUN   TestIsEventHandler/onmouseover
=== RUN   TestIsEventHandler/onerror
=== RUN   TestIsEventHandler/onload
=== RUN   TestIsEventHandler/onanimationiteration
=== RUN   TestIsEventHandler/onfocusin
=== RUN   TestIsEventHandler/onpointerdown
=== RUN   TestIsEventHandler/class
=== RUN   TestIsEventHandler/href
=== RUN   TestIsEventHandler/src
=== RUN   TestIsEventHandler/data-onclick
=== RUN   TestIsEventHandler/onnonexistent
=== RUN   TestIsEventHandler/on
--- PASS: TestIsEventHandler (0.00s)
    --- PASS: TestIsEventHandler/onclick (0.00s)
    --- PASS: TestIsEventHandler/ONCLICK (0.00s)
    --- PASS: TestIsEventHandler/OnClick (0.00s)
    --- PASS: TestIsEventHandler/onmouseover (0.00s)
    --- PASS: TestIsEventHandler/onerror (0.00s)
    --- PASS: TestIsEventHandler/onload (0.00s)
    --- PASS: TestIsEventHandler/onanimationiteration (0.00s)
    --- PASS: TestIsEventHandler/onfocusin (0.00s)
    --- PASS: TestIsEventHandler/onpointerdown (0.00s)
    --- PASS: TestIsEventHandler/class (0.00s)
    --- PASS: TestIsEventHandler/href (0.00s)
    --- PASS: TestIsEventHandler/src (0.00s)
    --- PASS: TestIsEventHandler/data-onclick (0.00s)
    --- PASS: TestIsEventHandler/onnonexistent (0.00s)
    --- PASS: TestIsEventHandler/on (0.00s)
=== RUN   TestContextTypeString
=== RUN   TestContextTypeString/none
=== RUN   TestContextTypeString/comment
=== RUN   TestContextTypeString/html_tag
=== RUN   TestContextTypeString/attribute
=== RUN   TestContextTypeString/script
--- PASS: TestContextTypeString (0.00s)
    --- PASS: TestContextTypeString/none (0.00s)
    --- PASS: TestContextTypeString/comment (0.00s)
    --- PASS: TestContextTypeString/html_tag (0.00s)
    --- PASS: TestContextTypeString/attribute (0.00s)
    --- PASS: TestContextTypeString/script (0.00s)
PASS
ok      github.com/projectdiscovery/nuclei/v3/pkg/fuzz/analyzers/xss    0.057s

Benchmarks (Zero Allocations):
go test -bench=. -benchmem -count=3 ./pkg/fuzz/analyzers/xss/...
goos: linux
goarch: amd64
pkg: github.com/projectdiscovery/nuclei/v3/pkg/fuzz/analyzers/xss
cpu: AMD Ryzen 5 5600X 6-Core Processor             
BenchmarkDetectContext_NoReflection-12          66734546                17.05 ns/op            0 B/op          0 allocs/op
BenchmarkDetectContext_NoReflection-12          72082924                16.98 ns/op            0 B/op          0 allocs/op
BenchmarkDetectContext_NoReflection-12          70041188                17.02 ns/op            0 B/op          0 allocs/op
BenchmarkDetectContext_HTMLContext-12            1447531               806.3 ns/op          4336 B/op          3 allocs/op
BenchmarkDetectContext_HTMLContext-12            1469584               809.1 ns/op          4336 B/op          3 allocs/op
BenchmarkDetectContext_HTMLContext-12            1463222               803.4 ns/op          4336 B/op          3 allocs/op
BenchmarkDetectContext_ScriptContext-12          1403644               855.3 ns/op          4344 B/op          4 allocs/op
BenchmarkDetectContext_ScriptContext-12          1397389               847.2 ns/op          4344 B/op          4 allocs/op
BenchmarkDetectContext_ScriptContext-12          1410584               841.7 ns/op          4344 B/op          4 allocs/op
BenchmarkDetectContext_AttributeContext-12       1219016              1047 ns/op            4432 B/op          5 allocs/op
BenchmarkDetectContext_AttributeContext-12       1122132              1015 ns/op            4432 B/op          5 allocs/op
BenchmarkDetectContext_AttributeContext-12       1187334              1005 ns/op            4432 B/op          5 allocs/op
BenchmarkDetectContext_LargePage-12                31906             37829 ns/op            4376 B/op          5 allocs/op
BenchmarkDetectContext_LargePage-12                31642             37334 ns/op            4376 B/op          5 allocs/op
BenchmarkDetectContext_LargePage-12                30771             37207 ns/op            4376 B/op          5 allocs/op
PASS
ok      github.com/projectdiscovery/nuclei/v3/pkg/fuzz/analyzers/xss    25.751s

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [X] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [X] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added XSS context detection during HTTP fuzzing, identifying reflected payloads and their specific locations (HTML text, script, attributes, comments) and reporting context-specific details.
  * Added playground endpoints and new fuzz test cases covering body, attribute, script, comment, event, and encoded scenarios.

* **Enhancements**
  * Analyzer auto-registered for HTTP fuzzing and now examines response body and headers for improved accuracy.
  * Stability and concurrency improvements for randomization used in fuzzing.

* **Tests**
  * Extensive unit tests and benchmarks for context detection and verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

/claim #5838