### PR TITLE
fix: replace panic with error handling in template loader

### DIFF
--- a/pkg/catalog/loader/loader.go
+++ b/pkg/catalog/loader/loader.go
@@ -717,7 +717,8 @@ func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) []*templ
 
 	dialers := protocolstate.GetDialersWithId(typesOpts.ExecutionId)
 	if dialers == nil {
-		store.logger.Error().Msgf("dialers with executionId %s not found", typesOpts.ExecutionId) 		return nil
+		store.logger.Error().Msgf("dialers with executionId %s not found", typesOpts.ExecutionId)
+		return nil
 	}
 
 	for _, templatePath := range includedTemplates {

--- a/pkg/catalog/loader/loader.go
+++ b/pkg/catalog/loader/loader.go
@@ -717,7 +717,7 @@ func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) []*templ
 
 	dialers := protocolstate.GetDialersWithId(typesOpts.ExecutionId)
 	if dialers == nil {
-		panic("dialers with executionId " + typesOpts.ExecutionId + " not found")
+		store.logger.Error().Msgf("dialers with executionId %s not found", typesOpts.ExecutionId) 		return nil
 	}
 
 	for _, templatePath := range includedTemplates {


### PR DESCRIPTION
Fixes #6674

Replace panic with error logging and return nil when dialers are not initialized, allowing callers to handle the situation gracefully.

## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->

### Proof

<!-- How has this been tested? Please describe the tests that you ran to verify your changes. -->

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when loading templates: errors are now logged and the process skips the problematic item instead of causing the application to crash, allowing the app to continue running normally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->