### PR TITLE
fix(authx): prevent race condition in dynamic secret fetch

### DIFF
--- a/pkg/authprovider/authx/dynamic.go
+++ b/pkg/authprovider/authx/dynamic.go
@@ -3,6 +3,7 @@ package authx
 import (
 	"fmt"
 	"strings"
+	"sync"
 	"sync/atomic"
 
 	"github.com/projectdiscovery/gologger"
@@ -31,7 +32,7 @@ type Dynamic struct {
 	Extracted     map[string]interface{} `json:"-" yaml:"-"`         // extracted values from the dynamic secret
 	fetchCallback LazyFetchSecret        `json:"-" yaml:"-"`
 	fetched       *atomic.Bool           `json:"-" yaml:"-"` // atomic flag to check if the secret has been fetched
-	fetching      *atomic.Bool           `json:"-" yaml:"-"` // atomic flag to prevent recursive fetch calls
+	fetchMu       sync.Mutex             `json:"-" yaml:"-"` // mutex to synchronize concurrent fetch calls
 	error         error                  `json:"-" yaml:"-"` // error if any
 }
 
@@ -71,7 +72,6 @@ func (d *Dynamic) UnmarshalJSON(data []byte) error {
 // Validate validates the dynamic secret
 func (d *Dynamic) Validate() error {
 	d.fetched = &atomic.Bool{}
-	d.fetching = &atomic.Bool{}
 	if d.TemplatePath == "" {
 		return errkit.New(" template-path is required for dynamic secret")
 	}
@@ -208,22 +208,25 @@ func (d *Dynamic) GetStrategies() []AuthStrategy {
 // Fetch fetches the dynamic secret
 // if isFatal is true, it will stop the execution if the secret could not be fetched
 func (d *Dynamic) Fetch(isFatal bool) error {
+	// Fast path: check if already fetched without locking
 	if d.fetched.Load() {
 		return d.error
 	}
 
-	// Try to set fetching flag atomically
-	if !d.fetching.CompareAndSwap(false, true) {
-		// Already fetching, return current error
+	// Slow path: acquire lock to ensure only one goroutine fetches
+	d.fetchMu.Lock()
+	defer d.fetchMu.Unlock()
+
+	// Double-check after acquiring lock - another goroutine may have completed the fetch
+	if d.fetched.Load() {
 		return d.error
 	}
 
 	// We're the only one fetching, call the callback
 	d.error = d.fetchCallback(d)
 
-	// Mark as fetched and clear fetching flag
+	// Mark as fetched
 	d.fetched.Store(true)
-	d.fetching.Store(false)
 
 	if d.error != nil && isFatal {
 		gologger.Fatal().Msgf("Could not fetch dynamic secret: %s\n", d.error)

--- a/pkg/authprovider/authx/dynamic_test.go
+++ b/pkg/authprovider/authx/dynamic_test.go
@@ -1,7 +1,10 @@
 package authx
 
 import (
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -122,4 +125,145 @@ func TestDynamicUnmarshalJSON(t *testing.T) {
 		err := d.UnmarshalJSON(data)
 		require.NoError(t, err)
 	})
+}
+
+// TestConcurrentFetch tests that concurrent calls to Fetch properly wait for
+// the first fetch to complete instead of returning immediately with empty auth credentials.
+// This is a regression test for https://github.com/projectdiscovery/nuclei/issues/6592
+func TestConcurrentFetch(t *testing.T) {
+	d := &Dynamic{
+		Secret: &Secret{
+			Type:    "Cookie",
+			Domains: []string{"example.com"},
+			Cookies: []Cookie{{Key: "session", Value: "{{token}}"}},
+		},
+		TemplatePath: "test.yaml",
+		Variables:    []KV{{Key: "user", Value: "test"}},
+	}
+
+	// Initialize the dynamic secret (normally done by Validate)
+	require.NoError(t, d.Validate())
+
+	var fetchCount atomic.Int32
+	fetchStarted := make(chan struct{})
+	fetchComplete := make(chan struct{})
+
+	// Set up a callback that simulates a slow fetch operation
+	d.SetLazyFetchCallback(func(d *Dynamic) error {
+		fetchCount.Add(1)
+		close(fetchStarted) // Signal that fetch has started
+		<-fetchComplete     // Wait for signal to complete the fetch
+		d.Extracted = map[string]interface{}{
+			"token": "extracted-token-value",
+		}
+		return nil
+	})
+
+	const numGoroutines = 10
+	var wg sync.WaitGroup
+	results := make([]error, numGoroutines)
+	allStarted := make(chan struct{})
+
+	// Launch multiple goroutines that will all try to fetch concurrently
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			<-allStarted // Wait for all goroutines to be ready
+			results[idx] = d.Fetch(false)
+		}(i)
+	}
+
+	// Start all goroutines at once
+	close(allStarted)
+
+	// Wait for the fetch to start
+	select {
+	case <-fetchStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("fetch did not start within timeout")
+	}
+
+	// Give goroutines time to attempt concurrent fetch
+	time.Sleep(100 * time.Millisecond)
+
+	// Complete the fetch
+	close(fetchComplete)
+
+	// Wait for all goroutines to finish
+	wg.Wait()
+
+	// Verify the callback was only called once
+	require.Equal(t, int32(1), fetchCount.Load(), "fetch callback should only be called once")
+
+	// Verify all goroutines received no error
+	for i, err := range results {
+		require.NoError(t, err, "goroutine %d should have no error", i)
+	}
+
+	// Verify the extracted value is available
+	require.Equal(t, "extracted-token-value", d.Extracted["token"])
+
+	// Verify subsequent calls don't trigger another fetch
+	err := d.Fetch(false)
+	require.NoError(t, err)
+	require.Equal(t, int32(1), fetchCount.Load(), "fetch callback should still only be called once after subsequent calls")
+}
+
+// TestConcurrentFetchWithError tests that concurrent calls properly handle errors
+func TestConcurrentFetchWithError(t *testing.T) {
+	d := &Dynamic{
+		TemplatePath: "test.yaml",
+		Variables:    []KV{{Key: "user", Value: "test"}},
+	}
+
+	require.NoError(t, d.Validate())
+
+	var fetchCount atomic.Int32
+	fetchStarted := make(chan struct{})
+	fetchComplete := make(chan struct{})
+
+	// Set up a callback that simulates a slow fetch operation that returns an error
+	d.SetLazyFetchCallback(func(d *Dynamic) error {
+		fetchCount.Add(1)
+		close(fetchStarted)
+		<-fetchComplete
+		// Return error - no extracted values
+		return nil // callback wrapper will detect no extracted values and return error
+	})
+
+	const numGoroutines = 5
+	var wg sync.WaitGroup
+	results := make([]error, numGoroutines)
+	allStarted := make(chan struct{})
+
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			<-allStarted
+			results[idx] = d.Fetch(false)
+		}(i)
+	}
+
+	close(allStarted)
+
+	select {
+	case <-fetchStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("fetch did not start within timeout")
+	}
+
+	time.Sleep(100 * time.Millisecond)
+	close(fetchComplete)
+	wg.Wait()
+
+	// Verify the callback was only called once
+	require.Equal(t, int32(1), fetchCount.Load())
+
+	// Verify all goroutines received the same error
+	for i, err := range results {
+		require.Error(t, err, "goroutine %d should have an error", i)
+		require.Contains(t, err.Error(), "no extracted values", "error message should indicate missing extracted values")
+	}
 }


### PR DESCRIPTION
/claim #6592

## Summary

Fixes race condition in dynamic secret fetching where concurrent template execution would start before authentication credentials were fully loaded, causing templates to run without proper authentication.

## Problem

When running authenticated scans with `-secret-file`, nuclei executes templates concurrently. Multiple goroutines can call `Dynamic.Fetch()` simultaneously during startup. The previous implementation used atomic flags but had a critical flaw:

```go
if !d.fetching.CompareAndSwap(false, true) {
    // Already fetching, return current error
    return d.error  // BUG: returns immediately with empty d.error!
}
```

**Race condition scenario:**
1. Goroutine A starts fetch, sets `fetching = true`
2. Goroutines B, C, D see `fetching = true` and return immediately with `d.error` (still nil/empty)
3. Templates execute without authentication credentials
4. Requests are sent as unauthenticated (AnonymousUser)
5. Eventually Goroutine A completes, but too late

## Solution

Replace the atomic flag approach with a `sync.Mutex` using the double-checked locking pattern:

1. **Fast path**: Check `fetched` flag without locking (common case after first fetch)
2. **Slow path**: Acquire mutex, double-check, execute fetch if needed
3. **Waiting**: All concurrent callers block on mutex until fetch completes
4. **Guarantee**: All goroutines receive fully populated auth credentials

**Key changes:**
- Replaced `fetching *atomic.Bool` with `fetchMu sync.Mutex`
- All concurrent callers now wait for fetch to complete
- Maintains thread-safety and performance with double-checked locking

## Why mutex instead of channels?

The competing PR #6832 uses channels (`done chan struct{}` + `sync.Once`), which is also valid. This PR uses a mutex because:

- **Simpler**: Standard mutex pattern vs channel + Once coordination
- **Clearer intent**: Mutex directly expresses mutual exclusion
- **Less error-prone**: No need to coordinate channel closing with Once
- **Equivalent performance**: Both approaches have similar overhead

## Testing

Added two comprehensive tests:

1. **TestConcurrentFetch**: Verifies 10 concurrent goroutines wait for fetch completion
   - Simulates slow network fetch
   - Verifies callback invoked exactly once
   - Confirms all goroutines receive complete credentials

2. **TestConcurrentFetchWithError**: Tests error propagation with concurrent access
   - Ensures errors are properly shared across waiting goroutines

## Test Results

```bash
$ go test ./pkg/authprovider/authx -v -run TestConcurrent
=== RUN   TestConcurrentFetch
--- PASS: TestConcurrentFetch (0.10s)
=== RUN   TestConcurrentFetchWithError
--- PASS: TestConcurrentFetchWithError (0.10s)
PASS
ok      github.com/projectdiscovery/nuclei/v3/pkg/authprovider/authx    0.476s

$ go test ./pkg/authprovider/authx -v
=== RUN   TestDynamicUnmarshalJSON
--- PASS: TestDynamicUnmarshalJSON (0.00s)
=== RUN   TestConcurrentFetch
--- PASS: TestConcurrentFetch (0.10s)
=== RUN   TestConcurrentFetchWithError
--- PASS: TestConcurrentFetchWithError (0.10s)
=== RUN   TestSecretsUnmarshal
--- PASS: TestSecretsUnmarshal (0.00s)
PASS
ok      github.com/projectdiscovery/nuclei/v3/pkg/authprovider/authx    0.446s
```

## Expected Behavior After Fix

With this fix, when running:
```bash
nuclei -secret-file django-login.yaml -target http://localhost:8000/ -v
```

All requests will be properly authenticated from the start. Server logs should show authenticated user (e.g., `<engbot@example.com>`) for all requests, with no `AnonymousUser` requests before the secret file completes.

## Checklist

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

Fixes #6592

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced reliability of concurrent authentication fetch requests to ensure consistent behavior and prevent race conditions during simultaneous access.

* **Tests**
  * Added comprehensive concurrency tests validating thread-safe behavior for concurrent authentication fetch operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->