### PR TITLE
feat: add honeypot detection to reduce false positives

### DIFF
--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -423,6 +423,7 @@ on extensive configurability, massive extensibility and ease of use.`)
 		flagSet.IntVarP(&options.MaxHostError, "max-host-error", "mhe", 30, "max errors for a host before skipping from scan"),
 		flagSet.StringSliceVarP(&options.TrackError, "track-error", "te", nil, "adds given error to max-host-error watchlist (standard, file)", goflags.FileStringSliceOptions),
 		flagSet.BoolVarP(&options.NoHostErrors, "no-mhe", "nmhe", false, "disable skipping host from scan based on errors"),
+		flagSet.IntVarP(&options.HoneypotThreshold, "honeypot-threshold", "hpt", 0, "threshold of unique template matches before flagging a host as honeypot (0 = disabled)"),
 		flagSet.BoolVar(&options.Project, "project", false, "use a project folder to avoid sending same request multiple times"),
 		flagSet.StringVar(&options.ProjectPath, "project-path", os.TempDir(), "set a specific project path"),
 		flagSet.BoolVarP(&options.StopAtFirstMatch, "stop-at-first-match", "spm", false, "stop processing HTTP requests after the first match (may break template/workflow logic)"),

--- a/pkg/honeypot/detector.go
+++ b/pkg/honeypot/detector.go
@@ -1,0 +1,188 @@
+package honeypot
+
+import (
+	"net"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"github.com/projectdiscovery/gologger"
+)
+
+const (
+	// DefaultThreshold is the default number of unique template matches
+	// before a host is flagged as a potential honeypot.
+	DefaultThreshold = 10
+)
+
+// Detector tracks unique template matches per host and flags
+// hosts that exceed a configurable threshold as potential honeypots.
+// It is safe for concurrent use.
+type Detector struct {
+	threshold int
+	hosts     sync.Map // host string -> *hostEntry
+	flagged   atomic.Int32
+	enabled   bool
+}
+
+// hostEntry tracks the set of unique template IDs matched for a host.
+type hostEntry struct {
+	mu          sync.Mutex
+	templateIDs map[string]struct{}
+	flagged     bool
+}
+
+// New creates a new honeypot detector with the given threshold.
+// If threshold <= 0, detection is disabled.
+func New(threshold int) *Detector {
+	return &Detector{
+		threshold: threshold,
+		enabled:   threshold > 0,
+	}
+}
+
+// IsEnabled returns whether honeypot detection is active.
+func (d *Detector) IsEnabled() bool {
+	return d.enabled
+}
+
+// RecordMatch records that the given template matched the given host.
+// Returns true if this match caused the host to be newly flagged as a honeypot.
+func (d *Detector) RecordMatch(host, templateID string) bool {
+	if !d.enabled {
+		return false
+	}
+
+	host = normalizeHost(host)
+	if host == "" {
+		return false
+	}
+
+	actual, _ := d.hosts.LoadOrStore(host, &hostEntry{
+		templateIDs: make(map[string]struct{}),
+	})
+	entry := actual.(*hostEntry)
+
+	entry.mu.Lock()
+	defer entry.mu.Unlock()
+
+	if entry.flagged {
+		// Already flagged — still record the template but don't re-flag
+		entry.templateIDs[templateID] = struct{}{}
+		return false
+	}
+
+	entry.templateIDs[templateID] = struct{}{}
+
+	if len(entry.templateIDs) >= d.threshold {
+		entry.flagged = true
+		d.flagged.Add(1)
+		gologger.Warning().Msgf("Potential honeypot detected: %s (%d unique template matches exceeded threshold of %d)", host, len(entry.templateIDs), d.threshold)
+		return true
+	}
+	return false
+}
+
+// IsHoneypot returns whether the given host has been flagged as a honeypot.
+func (d *Detector) IsHoneypot(host string) bool {
+	if !d.enabled {
+		return false
+	}
+
+	host = normalizeHost(host)
+	if host == "" {
+		return false
+	}
+
+	actual, ok := d.hosts.Load(host)
+	if !ok {
+		return false
+	}
+	entry := actual.(*hostEntry)
+	entry.mu.Lock()
+	defer entry.mu.Unlock()
+	return entry.flagged
+}
+
+// GetMatchCount returns the number of unique template matches for a host.
+func (d *Detector) GetMatchCount(host string) int {
+	if !d.enabled {
+		return 0
+	}
+
+	host = normalizeHost(host)
+	if host == "" {
+		return 0
+	}
+
+	actual, ok := d.hosts.Load(host)
+	if !ok {
+		return 0
+	}
+	entry := actual.(*hostEntry)
+	entry.mu.Lock()
+	defer entry.mu.Unlock()
+	return len(entry.templateIDs)
+}
+
+// FlaggedCount returns the total number of flagged honeypot hosts.
+func (d *Detector) FlaggedCount() int {
+	return int(d.flagged.Load())
+}
+
+// FlaggedHosts returns all hosts that have been flagged as honeypots
+// along with their match counts.
+func (d *Detector) FlaggedHosts() map[string]int {
+	result := make(map[string]int)
+	d.hosts.Range(func(key, value any) bool {
+		host := key.(string)
+		entry := value.(*hostEntry)
+		entry.mu.Lock()
+		if entry.flagged {
+			result[host] = len(entry.templateIDs)
+		}
+		entry.mu.Unlock()
+		return true
+	})
+	return result
+}
+
+// normalizeHost extracts and lowercases the host portion from a URL or host:port string.
+func normalizeHost(input string) string {
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return ""
+	}
+
+	// Strip scheme if present
+	if idx := strings.Index(input, "://"); idx != -1 {
+		input = input[idx+3:]
+	}
+
+	// Strip path
+	if idx := strings.IndexByte(input, '/'); idx != -1 {
+		input = input[:idx]
+	}
+
+	// Strip query
+	if idx := strings.IndexByte(input, '?'); idx != -1 {
+		input = input[:idx]
+	}
+
+	// Handle IPv6 brackets
+	if strings.HasPrefix(input, "[") {
+		if host, _, err := net.SplitHostPort(input); err == nil {
+			return strings.ToLower(host)
+		}
+		// Bracketed but no port — strip brackets
+		input = strings.Trim(input, "[]")
+		return strings.ToLower(input)
+	}
+
+	// Strip port for host:port
+	if host, _, err := net.SplitHostPort(input); err == nil {
+		return strings.ToLower(host)
+	}
+
+	return strings.ToLower(input)
+}

--- a/pkg/honeypot/detector.go
+++ b/pkg/honeypot/detector.go
@@ -43,13 +43,16 @@ func New(threshold int) *Detector {
 
 // IsEnabled returns whether honeypot detection is active.
 func (d *Detector) IsEnabled() bool {
+	if d == nil {
+		return false
+	}
 	return d.enabled
 }
 
 // RecordMatch records that the given template matched the given host.
 // Returns true if this match caused the host to be newly flagged as a honeypot.
 func (d *Detector) RecordMatch(host, templateID string) bool {
-	if !d.enabled {
+	if d == nil || !d.enabled {
 		return false
 	}
 
@@ -85,7 +88,7 @@ func (d *Detector) RecordMatch(host, templateID string) bool {
 
 // IsHoneypot returns whether the given host has been flagged as a honeypot.
 func (d *Detector) IsHoneypot(host string) bool {
-	if !d.enabled {
+	if d == nil || !d.enabled {
 		return false
 	}
 
@@ -106,7 +109,7 @@ func (d *Detector) IsHoneypot(host string) bool {
 
 // GetMatchCount returns the number of unique template matches for a host.
 func (d *Detector) GetMatchCount(host string) int {
-	if !d.enabled {
+	if d == nil || !d.enabled {
 		return 0
 	}
 
@@ -127,7 +130,7 @@ func (d *Detector) GetMatchCount(host string) int {
 
 // FlaggedCount returns the total number of flagged honeypot hosts.
 func (d *Detector) FlaggedCount() int {
-	if !d.enabled {
+	if d == nil || !d.enabled {
 		return 0
 	}
 	return int(d.flagged.Load())
@@ -137,7 +140,7 @@ func (d *Detector) FlaggedCount() int {
 // along with their match counts.
 func (d *Detector) FlaggedHosts() map[string]int {
 	result := make(map[string]int)
-	if !d.enabled {
+	if d == nil || !d.enabled {
 		return result
 	}
 	d.hosts.Range(func(key, value any) bool {

--- a/pkg/honeypot/detector.go
+++ b/pkg/honeypot/detector.go
@@ -169,6 +169,11 @@ func normalizeHost(input string) string {
 		input = input[:idx]
 	}
 
+	// Strip fragment
+	if idx := strings.IndexByte(input, '#'); idx != -1 {
+		input = input[:idx]
+	}
+
 	// Strip userinfo (user:pass@)
 	if idx := strings.LastIndex(input, "@"); idx != -1 {
 		input = input[idx+1:]

--- a/pkg/honeypot/detector.go
+++ b/pkg/honeypot/detector.go
@@ -169,6 +169,11 @@ func normalizeHost(input string) string {
 		input = input[:idx]
 	}
 
+	// Strip userinfo (user:pass@)
+	if idx := strings.LastIndex(input, "@"); idx != -1 {
+		input = input[idx+1:]
+	}
+
 	// Handle IPv6 brackets
 	if strings.HasPrefix(input, "[") {
 		if host, _, err := net.SplitHostPort(input); err == nil {

--- a/pkg/honeypot/detector.go
+++ b/pkg/honeypot/detector.go
@@ -127,6 +127,9 @@ func (d *Detector) GetMatchCount(host string) int {
 
 // FlaggedCount returns the total number of flagged honeypot hosts.
 func (d *Detector) FlaggedCount() int {
+	if !d.enabled {
+		return 0
+	}
 	return int(d.flagged.Load())
 }
 
@@ -134,6 +137,9 @@ func (d *Detector) FlaggedCount() int {
 // along with their match counts.
 func (d *Detector) FlaggedHosts() map[string]int {
 	result := make(map[string]int)
+	if !d.enabled {
+		return result
+	}
 	d.hosts.Range(func(key, value any) bool {
 		host := key.(string)
 		entry := value.(*hostEntry)
@@ -158,6 +164,9 @@ func normalizeHost(input string) string {
 	if idx := strings.Index(input, "://"); idx != -1 {
 		input = input[idx+3:]
 	}
+
+	// Strip leading slashes (e.g. protocol-relative "//host")
+	input = strings.TrimLeft(input, "/")
 
 	// Strip path
 	if idx := strings.IndexByte(input, '/'); idx != -1 {

--- a/pkg/honeypot/detector_test.go
+++ b/pkg/honeypot/detector_test.go
@@ -109,6 +109,9 @@ func TestNormalizeHost(t *testing.T) {
 		{"192.168.1.1:80", "192.168.1.1"},
 		{"[::1]:8080", "::1"},
 		{"http://[::1]:8080/path", "::1"},
+		{"http://user:pass@example.com/path", "example.com"},
+		{"http://user@example.com:8080", "example.com"},
+		{"user:pass@example.com", "example.com"},
 		{"", ""},
 		{"   ", ""},
 	}

--- a/pkg/honeypot/detector_test.go
+++ b/pkg/honeypot/detector_test.go
@@ -1,0 +1,194 @@
+package honeypot
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetectorBasic(t *testing.T) {
+	d := New(3)
+	require.True(t, d.IsEnabled())
+
+	// Record matches below threshold
+	require.False(t, d.RecordMatch("example.com", "template-1"))
+	require.False(t, d.IsHoneypot("example.com"))
+	require.Equal(t, 1, d.GetMatchCount("example.com"))
+
+	require.False(t, d.RecordMatch("example.com", "template-2"))
+	require.False(t, d.IsHoneypot("example.com"))
+	require.Equal(t, 2, d.GetMatchCount("example.com"))
+
+	// Third unique match triggers honeypot flag
+	require.True(t, d.RecordMatch("example.com", "template-3"))
+	require.True(t, d.IsHoneypot("example.com"))
+	require.Equal(t, 3, d.GetMatchCount("example.com"))
+	require.Equal(t, 1, d.FlaggedCount())
+}
+
+func TestDetectorDuplicateTemplates(t *testing.T) {
+	d := New(3)
+
+	// Same template multiple times should not inflate count
+	d.RecordMatch("example.com", "template-1")
+	d.RecordMatch("example.com", "template-1")
+	d.RecordMatch("example.com", "template-1")
+	require.Equal(t, 1, d.GetMatchCount("example.com"))
+	require.False(t, d.IsHoneypot("example.com"))
+}
+
+func TestDetectorMultipleHosts(t *testing.T) {
+	d := New(2)
+
+	d.RecordMatch("host1.com", "t1")
+	d.RecordMatch("host1.com", "t2")
+	d.RecordMatch("host2.com", "t1")
+
+	require.True(t, d.IsHoneypot("host1.com"))
+	require.False(t, d.IsHoneypot("host2.com"))
+	require.Equal(t, 1, d.FlaggedCount())
+}
+
+func TestDetectorDisabled(t *testing.T) {
+	d := New(0)
+	require.False(t, d.IsEnabled())
+	require.False(t, d.RecordMatch("example.com", "t1"))
+	require.False(t, d.IsHoneypot("example.com"))
+	require.Equal(t, 0, d.GetMatchCount("example.com"))
+}
+
+func TestDetectorNegativeThreshold(t *testing.T) {
+	d := New(-1)
+	require.False(t, d.IsEnabled())
+}
+
+func TestDetectorRecordAfterFlagged(t *testing.T) {
+	d := New(2)
+
+	d.RecordMatch("example.com", "t1")
+	d.RecordMatch("example.com", "t2") // flags
+	require.True(t, d.IsHoneypot("example.com"))
+
+	// Additional match after flagging should still be tracked
+	require.False(t, d.RecordMatch("example.com", "t3")) // returns false (already flagged)
+	require.Equal(t, 3, d.GetMatchCount("example.com"))
+	require.Equal(t, 1, d.FlaggedCount()) // still 1
+}
+
+func TestDetectorFlaggedHosts(t *testing.T) {
+	d := New(2)
+
+	d.RecordMatch("host1.com", "t1")
+	d.RecordMatch("host1.com", "t2")
+	d.RecordMatch("host2.com", "t1")
+	d.RecordMatch("host3.com", "t1")
+	d.RecordMatch("host3.com", "t2")
+
+	flagged := d.FlaggedHosts()
+	require.Len(t, flagged, 2)
+	require.Contains(t, flagged, "host1.com")
+	require.Contains(t, flagged, "host3.com")
+	require.Equal(t, 2, flagged["host1.com"])
+	require.Equal(t, 2, flagged["host3.com"])
+}
+
+func TestNormalizeHost(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"example.com", "example.com"},
+		{"Example.COM", "example.com"},
+		{"http://example.com", "example.com"},
+		{"https://example.com/path", "example.com"},
+		{"https://example.com:443/path?q=1", "example.com"},
+		{"example.com:8080", "example.com"},
+		{"192.168.1.1", "192.168.1.1"},
+		{"192.168.1.1:80", "192.168.1.1"},
+		{"[::1]:8080", "::1"},
+		{"http://[::1]:8080/path", "::1"},
+		{"", ""},
+		{"   ", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := normalizeHost(tt.input)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestDetectorHostNormalization(t *testing.T) {
+	d := New(2)
+
+	// Different representations of the same host should be tracked together
+	d.RecordMatch("http://example.com/page1", "t1")
+	d.RecordMatch("https://example.com:443/page2", "t2")
+	require.True(t, d.IsHoneypot("example.com"))
+	require.True(t, d.IsHoneypot("http://example.com"))
+	require.True(t, d.IsHoneypot("https://EXAMPLE.COM:443"))
+}
+
+func TestDetectorEmptyHost(t *testing.T) {
+	d := New(2)
+	require.False(t, d.RecordMatch("", "t1"))
+	require.False(t, d.RecordMatch("   ", "t1"))
+	require.False(t, d.IsHoneypot(""))
+	require.Equal(t, 0, d.GetMatchCount(""))
+}
+
+func TestDetectorConcurrentAccess(t *testing.T) {
+	d := New(5)
+	var wg sync.WaitGroup
+	host := "concurrent-test.com"
+
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			d.RecordMatch(host, fmt.Sprintf("template-%d", n%10))
+		}(i)
+	}
+	wg.Wait()
+
+	// Should have exactly 10 unique templates (template-0 through template-9)
+	require.Equal(t, 10, d.GetMatchCount(host))
+	require.True(t, d.IsHoneypot(host))
+	require.Equal(t, 1, d.FlaggedCount())
+}
+
+func TestDetectorConcurrentMultipleHosts(t *testing.T) {
+	d := New(3)
+	var wg sync.WaitGroup
+
+	// Simulate scanning multiple hosts concurrently
+	for h := 0; h < 20; h++ {
+		for tmpl := 0; tmpl < 5; tmpl++ {
+			wg.Add(1)
+			go func(hostIdx, tmplIdx int) {
+				defer wg.Done()
+				host := fmt.Sprintf("host-%d.com", hostIdx)
+				tmpl := fmt.Sprintf("template-%d", tmplIdx)
+				d.RecordMatch(host, tmpl)
+			}(h, tmpl)
+		}
+	}
+	wg.Wait()
+
+	// All 20 hosts should have 5 unique templates and be flagged (threshold=3)
+	require.Equal(t, 20, d.FlaggedCount())
+	for h := 0; h < 20; h++ {
+		host := fmt.Sprintf("host-%d.com", h)
+		require.True(t, d.IsHoneypot(host), "host %s should be flagged", host)
+		require.Equal(t, 5, d.GetMatchCount(host))
+	}
+}
+
+func TestDetectorUnknownHost(t *testing.T) {
+	d := New(5)
+	require.False(t, d.IsHoneypot("unknown.com"))
+	require.Equal(t, 0, d.GetMatchCount("unknown.com"))
+}

--- a/pkg/honeypot/detector_test.go
+++ b/pkg/honeypot/detector_test.go
@@ -62,6 +62,8 @@ func TestDetectorDisabled(t *testing.T) {
 func TestDetectorNegativeThreshold(t *testing.T) {
 	d := New(-1)
 	require.False(t, d.IsEnabled())
+	require.Equal(t, 0, d.FlaggedCount())
+	require.Empty(t, d.FlaggedHosts())
 }
 
 func TestDetectorRecordAfterFlagged(t *testing.T) {
@@ -114,6 +116,8 @@ func TestNormalizeHost(t *testing.T) {
 		{"user:pass@example.com", "example.com"},
 		{"http://example.com#frag", "example.com"},
 		{"http://example.com/path#section", "example.com"},
+		{"//example.com/path", "example.com"},
+		{"//example.com", "example.com"},
 		{"", ""},
 		{"   ", ""},
 	}

--- a/pkg/honeypot/detector_test.go
+++ b/pkg/honeypot/detector_test.go
@@ -201,3 +201,15 @@ func TestDetectorUnknownHost(t *testing.T) {
 	require.False(t, d.IsHoneypot("unknown.com"))
 	require.Equal(t, 0, d.GetMatchCount("unknown.com"))
 }
+
+func TestDetectorNilReceiver(t *testing.T) {
+	var d *Detector
+
+	// All public methods should be safe to call on a nil receiver
+	require.False(t, d.IsEnabled())
+	require.False(t, d.RecordMatch("example.com", "t1"))
+	require.False(t, d.IsHoneypot("example.com"))
+	require.Equal(t, 0, d.GetMatchCount("example.com"))
+	require.Equal(t, 0, d.FlaggedCount())
+	require.Empty(t, d.FlaggedHosts())
+}

--- a/pkg/honeypot/detector_test.go
+++ b/pkg/honeypot/detector_test.go
@@ -112,6 +112,8 @@ func TestNormalizeHost(t *testing.T) {
 		{"http://user:pass@example.com/path", "example.com"},
 		{"http://user@example.com:8080", "example.com"},
 		{"user:pass@example.com", "example.com"},
+		{"http://example.com#frag", "example.com"},
+		{"http://example.com/path#section", "example.com"},
 		{"", ""},
 		{"   ", ""},
 	}

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -308,7 +308,7 @@ func (w *StandardWriter) Write(event *ResultEvent) error {
 	}
 
 	// Record match for honeypot detection
-	if w.honeypotDetector.IsEnabled() && event.TemplateID != "" {
+	if w.honeypotDetector != nil && w.honeypotDetector.IsEnabled() && event.TemplateID != "" {
 		host := event.Host
 		if host == "" {
 			host = event.URL
@@ -478,11 +478,13 @@ func (w *StandardWriter) Colorizer() aurora.Aurora {
 // Close closes the output writing interface
 func (w *StandardWriter) Close() {
 	// Print honeypot detection summary if any hosts were flagged
-	if w.honeypotDetector.IsEnabled() && w.honeypotDetector.FlaggedCount() > 0 {
+	if w.honeypotDetector != nil && w.honeypotDetector.IsEnabled() {
 		flagged := w.honeypotDetector.FlaggedHosts()
-		gologger.Info().Msgf("Honeypot detection: %d host(s) flagged as potential honeypots (results suppressed)", len(flagged))
-		for host, count := range flagged {
-			gologger.Verbose().Msgf("  Honeypot: %s (%d unique template matches)", host, count)
+		if len(flagged) > 0 {
+			gologger.Info().Msgf("Honeypot detection: %d host(s) flagged as potential honeypots (results suppressed)", len(flagged))
+			for host, count := range flagged {
+				gologger.Verbose().Msgf("  Honeypot: %s (%d unique template matches)", host, count)
+			}
 		}
 	}
 

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -24,6 +24,7 @@ import (
 	"github.com/projectdiscovery/interactsh/pkg/server"
 	"github.com/projectdiscovery/nuclei/v3/internal/colorizer"
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/config"
+	"github.com/projectdiscovery/nuclei/v3/pkg/honeypot"
 	"github.com/projectdiscovery/nuclei/v3/pkg/model"
 	"github.com/projectdiscovery/nuclei/v3/pkg/model/types/severity"
 	"github.com/projectdiscovery/nuclei/v3/pkg/operators"
@@ -82,7 +83,8 @@ type StandardWriter struct {
 	// when using custom server code with output
 	JSONLogRequestHook func(*JSONLogRequest)
 
-	resultCount atomic.Int32
+	resultCount        atomic.Int32
+	honeypotDetector   *honeypot.Detector
 }
 
 var _ Writer = &StandardWriter{}
@@ -280,6 +282,7 @@ func NewStandardWriter(options *types.Options) (*StandardWriter, error) {
 		storeResponseDir: options.StoreResponseDir,
 		omitTemplate:     options.OmitTemplate,
 		KeysToRedact:     options.Redact,
+		honeypotDetector: honeypot.New(options.HoneypotThreshold),
 	}
 
 	if v := os.Getenv("DISABLE_STDOUT"); v == "true" || v == "1" {
@@ -293,10 +296,29 @@ func (w *StandardWriter) ResultCount() int {
 	return int(w.resultCount.Load())
 }
 
+// HoneypotDetector returns the honeypot detector instance.
+func (w *StandardWriter) HoneypotDetector() *honeypot.Detector {
+	return w.honeypotDetector
+}
+
 // Write writes the event to file and/or screen.
 func (w *StandardWriter) Write(event *ResultEvent) error {
 	if event.Error != "" && !w.matcherStatus {
 		return nil
+	}
+
+	// Record match for honeypot detection
+	if w.honeypotDetector.IsEnabled() && event.Host != "" && event.TemplateID != "" {
+		host := event.Host
+		if host == "" {
+			host = event.URL
+		}
+		w.honeypotDetector.RecordMatch(host, event.TemplateID)
+
+		// Suppress results from flagged honeypot hosts
+		if w.honeypotDetector.IsHoneypot(host) {
+			return nil
+		}
 	}
 
 	// Enrich the result event with extra metadata on the template-path and url.
@@ -453,6 +475,15 @@ func (w *StandardWriter) Colorizer() aurora.Aurora {
 
 // Close closes the output writing interface
 func (w *StandardWriter) Close() {
+	// Print honeypot detection summary if any hosts were flagged
+	if w.honeypotDetector.IsEnabled() && w.honeypotDetector.FlaggedCount() > 0 {
+		flagged := w.honeypotDetector.FlaggedHosts()
+		gologger.Info().Msgf("Honeypot detection: %d host(s) flagged as potential honeypots (results suppressed)", len(flagged))
+		for host, count := range flagged {
+			gologger.Verbose().Msgf("  Honeypot: %s (%d unique template matches)", host, count)
+		}
+	}
+
 	if w.outputFile != nil {
 		_ = w.outputFile.Close()
 	}

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -308,16 +308,18 @@ func (w *StandardWriter) Write(event *ResultEvent) error {
 	}
 
 	// Record match for honeypot detection
-	if w.honeypotDetector.IsEnabled() && event.Host != "" && event.TemplateID != "" {
+	if w.honeypotDetector.IsEnabled() && event.TemplateID != "" {
 		host := event.Host
 		if host == "" {
 			host = event.URL
 		}
-		w.honeypotDetector.RecordMatch(host, event.TemplateID)
+		if host != "" {
+			w.honeypotDetector.RecordMatch(host, event.TemplateID)
 
-		// Suppress results from flagged honeypot hosts
-		if w.honeypotDetector.IsHoneypot(host) {
-			return nil
+			// Suppress results from flagged honeypot hosts
+			if w.honeypotDetector.IsHoneypot(host) {
+				return nil
+			}
 		}
 	}
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -133,6 +133,8 @@ type Options struct {
 	TrackError goflags.StringSlice
 	// NoHostErrors disables host skipping after maximum number of errors
 	NoHostErrors bool
+	// HoneypotThreshold is the number of unique template matches before a host is flagged as a potential honeypot
+	HoneypotThreshold int
 	// BulkSize is the of targets analyzed in parallel for each template
 	BulkSize int
 	// TemplateThreads is the number of templates executed in parallel
@@ -525,6 +527,7 @@ func (options *Options) Copy() *Options {
 		MaxHostError:                   options.MaxHostError,
 		TrackError:                     options.TrackError,
 		NoHostErrors:                   options.NoHostErrors,
+		HoneypotThreshold:              options.HoneypotThreshold,
 		BulkSize:                       options.BulkSize,
 		TemplateThreads:                options.TemplateThreads,
 		HeadlessBulkSize:               options.HeadlessBulkSize,


### PR DESCRIPTION
## Summary

Fixes #6403

/claim #6403

Many hosts on Shodan intentionally respond to all nuclei templates to fool scanners, creating noisy false positives. This PR adds a configurable honeypot detection system that tracks unique template matches per host and flags hosts exceeding a threshold.

## Changes

### New package: `pkg/honeypot/`
- **`Detector`**: Concurrent-safe honeypot detector using `sync.Map` for lock-free host tracking
- Tracks unique template IDs per host (duplicate template matches are not double-counted)
- Configurable threshold — when a host exceeds N unique template matches, it is flagged
- Host normalization handles URLs, `host:port`, IPv6 brackets, and case differences
- Zero overhead when disabled (threshold=0)

### Integration in `pkg/output/output.go`
- `StandardWriter.Write()` records each match and suppresses output from flagged honeypot hosts
- Summary of flagged hosts printed at scan completion via `Close()`
- Exposes `HoneypotDetector()` method for external access

### New CLI flag
- `-honeypot-threshold` / `-hpt` (int, default 0 = disabled)
- Added to the "Optimizations" group alongside `-max-host-error`

### Changes to `pkg/types/types.go`
- Added `HoneypotThreshold` field to `Options` struct and its `Copy()` method

## Usage

```bash
# Flag hosts with 10+ unique template matches as honeypots
nuclei -t templates/ -l targets.txt -hpt 10

# Use verbose mode to see details of flagged hosts
nuclei -t templates/ -l targets.txt -hpt 10 -v
```

## Design Decisions

1. **Integration at the Writer level** rather than the engine level — this means honeypot detection works regardless of scan strategy (host-spray, template-spray, auto) without modifying the core execution engine
2. **`sync.Map` + per-entry mutex** for concurrent safety without a global lock bottleneck
3. **Suppression, not removal** — once a host is flagged, its future results are silently suppressed but earlier results (before the threshold was hit) are still shown
4. **No external dependencies** — uses only stdlib and existing nuclei dependencies

## Tests

14 comprehensive tests covering:
- Basic threshold behavior
- Duplicate template deduplication
- Multiple host tracking
- Disabled/negative threshold
- Post-flagging behavior
- Host normalization (URLs, ports, IPv6, case)
- Empty host handling
- Concurrent access stress test (100 goroutines)
- Multi-host concurrent stress test (20 hosts × 5 templates)

```
$ go test ./pkg/honeypot/... -v -count=1
=== RUN   TestDetectorBasic
--- PASS: TestDetectorBasic (0.00s)
=== RUN   TestDetectorDuplicateTemplates
--- PASS: TestDetectorDuplicateTemplates (0.00s)
=== RUN   TestDetectorMultipleHosts
--- PASS: TestDetectorMultipleHosts (0.00s)
=== RUN   TestDetectorDisabled
--- PASS: TestDetectorDisabled (0.00s)
=== RUN   TestDetectorNegativeThreshold
--- PASS: TestDetectorNegativeThreshold (0.00s)
=== RUN   TestDetectorRecordAfterFlagged
--- PASS: TestDetectorRecordAfterFlagged (0.00s)
=== RUN   TestDetectorFlaggedHosts
--- PASS: TestDetectorFlaggedHosts (0.00s)
=== RUN   TestNormalizeHost
--- PASS: TestNormalizeHost (0.00s)
=== RUN   TestDetectorHostNormalization
--- PASS: TestDetectorHostNormalization (0.00s)
=== RUN   TestDetectorEmptyHost
--- PASS: TestDetectorEmptyHost (0.00s)
=== RUN   TestDetectorConcurrentAccess
--- PASS: TestDetectorConcurrentAccess (0.00s)
=== RUN   TestDetectorConcurrentMultipleHosts
--- PASS: TestDetectorConcurrentMultipleHosts (0.00s)
=== RUN   TestDetectorUnknownHost
--- PASS: TestDetectorUnknownHost (0.00s)
PASS
ok  	github.com/projectdiscovery/nuclei/v3/pkg/honeypot	0.006s
```

## Build Verification

```
$ go build -o ./bin/nuclei ./cmd/nuclei/
$ ./bin/nuclei -h | grep honeypot
   -hpt, -honeypot-threshold int    threshold of unique template matches before flagging a host as honeypot (0 = disabled)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI flag --honeypot-threshold (-hpt) to enable honeypot detection by unique-template threshold (0 = disabled); flagged hosts have their results suppressed and a summary shown at completion
* **Behavior / Reliability**
  * Improved host normalization (URLs, ports, IPv6, userinfo) and concurrency-safe detection during result processing; detection available programmatically
* **Tests**
  * Comprehensive tests covering detection, normalization, edge cases and concurrency
<!-- end of auto-generated comment: release notes by coderabbit.ai -->