### PR TITLE
fix: propagate execution context to JS library network dials

### DIFF
--- a/pkg/js/compiler/pool.go
+++ b/pkg/js/compiler/pool.go
@@ -87,6 +87,7 @@ func executeWithRuntime(runtime *goja.Runtime, p *goja.Program, args *ExecuteArg
 		}
 		runtime.RemoveContextValue("executionId")
 		runtime.RemoveContextValue("ctx")
+		libs.RemoveDialContext(opts.ExecutionId)
 	}()
 
 	// TODO(dwisiswant0): remove this once we get the RCA.

--- a/pkg/js/compiler/pool.go
+++ b/pkg/js/compiler/pool.go
@@ -34,6 +34,7 @@ import (
 	_ "github.com/projectdiscovery/nuclei/v3/pkg/js/generated/go/libvnc"
 	"github.com/projectdiscovery/nuclei/v3/pkg/js/global"
 	"github.com/projectdiscovery/nuclei/v3/pkg/js/gojs"
+	"github.com/projectdiscovery/nuclei/v3/pkg/js/libs"
 	"github.com/projectdiscovery/nuclei/v3/pkg/js/libs/goconsole"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
 	"github.com/projectdiscovery/nuclei/v3/pkg/utils/json"
@@ -85,6 +86,7 @@ func executeWithRuntime(runtime *goja.Runtime, p *goja.Program, args *ExecuteArg
 			opts.Cleanup(runtime)
 		}
 		runtime.RemoveContextValue("executionId")
+		runtime.RemoveContextValue("ctx")
 	}()
 
 	// TODO(dwisiswant0): remove this once we get the RCA.
@@ -113,6 +115,8 @@ func executeWithRuntime(runtime *goja.Runtime, p *goja.Program, args *ExecuteArg
 
 	// inject execution id and context
 	runtime.SetContextValue("executionId", opts.ExecutionId)
+	runtime.SetContextValue("ctx", opts.Context)
+	libs.SetDialContext(opts.ExecutionId, opts.Context)
 
 	// execute the script
 	return runtime.RunProgram(p)

--- a/pkg/js/global/scripts.go
+++ b/pkg/js/global/scripts.go
@@ -13,6 +13,7 @@ import (
 	"github.com/logrusorgru/aurora"
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/nuclei/v3/pkg/js/gojs"
+	"github.com/projectdiscovery/nuclei/v3/pkg/js/libs"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/utils/vardump"
 	"github.com/projectdiscovery/nuclei/v3/pkg/types"
@@ -113,22 +114,24 @@ func initBuiltInFunc(runtime *goja.Runtime) {
 		},
 		Description: "isPortOpen checks if given TCP port is open on host. timeout is optional and defaults to 5 seconds",
 		FuncDecl: func(ctx context.Context, host string, port string, timeout ...int) (bool, error) {
-			if len(timeout) > 0 {
-				var cancel context.CancelFunc
-				ctx, cancel = context.WithTimeout(ctx, time.Duration(timeout[0])*time.Second)
-				defer cancel()
-			}
 			if host == "" || port == "" {
 				return false, errkit.New("isPortOpen: host or port is empty")
 			}
 
 			executionId := ctx.Value("executionId").(string)
+			dialCtx := libs.GetDialContext(ctx)
+			if len(timeout) > 0 {
+				var cancel context.CancelFunc
+				dialCtx, cancel = context.WithTimeout(dialCtx, time.Duration(timeout[0])*time.Second)
+				defer cancel()
+			}
+
 			dialer := protocolstate.GetDialersWithId(executionId)
 			if dialer == nil {
 				panic("dialers with executionId " + executionId + " not found")
 			}
 
-			conn, err := dialer.Fastdialer.Dial(ctx, "tcp", net.JoinHostPort(host, port))
+			conn, err := dialer.Fastdialer.Dial(dialCtx, "tcp", net.JoinHostPort(host, port))
 			if err != nil {
 				return false, err
 			}
@@ -144,22 +147,24 @@ func initBuiltInFunc(runtime *goja.Runtime) {
 		},
 		Description: "isUDPPortOpen checks if the given UDP port is open on the host. Timeout is optional and defaults to 5 seconds.",
 		FuncDecl: func(ctx context.Context, host string, port string, timeout ...int) (bool, error) {
-			if len(timeout) > 0 {
-				var cancel context.CancelFunc
-				ctx, cancel = context.WithTimeout(ctx, time.Duration(timeout[0])*time.Second)
-				defer cancel()
-			}
 			if host == "" || port == "" {
 				return false, errkit.New("isPortOpen: host or port is empty")
 			}
 
 			executionId := ctx.Value("executionId").(string)
+			dialCtx := libs.GetDialContext(ctx)
+			if len(timeout) > 0 {
+				var cancel context.CancelFunc
+				dialCtx, cancel = context.WithTimeout(dialCtx, time.Duration(timeout[0])*time.Second)
+				defer cancel()
+			}
+
 			dialer := protocolstate.GetDialersWithId(executionId)
 			if dialer == nil {
 				panic("dialers with executionId " + executionId + " not found")
 			}
 
-			conn, err := dialer.Fastdialer.Dial(ctx, "udp", net.JoinHostPort(host, port))
+			conn, err := dialer.Fastdialer.Dial(dialCtx, "udp", net.JoinHostPort(host, port))
 			if err != nil {
 				return false, err
 			}

--- a/pkg/js/libs/kerberos/sendtokdc.go
+++ b/pkg/js/libs/kerberos/sendtokdc.go
@@ -5,7 +5,6 @@ package kerberos
 // it is copied here because the library does not export "SendToKDC()"
 
 import (
-	"context"
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
@@ -81,7 +80,7 @@ func sendToKDCTcp(kclient *Client, msg string) ([]byte, error) {
 			// use that ip address instead of realm/domain for resolving
 			host = kclient.config.ip
 		}
-		tcpConn, err := dialers.Fastdialer.Dial(context.TODO(), "tcp", net.JoinHostPort(host, port))
+		tcpConn, err := dialers.Fastdialer.Dial(kclient.nj.DialContext(), "tcp", net.JoinHostPort(host, port))
 		if err != nil {
 			errs = append(errs, fmt.Sprintf("error establishing connection to %s: %v", kdcs[i], err))
 			continue
@@ -121,7 +120,7 @@ func sendToKDCUdp(kclient *Client, msg string) ([]byte, error) {
 			// use that ip address instead of realm/domain for resolving
 			host = kclient.config.ip
 		}
-		udpConn, err := dialers.Fastdialer.Dial(context.TODO(), "udp", net.JoinHostPort(host, port))
+		udpConn, err := dialers.Fastdialer.Dial(kclient.nj.DialContext(), "udp", net.JoinHostPort(host, port))
 		if err != nil {
 			errs = append(errs, fmt.Sprintf("error establishing connection to %s: %v", kdcs[i], err))
 			continue

--- a/pkg/js/libs/ldap/ldap.go
+++ b/pkg/js/libs/ldap/ldap.go
@@ -1,7 +1,6 @@
 package ldap
 
 import (
-	"context"
 	"crypto/tls"
 	"fmt"
 	"net"
@@ -97,7 +96,7 @@ func NewClient(call goja.ConstructorCall, runtime *goja.Runtime) *goja.Object {
 		if u.Path == "" || u.Path == "/" {
 			u.Path = "/var/run/slapd/ldapi"
 		}
-		conn, err = dialers.Fastdialer.Dial(context.TODO(), "unix", u.Path)
+		conn, err = dialers.Fastdialer.Dial(c.nj.DialContext(), "unix", u.Path)
 		c.nj.HandleError(err, "failed to connect to ldap server")
 	} else {
 		host, port, err := net.SplitHostPort(u.Host)
@@ -116,12 +115,12 @@ func NewClient(call goja.ConstructorCall, runtime *goja.Runtime) *goja.Object {
 			if port == "" {
 				port = ldap.DefaultLdapPort
 			}
-			conn, err = dialers.Fastdialer.Dial(context.TODO(), "udp", net.JoinHostPort(host, port))
+			conn, err = dialers.Fastdialer.Dial(c.nj.DialContext(), "udp", net.JoinHostPort(host, port))
 		case "ldap":
 			if port == "" {
 				port = ldap.DefaultLdapPort
 			}
-			conn, err = dialers.Fastdialer.Dial(context.TODO(), "tcp", net.JoinHostPort(host, port))
+			conn, err = dialers.Fastdialer.Dial(c.nj.DialContext(), "tcp", net.JoinHostPort(host, port))
 		case "ldaps":
 			if port == "" {
 				port = ldap.DefaultLdapsPort
@@ -130,7 +129,7 @@ func NewClient(call goja.ConstructorCall, runtime *goja.Runtime) *goja.Object {
 			if c.cfg.ServerName != "" {
 				serverName = c.cfg.ServerName
 			}
-			conn, err = dialers.Fastdialer.DialTLSWithConfig(context.TODO(), "tcp", net.JoinHostPort(host, port),
+			conn, err = dialers.Fastdialer.DialTLSWithConfig(c.nj.DialContext(), "tcp", net.JoinHostPort(host, port),
 				&tls.Config{InsecureSkipVerify: true, MinVersion: tls.VersionTLS10, ServerName: serverName})
 		default:
 			err = fmt.Errorf("unsupported ldap url schema %v", u.Scheme)

--- a/pkg/js/libs/mssql/mssql.go
+++ b/pkg/js/libs/mssql/mssql.go
@@ -11,6 +11,7 @@ import (
 
 	_ "github.com/microsoft/go-mssqldb"
 	"github.com/praetorian-inc/fingerprintx/pkg/plugins/services/mssql"
+	"github.com/projectdiscovery/nuclei/v3/pkg/js/libs"
 	"github.com/projectdiscovery/nuclei/v3/pkg/js/utils"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
 )
@@ -126,7 +127,7 @@ func isMssql(executionId string, host string, port int) (bool, error) {
 		return false, fmt.Errorf("dialers not initialized for %s", executionId)
 	}
 
-	conn, err := dialer.Fastdialer.Dial(context.TODO(), "tcp", net.JoinHostPort(host, fmt.Sprintf("%d", port)))
+	conn, err := dialer.Fastdialer.Dial(libs.GetDialContext(executionId), "tcp", net.JoinHostPort(host, fmt.Sprintf("%d", port)))
 	if err != nil {
 		return false, err
 	}

--- a/pkg/js/libs/mysql/mysql.go
+++ b/pkg/js/libs/mysql/mysql.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-sql-driver/mysql"
 	"github.com/praetorian-inc/fingerprintx/pkg/plugins"
 	mysqlplugin "github.com/praetorian-inc/fingerprintx/pkg/plugins/services/mysql"
+	"github.com/projectdiscovery/nuclei/v3/pkg/js/libs"
 	"github.com/projectdiscovery/nuclei/v3/pkg/js/utils"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
 )
@@ -52,7 +53,7 @@ func isMySQL(executionId string, host string, port int) (bool, error) {
 		return false, fmt.Errorf("dialers not initialized for %s", executionId)
 	}
 
-	conn, err := dialer.Fastdialer.Dial(context.TODO(), "tcp", net.JoinHostPort(host, fmt.Sprintf("%d", port)))
+	conn, err := dialer.Fastdialer.Dial(libs.GetDialContext(executionId), "tcp", net.JoinHostPort(host, fmt.Sprintf("%d", port)))
 	if err != nil {
 		return false, err
 	}
@@ -151,7 +152,7 @@ func fingerprintMySQL(executionId string, host string, port int) (MySQLInfo, err
 		return MySQLInfo{}, fmt.Errorf("dialers not initialized for %s", executionId)
 	}
 
-	conn, err := dialer.Fastdialer.Dial(context.TODO(), "tcp", net.JoinHostPort(host, fmt.Sprintf("%d", port)))
+	conn, err := dialer.Fastdialer.Dial(libs.GetDialContext(executionId), "tcp", net.JoinHostPort(host, fmt.Sprintf("%d", port)))
 	if err != nil {
 		return info, err
 	}

--- a/pkg/js/libs/mysql/mysql_private.go
+++ b/pkg/js/libs/mysql/mysql_private.go
@@ -7,6 +7,8 @@ import (
 	"net"
 	"net/url"
 	"strings"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/js/libs"
 )
 
 type (
@@ -84,7 +86,7 @@ func connectWithDSN(executionId string, dsn string) (bool, error) {
 	db.SetMaxOpenConns(1)
 	db.SetMaxIdleConns(0)
 
-	ctx := context.WithValue(context.Background(), "executionId", executionId) // nolint: staticcheck
+	ctx := context.WithValue(libs.GetDialContext(executionId), "executionId", executionId) // nolint: staticcheck
 	err = db.PingContext(ctx)
 	if err != nil {
 		return false, err

--- a/pkg/js/libs/oracle/oracle.go
+++ b/pkg/js/libs/oracle/oracle.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/praetorian-inc/fingerprintx/pkg/plugins"
 	"github.com/praetorian-inc/fingerprintx/pkg/plugins/services/oracledb"
+	"github.com/projectdiscovery/nuclei/v3/pkg/js/libs"
 	"github.com/projectdiscovery/nuclei/v3/pkg/js/utils"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
 	goora "github.com/sijms/go-ora/v2"
@@ -61,7 +62,7 @@ func isOracle(executionId string, host string, port int) (IsOracleResponse, erro
 	}
 
 	timeout := 5 * time.Second
-	conn, err := dialer.Fastdialer.Dial(context.TODO(), "tcp", net.JoinHostPort(host, strconv.Itoa(port)))
+	conn, err := dialer.Fastdialer.Dial(libs.GetDialContext(executionId), "tcp", net.JoinHostPort(host, strconv.Itoa(port)))
 	if err != nil {
 		return resp, err
 	}

--- a/pkg/js/libs/oracle/oracledialer.go
+++ b/pkg/js/libs/oracle/oracledialer.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"time"
 
+	"github.com/projectdiscovery/nuclei/v3/pkg/js/libs"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
 )
 
@@ -27,11 +28,11 @@ func (o *oracleCustomDialer) dialWithCtx(ctx context.Context, network, address s
 }
 
 func (o *oracleCustomDialer) Dial(network, address string) (net.Conn, error) {
-	return o.dialWithCtx(context.TODO(), network, address)
+	return o.dialWithCtx(libs.GetDialContext(o.executionId), network, address)
 }
 
 func (o *oracleCustomDialer) DialTimeout(network, address string, timeout time.Duration) (net.Conn, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := context.WithTimeout(libs.GetDialContext(o.executionId), timeout)
 	defer cancel()
 
 	return o.dialWithCtx(ctx, network, address)

--- a/pkg/js/libs/pop3/pop3.go
+++ b/pkg/js/libs/pop3/pop3.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/praetorian-inc/fingerprintx/pkg/plugins"
 	"github.com/praetorian-inc/fingerprintx/pkg/plugins/services/pop3"
+	"github.com/projectdiscovery/nuclei/v3/pkg/js/libs"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
 )
 
@@ -49,7 +50,7 @@ func isPoP3(executionId string, host string, port int) (IsPOP3Response, error) {
 	}
 
 	timeout := 5 * time.Second
-	conn, err := dialer.Fastdialer.Dial(context.TODO(), "tcp", net.JoinHostPort(host, strconv.Itoa(port)))
+	conn, err := dialer.Fastdialer.Dial(libs.GetDialContext(executionId), "tcp", net.JoinHostPort(host, strconv.Itoa(port)))
 	if err != nil {
 		return resp, err
 	}

--- a/pkg/js/libs/postgres/postgres.go
+++ b/pkg/js/libs/postgres/postgres.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-pg/pg/v10"
 	"github.com/praetorian-inc/fingerprintx/pkg/plugins"
 	postgres "github.com/praetorian-inc/fingerprintx/pkg/plugins/services/postgresql"
+	"github.com/projectdiscovery/nuclei/v3/pkg/js/libs"
 	utils "github.com/projectdiscovery/nuclei/v3/pkg/js/utils"
 	"github.com/projectdiscovery/nuclei/v3/pkg/js/utils/pgwrap"   //nolint:staticcheck // need to call init
 	_ "github.com/projectdiscovery/nuclei/v3/pkg/js/utils/pgwrap" //nolint:staticcheck
@@ -51,7 +52,7 @@ func isPostgres(executionId string, host string, port int) (bool, error) {
 		return false, fmt.Errorf("dialers not initialized for %s", executionId)
 	}
 
-	conn, err := dialer.Fastdialer.Dial(context.TODO(), "tcp", fmt.Sprintf("%s:%d", host, port))
+	conn, err := dialer.Fastdialer.Dial(libs.GetDialContext(executionId), "tcp", fmt.Sprintf("%s:%d", host, port))
 	if err != nil {
 		return false, err
 	}
@@ -184,7 +185,7 @@ func connect(executionId string, host string, port int, username string, passwor
 
 	target := net.JoinHostPort(host, fmt.Sprintf("%d", port))
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(libs.GetDialContext(executionId))
 	defer cancel()
 
 	dialer := protocolstate.GetDialersWithId(executionId)

--- a/pkg/js/libs/rdp/rdp.go
+++ b/pkg/js/libs/rdp/rdp.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/praetorian-inc/fingerprintx/pkg/plugins"
 	"github.com/praetorian-inc/fingerprintx/pkg/plugins/services/rdp"
+	"github.com/projectdiscovery/nuclei/v3/pkg/js/libs"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
 )
 
@@ -52,7 +53,7 @@ func isRDP(executionId string, host string, port int) (IsRDPResponse, error) {
 	}
 
 	timeout := 5 * time.Second
-	conn, err := dialer.Fastdialer.Dial(context.TODO(), "tcp", fmt.Sprintf("%s:%d", host, port))
+	conn, err := dialer.Fastdialer.Dial(libs.GetDialContext(executionId), "tcp", fmt.Sprintf("%s:%d", host, port))
 	if err != nil {
 		return resp, err
 	}
@@ -110,7 +111,7 @@ func checkRDPAuth(executionId string, host string, port int) (CheckRDPAuthRespon
 		return CheckRDPAuthResponse{}, fmt.Errorf("dialers not initialized for %s", executionId)
 	}
 	timeout := 5 * time.Second
-	conn, err := dialer.Fastdialer.Dial(context.TODO(), "tcp", fmt.Sprintf("%s:%d", host, port))
+	conn, err := dialer.Fastdialer.Dial(libs.GetDialContext(executionId), "tcp", fmt.Sprintf("%s:%d", host, port))
 	if err != nil {
 		return resp, err
 	}
@@ -210,7 +211,7 @@ func checkRDPEncryption(executionId string, host string, port int) (RDPEncryptio
 	}
 
 	for name, value := range protocols {
-		ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+		ctx, cancel := context.WithTimeout(libs.GetDialContext(executionId), defaultTimeout)
 		defer cancel()
 		conn, err := dialer.Fastdialer.Dial(ctx, "tcp", net.JoinHostPort(host, strconv.Itoa(port)))
 		if err != nil {
@@ -247,7 +248,7 @@ func checkRDPEncryption(executionId string, host string, port int) (RDPEncryptio
 	}
 
 	for encryptionLevel, value := range ciphers {
-		ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+		ctx, cancel := context.WithTimeout(libs.GetDialContext(executionId), defaultTimeout)
 		defer cancel()
 		conn, err := dialer.Fastdialer.Dial(ctx, "tcp", net.JoinHostPort(host, strconv.Itoa(port)))
 		if err != nil {

--- a/pkg/js/libs/redis/redis.go
+++ b/pkg/js/libs/redis/redis.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/projectdiscovery/nuclei/v3/pkg/js/libs"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
 	"github.com/redis/go-redis/v9"
 
@@ -40,13 +41,13 @@ func getServerInfo(executionId string, host string, port int) (string, error) {
 	}()
 
 	// Ping the Redis server
-	_, err := client.Ping(context.TODO()).Result()
+	_, err := client.Ping(libs.GetDialContext(executionId)).Result()
 	if err != nil {
 		return "", err
 	}
 
 	// Get Redis server info
-	infoCmd := client.Info(context.TODO())
+	infoCmd := client.Info(libs.GetDialContext(executionId))
 	if infoCmd.Err() != nil {
 		return "", infoCmd.Err()
 	}
@@ -81,12 +82,12 @@ func connect(executionId string, host string, port int, password string) (bool, 
 		_ = client.Close()
 	}()
 
-	_, err := client.Ping(context.TODO()).Result()
+	_, err := client.Ping(libs.GetDialContext(executionId)).Result()
 	if err != nil {
 		return false, err
 	}
 	// Get Redis server info
-	infoCmd := client.Info(context.TODO())
+	infoCmd := client.Info(libs.GetDialContext(executionId))
 	if infoCmd.Err() != nil {
 		return false, infoCmd.Err()
 	}
@@ -122,13 +123,13 @@ func getServerInfoAuth(executionId string, host string, port int, password strin
 	}()
 
 	// Ping the Redis server
-	_, err := client.Ping(context.TODO()).Result()
+	_, err := client.Ping(libs.GetDialContext(executionId)).Result()
 	if err != nil {
 		return "", err
 	}
 
 	// Get Redis server info
-	infoCmd := client.Info(context.TODO())
+	infoCmd := client.Info(libs.GetDialContext(executionId))
 	if infoCmd.Err() != nil {
 		return "", infoCmd.Err()
 	}
@@ -156,7 +157,7 @@ func isAuthenticated(executionId string, host string, port int) (bool, error) {
 		return false, fmt.Errorf("dialers not initialized for %s", executionId)
 	}
 
-	conn, err := dialer.Fastdialer.Dial(context.TODO(), "tcp", fmt.Sprintf("%s:%d", host, port))
+	conn, err := dialer.Fastdialer.Dial(libs.GetDialContext(executionId), "tcp", fmt.Sprintf("%s:%d", host, port))
 	if err != nil {
 		return false, err
 	}
@@ -194,13 +195,13 @@ func RunLuaScript(ctx context.Context, host string, port int, password string, s
 	}()
 
 	// Ping the Redis server
-	_, err := client.Ping(context.TODO()).Result()
+	_, err := client.Ping(libs.GetDialContext(ctx)).Result()
 	if err != nil {
 		return "", err
 	}
 
 	// Get Redis server info
-	infoCmd := client.Eval(context.Background(), script, []string{})
+	infoCmd := client.Eval(libs.GetDialContext(ctx), script, []string{})
 
 	if infoCmd.Err() != nil {
 		return "", infoCmd.Err()

--- a/pkg/js/libs/smb/smb.go
+++ b/pkg/js/libs/smb/smb.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/praetorian-inc/fingerprintx/pkg/plugins"
 	"github.com/projectdiscovery/go-smb2"
+	"github.com/projectdiscovery/nuclei/v3/pkg/js/libs"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
 	"github.com/zmap/zgrab2/lib/smb/smb"
 )
@@ -49,7 +50,7 @@ func connectSMBInfoMode(executionId string, host string, port int) (*smb.SMBLog,
 	if dialer == nil {
 		return nil, fmt.Errorf("dialers not initialized for %s", executionId)
 	}
-	conn, err := dialer.Fastdialer.Dial(context.TODO(), "tcp", fmt.Sprintf("%s:%d", host, port))
+	conn, err := dialer.Fastdialer.Dial(libs.GetDialContext(executionId), "tcp", fmt.Sprintf("%s:%d", host, port))
 	if err != nil {
 		return nil, err
 	}
@@ -61,7 +62,7 @@ func connectSMBInfoMode(executionId string, host string, port int) (*smb.SMBLog,
 	}
 
 	// try to negotiate SMBv1
-	conn, err = dialer.Fastdialer.Dial(context.TODO(), "tcp", fmt.Sprintf("%s:%d", host, port))
+	conn, err = dialer.Fastdialer.Dial(libs.GetDialContext(executionId), "tcp", fmt.Sprintf("%s:%d", host, port))
 	if err != nil {
 		return nil, err
 	}
@@ -126,7 +127,7 @@ func listShares(executionId string, host string, port int, user string, password
 		return nil, fmt.Errorf("dialers not initialized for %s", executionId)
 	}
 
-	conn, err := dialer.Fastdialer.Dial(context.TODO(), "tcp", fmt.Sprintf("%s:%d", host, port))
+	conn, err := dialer.Fastdialer.Dial(libs.GetDialContext(executionId), "tcp", fmt.Sprintf("%s:%d", host, port))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/js/libs/smb/smb_private.go
+++ b/pkg/js/libs/smb/smb_private.go
@@ -1,13 +1,13 @@
 package smb
 
 import (
-	"context"
 	"fmt"
 	"net"
 	"time"
 
 	"github.com/praetorian-inc/fingerprintx/pkg/plugins"
 	"github.com/praetorian-inc/fingerprintx/pkg/plugins/services/smb"
+	"github.com/projectdiscovery/nuclei/v3/pkg/js/libs"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
 	zgrabsmb "github.com/zmap/zgrab2/lib/smb/smb"
 )
@@ -25,7 +25,7 @@ func collectSMBv2Metadata(executionId string, host string, port int, timeout tim
 		return nil, fmt.Errorf("dialers not initialized for %s", executionId)
 	}
 
-	conn, err := dialer.Fastdialer.Dial(context.TODO(), "tcp", net.JoinHostPort(host, fmt.Sprintf("%d", port)))
+	conn, err := dialer.Fastdialer.Dial(libs.GetDialContext(executionId), "tcp", net.JoinHostPort(host, fmt.Sprintf("%d", port)))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/js/libs/smb/smbghost.go
+++ b/pkg/js/libs/smb/smbghost.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/projectdiscovery/nuclei/v3/pkg/js/libs/structs"
+	"github.com/projectdiscovery/nuclei/v3/pkg/js/libs"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
 	"github.com/projectdiscovery/utils/reader"
 )
@@ -42,7 +43,7 @@ func detectSMBGhost(executionId string, host string, port int) (bool, error) {
 	if dialer == nil {
 		return false, fmt.Errorf("dialers not initialized for %s", executionId)
 	}
-	conn, err := dialer.Fastdialer.Dial(context.TODO(), "tcp", addr)
+	conn, err := dialer.Fastdialer.Dial(libs.GetDialContext(executionId), "tcp", addr)
 	if err != nil {
 		return false, err
 

--- a/pkg/js/libs/smtp/smtp.go
+++ b/pkg/js/libs/smtp/smtp.go
@@ -1,7 +1,6 @@
 package smtp
 
 import (
-	"context"
 	"fmt"
 	"net"
 	"net/smtp"
@@ -95,7 +94,7 @@ func (c *Client) IsSMTP() (SMTPResponse, error) {
 		return SMTPResponse{}, fmt.Errorf("dialers not initialized for %s", executionId)
 	}
 
-	conn, err := dialer.Fastdialer.Dial(context.TODO(), "tcp", net.JoinHostPort(c.host, c.port))
+	conn, err := dialer.Fastdialer.Dial(c.nj.DialContext(), "tcp", net.JoinHostPort(c.host, c.port))
 	if err != nil {
 		return resp, err
 	}
@@ -139,7 +138,7 @@ func (c *Client) IsOpenRelay(msg *SMTPMessage) (bool, error) {
 	}
 
 	addr := net.JoinHostPort(c.host, c.port)
-	conn, err := dialer.Fastdialer.Dial(context.TODO(), "tcp", addr)
+	conn, err := dialer.Fastdialer.Dial(c.nj.DialContext(), "tcp", addr)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/js/libs/telnet/telnet.go
+++ b/pkg/js/libs/telnet/telnet.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/praetorian-inc/fingerprintx/pkg/plugins"
 	"github.com/praetorian-inc/fingerprintx/pkg/plugins/services/telnet"
+	"github.com/projectdiscovery/nuclei/v3/pkg/js/libs"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
 	"github.com/projectdiscovery/nuclei/v3/pkg/utils/telnetmini"
 )
@@ -88,7 +89,7 @@ func isTelnet(executionId string, host string, port int) (IsTelnetResponse, erro
 		return IsTelnetResponse{}, fmt.Errorf("dialers not initialized for %s", executionId)
 	}
 
-	conn, err := dialer.Fastdialer.Dial(context.TODO(), "tcp", net.JoinHostPort(host, strconv.Itoa(port)))
+	conn, err := dialer.Fastdialer.Dial(libs.GetDialContext(executionId), "tcp", net.JoinHostPort(host, strconv.Itoa(port)))
 	if err != nil {
 		return resp, err
 	}
@@ -132,7 +133,7 @@ func (c *TelnetClient) Connect(ctx context.Context, host string, port int, usern
 	}
 
 	// Create TCP connection
-	conn, err := dialer.Fastdialer.Dial(context.TODO(), "tcp", net.JoinHostPort(host, strconv.Itoa(port)))
+	conn, err := dialer.Fastdialer.Dial(libs.GetDialContext(ctx), "tcp", net.JoinHostPort(host, strconv.Itoa(port)))
 	if err != nil {
 		return false, err
 	}
@@ -180,7 +181,7 @@ func (c *TelnetClient) Info(ctx context.Context, host string, port int) (TelnetI
 		return TelnetInfoResponse{}, fmt.Errorf("dialers not initialized for %s", executionId)
 	}
 
-	conn, err := dialer.Fastdialer.Dial(context.TODO(), "tcp", net.JoinHostPort(host, strconv.Itoa(port)))
+	conn, err := dialer.Fastdialer.Dial(libs.GetDialContext(ctx), "tcp", net.JoinHostPort(host, strconv.Itoa(port)))
 	if err != nil {
 		return TelnetInfoResponse{}, err
 	}
@@ -226,7 +227,7 @@ func (c *TelnetClient) GetTelnetNTLMInfo(ctx context.Context, host string, port 
 	}
 
 	// Create TCP connection
-	conn, err := dialer.Fastdialer.Dial(context.TODO(), "tcp", net.JoinHostPort(host, strconv.Itoa(port)))
+	conn, err := dialer.Fastdialer.Dial(libs.GetDialContext(ctx), "tcp", net.JoinHostPort(host, strconv.Itoa(port)))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/js/libs/utils.go
+++ b/pkg/js/libs/utils.go
@@ -14,6 +14,12 @@ func SetDialContext(executionId string, ctx context.Context) {
 	dialContexts.Store(executionId, ctx)
 }
 
+// RemoveDialContext removes the stored execution context for the given executionId.
+// This should be called during cleanup to prevent memory leaks.
+func RemoveDialContext(executionId string) {
+	dialContexts.Delete(executionId)
+}
+
 // GetDialContext returns the execution context for network dials.
 // It accepts either a context.Context (the goja runtime context) or
 // a string (executionId) for backward compatibility with @memo functions.
@@ -28,7 +34,9 @@ func GetDialContext(key any) context.Context {
 		if execCtx, ok := v.Value("ctx").(context.Context); ok {
 			return execCtx
 		}
-		return context.Background()
+		// Fall back to the caller's context rather than a bare Background,
+		// so at least the parent's cancellation is respected.
+		return v
 	case string:
 		if val, ok := dialContexts.Load(v); ok {
 			return val.(context.Context)

--- a/pkg/js/libs/utils.go
+++ b/pkg/js/libs/utils.go
@@ -1,0 +1,40 @@
+package libs
+
+import (
+	"context"
+	"sync"
+)
+
+var dialContexts sync.Map
+
+// SetDialContext stores the execution context for a given executionId.
+// This is called by the JS compiler before running a script.
+// Used as a fallback for @memo functions that only have executionId.
+func SetDialContext(executionId string, ctx context.Context) {
+	dialContexts.Store(executionId, ctx)
+}
+
+// GetDialContext returns the execution context for network dials.
+// It accepts either a context.Context (the goja runtime context) or
+// a string (executionId) for backward compatibility with @memo functions.
+//
+// When passed a goja context, it extracts the per-execution context
+// stored by the JS compiler — this is the correct, race-free path.
+// When passed an executionId string, it falls back to a shared map
+// which is acceptable for @memo functions (cached, first-call-only).
+func GetDialContext(key any) context.Context {
+	switch v := key.(type) {
+	case context.Context:
+		if execCtx, ok := v.Value("ctx").(context.Context); ok {
+			return execCtx
+		}
+		return context.Background()
+	case string:
+		if val, ok := dialContexts.Load(v); ok {
+			return val.(context.Context)
+		}
+		return context.Background()
+	default:
+		return context.Background()
+	}
+}

--- a/pkg/js/libs/vnc/vnc.go
+++ b/pkg/js/libs/vnc/vnc.go
@@ -10,6 +10,7 @@ import (
 	vnclib "github.com/alexsnet/go-vnc"
 	"github.com/praetorian-inc/fingerprintx/pkg/plugins"
 	vncplugin "github.com/praetorian-inc/fingerprintx/pkg/plugins/services/vnc"
+	"github.com/projectdiscovery/nuclei/v3/pkg/js/libs"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
 	stringsutil "github.com/projectdiscovery/utils/strings"
 )
@@ -49,12 +50,12 @@ type (
 // const connected = client.Connect('acme.com', 5900, 'password');
 // ```
 func (c *VNCClient) Connect(ctx context.Context, host string, port int, password string) (bool, error) {
-	executionId := ctx.Value("executionId").(string)
-	return connect(executionId, host, port, password)
+	return connect(ctx, host, port, password)
 }
 
 // connect attempts to authenticate with a VNC server using the given password
-func connect(executionId string, host string, port int, password string) (bool, error) {
+func connect(ctx context.Context, host string, port int, password string) (bool, error) {
+	executionId := ctx.Value("executionId").(string)
 	if host == "" || port <= 0 {
 		return false, fmt.Errorf("invalid host or port")
 	}
@@ -68,7 +69,8 @@ func connect(executionId string, host string, port int, password string) (bool, 
 		return false, fmt.Errorf("dialers not initialized for %s", executionId)
 	}
 
-	conn, err := dialer.Fastdialer.Dial(context.TODO(), "tcp", net.JoinHostPort(host, strconv.Itoa(port)))
+	dialCtx := libs.GetDialContext(ctx)
+	conn, err := dialer.Fastdialer.Dial(dialCtx, "tcp", net.JoinHostPort(host, strconv.Itoa(port)))
 	if err != nil {
 		return false, err
 	}
@@ -83,7 +85,7 @@ func connect(executionId string, host string, port int, password string) (bool, 
 	vncConfig := vnclib.NewClientConfig(password)
 
 	// Attempt to connect and authenticate
-	c, err := vnclib.Connect(context.TODO(), conn, vncConfig)
+	c, err := vnclib.Connect(dialCtx, conn, vncConfig)
 	if err != nil {
 		// Check for specific authentication errors
 		if isAuthError(err) {
@@ -132,7 +134,7 @@ func isVNC(executionId string, host string, port int) (IsVNCResponse, error) {
 	if dialer == nil {
 		return IsVNCResponse{}, fmt.Errorf("dialers not initialized for %s", executionId)
 	}
-	conn, err := dialer.Fastdialer.Dial(context.TODO(), "tcp", net.JoinHostPort(host, strconv.Itoa(port)))
+	conn, err := dialer.Fastdialer.Dial(libs.GetDialContext(executionId), "tcp", net.JoinHostPort(host, strconv.Itoa(port)))
 	if err != nil {
 		return resp, err
 	}

--- a/pkg/js/utils/nucleijs.go
+++ b/pkg/js/utils/nucleijs.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"strings"
@@ -48,6 +49,18 @@ func (j *NucleiJS) ExecutionId() string {
 		return ""
 	}
 	return executionId.(string)
+}
+
+// DialContext returns the per-execution context stored in the goja runtime.
+// This context carries the JS execution deadline, ensuring network dials
+// are cancelled when the execution times out.
+func (j *NucleiJS) DialContext() context.Context {
+	if ctx, ok := j.vm.GetContextValue("ctx"); ok {
+		if execCtx, ok := ctx.(context.Context); ok {
+			return execCtx
+		}
+	}
+	return context.Background()
 }
 
 // see: https://arc.net/l/quote/wpenftpc for throwing docs

--- a/pkg/js/utils/pgwrap/pgwrap.go
+++ b/pkg/js/utils/pgwrap/pgwrap.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/lib/pq"
 	"github.com/projectdiscovery/fastdialer/fastdialer"
+	"github.com/projectdiscovery/nuclei/v3/pkg/js/libs"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
 )
 
@@ -27,7 +28,7 @@ func (p *pgDial) Dial(network, address string) (net.Conn, error) {
 	if dialers == nil {
 		return nil, fmt.Errorf("dialers not initialized for %s", p.executionId)
 	}
-	return dialers.Fastdialer.Dial(context.TODO(), network, address)
+	return dialers.Fastdialer.Dial(libs.GetDialContext(p.executionId), network, address)
 }
 
 func (p *pgDial) DialTimeout(network, address string, timeout time.Duration) (net.Conn, error) {
@@ -35,7 +36,7 @@ func (p *pgDial) DialTimeout(network, address string, timeout time.Duration) (ne
 	if dialers == nil {
 		return nil, fmt.Errorf("dialers not initialized for %s", p.executionId)
 	}
-	ctx, cancel := context.WithTimeoutCause(context.Background(), timeout, fastdialer.ErrDialTimeout)
+	ctx, cancel := context.WithTimeoutCause(libs.GetDialContext(p.executionId), timeout, fastdialer.ErrDialTimeout)
 	defer cancel()
 	return dialers.Fastdialer.Dial(ctx, network, address)
 }


### PR DESCRIPTION
## Proposed changes

All 16 JS protocol library implementations extract only `executionId` from the goja runtime context and pass `context.TODO()` to fastdialer network dials. This means network I/O inside JS scripts has no execution deadline. When a JS execution times out, the goroutine continues running indefinitely, holding pool slots and starving subsequent templates.

This PR:
- Adds `GetDialContext`/`SetDialContext`/`RemoveDialContext` helpers in `pkg/js/libs/utils.go`
- Stores the execution context in the goja runtime via `SetContextValue("ctx", opts.Context)`
- Adds `DialContext()` method to `NucleiJS` for generated bindings
- Threads the execution context through all JS library dial calls so they respect cancellation
- Updates `isPortOpen`/`isUDPPortOpen` global scripts to use the execution context
- Cleans up `dialContexts` entries in the defer to prevent memory leaks

Fixes #6877

### Proof

- `go build ./cmd/nuclei/` compiles
- `go test ./pkg/js/compiler/...` passes
- `golangci-lint run ./pkg/js/...` clean
- Verified JS templates fire consistently across 4 consecutive scans against a /24 network

## Checklist

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)