### PR TITLE
fix: ensure secret-file secrets are fetched before template execution (#6592)

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -681,8 +681,8 @@ func (r *Runner) RunEnumeration() error {
 	// display execution info like version , templates used etc
 	r.displayExecutionInfo(store)
 
-	// prefetch secrets if enabled
-	if executorOpts.AuthProvider != nil && r.options.PreFetchSecrets {
+	// prefetch secrets if auth provider is configured
+	if executorOpts.AuthProvider != nil {
 		r.Logger.Info().Msgf("Pre-fetching secrets from authprovider[s]")
 		if err := executorOpts.AuthProvider.PreFetchSecrets(); err != nil {
 			return errors.Wrap(err, "could not pre-fetch secrets")

--- a/lib/sdk_private.go
+++ b/lib/sdk_private.go
@@ -229,7 +229,7 @@ func (e *NucleiEngine) init(ctx context.Context) error {
 	}
 
 	// prefetch secrets
-	if e.executerOpts.AuthProvider != nil && e.opts.PreFetchSecrets {
+	if e.executerOpts.AuthProvider != nil {
 		if err := e.executerOpts.AuthProvider.PreFetchSecrets(); err != nil {
 			return errors.Wrap(err, "could not prefetch secrets")
 		}

--- a/pkg/authprovider/authx/dynamic.go
+++ b/pkg/authprovider/authx/dynamic.go
@@ -3,7 +3,7 @@ package authx
 import (
 	"fmt"
 	"strings"
-	"sync/atomic"
+	"sync"
 
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/replacer"
@@ -29,10 +29,9 @@ type Dynamic struct {
 	Variables     []KV                   `json:"variables" yaml:"variables"`
 	Input         string                 `json:"input" yaml:"input"` // (optional) target for the dynamic secret
 	Extracted     map[string]interface{} `json:"-" yaml:"-"`         // extracted values from the dynamic secret
-	fetchCallback LazyFetchSecret        `json:"-" yaml:"-"`
-	fetched       *atomic.Bool           `json:"-" yaml:"-"` // atomic flag to check if the secret has been fetched
-	fetching      *atomic.Bool           `json:"-" yaml:"-"` // atomic flag to prevent recursive fetch calls
-	error         error                  `json:"-" yaml:"-"` // error if any
+	fetchCallback LazyFetchSecret `json:"-" yaml:"-"`
+	fetchOnce     sync.Once      `json:"-" yaml:"-"` // ensures fetch is executed exactly once; concurrent callers block until done
+	error         error          `json:"-" yaml:"-"` // error if any
 }
 
 func (d *Dynamic) GetDomainAndDomainRegex() ([]string, []string) {
@@ -70,8 +69,6 @@ func (d *Dynamic) UnmarshalJSON(data []byte) error {
 
 // Validate validates the dynamic secret
 func (d *Dynamic) Validate() error {
-	d.fetched = &atomic.Bool{}
-	d.fetching = &atomic.Bool{}
 	if d.TemplatePath == "" {
 		return errkit.New(" template-path is required for dynamic secret")
 	}
@@ -183,14 +180,8 @@ func (d *Dynamic) applyValuesToSecret(secret *Secret) error {
 
 // GetStrategy returns the auth strategies for the dynamic secret
 func (d *Dynamic) GetStrategies() []AuthStrategy {
-	if d.fetched.Load() {
-		if d.error != nil {
-			return nil
-		}
-	} else {
-		// Try to fetch if not already fetched
-		_ = d.Fetch(true)
-	}
+	// Fetch blocks until the secret is fetched (or was already fetched)
+	_ = d.Fetch(true)
 
 	if d.error != nil {
 		return nil
@@ -207,23 +198,16 @@ func (d *Dynamic) GetStrategies() []AuthStrategy {
 
 // Fetch fetches the dynamic secret
 // if isFatal is true, it will stop the execution if the secret could not be fetched
+// sync.Once ensures the fetch callback runs exactly once; concurrent callers
+// block until the first call completes.
 func (d *Dynamic) Fetch(isFatal bool) error {
-	if d.fetched.Load() {
-		return d.error
-	}
-
-	// Try to set fetching flag atomically
-	if !d.fetching.CompareAndSwap(false, true) {
-		// Already fetching, return current error
-		return d.error
-	}
-
-	// We're the only one fetching, call the callback
-	d.error = d.fetchCallback(d)
-
-	// Mark as fetched and clear fetching flag
-	d.fetched.Store(true)
-	d.fetching.Store(false)
+	d.fetchOnce.Do(func() {
+		if d.fetchCallback == nil {
+			d.error = fmt.Errorf("fetch callback not set for dynamic secret")
+			return
+		}
+		d.error = d.fetchCallback(d)
+	})
 
 	if d.error != nil && isFatal {
 		gologger.Fatal().Msgf("Could not fetch dynamic secret: %s\n", d.error)

--- a/pkg/authprovider/authx/dynamic_test.go
+++ b/pkg/authprovider/authx/dynamic_test.go
@@ -1,7 +1,10 @@
 package authx
 
 import (
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -121,5 +124,66 @@ func TestDynamicUnmarshalJSON(t *testing.T) {
 		var d Dynamic
 		err := d.UnmarshalJSON(data)
 		require.NoError(t, err)
+	})
+}
+
+func TestConcurrentFetch(t *testing.T) {
+	t.Run("concurrent-fetch-waits", func(t *testing.T) {
+		var callCount atomic.Int32
+
+		d := &Dynamic{
+			Secret: &Secret{
+				Type:    "Header",
+				Domains: []string{"example.com"},
+				Headers: []KV{{Key: "Authorization", Value: "{{token}}"}},
+			},
+			TemplatePath: "test.yaml",
+			Variables:    []KV{{Key: "username", Value: "test"}},
+		}
+		require.NoError(t, d.Validate())
+
+		d.SetLazyFetchCallback(func(d *Dynamic) error {
+			callCount.Add(1)
+			// Simulate slow network fetch
+			time.Sleep(100 * time.Millisecond)
+			d.Extracted = map[string]interface{}{
+				"token": "Bearer secret-token",
+			}
+			return nil
+		})
+
+		// Launch multiple goroutines that all call Fetch concurrently
+		const numGoroutines = 10
+		var wg sync.WaitGroup
+		errs := make([]error, numGoroutines)
+
+		// Use a barrier to ensure all goroutines start at the same time
+		barrier := make(chan struct{})
+
+		for i := 0; i < numGoroutines; i++ {
+			wg.Add(1)
+			go func(idx int) {
+				defer wg.Done()
+				<-barrier // wait for barrier
+				errs[idx] = d.Fetch(false)
+			}(i)
+		}
+
+		// Release all goroutines at once
+		close(barrier)
+		wg.Wait()
+
+		// The fetch callback should have been called exactly once
+		require.Equal(t, int32(1), callCount.Load(), "fetch callback should be called exactly once")
+
+		// All goroutines should have received nil error
+		for i, err := range errs {
+			require.NoError(t, err, "goroutine %d should not have received an error", i)
+		}
+
+		// Verify the secret was properly populated
+		strategies := d.GetStrategies()
+		require.NotNil(t, strategies, "strategies should not be nil after fetch")
+		require.Len(t, strategies, 1, "should have exactly one strategy")
 	})
 }


### PR DESCRIPTION
## Proposed Changes

/claim #6592

Fixes https://github.com/projectdiscovery/nuclei/issues/6592

When running `nuclei -secret-file <file> -target <url>`, templates start executing before the secret-file template finishes authentication, causing requests to go out unauthenticated.

### Root Cause

Two issues combine to cause this:

1. **`PreFetchSecrets` gated behind `-ps` flag**: In `runner.go` and `sdk_private.go`, `PreFetchSecrets()` was only called when the `-ps` (prefetch-secrets) flag was explicitly set. Without it, dynamic secrets were lazily fetched during concurrent template execution — too late.

2. **Race condition in `Dynamic.Fetch()`**: The `Fetch()` method used `atomic.Bool` flags (`fetched`/`fetching`) with `CompareAndSwap`. When multiple goroutines called `Fetch()` concurrently, the second caller would see `fetching=true`, skip the fetch, and return `d.error` (which was still `nil` since the first goroutine had not finished). This caused requests to proceed without authentication.

### Fix

- **Always pre-fetch when AuthProvider is configured** — removed the `PreFetchSecrets` flag gate in both `runner.go` and `sdk_private.go`. When `-secret-file` is used, secrets are now always fetched before template execution begins.
- **Replace atomic flags with `sync.Once`** — `Dynamic.Fetch()` now uses `sync.Once` so the fetch callback runs exactly once, and all concurrent callers block until it completes.
- **Nil callback guard** — added defensive nil check for `fetchCallback` inside `Fetch()`.

### Proof

**Before (broken):** Templates fire immediately, requests go out as `AnonymousUser` until login completes:
```
AnonymousUser    GET /wp-content/plugins/...
AnonymousUser    GET /login-x.php
AnonymousUser    POST /guest_auth/...
POST /accounts/login/ → 302 (login completes)
engbot@example.com    GET /wp-content/plugins/...  ← only now authenticated
```

**After (fixed):** `PreFetchSecrets()` runs first, login completes, then all templates execute authenticated:
```
POST /accounts/login/ → 302 (login completes first)
engbot@example.com    GET /wp-content/plugins/...
engbot@example.com    POST /cgi-bin/rpc
engbot@example.com    GET /export/...
```

**Concurrent fetch test with race detector:**
```
$ go test ./pkg/authprovider/authx/... -v -count=1 -race
=== RUN   TestConcurrentFetch
=== RUN   TestConcurrentFetch/concurrent-fetch-waits
--- PASS: TestConcurrentFetch (0.10s)
    --- PASS: TestConcurrentFetch/concurrent-fetch-waits (0.10s)
PASS
ok  	github.com/projectdiscovery/nuclei/v3/pkg/authprovider/authx	2.157s
```

## Checklist

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Behavior Changes**
  * Secrets are now automatically prefetched when an authentication provider is configured, without requiring explicit opt-in via configuration flags.

* **Tests**
  * Added test coverage for concurrent secret fetch operations to ensure proper synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->