### PR TITLE
fix(loader): replace panic with error handling for missing dialers (#6674)

### DIFF
--- a/pkg/catalog/loader/loader.go
+++ b/pkg/catalog/loader/loader.go
@@ -637,7 +637,7 @@ func isParsingError(store *Store, message string, template string, err error) bo
 }
 
 // LoadTemplates takes a list of templates and returns paths for them
-func (store *Store) LoadTemplates(templatesList []string) []*templates.Template {
+func (store *Store) LoadTemplates(templatesList []string) ([]*templates.Template, error) {
 	return store.LoadTemplatesWithTags(templatesList, nil)
 }
 
@@ -668,7 +668,7 @@ func (store *Store) LoadWorkflows(workflowsList []string) []*templates.Template 
 
 // LoadTemplatesWithTags takes a list of templates and extra tags
 // returning templates that match.
-func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) []*templates.Template {
+func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) ([]*templates.Template, error) {
 	defer store.saveMetadataIndexOnce()
 
 	indexFilter := store.indexFilter
@@ -717,7 +717,7 @@ func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) []*templ
 
 	dialers := protocolstate.GetDialersWithId(typesOpts.ExecutionId)
 	if dialers == nil {
-		panic("dialers with executionId " + typesOpts.ExecutionId + " not found")
+		return nil, fmt.Errorf("dialers with executionId %s not found", typesOpts.ExecutionId)
 	}
 
 	for _, templatePath := range includedTemplates {


### PR DESCRIPTION
## Problem
The template loader panicked when `protocolstate.GetDialersWithId()` returned nil, which is too harsh for a public API.

## Solution
- Replaced `panic()` with proper error return
- Updated `LoadTemplates()` and `LoadTemplatesWithTags()` signatures to return `error`
- This allows callers to handle the situation gracefully

## Changes
- `pkg/catalog/loader/loader.go`: Modified function signatures and error handling

## Testing
Callers can now check for errors:
```go
templates, err := store.LoadTemplates(templateList)
if err != nil {
    // Handle error gracefully
    log.Error().Err(err).Msg("Failed to load templates")
    return
}
```

## Breaking Changes
- `LoadTemplates()` and `LoadTemplatesWithTags()` now return `([]*templates.Template, error)` instead of `[]*templates.Template`
- Callers need to be updated to handle the error return

Fixes #6674

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented rare crashes when loading templates by handling missing execution contexts gracefully.
  * Improved error messages when required resources aren’t found, aiding quicker troubleshooting.
* **Refactor**
  * Streamlined error handling during template loading to improve reliability and consistency across scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->