### PR TITLE
fix(fuzz): use OrderedMap for path segments to ensure deterministic iteration

### DIFF
--- a/pkg/fuzz/component/path.go
+++ b/pkg/fuzz/component/path.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz/dataformat"
 	"github.com/projectdiscovery/retryablehttp-go"
+	mapsutil "github.com/projectdiscovery/utils/maps"
 	urlutil "github.com/projectdiscovery/utils/url"
 )
 
@@ -36,7 +37,8 @@ func (q *Path) Parse(req *retryablehttp.Request) (bool, error) {
 	q.value = NewValue("")
 
 	splitted := strings.Split(req.Path, "/")
-	values := make(map[string]interface{})
+	segments := mapsutil.NewOrderedMap[string, any]()
+	segmentIndex := 0
 	for i, segment := range splitted {
 		if segment == "" && i == 0 {
 			// Skip the first empty segment from leading "/"
@@ -47,10 +49,11 @@ func (q *Path) Parse(req *retryablehttp.Request) (bool, error) {
 			continue
 		}
 		// Use 1-based indexing and store individual segments
-		key := strconv.Itoa(len(values) + 1)
-		values[key] = segment
+		segmentIndex++
+		key := strconv.Itoa(segmentIndex)
+		segments.Set(key, segment)
 	}
-	q.value.SetParsed(dataformat.KVMap(values), "")
+	q.value.SetParsed(dataformat.KVOrderedMap(&segments), "")
 	return true, nil
 }
 
@@ -109,8 +112,12 @@ func (q *Path) Rebuild() (*retryablehttp.Request, error) {
 
 		// Check if we have a replacement for this segment
 		key := strconv.Itoa(segmentIndex)
-		if newValue, exists := q.value.parsed.Map.GetOrDefault(key, "").(string); exists && newValue != "" {
-			rebuiltSegments = append(rebuiltSegments, newValue)
+		if val := q.value.parsed.Get(key); val != nil {
+			if newValue, ok := val.(string); ok && newValue != "" {
+				rebuiltSegments = append(rebuiltSegments, newValue)
+			} else {
+				rebuiltSegments = append(rebuiltSegments, originalSegment)
+			}
 		} else {
 			rebuiltSegments = append(rebuiltSegments, originalSegment)
 		}

--- a/pkg/fuzz/component/path_test.go
+++ b/pkg/fuzz/component/path_test.go
@@ -80,6 +80,32 @@ func TestURLComponent_NestedPaths(t *testing.T) {
 	}
 }
 
+func TestPathComponent_DeterministicIteration(t *testing.T) {
+	// Verify that path segments are always iterated in insertion order.
+	// Before the fix, a plain Go map caused non-deterministic iteration,
+	// which randomly skipped path segments during fuzzing.
+	for run := 0; run < 100; run++ {
+		path := NewPath()
+		req, err := retryablehttp.NewRequest(http.MethodGet, "https://example.com/user/55/profile", nil)
+		require.NoError(t, err)
+
+		found, err := path.Parse(req)
+		require.NoError(t, err)
+		require.True(t, found)
+
+		var keys []string
+		var values []string
+		err = path.Iterate(func(key string, value interface{}) error {
+			keys = append(keys, key)
+			values = append(values, value.(string))
+			return nil
+		})
+		require.NoError(t, err)
+		require.Equal(t, []string{"1", "2", "3"}, keys, "run %d: unexpected keys", run)
+		require.Equal(t, []string{"user", "55", "profile"}, values, "run %d: unexpected values", run)
+	}
+}
+
 func TestPathComponent_SQLInjection(t *testing.T) {
 	path := NewPath()
 	req, err := retryablehttp.NewRequest(http.MethodGet, "https://example.com/user/55/profile", nil)


### PR DESCRIPTION
## Summary

Fix non-deterministic path-based fuzzing that causes path segments (especially numeric ones like `55` in `/user/55/profile`) to be randomly skipped.

Fixes #6398

## Root Cause

`Path.Parse()` stores path segments in a plain Go `map[string]interface{}`. Since Go maps have **non-deterministic iteration order**, `Path.Iterate()` yields segments in random order, causing the fuzzing engine to sometimes skip segments.

## Fix

- Replace `map[string]interface{}` with `mapsutil.OrderedMap` in `Path.Parse()`, matching the pattern already used by the `Cookie` component
- Use `dataformat.KVOrderedMap()` instead of `dataformat.KVMap()` to preserve insertion order
- Update `Path.Rebuild()` to use `KV.Get()` instead of direct `.Map.GetOrDefault()` access (which would be nil with OrderedMap)
- Add `TestPathComponent_DeterministicIteration` regression test that runs 100 iterations to verify stable ordering

## Changes

2 files, minimal diff:
- `pkg/fuzz/component/path.go` — 19 lines changed
- `pkg/fuzz/component/path_test.go` — 26 lines added

## Testing

All existing tests pass, plus the new deterministic iteration test:

```
=== RUN   TestURLComponent
--- PASS: TestURLComponent (0.00s)
=== RUN   TestURLComponent_NestedPaths
--- PASS: TestURLComponent_NestedPaths (0.00s)
=== RUN   TestPathComponent_DeterministicIteration
--- PASS: TestPathComponent_DeterministicIteration (0.00s)
=== RUN   TestPathComponent_SQLInjection
    path_test.go:123: Original path: /user/55/profile
    path_test.go:127: Key: 1, Value: user
    path_test.go:127: Key: 2, Value: 55
    path_test.go:127: Key: 3, Value: profile
    path_test.go:146: Modified path: /user/55 OR True/profile
--- PASS: TestPathComponent_SQLInjection (0.00s)
PASS
ok  github.com/projectdiscovery/nuclei/v3/pkg/fuzz/component
```

Full fuzz package suite also passes: `go test ./pkg/fuzz/... ✅`

## Checklist

- [x] Pull request is created against the `dev` branch
- [x] All checks passed (`go vet`, `go test ./pkg/fuzz/...`)
- [x] Tests added that prove the fix is effective
- [x] Minimal, focused change following existing conventions (Cookie component pattern)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed non-deterministic iteration of path segments to ensure consistent and predictable ordering when processing URLs.

* **Tests**
  * Added verification test to confirm deterministic path segment iteration behavior across multiple runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->