### PR TITLE
fix(fuzz): use OrderedMap for deterministic path iteration

### DIFF
--- a/pkg/fuzz/component/path.go
+++ b/pkg/fuzz/component/path.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz/dataformat"
 	"github.com/projectdiscovery/retryablehttp-go"
+	mapsutil "github.com/projectdiscovery/utils/maps"
 	urlutil "github.com/projectdiscovery/utils/url"
 )
 
@@ -36,7 +37,7 @@ func (q *Path) Parse(req *retryablehttp.Request) (bool, error) {
 	q.value = NewValue("")
 
 	splitted := strings.Split(req.Path, "/")
-	values := make(map[string]interface{})
+	values := mapsutil.NewOrderedMap[string, any]()
 	for i, segment := range splitted {
 		if segment == "" && i == 0 {
 			// Skip the first empty segment from leading "/"
@@ -47,10 +48,10 @@ func (q *Path) Parse(req *retryablehttp.Request) (bool, error) {
 			continue
 		}
 		// Use 1-based indexing and store individual segments
-		key := strconv.Itoa(len(values) + 1)
-		values[key] = segment
+		key := strconv.Itoa(values.Len() + 1)
+		values.Set(key, segment)
 	}
-	q.value.SetParsed(dataformat.KVMap(values), "")
+	q.value.SetParsed(dataformat.KVOrderedMap(&values), "")
 	return true, nil
 }
 
@@ -109,8 +110,12 @@ func (q *Path) Rebuild() (*retryablehttp.Request, error) {
 
 		// Check if we have a replacement for this segment
 		key := strconv.Itoa(segmentIndex)
-		if newValue, exists := q.value.parsed.Map.GetOrDefault(key, "").(string); exists && newValue != "" {
-			rebuiltSegments = append(rebuiltSegments, newValue)
+		if val := q.value.parsed.Get(key); val != nil {
+			if newValue, ok := val.(string); ok && newValue != "" {
+				rebuiltSegments = append(rebuiltSegments, newValue)
+			} else {
+				rebuiltSegments = append(rebuiltSegments, originalSegment)
+			}
 		} else {
 			rebuiltSegments = append(rebuiltSegments, originalSegment)
 		}

--- a/pkg/fuzz/component/path_test.go
+++ b/pkg/fuzz/component/path_test.go
@@ -80,6 +80,36 @@ func TestURLComponent_NestedPaths(t *testing.T) {
 	}
 }
 
+func TestPathComponent_DeterministicIteration(t *testing.T) {
+	// Regression test for https://github.com/projectdiscovery/nuclei/issues/6398
+	// Path iteration must be deterministic to ensure all path segments are fuzzed
+	for run := 0; run < 100; run++ {
+		path := NewPath()
+		req, err := retryablehttp.NewRequest(http.MethodGet, "https://example.com/user/55/profile", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		found, err := path.Parse(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !found {
+			t.Fatal("expected path to be found")
+		}
+
+		var keys []string
+		var vals []string
+		_ = path.Iterate(func(key string, value interface{}) error {
+			keys = append(keys, key)
+			vals = append(vals, value.(string))
+			return nil
+		})
+
+		require.Equal(t, []string{"1", "2", "3"}, keys, "run %d: keys must be in insertion order", run)
+		require.Equal(t, []string{"user", "55", "profile"}, vals, "run %d: values must be in insertion order", run)
+	}
+}
+
 func TestPathComponent_SQLInjection(t *testing.T) {
 	path := NewPath()
 	req, err := retryablehttp.NewRequest(http.MethodGet, "https://example.com/user/55/profile", nil)


### PR DESCRIPTION
## Proposed changes

Fix non-deterministic path-based fuzzing that causes numeric path segments to be randomly skipped.

### Root cause

`Path.Parse()` stores segments in a plain Go `map[string]interface{}`. Since Go maps have non-deterministic iteration order, `Path.Iterate()` yields segments in random order, causing the fuzzing engine to sometimes skip segments during path-based fuzzing (e.g. `/user/55/profile`).

### Fix

- Replace the plain map with `mapsutil.OrderedMap` in `Path.Parse()`, matching the pattern already used by the `Cookie` component
- Update `Path.Rebuild()` to use the `KV.Get()` accessor instead of directly accessing the `.Map` field (which is nil when using OrderedMap)
- Add a deterministic iteration regression test that runs 100 iterations to verify order stability

### Proof

All existing tests pass, plus a new regression test:

```
$ go test -v -run "TestURLComponent|TestPathComponent|TestURLComponent_NestedPaths" ./pkg/fuzz/component/
=== RUN   TestURLComponent
--- PASS: TestURLComponent (0.00s)
=== RUN   TestURLComponent_NestedPaths
    path_test.go:64: Key: 1, Value: user
    path_test.go:64: Key: 2, Value: 753
    path_test.go:64: Key: 3, Value: profile
--- PASS: TestURLComponent_NestedPaths (0.00s)
=== RUN   TestPathComponent_DeterministicIteration
--- PASS: TestPathComponent_DeterministicIteration (0.00s)
=== RUN   TestPathComponent_SQLInjection
    path_test.go:127: Original path: /user/55/profile
    path_test.go:131: Key: 1, Value: user
    path_test.go:131: Key: 2, Value: 55
    path_test.go:131: Key: 3, Value: profile
    path_test.go:150: Modified path: /user/55 OR True/profile
    path_test.go:158: Full URL: https://example.com/user/55 OR True/profile
--- PASS: TestPathComponent_SQLInjection (0.00s)
PASS
ok      github.com/projectdiscovery/nuclei/v3/pkg/fuzz/component        0.009s
```

Full fuzz package tests:

```
$ go test ./pkg/fuzz/...
ok      github.com/projectdiscovery/nuclei/v3/pkg/fuzz                  0.059s
ok      github.com/projectdiscovery/nuclei/v3/pkg/fuzz/analyzers/time   0.902s
ok      github.com/projectdiscovery/nuclei/v3/pkg/fuzz/component        0.011s
ok      github.com/projectdiscovery/nuclei/v3/pkg/fuzz/dataformat       0.004s
ok      github.com/projectdiscovery/nuclei/v3/pkg/fuzz/stats            0.002s
```

Build and vet clean:

```
$ go build ./...
$ go vet ./pkg/fuzz/...
(no output - clean)
```

## Checklist

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

Fixes #6398

/claim #6398

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency and reliability of URL path segment handling through enhanced parsing and rebuilding logic with better null and type safety checks.

* **Tests**
  * Added regression test to ensure deterministic iteration of path segments during URL parsing and fuzzing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->