### PR TITLE
Refactor: replace panic with error handling in template loader (#6674)

### DIFF
--- a/lazy.go
+++ b/lazy.go
@@ -28,6 +28,7 @@ type AuthLazyFetchOptions struct {
 }
 
 // GetAuthTmplStore create new loader for loading auth templates
+// Note: this function mutates opts; callers should pass a copy.
 func GetAuthTmplStore(opts *types.Options, catalog catalog.Catalog, execOpts *protocols.ExecutorOptions) (*loader.Store, error) {
 	tmpls := []string{}
 	for _, file := range opts.SecretsFile {

--- a/lazy.go
+++ b/lazy.go
@@ -122,8 +122,14 @@ func GetLazyAuthFetchCallback(opts *AuthLazyFetchOptions) authx.LazyFetchSecret 
 				// largest value as the extracted value
 				for _, value := range v {
 					oldVal, ok := data[k]
-					if !ok || len(value) > len(oldVal.(string)) {
+					if !ok {
 						data[k] = value
+						continue
+					}
+					if oldStr, ok := oldVal.(string); ok {
+						if len(value) > len(oldStr) {
+							data[k] = value
+						}
 					}
 				}
 			}
@@ -145,7 +151,11 @@ func GetLazyAuthFetchCallback(opts *AuthLazyFetchOptions) authx.LazyFetchSecret 
 		}
 		_, err := tmpl.Executer.ExecuteWithResults(ctx)
 		if err != nil {
-			finalErr = err
+			if finalErr != nil {
+				finalErr = fmt.Errorf("%w; execute error: %v", finalErr, err)
+			} else {
+				finalErr = err
+			}
 		}
 		// store extracted result in auth context
 		d.Extracted = data

--- a/lazy.go
+++ b/lazy.go
@@ -1,0 +1,157 @@
+package runner
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/authprovider/authx"
+	"github.com/projectdiscovery/nuclei/v3/pkg/catalog"
+	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/disk"
+	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/loader"
+	"github.com/projectdiscovery/nuclei/v3/pkg/output"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/contextargs"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/generators"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/helpers/writer"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/replacer"
+	"github.com/projectdiscovery/nuclei/v3/pkg/scan"
+	"github.com/projectdiscovery/nuclei/v3/pkg/types"
+	"github.com/projectdiscovery/utils/env"
+	"github.com/projectdiscovery/utils/errkit"
+)
+
+type AuthLazyFetchOptions struct {
+	TemplateStore *loader.Store
+	ExecOpts      *protocols.ExecutorOptions
+	OnError       func(error)
+}
+
+// GetAuthTmplStore create new loader for loading auth templates
+func GetAuthTmplStore(opts *types.Options, catalog catalog.Catalog, execOpts *protocols.ExecutorOptions) (*loader.Store, error) {
+	tmpls := []string{}
+	for _, file := range opts.SecretsFile {
+		data, err := authx.GetTemplatePathsFromSecretFile(file)
+		if err != nil {
+			return nil, errkit.Wrap(err, "failed to get template paths from secrets file")
+		}
+		tmpls = append(tmpls, data...)
+	}
+	opts.Templates = tmpls
+	opts.Workflows = nil
+	opts.RemoteTemplateDomainList = nil
+	opts.TemplateURLs = nil
+	opts.WorkflowURLs = nil
+	opts.ExcludedTemplates = nil
+	opts.Tags = nil
+	opts.ExcludeTags = nil
+	opts.IncludeTemplates = nil
+	opts.Authors = nil
+	opts.Severities = nil
+	opts.ExcludeSeverities = nil
+	opts.IncludeTags = nil
+	opts.IncludeIds = nil
+	opts.ExcludeIds = nil
+	opts.Protocols = nil
+	opts.ExcludeProtocols = nil
+	opts.IncludeConditions = nil
+	cfg := loader.NewConfig(opts, catalog, execOpts)
+	cfg.StoreId = loader.AuthStoreId
+	store, err := loader.New(cfg)
+	if err != nil {
+		return nil, errkit.Wrap(err, "failed to initialize dynamic auth templates store")
+	}
+	return store, nil
+}
+
+// GetLazyAuthFetchCallback returns a lazy fetch callback for auth secrets
+func GetLazyAuthFetchCallback(opts *AuthLazyFetchOptions) authx.LazyFetchSecret {
+	return func(d *authx.Dynamic) error {
+		tmpls, err := opts.TemplateStore.LoadTemplates([]string{d.TemplatePath})
+		if err != nil {
+			return err
+		}
+		if len(tmpls) == 0 {
+			return fmt.Errorf("%w for path: %s", disk.ErrNoTemplatesFound, d.TemplatePath)
+		}
+		if len(tmpls) > 1 {
+			return fmt.Errorf("multiple templates found for path: %s", d.TemplatePath)
+		}
+		data := map[string]interface{}{}
+		tmpl := tmpls[0]
+		// add args to tmpl here
+		vars := map[string]interface{}{}
+		mainCtx := context.Background()
+		ctx := scan.NewScanContext(mainCtx, contextargs.NewWithInput(mainCtx, d.Input))
+
+		cliVars := map[string]interface{}{}
+		if opts.ExecOpts.Options != nil {
+			// gets variables passed from cli -v and -env-vars
+			cliVars = generators.BuildPayloadFromOptions(opts.ExecOpts.Options)
+		}
+
+		for _, v := range d.Variables {
+			//  Check if the template has any env variables and expand them
+			if strings.HasPrefix(v.Value, "$") {
+				env.ExpandWithEnv(&v.Value)
+			}
+			if strings.Contains(v.Value, "{{") {
+				// if variables had value like {{username}}, then replace it with the value from cliVars
+				// variables:
+				//     - key: username
+				//       value: {{username}}
+				v.Value = replacer.Replace(v.Value, cliVars)
+			}
+			vars[v.Key] = v.Value
+			ctx.Input.Add(v.Key, v.Value)
+		}
+
+		var finalErr error
+		ctx.OnResult = func(e *output.InternalWrappedEvent) {
+			if e == nil {
+				finalErr = fmt.Errorf("no result found for template: %s", d.TemplatePath)
+				return
+			}
+			if !e.HasOperatorResult() {
+				finalErr = fmt.Errorf("no result found for template: %s", d.TemplatePath)
+				return
+			}
+			// dynamic values
+			for k, v := range e.OperatorsResult.DynamicValues {
+				// Iterate through all the values and choose the
+				// largest value as the extracted value
+				for _, value := range v {
+					oldVal, ok := data[k]
+					if !ok || len(value) > len(oldVal.(string)) {
+						data[k] = value
+					}
+				}
+			}
+			// named extractors
+			for k, v := range e.OperatorsResult.Extracts {
+				if len(v) > 0 {
+					data[k] = v[0]
+				}
+			}
+			if len(data) == 0 {
+				if e.OperatorsResult.Matched {
+					finalErr = fmt.Errorf("match found but no (dynamic/extracted) values found for template: %s", d.TemplatePath)
+				} else {
+					finalErr = fmt.Errorf("no match or (dynamic/extracted) values found for template: %s", d.TemplatePath)
+				}
+			}
+			// log result of template in result file/screen
+			_ = writer.WriteResult(e, opts.ExecOpts.Output, opts.ExecOpts.Progress, opts.ExecOpts.IssuesClient)
+		}
+		_, err := tmpl.Executer.ExecuteWithResults(ctx)
+		if err != nil {
+			finalErr = err
+		}
+		// store extracted result in auth context
+		d.Extracted = data
+		if finalErr != nil && opts.OnError != nil {
+			opts.OnError(finalErr)
+		}
+		return finalErr
+	}
+}

--- a/loader.go
+++ b/loader.go
@@ -343,10 +343,10 @@ func (store *Store) Load() error {
 	return nil
 }
 
-var templateIDPathMap map[string]string
+var templateIDPathMap *mapsutil.SyncLockMap[string, string]
 
 func init() {
-	templateIDPathMap = make(map[string]string)
+	templateIDPathMap = mapsutil.NewSyncLockMap[string, string]()
 }
 
 // buildIndexFilter creates an [index.Filter] from the store configuration.
@@ -585,8 +585,8 @@ func (store *Store) areWorkflowOrTemplatesValid(filteredTemplatePaths map[string
 			// clustering, AFAIK.
 			continue
 		} else {
-			if existingTemplatePath, found := templateIDPathMap[template.ID]; !found {
-				templateIDPathMap[template.ID] = templatePath
+			if existingTemplatePath, found := templateIDPathMap.Get(template.ID); !found {
+				_ = templateIDPathMap.Set(template.ID, template.Path)
 			} else {
 				// TODO: until https://github.com/projectdiscovery/nuclei-templates/issues/11324 is deployed
 				// disable strict validation to allow GH actions to run
@@ -713,7 +713,7 @@ func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) ([]*temp
 
 	wgLoadTemplates, errWg := syncutil.New(syncutil.WithSize(concurrency))
 	if errWg != nil {
-		panic("could not create wait group")
+		return nil, fmt.Errorf("could not create wait group: %w", errWg)
 	}
 
 	if typesOpts.ExecutionId == "" {
@@ -880,18 +880,18 @@ func IsHTTPBasedProtocolUsed(store *Store) bool {
 }
 
 func workflowContainsProtocol(workflow []*workflows.WorkflowTemplate) bool {
-	for _, workflow := range workflow {
-		for _, template := range workflow.Matchers {
+	for _, wf := range workflow {
+		for _, template := range wf.Matchers {
 			if workflowContainsProtocol(template.Subtemplates) {
 				return true
 			}
 		}
-		for _, template := range workflow.Subtemplates {
+		for _, template := range wf.Subtemplates {
 			if workflowContainsProtocol(template.Subtemplates) {
 				return true
 			}
 		}
-		for _, executer := range workflow.Executers {
+		for _, executer := range wf.Executers {
 			if executer.TemplateType == templateTypes.HTTPProtocol || executer.TemplateType == templateTypes.HeadlessProtocol {
 				return true
 			}

--- a/loader.go
+++ b/loader.go
@@ -1,0 +1,909 @@
+package loader
+
+import (
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/logrusorgru/aurora"
+	"github.com/pkg/errors"
+	"github.com/projectdiscovery/gologger"
+	"github.com/projectdiscovery/nuclei/v3/pkg/catalog"
+	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/config"
+	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/index"
+	"github.com/projectdiscovery/nuclei/v3/pkg/keys"
+	"github.com/projectdiscovery/nuclei/v3/pkg/model/types/severity"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
+	"github.com/projectdiscovery/nuclei/v3/pkg/templates"
+	templateTypes "github.com/projectdiscovery/nuclei/v3/pkg/templates/types"
+	"github.com/projectdiscovery/nuclei/v3/pkg/types"
+	"github.com/projectdiscovery/nuclei/v3/pkg/utils/stats"
+	"github.com/projectdiscovery/nuclei/v3/pkg/workflows"
+	"github.com/projectdiscovery/retryablehttp-go"
+	"github.com/projectdiscovery/utils/errkit"
+	mapsutil "github.com/projectdiscovery/utils/maps"
+	sliceutil "github.com/projectdiscovery/utils/slice"
+	stringsutil "github.com/projectdiscovery/utils/strings"
+	syncutil "github.com/projectdiscovery/utils/sync"
+	urlutil "github.com/projectdiscovery/utils/url"
+	"github.com/rs/xid"
+)
+
+const (
+	httpPrefix  = "http://"
+	httpsPrefix = "https://"
+	AuthStoreId = "auth_store"
+)
+
+var (
+	TrustedTemplateDomains = []string{"cloud.projectdiscovery.io"}
+)
+
+// Config contains the configuration options for the loader
+type Config struct {
+	StoreId                  string // used to set store id (optional)
+	Templates                []string
+	TemplateURLs             []string
+	Workflows                []string
+	WorkflowURLs             []string
+	ExcludeTemplates         []string
+	IncludeTemplates         []string
+	RemoteTemplateDomainList []string
+	AITemplatePrompt         string
+
+	Tags              []string
+	ExcludeTags       []string
+	Protocols         templateTypes.ProtocolTypes
+	ExcludeProtocols  templateTypes.ProtocolTypes
+	Authors           []string
+	Severities        severity.Severities
+	ExcludeSeverities severity.Severities
+	IncludeTags       []string
+	IncludeIds        []string
+	ExcludeIds        []string
+	IncludeConditions []string
+
+	Catalog         catalog.Catalog
+	ExecutorOptions *protocols.ExecutorOptions
+	Logger          *gologger.Logger
+}
+
+// Store is a storage for loaded nuclei templates
+type Store struct {
+	id             string // id of the store (optional)
+	tagFilter      *templates.TagFilter
+	config         *Config
+	finalTemplates []string
+	finalWorkflows []string
+
+	templates []*templates.Template
+	workflows []*templates.Template
+
+	preprocessor templates.Preprocessor
+
+	logger *gologger.Logger
+
+	// parserCacheOnce is used to cache the parser cache result
+	parserCacheOnce func() *templates.Cache
+
+	// metadataIndex is the template metadata cache
+	metadataIndex *index.Index
+
+	// indexFilter is the cached filter for metadata matching
+	indexFilter *index.Filter
+
+	// saveTemplatesIndexOnce is used to ensure we only save the metadata index
+	// once
+	saveMetadataIndexOnce func()
+
+	// NotFoundCallback is called for each not found template
+	// This overrides error handling for not found templates
+	NotFoundCallback func(template string) bool
+}
+
+// NewConfig returns a new loader config
+func NewConfig(options *types.Options, catalog catalog.Catalog, executerOpts *protocols.ExecutorOptions) *Config {
+	loaderConfig := Config{
+		Templates:                options.Templates,
+		Workflows:                options.Workflows,
+		RemoteTemplateDomainList: options.RemoteTemplateDomainList,
+		TemplateURLs:             options.TemplateURLs,
+		WorkflowURLs:             options.WorkflowURLs,
+		ExcludeTemplates:         options.ExcludedTemplates,
+		Tags:                     options.Tags,
+		ExcludeTags:              options.ExcludeTags,
+		IncludeTemplates:         options.IncludeTemplates,
+		Authors:                  options.Authors,
+		Severities:               options.Severities,
+		ExcludeSeverities:        options.ExcludeSeverities,
+		IncludeTags:              options.IncludeTags,
+		IncludeIds:               options.IncludeIds,
+		ExcludeIds:               options.ExcludeIds,
+		Protocols:                options.Protocols,
+		ExcludeProtocols:         options.ExcludeProtocols,
+		IncludeConditions:        options.IncludeConditions,
+		Catalog:                  catalog,
+		ExecutorOptions:          executerOpts,
+		AITemplatePrompt:         options.AITemplatePrompt,
+		Logger:                   options.Logger,
+	}
+	loaderConfig.RemoteTemplateDomainList = append(loaderConfig.RemoteTemplateDomainList, TrustedTemplateDomains...)
+	return &loaderConfig
+}
+
+// New creates a new template store based on provided configuration
+func New(cfg *Config) (*Store, error) {
+	// tagFilter only for IncludeConditions (advanced filtering).
+	// All other filtering (tags, authors, severities, IDs, protocols, paths) is
+	// handled by [index.Filter].
+	tagFilter, err := templates.NewTagFilter(&templates.TagFilterConfig{
+		IncludeConditions: cfg.IncludeConditions,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	store := &Store{
+		id:             cfg.StoreId,
+		config:         cfg,
+		tagFilter:      tagFilter,
+		finalTemplates: cfg.Templates,
+		finalWorkflows: cfg.Workflows,
+		logger:         cfg.Logger,
+	}
+
+	store.parserCacheOnce = sync.OnceValue(func() *templates.Cache {
+		if cfg.ExecutorOptions == nil || cfg.ExecutorOptions.Parser == nil {
+			return nil
+		}
+
+		if parser, ok := cfg.ExecutorOptions.Parser.(*templates.Parser); ok {
+			return parser.Cache()
+		}
+
+		return nil
+	})
+
+	// Initialize metadata index and filter (load from disk & cache for reuse)
+	store.metadataIndex = store.loadTemplatesIndex()
+	store.indexFilter = store.buildIndexFilter()
+	if cfg.ExecutorOptions != nil {
+		cfg.ExecutorOptions.TemplateVerificationCallback = store.getTemplateVerification
+	}
+	store.saveMetadataIndexOnce = sync.OnceFunc(func() {
+		if store.metadataIndex == nil {
+			return
+		}
+
+		if err := store.metadataIndex.Save(); err != nil {
+			store.logger.Warning().Msgf("Could not save metadata cache: %v", err)
+		} else {
+			store.logger.Verbose().Msgf("Saved %d templates to metadata cache", store.metadataIndex.Size())
+		}
+	})
+
+	// Do a check to see if we have URLs in templates flag, if so
+	// we need to process them separately and remove them from the initial list
+	var templatesFinal []string
+	for _, template := range cfg.Templates {
+		// TODO: Add and replace this with urlutil.IsURL() helper
+		if stringsutil.HasPrefixAny(template, httpPrefix, httpsPrefix) {
+			cfg.TemplateURLs = append(cfg.TemplateURLs, template)
+		} else {
+			templatesFinal = append(templatesFinal, template)
+		}
+	}
+
+	// fix editor paths
+	remoteTemplates := []string{}
+	for _, v := range cfg.TemplateURLs {
+		if _, err := urlutil.Parse(v); err == nil {
+			remoteTemplates = append(remoteTemplates, handleTemplatesEditorURLs(v))
+		} else {
+			templatesFinal = append(templatesFinal, v) // something went wrong, treat it as a file
+		}
+	}
+
+	cfg.TemplateURLs = remoteTemplates
+	store.finalTemplates = templatesFinal
+
+	urlBasedTemplatesProvided := len(cfg.TemplateURLs) > 0 || len(cfg.WorkflowURLs) > 0
+	if urlBasedTemplatesProvided {
+		remoteTemplates, remoteWorkflows, err := getRemoteTemplatesAndWorkflows(cfg.TemplateURLs, cfg.WorkflowURLs, cfg.RemoteTemplateDomainList)
+		if err != nil {
+			return store, err
+		}
+
+		store.finalTemplates = append(store.finalTemplates, remoteTemplates...)
+		store.finalWorkflows = append(store.finalWorkflows, remoteWorkflows...)
+	}
+
+	// Handle AI template generation if prompt is provided
+	if len(cfg.AITemplatePrompt) > 0 {
+		aiTemplates, err := getAIGeneratedTemplates(cfg.AITemplatePrompt, cfg.ExecutorOptions.Options)
+		if err != nil {
+			return nil, err
+		}
+		store.finalTemplates = append(store.finalTemplates, aiTemplates...)
+	}
+
+	// Handle a dot as the current working directory
+	if len(store.finalTemplates) == 1 && store.finalTemplates[0] == "." {
+		currentDirectory, err := os.Getwd()
+		if err != nil {
+			return nil, errors.Wrap(err, "could not get current directory")
+		}
+		store.finalTemplates = []string{currentDirectory}
+	}
+
+	// Handle a case with no templates or workflows, where we use base directory
+	if len(store.finalTemplates) == 0 && len(store.finalWorkflows) == 0 && !urlBasedTemplatesProvided {
+		store.finalTemplates = []string{config.DefaultConfig.TemplatesDirectory}
+	}
+
+	return store, nil
+}
+
+func (store *Store) getTemplateVerification(templatePath string) *protocols.TemplateVerification {
+	if store.metadataIndex == nil {
+		return nil
+	}
+
+	metadata, found := store.metadataIndex.Get(templatePath)
+	if !found {
+		return nil
+	}
+
+	return &protocols.TemplateVerification{
+		Verified: metadata.Verified,
+		Verifier: metadata.TemplateVerifier,
+	}
+}
+
+func handleTemplatesEditorURLs(input string) string {
+	parsed, err := url.Parse(input)
+	if err != nil {
+		return input
+	}
+
+	if !strings.HasSuffix(parsed.Hostname(), "cloud.projectdiscovery.io") {
+		return input
+	}
+
+	if strings.HasSuffix(parsed.Path, ".yaml") {
+		return input
+	}
+
+	parsed.Path = fmt.Sprintf("%s.yaml", parsed.Path)
+	finalURL := parsed.String()
+
+	return finalURL
+}
+
+// ReadTemplateFromURI should only be used for viewing templates
+// and should not be used anywhere else like loading and executing templates
+// there is no sandbox restriction here
+func (store *Store) ReadTemplateFromURI(uri string, remote bool) ([]byte, error) {
+	if stringsutil.HasPrefixAny(uri, httpPrefix, httpsPrefix) && remote {
+		uri = handleTemplatesEditorURLs(uri)
+
+		remoteTemplates, _, err := getRemoteTemplatesAndWorkflows([]string{uri}, nil, store.config.RemoteTemplateDomainList)
+		if err != nil || len(remoteTemplates) == 0 {
+			return nil, errkit.Wrapf(err, "Could not load template %s: got %v", uri, remoteTemplates)
+		}
+
+		resp, err := retryablehttp.Get(remoteTemplates[0])
+		if err != nil {
+			return nil, err
+		}
+
+		defer func() {
+			_ = resp.Body.Close()
+		}()
+
+		return io.ReadAll(resp.Body)
+	} else {
+		return os.ReadFile(uri)
+	}
+}
+
+func (store *Store) ID() string {
+	return store.id
+}
+
+// Templates returns all the templates in the store
+func (store *Store) Templates() []*templates.Template {
+	return store.templates
+}
+
+// Workflows returns all the workflows in the store
+func (store *Store) Workflows() []*templates.Template {
+	return store.workflows
+}
+
+// RegisterPreprocessor allows a custom preprocessor to be passed to the store to run against templates
+func (store *Store) RegisterPreprocessor(preprocessor templates.Preprocessor) {
+	store.preprocessor = preprocessor
+}
+
+// Load loads all the templates from a store, performs filtering and returns
+// the complete compiled templates for a nuclei execution configuration.
+func (store *Store) Load() error {
+	var err error
+	store.templates, err = store.LoadTemplates(store.finalTemplates)
+	if err != nil {
+		return err
+	}
+	store.workflows = store.LoadWorkflows(store.finalWorkflows)
+	return nil
+}
+
+var templateIDPathMap map[string]string
+
+func init() {
+	templateIDPathMap = make(map[string]string)
+}
+
+// buildIndexFilter creates an [index.Filter] from the store configuration.
+// This filter handles all basic filtering (paths, tags, authors, severities,
+// IDs, protocols). Advanced IncludeConditions filtering is handled separately
+// by tagFilter.
+func (store *Store) buildIndexFilter() *index.Filter {
+	includeTemplates, _ := store.config.Catalog.GetTemplatesPath(store.config.IncludeTemplates)
+	excludeTemplates, _ := store.config.Catalog.GetTemplatesPath(store.config.ExcludeTemplates)
+
+	return &index.Filter{
+		Authors:              store.config.Authors,
+		Tags:                 store.config.Tags,
+		ExcludeTags:          store.config.ExcludeTags,
+		IncludeTags:          store.config.IncludeTags,
+		IDs:                  store.config.IncludeIds,
+		ExcludeIDs:           store.config.ExcludeIds,
+		IncludeTemplates:     includeTemplates,
+		ExcludeTemplates:     excludeTemplates,
+		Severities:           []severity.Severity(store.config.Severities),
+		ExcludeSeverities:    []severity.Severity(store.config.ExcludeSeverities),
+		ProtocolTypes:        []templateTypes.ProtocolType(store.config.Protocols),
+		ExcludeProtocolTypes: []templateTypes.ProtocolType(store.config.ExcludeProtocols),
+	}
+}
+
+func (store *Store) loadTemplatesIndex() *index.Index {
+	var metadataIdx *index.Index
+
+	idx, err := index.NewDefaultIndex()
+	if err != nil {
+		store.logger.Warning().Msgf("Could not create metadata cache: %v", err)
+	} else {
+		metadataIdx = idx
+		if err := metadataIdx.Load(); err != nil {
+			store.logger.Warning().Msgf("Could not load metadata cache: %v", err)
+		}
+	}
+
+	return metadataIdx
+}
+
+// LoadTemplatesOnlyMetadata loads only the metadata of the templates
+func (store *Store) LoadTemplatesOnlyMetadata() error {
+	defer store.saveMetadataIndexOnce()
+
+	templatePaths, errs := store.config.Catalog.GetTemplatesPath(store.finalTemplates)
+	store.logErroredTemplates(errs)
+
+	indexFilter := store.indexFilter
+	validPaths := make(map[string]struct{})
+
+	for _, templatePath := range templatePaths {
+		if store.metadataIndex != nil {
+			if metadata, found := store.metadataIndex.Get(templatePath); found {
+				if !indexFilter.Matches(metadata) {
+					continue
+				}
+
+				if store.tagFilter != nil {
+					loaded, err := store.config.ExecutorOptions.Parser.LoadTemplate(templatePath, store.tagFilter, nil, store.config.Catalog)
+					if !loaded {
+						if err != nil && strings.Contains(err.Error(), templates.ErrExcluded.Error()) {
+							stats.Increment(templates.TemplatesExcludedStats)
+							if config.DefaultConfig.LogAllEvents {
+								store.logger.Print().Msgf("[%v] %v\n", aurora.Yellow("WRN").String(), err.Error())
+							}
+						}
+						continue
+					}
+				}
+
+				validPaths[templatePath] = struct{}{}
+				continue
+			}
+		}
+
+		loaded, err := store.config.ExecutorOptions.Parser.LoadTemplate(templatePath, store.tagFilter, nil, store.config.Catalog)
+		if loaded {
+			templatesCache := store.parserCacheOnce()
+			if templatesCache != nil {
+				if template, _, _ := templatesCache.Has(templatePath); template != nil {
+					var metadata *index.Metadata
+
+					if store.metadataIndex != nil {
+						metadata, _ = store.metadataIndex.SetFromTemplate(templatePath, template)
+					} else {
+						metadata = index.NewMetadataFromTemplate(templatePath, template)
+					}
+
+					if !indexFilter.Matches(metadata) {
+						continue
+					}
+
+					validPaths[templatePath] = struct{}{}
+					continue
+				}
+			}
+
+			validPaths[templatePath] = struct{}{}
+		}
+
+		if err != nil {
+			if strings.Contains(err.Error(), templates.ErrExcluded.Error()) {
+				stats.Increment(templates.TemplatesExcludedStats)
+				if config.DefaultConfig.LogAllEvents {
+					store.logger.Print().Msgf("[%v] %v\n", aurora.Yellow("WRN").String(), err.Error())
+				}
+				continue
+			}
+
+			store.logger.Warning().Msg(err.Error())
+		}
+	}
+
+	templatesCache := store.parserCacheOnce()
+	if templatesCache == nil {
+		return errors.New("invalid parser")
+	}
+
+	loadedTemplateIDs := mapsutil.NewSyncLockMap[string, struct{}]()
+	caps := templates.Capabilities{
+		Headless:      store.config.ExecutorOptions.Options.Headless,
+		Code:          store.config.ExecutorOptions.Options.EnableCodeTemplates,
+		DAST:          store.config.ExecutorOptions.Options.DAST,
+		SelfContained: store.config.ExecutorOptions.Options.EnableSelfContainedTemplates,
+		File:          store.config.ExecutorOptions.Options.EnableFileTemplates,
+	}
+	isListOrDisplay := store.config.ExecutorOptions.Options.TemplateList ||
+		store.config.ExecutorOptions.Options.TemplateDisplay
+
+	for templatePath := range validPaths {
+		template, _, _ := templatesCache.Has(templatePath)
+		if template == nil {
+			continue
+		}
+
+		if !isListOrDisplay && !template.IsEnabledFor(caps) {
+			continue
+		}
+
+		if loadedTemplateIDs.Has(template.ID) {
+			store.logger.Debug().Msgf("Skipping duplicate template ID '%s' from path '%s'", template.ID, templatePath)
+			continue
+		}
+
+		_ = loadedTemplateIDs.Set(template.ID, struct{}{})
+		template.Path = templatePath
+		store.templates = append(store.templates, template)
+	}
+
+	return nil
+}
+
+// ValidateTemplates takes a list of templates and validates them
+// erroring out on discovering any faulty templates.
+func (store *Store) ValidateTemplates() error {
+	templatePaths, errs := store.config.Catalog.GetTemplatesPath(store.finalTemplates)
+	store.logErroredTemplates(errs)
+
+	workflowPaths, errs := store.config.Catalog.GetTemplatesPath(store.finalWorkflows)
+	store.logErroredTemplates(errs)
+
+	templatePathsMap := make(map[string]struct{}, len(templatePaths))
+	for _, path := range templatePaths {
+		templatePathsMap[path] = struct{}{}
+	}
+
+	workflowPathsMap := make(map[string]struct{}, len(workflowPaths))
+	for _, path := range workflowPaths {
+		workflowPathsMap[path] = struct{}{}
+	}
+
+	if store.areTemplatesValid(templatePathsMap) && store.areWorkflowsValid(workflowPathsMap) {
+		return nil
+	}
+
+	return errors.New("errors occurred during template validation")
+}
+
+func (store *Store) areWorkflowsValid(filteredWorkflowPaths map[string]struct{}) bool {
+	return store.areWorkflowOrTemplatesValid(filteredWorkflowPaths, true, func(templatePath string, tagFilter *templates.TagFilter) (bool, error) {
+		return store.config.ExecutorOptions.Parser.LoadWorkflow(templatePath, store.config.Catalog)
+	})
+}
+
+func (store *Store) areTemplatesValid(filteredTemplatePaths map[string]struct{}) bool {
+	return store.areWorkflowOrTemplatesValid(filteredTemplatePaths, false, func(templatePath string, tagFilter *templates.TagFilter) (bool, error) {
+		return store.config.ExecutorOptions.Parser.LoadTemplate(templatePath, store.tagFilter, nil, store.config.Catalog)
+	})
+}
+
+func (store *Store) areWorkflowOrTemplatesValid(filteredTemplatePaths map[string]struct{}, isWorkflow bool, load func(templatePath string, tagFilter *templates.TagFilter) (bool, error)) bool {
+	areTemplatesValid := true
+	parsedCache := store.parserCacheOnce()
+
+	for templatePath := range filteredTemplatePaths {
+		if _, err := load(templatePath, store.tagFilter); err != nil {
+			if isParsingError(store, "Error occurred loading template %s: %s\n", templatePath, err) {
+				areTemplatesValid = false
+				continue
+			}
+		}
+
+		var template *templates.Template
+		var err error
+
+		if parsedCache != nil {
+			if cachedTemplate, _, cacheErr := parsedCache.Has(templatePath); cacheErr == nil && cachedTemplate != nil {
+				template = cachedTemplate
+			}
+		}
+
+		if template == nil {
+			template, err = templates.Parse(templatePath, store.preprocessor, store.config.ExecutorOptions)
+			if err != nil {
+				if isParsingError(store, "Error occurred parsing template %s: %s\n", templatePath, err) {
+					areTemplatesValid = false
+					continue
+				}
+			}
+		}
+
+		if template == nil {
+			// NOTE(dwisiswant0): possibly global matchers template.
+			// This could definitely be handled better, for example by returning an
+			// `ErrGlobalMatchersTemplate` during `templates.Parse` and checking it
+			// with `errors.Is`.
+			//
+			// However, I'm not sure if every reference to it should be handled
+			// that way. Returning a `templates.Template` pointer would mean it's
+			// an active template (sending requests), and adding a specific field
+			// like `isGlobalMatchers` in `templates.Template` (then checking it
+			// with a `*templates.Template.IsGlobalMatchersEnabled` method) would
+			// just introduce more unknown issues - like during template
+			// clustering, AFAIK.
+			continue
+		} else {
+			if existingTemplatePath, found := templateIDPathMap[template.ID]; !found {
+				templateIDPathMap[template.ID] = templatePath
+			} else {
+				// TODO: until https://github.com/projectdiscovery/nuclei-templates/issues/11324 is deployed
+				// disable strict validation to allow GH actions to run
+				// areTemplatesValid = false
+				store.logger.Warning().Msgf("Found duplicate template ID during validation '%s' => '%s': %s\n", templatePath, existingTemplatePath, template.ID)
+			}
+
+			if !isWorkflow && template.HasWorkflows() {
+				continue
+			}
+		}
+
+		if isWorkflow {
+			if !areWorkflowTemplatesValid(store, template.Workflows) {
+				areTemplatesValid = false
+				continue
+			}
+		}
+	}
+
+	return areTemplatesValid
+}
+
+func areWorkflowTemplatesValid(store *Store, workflows []*workflows.WorkflowTemplate) bool {
+	for _, workflow := range workflows {
+		if !areWorkflowTemplatesValid(store, workflow.Subtemplates) {
+			return false
+		}
+
+		_, err := store.config.Catalog.GetTemplatePath(workflow.Template)
+		if err != nil {
+			if isParsingError(store, "Error occurred loading template %s: %s\n", workflow.Template, err) {
+				return false
+			}
+		}
+	}
+
+	return true
+}
+
+func isParsingError(store *Store, message string, template string, err error) bool {
+	if errors.Is(err, templates.ErrExcluded) {
+		return false
+	}
+
+	if errors.Is(err, templates.ErrCreateTemplateExecutor) {
+		return false
+	}
+
+	store.logger.Error().Msgf(message, template, err)
+
+	return true
+}
+
+// LoadTemplates takes a list of templates and returns paths for them
+func (store *Store) LoadTemplates(templatesList []string) ([]*templates.Template, error) {
+	return store.LoadTemplatesWithTags(templatesList, nil)
+}
+
+// LoadWorkflows takes a list of workflows and returns paths for them
+func (store *Store) LoadWorkflows(workflowsList []string) []*templates.Template {
+	includedWorkflows, errs := store.config.Catalog.GetTemplatesPath(workflowsList)
+	store.logErroredTemplates(errs)
+
+	loadedWorkflows := make([]*templates.Template, 0, len(includedWorkflows))
+	for _, workflowPath := range includedWorkflows {
+		loaded, err := store.config.ExecutorOptions.Parser.LoadWorkflow(workflowPath, store.config.Catalog)
+		if err != nil {
+			store.logger.Warning().Msgf("Could not load workflow %s: %s\n", workflowPath, err)
+		}
+
+		if loaded {
+			parsed, err := templates.Parse(workflowPath, store.preprocessor, store.config.ExecutorOptions)
+			if err != nil {
+				store.logger.Warning().Msgf("Could not parse workflow %s: %s\n", workflowPath, err)
+			} else if parsed != nil {
+				loadedWorkflows = append(loadedWorkflows, parsed)
+			}
+		}
+	}
+
+	return loadedWorkflows
+}
+
+// LoadTemplatesWithTags takes a list of templates and extra tags
+// returning templates that match.
+func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) ([]*templates.Template, error) {
+	defer store.saveMetadataIndexOnce()
+
+	indexFilter := store.indexFilter
+
+	includedTemplates, errs := store.config.Catalog.GetTemplatesPath(templatesList)
+	store.logErroredTemplates(errs)
+
+	loadedTemplates := sliceutil.NewSyncSlice[*templates.Template]()
+	loadedTemplateIDs := mapsutil.NewSyncLockMap[string, struct{}]()
+
+	loadTemplate := func(tmpl *templates.Template) {
+		if loadedTemplateIDs.Has(tmpl.ID) {
+			store.logger.Debug().Msgf("Skipping duplicate template ID '%s' from path '%s'", tmpl.ID, tmpl.Path)
+			return
+		}
+
+		_ = loadedTemplateIDs.Set(tmpl.ID, struct{}{})
+
+		loadedTemplates.Append(tmpl)
+		// increment signed/unsigned counters
+		if tmpl.Verified {
+			if tmpl.TemplateVerifier == "" {
+				templates.SignatureStats[keys.PDVerifier].Add(1)
+			} else {
+				templates.SignatureStats[tmpl.TemplateVerifier].Add(1)
+			}
+		} else {
+			templates.SignatureStats[templates.Unsigned].Add(1)
+		}
+	}
+
+	typesOpts := store.config.ExecutorOptions.Options
+	concurrency := typesOpts.TemplateLoadingConcurrency
+	if concurrency <= 0 {
+		concurrency = types.DefaultTemplateLoadingConcurrency
+	}
+
+	wgLoadTemplates, errWg := syncutil.New(syncutil.WithSize(concurrency))
+	if errWg != nil {
+		panic("could not create wait group")
+	}
+
+	if typesOpts.ExecutionId == "" {
+		typesOpts.ExecutionId = xid.New().String()
+	}
+
+	dialers := protocolstate.GetDialersWithId(typesOpts.ExecutionId)
+	if dialers == nil {
+		return nil, fmt.Errorf("dialers with executionId %s not found", typesOpts.ExecutionId)
+	}
+
+	for _, templatePath := range includedTemplates {
+		wgLoadTemplates.Add()
+		go func(templatePath string) {
+			defer wgLoadTemplates.Done()
+
+			var (
+				metadata       *index.Metadata
+				metadataCached bool
+			)
+
+			if store.metadataIndex != nil {
+				if cachedMetadata, found := store.metadataIndex.Get(templatePath); found {
+					metadata = cachedMetadata
+					if !indexFilter.Matches(metadata) {
+						return
+					}
+					// NOTE(dwisiswant0): else, tagFilter probably exists (for
+					// IncludeConditions), which still need to check via
+					// LoadTemplate.
+
+					metadataCached = true
+				}
+			}
+
+			loaded, err := store.config.ExecutorOptions.Parser.LoadTemplate(templatePath, store.tagFilter, tags, store.config.Catalog)
+			if loaded {
+				parsed, err := templates.Parse(templatePath, store.preprocessor, store.config.ExecutorOptions)
+
+				if parsed != nil && !metadataCached {
+					if store.metadataIndex != nil {
+						metadata, _ = store.metadataIndex.SetFromTemplate(templatePath, parsed)
+					} else {
+						metadata = index.NewMetadataFromTemplate(templatePath, parsed)
+					}
+
+					if metadata != nil && !indexFilter.Matches(metadata) {
+						return
+					}
+				}
+
+				if err != nil {
+					// exclude templates not compatible with offline matching from total runtime warning stats
+					if !errors.Is(err, templates.ErrIncompatibleWithOfflineMatching) {
+						stats.Increment(templates.RuntimeWarningsStats)
+					}
+					store.logger.Warning().Msgf("Could not parse template %s: %s\n", templatePath, err)
+				} else if parsed != nil {
+					if !parsed.Verified && typesOpts.DisableUnsignedTemplates {
+						// skip unverified templates when prompted to
+						stats.Increment(templates.SkippedUnsignedStats)
+						return
+					}
+
+					if parsed.SelfContained && !typesOpts.EnableSelfContainedTemplates {
+						stats.Increment(templates.ExcludedSelfContainedStats)
+						return
+					}
+
+					if parsed.HasFileRequest() && !typesOpts.EnableFileTemplates {
+						stats.Increment(templates.ExcludedFileStats)
+						return
+					}
+
+					// if template has request signature like aws then only signed and verified templates are allowed
+					if parsed.UsesRequestSignature() && !parsed.Verified {
+						stats.Increment(templates.SkippedRequestSignatureStats)
+						return
+					}
+					// DAST only templates
+					// Skip DAST filter when loading auth templates
+					if store.ID() != AuthStoreId && typesOpts.DAST {
+						// check if the template is a DAST template
+						// also allow global matchers template to be loaded
+						if parsed.IsFuzzableRequest() || parsed.IsGlobalMatchersTemplate() {
+							if parsed.HasHeadlessRequest() && !typesOpts.Headless {
+								stats.Increment(templates.ExcludedHeadlessTmplStats)
+								if config.DefaultConfig.LogAllEvents {
+									store.logger.Print().Msgf("[%v] Headless flag is required for headless template '%s'.\n", aurora.Yellow("WRN").String(), templatePath)
+								}
+							} else {
+								loadTemplate(parsed)
+							}
+						}
+					} else if parsed.HasHeadlessRequest() && !typesOpts.Headless {
+						// donot include headless template in final list if headless flag is not set
+						stats.Increment(templates.ExcludedHeadlessTmplStats)
+						if config.DefaultConfig.LogAllEvents {
+							store.logger.Print().Msgf("[%v] Headless flag is required for headless template '%s'.\n", aurora.Yellow("WRN").String(), templatePath)
+						}
+					} else if parsed.HasCodeRequest() && !typesOpts.EnableCodeTemplates {
+						// donot include 'Code' protocol custom template in final list if code flag is not set
+						stats.Increment(templates.ExcludedCodeTmplStats)
+						if config.DefaultConfig.LogAllEvents {
+							store.logger.Print().Msgf("[%v] Code flag is required for code protocol template '%s'.\n", aurora.Yellow("WRN").String(), templatePath)
+						}
+					} else if parsed.HasCodeRequest() && !parsed.Verified && !parsed.HasWorkflows() {
+						// donot include unverified 'Code' protocol custom template in final list
+						stats.Increment(templates.SkippedCodeTmplTamperedStats)
+						// these will be skipped so increment skip counter
+						stats.Increment(templates.SkippedUnsignedStats)
+						if config.DefaultConfig.LogAllEvents {
+							store.logger.Print().Msgf("[%v] Tampered/Unsigned template at %v.\n", aurora.Yellow("WRN").String(), templatePath)
+						}
+					} else if parsed.IsFuzzableRequest() && !typesOpts.DAST {
+						stats.Increment(templates.ExludedDastTmplStats)
+						if config.DefaultConfig.LogAllEvents {
+							store.logger.Print().Msgf("[%v] -dast flag is required for DAST template '%s'.\n", aurora.Yellow("WRN").String(), templatePath)
+						}
+					} else {
+						loadTemplate(parsed)
+					}
+				}
+			}
+			if err != nil {
+				if strings.Contains(err.Error(), templates.ErrExcluded.Error()) {
+					stats.Increment(templates.TemplatesExcludedStats)
+					if config.DefaultConfig.LogAllEvents {
+						store.logger.Print().Msgf("[%v] %v\n", aurora.Yellow("WRN").String(), err.Error())
+					}
+					return
+				}
+				store.logger.Warning().Msg(err.Error())
+			}
+		}(templatePath)
+	}
+
+	wgLoadTemplates.Wait()
+
+	sort.SliceStable(loadedTemplates.Slice, func(i, j int) bool {
+		return loadedTemplates.Slice[i].Path < loadedTemplates.Slice[j].Path
+	})
+
+	return loadedTemplates.Slice, nil
+}
+
+// IsHTTPBasedProtocolUsed returns true if http/headless protocol is being used for
+// any templates.
+func IsHTTPBasedProtocolUsed(store *Store) bool {
+	templates := append(store.Templates(), store.Workflows()...)
+
+	for _, template := range templates {
+		if template.HasHTTPRequest() || template.HasHeadlessRequest() {
+			return true
+		}
+
+		if template.HasWorkflows() {
+			if workflowContainsProtocol(template.Workflows) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func workflowContainsProtocol(workflow []*workflows.WorkflowTemplate) bool {
+	for _, workflow := range workflow {
+		for _, template := range workflow.Matchers {
+			if workflowContainsProtocol(template.Subtemplates) {
+				return true
+			}
+		}
+		for _, template := range workflow.Subtemplates {
+			if workflowContainsProtocol(template.Subtemplates) {
+				return true
+			}
+		}
+		for _, executer := range workflow.Executers {
+			if executer.TemplateType == templateTypes.HTTPProtocol || executer.TemplateType == templateTypes.HeadlessProtocol {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (s *Store) logErroredTemplates(erred map[string]error) {
+	for template, err := range erred {
+		if s.NotFoundCallback == nil || !s.NotFoundCallback(template) {
+			s.logger.Error().Msgf("Could not find template '%s': %s", template, err)
+		}
+	}
+}

--- a/loader_bench_test.go
+++ b/loader_bench_test.go
@@ -1,0 +1,243 @@
+package loader_test
+
+import (
+	"testing"
+
+	"github.com/projectdiscovery/gologger"
+	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/config"
+	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/disk"
+	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/loader"
+	"github.com/projectdiscovery/nuclei/v3/pkg/loader/workflow"
+	"github.com/projectdiscovery/nuclei/v3/pkg/model/types/severity"
+	"github.com/projectdiscovery/nuclei/v3/pkg/templates"
+	templateTypes "github.com/projectdiscovery/nuclei/v3/pkg/templates/types"
+	"github.com/projectdiscovery/nuclei/v3/pkg/testutils"
+)
+
+func BenchmarkStoreValidateTemplates(b *testing.B) {
+	options := testutils.DefaultOptions.Copy()
+	options.Logger = &gologger.Logger{}
+	testutils.Init(options)
+
+	catalog := disk.NewCatalog(config.DefaultConfig.TemplatesDirectory)
+	executerOpts := testutils.NewMockExecuterOptions(options, nil)
+	executerOpts.Parser = templates.NewParser()
+
+	workflowLoader, err := workflow.NewLoader(executerOpts)
+	if err != nil {
+		b.Fatalf("could not create workflow loader: %s", err)
+	}
+	executerOpts.WorkflowLoader = workflowLoader
+
+	loaderCfg := loader.NewConfig(options, catalog, executerOpts)
+
+	store, err := loader.New(loaderCfg)
+	if err != nil {
+		b.Fatalf("could not create store: %s", err)
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for b.Loop() {
+		_ = store.ValidateTemplates()
+	}
+}
+
+func BenchmarkLoadTemplates(b *testing.B) {
+	options := testutils.DefaultOptions.Copy()
+	options.Logger = &gologger.Logger{}
+	options.ExecutionId = "bench-load-templates"
+	testutils.Init(options)
+
+	catalog := disk.NewCatalog(config.DefaultConfig.TemplatesDirectory)
+	executerOpts := testutils.NewMockExecuterOptions(options, nil)
+	executerOpts.Parser = templates.NewParser()
+
+	workflowLoader, err := workflow.NewLoader(executerOpts)
+	if err != nil {
+		b.Fatalf("could not create workflow loader: %s", err)
+	}
+	executerOpts.WorkflowLoader = workflowLoader
+
+	b.Run("NoFilter", func(b *testing.B) {
+		loaderCfg := loader.NewConfig(options, catalog, executerOpts)
+		store, err := loader.New(loaderCfg)
+		if err != nil {
+			b.Fatalf("could not create store: %s", err)
+		}
+
+		b.ResetTimer()
+		b.ReportAllocs()
+
+		for b.Loop() {
+			_, _ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
+		}
+	})
+
+	b.Run("FilterBySeverityCritical", func(b *testing.B) {
+		opts := options.Copy()
+		opts.Severities = severity.Severities{severity.Critical}
+		loaderCfg := loader.NewConfig(opts, catalog, executerOpts)
+
+		store, err := loader.New(loaderCfg)
+		if err != nil {
+			b.Fatalf("could not create store: %s", err)
+		}
+
+		b.ResetTimer()
+		b.ReportAllocs()
+
+		for b.Loop() {
+			_, _ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
+		}
+	})
+
+	b.Run("FilterBySeverityHighCritical", func(b *testing.B) {
+		opts := options.Copy()
+		opts.Severities = severity.Severities{severity.High, severity.Critical}
+		loaderCfg := loader.NewConfig(opts, catalog, executerOpts)
+
+		store, err := loader.New(loaderCfg)
+		if err != nil {
+			b.Fatalf("could not create store: %s", err)
+		}
+
+		b.ResetTimer()
+		b.ReportAllocs()
+
+		for b.Loop() {
+			_, _ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
+		}
+	})
+
+	b.Run("FilterByAuthor", func(b *testing.B) {
+		opts := options.Copy()
+		opts.Authors = []string{"pdteam"}
+		loaderCfg := loader.NewConfig(opts, catalog, executerOpts)
+
+		store, err := loader.New(loaderCfg)
+		if err != nil {
+			b.Fatalf("could not create store: %s", err)
+		}
+
+		b.ResetTimer()
+		b.ReportAllocs()
+
+		for b.Loop() {
+			_, _ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
+		}
+	})
+
+	b.Run("FilterByTags", func(b *testing.B) {
+		opts := options.Copy()
+		opts.Tags = []string{"cve", "rce"}
+		loaderCfg := loader.NewConfig(opts, catalog, executerOpts)
+
+		store, err := loader.New(loaderCfg)
+		if err != nil {
+			b.Fatalf("could not create store: %s", err)
+		}
+
+		b.ResetTimer()
+		b.ReportAllocs()
+
+		for b.Loop() {
+			_, _ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
+		}
+	})
+
+	b.Run("FilterByProtocol", func(b *testing.B) {
+		opts := options.Copy()
+		opts.Protocols = templateTypes.ProtocolTypes{templateTypes.HTTPProtocol}
+		loaderCfg := loader.NewConfig(opts, catalog, executerOpts)
+
+		store, err := loader.New(loaderCfg)
+		if err != nil {
+			b.Fatalf("could not create store: %s", err)
+		}
+
+		b.ResetTimer()
+		b.ReportAllocs()
+
+		for b.Loop() {
+			_, _ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
+		}
+	})
+
+	b.Run("ComplexFilter", func(b *testing.B) {
+		opts := options.Copy()
+		opts.Severities = severity.Severities{severity.High, severity.Critical}
+		opts.Authors = []string{"pdteam"}
+		opts.Tags = []string{"cve"}
+		loaderCfg := loader.NewConfig(opts, catalog, executerOpts)
+
+		store, err := loader.New(loaderCfg)
+		if err != nil {
+			b.Fatalf("could not create store: %s", err)
+		}
+
+		b.ResetTimer()
+		b.ReportAllocs()
+
+		for b.Loop() {
+			_, _ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
+		}
+	})
+}
+
+func BenchmarkLoadTemplatesOnlyMetadata(b *testing.B) {
+	options := testutils.DefaultOptions.Copy()
+	options.Logger = &gologger.Logger{}
+	options.ExecutionId = "bench-metadata"
+	testutils.Init(options)
+
+	catalog := disk.NewCatalog(config.DefaultConfig.TemplatesDirectory)
+	executerOpts := testutils.NewMockExecuterOptions(options, nil)
+	executerOpts.Parser = templates.NewParser()
+
+	workflowLoader, err := workflow.NewLoader(executerOpts)
+	if err != nil {
+		b.Fatalf("could not create workflow loader: %s", err)
+	}
+	executerOpts.WorkflowLoader = workflowLoader
+
+	b.Run("WithoutFilter", func(b *testing.B) {
+		loaderCfg := loader.NewConfig(options, catalog, executerOpts)
+		store, err := loader.New(loaderCfg)
+		if err != nil {
+			b.Fatalf("could not create store: %s", err)
+		}
+
+		// Pre-warm the cache
+		_ = store.LoadTemplatesOnlyMetadata()
+
+		b.ResetTimer()
+		b.ReportAllocs()
+
+		for b.Loop() {
+			_ = store.LoadTemplatesOnlyMetadata()
+		}
+	})
+
+	b.Run("WithSeverityFilter", func(b *testing.B) {
+		opts := options.Copy()
+		opts.Severities = severity.Severities{severity.Critical}
+		loaderCfg := loader.NewConfig(opts, catalog, executerOpts)
+
+		store, err := loader.New(loaderCfg)
+		if err != nil {
+			b.Fatalf("could not create store: %s", err)
+		}
+
+		// Pre-warm the cache
+		_ = store.LoadTemplatesOnlyMetadata()
+
+		b.ResetTimer()
+		b.ReportAllocs()
+
+		for b.Loop() {
+			_ = store.LoadTemplatesOnlyMetadata()
+		}
+	})
+}

--- a/runner.go
+++ b/runner.go
@@ -361,7 +361,6 @@ func New(options *types.Options) (*Runner, error) {
 	opts.PollDuration = time.Duration(options.InteractionsPollDuration) * time.Second
 	opts.NoInteractsh = runner.options.NoInteractsh
 	opts.StopAtFirstMatch = runner.options.StopAtFirstMatch
-	opts.Debug = runner.options.Debug
 	opts.DebugRequest = runner.options.DebugRequests
 	opts.DebugResponse = runner.options.DebugResponse
 	if httpclient != nil {
@@ -587,6 +586,9 @@ func (r *Runner) RunEnumeration() error {
 		authOpts.LazyFetchSecret = GetLazyAuthFetchCallback(&AuthLazyFetchOptions{
 			TemplateStore: authTmplStore,
 			ExecOpts:      executorOpts,
+			OnError: func(err error) {
+				runner.Logger.Error().Msgf("auth template fetch failed: %s", err)
+			},
 		})
 		// initialize auth provider
 		provider, err := authprovider.NewAuthProvider(authOpts)
@@ -928,7 +930,10 @@ func (r *Runner) SaveResumeConfig(path string) error {
 	}
 	resumeCfgClone := r.resumeCfg.Clone()
 	resumeCfgClone.ResumeFrom = resumeCfgClone.Current
-	data, _ := json.MarshalIndent(resumeCfgClone, "", "\t")
+	data, err := json.MarshalIndent(resumeCfgClone, "", "\t")
+	if err != nil {
+		return err
+	}
 
 	return os.WriteFile(path, data, permissionutil.ConfigFilePermission)
 }
@@ -977,7 +982,9 @@ func UploadResultsToCloud(options *types.Options) error {
 			options.Logger.Warning().Msgf("[%s] failed to upload: %s\n", r.TemplateID, err)
 		}
 	}
-	uploadWriter.Close()
+	if err := uploadWriter.Close(); err != nil {
+		options.Logger.Warning().Msgf("Could not close upload writer: %s\n", err)
+	}
 	return nil
 }
 
@@ -1003,7 +1010,7 @@ func Walk(s interface{}, callback WalkFunc) {
 		}
 		if field.Kind() == reflect.Struct {
 			Walk(field.Addr().Interface(), callback)
-		} else if field.Kind() == reflect.Ptr && field.Elem().Kind() == reflect.Struct {
+		} else if field.Kind() == reflect.Ptr && !field.IsNil() && field.Elem().Kind() == reflect.Struct {
 			Walk(field.Interface(), callback)
 		} else {
 			callback(field, fieldType)
@@ -1021,10 +1028,10 @@ func expandEndVars(f reflect.Value, fieldType reflect.StructField) {
 	if f.Kind() == reflect.String {
 		str := f.String()
 		if strings.HasPrefix(str, "$") {
-			env := strings.TrimPrefix(str, "$")
-			retrievedEnv := os.Getenv(env)
+			envKey := strings.TrimPrefix(str, "$")
+			retrievedEnv := os.Getenv(envKey)
 			if retrievedEnv != "" {
-				f.SetString(os.Getenv(env))
+				f.SetString(os.Getenv(envKey))
 			}
 		}
 	}

--- a/runner.go
+++ b/runner.go
@@ -1,0 +1,1038 @@
+package runner
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/projectdiscovery/gologger"
+	"github.com/projectdiscovery/nuclei/v3/internal/pdcp"
+	"github.com/projectdiscovery/nuclei/v3/internal/server"
+	"github.com/projectdiscovery/nuclei/v3/pkg/authprovider"
+	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz/frequency"
+	"github.com/projectdiscovery/nuclei/v3/pkg/input/provider"
+	"github.com/projectdiscovery/nuclei/v3/pkg/installer"
+	"github.com/projectdiscovery/nuclei/v3/pkg/loader/parser"
+	outputstats "github.com/projectdiscovery/nuclei/v3/pkg/output/stats"
+	"github.com/projectdiscovery/nuclei/v3/pkg/scan/events"
+	"github.com/projectdiscovery/nuclei/v3/pkg/utils/json"
+	uncoverlib "github.com/projectdiscovery/uncover"
+	pdcpauth "github.com/projectdiscovery/utils/auth/pdcp"
+	"github.com/projectdiscovery/utils/env"
+	fileutil "github.com/projectdiscovery/utils/file"
+	permissionutil "github.com/projectdiscovery/utils/permission"
+	pprofutil "github.com/projectdiscovery/utils/pprof"
+	updateutils "github.com/projectdiscovery/utils/update"
+
+	"github.com/logrusorgru/aurora"
+	"github.com/pkg/errors"
+	"github.com/projectdiscovery/ratelimit"
+
+	"github.com/projectdiscovery/nuclei/v3/internal/colorizer"
+	"github.com/projectdiscovery/nuclei/v3/internal/httpapi"
+	"github.com/projectdiscovery/nuclei/v3/pkg/catalog"
+	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/config"
+	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/disk"
+	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/loader"
+	"github.com/projectdiscovery/nuclei/v3/pkg/core"
+	"github.com/projectdiscovery/nuclei/v3/pkg/external/customtemplates"
+	fuzzStats "github.com/projectdiscovery/nuclei/v3/pkg/fuzz/stats"
+	"github.com/projectdiscovery/nuclei/v3/pkg/input"
+	parsers "github.com/projectdiscovery/nuclei/v3/pkg/loader/workflow"
+	"github.com/projectdiscovery/nuclei/v3/pkg/output"
+	"github.com/projectdiscovery/nuclei/v3/pkg/progress"
+	"github.com/projectdiscovery/nuclei/v3/pkg/projectfile"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/automaticscan"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/contextargs"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/globalmatchers"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/hosterrorscache"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/interactsh"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolinit"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/uncover"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/utils/excludematchers"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/headless/engine"
+	httpProtocol "github.com/projectdiscovery/nuclei/v3/pkg/protocols/http"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/http/httpclientpool"
+	"github.com/projectdiscovery/nuclei/v3/pkg/reporting"
+	"github.com/projectdiscovery/nuclei/v3/pkg/templates"
+	"github.com/projectdiscovery/nuclei/v3/pkg/types"
+	"github.com/projectdiscovery/nuclei/v3/pkg/utils"
+	"github.com/projectdiscovery/nuclei/v3/pkg/utils/stats"
+	"github.com/projectdiscovery/nuclei/v3/pkg/utils/yaml"
+	"github.com/projectdiscovery/retryablehttp-go"
+	ptrutil "github.com/projectdiscovery/utils/ptr"
+)
+
+var (
+	// HideAutoSaveMsg is a global variable to hide the auto-save message
+	HideAutoSaveMsg = false
+	// EnableCloudUpload is global variable to enable cloud upload
+	EnableCloudUpload = false
+)
+
+// Runner is a client for running the enumeration process.
+type Runner struct {
+	output             output.Writer
+	interactsh         *interactsh.Client
+	options            *types.Options
+	projectFile        *projectfile.ProjectFile
+	catalog            catalog.Catalog
+	progress           progress.Progress
+	colorizer          aurora.Aurora
+	issuesClient       reporting.Client
+	browser            *engine.Browser
+	rateLimiter        *ratelimit.Limiter
+	hostErrors         hosterrorscache.CacheInterface
+	resumeCfg          *types.ResumeCfg
+	pprofServer        *pprofutil.PprofServer
+	pdcpUploadErrMsg   string
+	inputProvider      provider.InputProvider
+	fuzzFrequencyCache *frequency.Tracker
+	httpStats          *outputstats.Tracker
+	Logger             *gologger.Logger
+
+	//general purpose temporary directory
+	tmpDir          string
+	parser          parser.Parser
+	httpApiEndpoint *httpapi.Server
+	fuzzStats       *fuzzStats.Tracker
+	dastServer      *server.DASTServer
+}
+
+// New creates a new client for running the enumeration process.
+func New(options *types.Options) (*Runner, error) {
+	runner := &Runner{
+		options: options,
+		Logger:  options.Logger,
+	}
+
+	if options.HealthCheck {
+		runner.Logger.Print().Msgf("%s\n", DoHealthCheck(options))
+		os.Exit(0)
+	}
+
+	//  Version check by default
+	if config.DefaultConfig.CanCheckForUpdates() {
+		if err := installer.NucleiVersionCheck(); err != nil {
+			if options.Verbose || options.Debug {
+				runner.Logger.Error().Msgf("nuclei version check failed got: %s\n", err)
+			}
+		}
+
+		// check for custom template updates and update if available
+		ctm, err := customtemplates.NewCustomTemplatesManager(options)
+		if err != nil {
+			runner.Logger.Error().Label("custom-templates").Msgf("Failed to create custom templates manager: %s\n", err)
+		}
+
+		// Check for template updates and update if available.
+		// If the custom templates manager is not nil, we will install custom templates if there is a fresh installation
+		tm := &installer.TemplateManager{
+			CustomTemplates:        ctm,
+			DisablePublicTemplates: options.PublicTemplateDisableDownload,
+		}
+		if err := tm.FreshInstallIfNotExists(); err != nil {
+			runner.Logger.Warning().Msgf("failed to install nuclei templates: %s\n", err)
+		}
+		if err := tm.UpdateIfOutdated(); err != nil {
+			runner.Logger.Warning().Msgf("failed to update nuclei templates: %s\n", err)
+		}
+
+		if config.DefaultConfig.NeedsIgnoreFileUpdate() {
+			if err := installer.UpdateIgnoreFile(); err != nil {
+				runner.Logger.Warning().Msgf("failed to update nuclei ignore file: %s\n", err)
+			}
+		}
+
+		if options.UpdateTemplates {
+			// we automatically check for updates unless explicitly disabled
+			// this print statement is only to inform the user that there are no updates
+			if !config.DefaultConfig.NeedsTemplateUpdate() {
+				runner.Logger.Info().Msgf("No new updates found for nuclei templates")
+			}
+			// manually trigger update of custom templates
+			if ctm != nil {
+				ctm.Update(context.TODO())
+			}
+		}
+	}
+
+	if op, ok := options.Parser.(*templates.Parser); ok {
+		// Enable passing in an existing parser instance
+		// This uses a type assertion to avoid an import loop
+		runner.parser = op
+	} else {
+		parser := templates.NewParser()
+		if options.Validate {
+			parser.ShouldValidate = true
+		}
+		// TODO: refactor to pass options reference globally without cycles
+		parser.NoStrictSyntax = options.NoStrictSyntax
+		runner.parser = parser
+	}
+
+	yaml.StrictSyntax = !options.NoStrictSyntax
+
+	if options.Headless {
+		if engine.MustDisableSandbox() {
+			runner.Logger.Warning().Msgf("The current platform and privileged user will run the browser without sandbox\n")
+		}
+		browser, err := engine.New(options)
+		if err != nil {
+			return nil, err
+		}
+		runner.browser = browser
+	}
+
+	runner.catalog = disk.NewCatalog(config.DefaultConfig.TemplatesDirectory)
+
+	var httpclient *retryablehttp.Client
+	if options.ProxyInternal && options.AliveHttpProxy != "" || options.AliveSocksProxy != "" {
+		var err error
+		httpclient, err = httpclientpool.Get(options, &httpclientpool.Configuration{})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if err := reporting.CreateConfigIfNotExists(); err != nil {
+		return nil, err
+	}
+	reportingOptions, err := createReportingOptions(options)
+	if err != nil {
+		return nil, err
+	}
+	if reportingOptions != nil && httpclient != nil {
+		reportingOptions.HttpClient = httpclient
+	}
+
+	if reportingOptions != nil {
+		client, err := reporting.New(reportingOptions, options.ReportingDB, false)
+		if err != nil {
+			return nil, errors.Wrap(err, "could not create issue reporting client")
+		}
+		runner.issuesClient = client
+	}
+
+	// output coloring
+	useColor := !options.NoColor
+	runner.colorizer = aurora.NewAurora(useColor)
+	templates.Colorizer = runner.colorizer
+	templates.SeverityColorizer = colorizer.New(runner.colorizer)
+
+	if options.EnablePprof {
+		runner.pprofServer = pprofutil.NewPprofServer()
+		runner.pprofServer.Start()
+	}
+
+	if options.HttpApiEndpoint != "" {
+		apiServer := httpapi.New(options.HttpApiEndpoint, options)
+		runner.Logger.Info().Msgf("Listening api endpoint on: %s", options.HttpApiEndpoint)
+		runner.httpApiEndpoint = apiServer
+		go func() {
+			if err := apiServer.Start(); err != nil {
+				runner.Logger.Error().Msgf("Failed to start API server: %s", err)
+			}
+		}()
+	}
+
+	if (len(options.Templates) == 0 || !options.NewTemplates || (options.TargetsFilePath == "" && !options.Stdin && len(options.Targets) == 0)) && options.UpdateTemplates {
+		os.Exit(0)
+	}
+
+	tmpDir, err := os.MkdirTemp("", "nuclei-tmp-*")
+	if err != nil {
+		return nil, errors.Wrap(err, "could not create temporary directory")
+	}
+	runner.tmpDir = tmpDir
+
+	// Cleanup tmpDir only if initialization fails
+	// On successful initialization, Close() method will handle cleanup
+	cleanupOnError := true
+	defer func() {
+		if cleanupOnError && runner.tmpDir != "" {
+			_ = os.RemoveAll(runner.tmpDir)
+		}
+	}()
+
+	// create the input provider and load the inputs
+	inputProvider, err := provider.NewInputProvider(provider.InputOptions{Options: options, TempDir: runner.tmpDir})
+	if err != nil {
+		return nil, errors.Wrap(err, "could not create input provider")
+	}
+	runner.inputProvider = inputProvider
+
+	// Create the output file if asked
+	outputWriter, err := output.NewStandardWriter(options)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not create output file")
+	}
+	// setup a proxy writer to automatically upload results to PDCP
+	runner.output = runner.setupPDCPUpload(outputWriter)
+	if options.HTTPStats {
+		runner.httpStats = outputstats.NewTracker()
+		runner.output = output.NewMultiWriter(runner.output, output.NewTrackerWriter(runner.httpStats))
+	}
+
+	if options.JSONL && options.EnableProgressBar {
+		options.StatsJSON = true
+	}
+	if options.StatsJSON {
+		options.EnableProgressBar = true
+	}
+	// Creates the progress tracking object
+	var progressErr error
+	statsInterval := options.StatsInterval
+	runner.progress, progressErr = progress.NewStatsTicker(statsInterval, options.EnableProgressBar, options.StatsJSON, false, options.MetricsPort)
+	if progressErr != nil {
+		return nil, progressErr
+	}
+
+	// create project file if requested or load the existing one
+	if options.Project {
+		var projectFileErr error
+		runner.projectFile, projectFileErr = projectfile.New(&projectfile.Options{Path: options.ProjectPath, Cleanup: utils.IsBlank(options.ProjectPath)})
+		if projectFileErr != nil {
+			return nil, projectFileErr
+		}
+	}
+
+	// create the resume configuration structure
+	resumeCfg := types.NewResumeCfg()
+	if runner.options.ShouldLoadResume() {
+		runner.Logger.Info().Msg("Resuming from save checkpoint")
+		file, err := os.ReadFile(runner.options.Resume)
+		if err != nil {
+			return nil, err
+		}
+		err = json.Unmarshal(file, &resumeCfg)
+		if err != nil {
+			return nil, err
+		}
+		resumeCfg.Compile()
+	}
+	runner.resumeCfg = resumeCfg
+
+	if options.DASTReport || options.DASTServer {
+		var err error
+		runner.fuzzStats, err = fuzzStats.NewTracker()
+		if err != nil {
+			return nil, errors.Wrap(err, "could not create fuzz stats db")
+		}
+		if !options.DASTServer {
+			dastServer, err := server.NewStatsServer(runner.fuzzStats)
+			if err != nil {
+				return nil, errors.Wrap(err, "could not create dast server")
+			}
+			runner.dastServer = dastServer
+		}
+	}
+
+	if runner.fuzzStats != nil {
+		outputWriter.JSONLogRequestHook = func(request *output.JSONLogRequest) {
+			if request.Error == "none" || request.Error == "" {
+				return
+			}
+			runner.fuzzStats.RecordErrorEvent(fuzzStats.ErrorEvent{
+				TemplateID: request.Template,
+				URL:        request.Input,
+				Error:      request.Error,
+			})
+		}
+	}
+
+	opts := interactsh.DefaultOptions(runner.output, runner.issuesClient, runner.progress)
+	opts.Logger = runner.Logger
+	opts.Debug = runner.options.Debug
+	opts.NoColor = runner.options.NoColor
+	if options.InteractshURL != "" {
+		opts.ServerURL = options.InteractshURL
+	}
+	opts.Authorization = options.InteractshToken
+	opts.CacheSize = options.InteractionsCacheSize
+	opts.Eviction = time.Duration(options.InteractionsEviction) * time.Second
+	opts.CooldownPeriod = time.Duration(options.InteractionsCoolDownPeriod) * time.Second
+	opts.PollDuration = time.Duration(options.InteractionsPollDuration) * time.Second
+	opts.NoInteractsh = runner.options.NoInteractsh
+	opts.StopAtFirstMatch = runner.options.StopAtFirstMatch
+	opts.Debug = runner.options.Debug
+	opts.DebugRequest = runner.options.DebugRequests
+	opts.DebugResponse = runner.options.DebugResponse
+	if httpclient != nil {
+		opts.HTTPClient = httpclient
+	}
+	if opts.HTTPClient == nil {
+		httpOpts := retryablehttp.DefaultOptionsSingle
+		httpOpts.Timeout = 20 * time.Second // for stability reasons
+		if options.Timeout > 20 {
+			httpOpts.Timeout = time.Duration(options.Timeout) * time.Second
+		}
+		// in testing it was found most of times when interactsh failed, it was due to failure in registering /polling requests
+		opts.HTTPClient = retryablehttp.NewClient(retryablehttp.DefaultOptionsSingle)
+	}
+	interactshClient, err := interactsh.New(opts)
+	if err != nil {
+		runner.Logger.Error().Msgf("Could not create interactsh client: %s", err)
+	} else {
+		runner.interactsh = interactshClient
+	}
+
+	if options.RateLimitMinute > 0 {
+		runner.Logger.Print().Msgf("[%v] %v", aurora.BrightYellow("WRN"), "rate limit per minute is deprecated - use rate-limit-duration")
+		options.RateLimit = options.RateLimitMinute
+		options.RateLimitDuration = time.Minute
+	}
+	if options.RateLimit > 0 && options.RateLimitDuration == 0 {
+		options.RateLimitDuration = time.Second
+	}
+	runner.rateLimiter = utils.GetRateLimiter(context.Background(), options.RateLimit, options.RateLimitDuration)
+
+	// Initialization successful, disable cleanup on error
+	cleanupOnError = false
+	return runner, nil
+}
+
+// runStandardEnumeration runs standard enumeration
+func (r *Runner) runStandardEnumeration(executerOpts *protocols.ExecutorOptions, store *loader.Store, engine *core.Engine) (*atomic.Bool, error) {
+	if r.options.AutomaticScan {
+		return r.executeSmartWorkflowInput(executerOpts, store, engine)
+	}
+	return r.executeTemplatesInput(store, engine)
+}
+
+// Close releases all the resources and cleans up
+func (r *Runner) Close() {
+	if r.dastServer != nil {
+		r.dastServer.Close()
+	}
+	if r.httpStats != nil {
+		r.httpStats.DisplayTopStats(r.options.NoColor)
+	}
+	// dump hosterrors cache
+	if r.hostErrors != nil {
+		r.hostErrors.Close()
+	}
+	if r.output != nil {
+		r.output.Close()
+	}
+	if r.issuesClient != nil {
+		r.issuesClient.Close()
+	}
+	if r.projectFile != nil {
+		r.projectFile.Close()
+	}
+	if r.inputProvider != nil {
+		r.inputProvider.Close()
+	}
+	protocolinit.Close(r.options.ExecutionId)
+	if r.pprofServer != nil {
+		r.pprofServer.Stop()
+	}
+	if r.rateLimiter != nil {
+		r.rateLimiter.Stop()
+	}
+	r.progress.Stop()
+	if r.browser != nil {
+		r.browser.Close()
+	}
+	if r.tmpDir != "" {
+		_ = os.RemoveAll(r.tmpDir)
+	}
+
+	//this is no-op unless nuclei is built with stats build tag
+	events.Close()
+}
+
+// setupPDCPUpload sets up the PDCP upload writer
+// by creating a new writer and returning it
+func (r *Runner) setupPDCPUpload(writer output.Writer) output.Writer {
+	// if scanid is given implicitly consider that scan upload is enabled
+	if r.options.ScanID != "" {
+		r.options.EnableCloudUpload = true
+	}
+	if !r.options.EnableCloudUpload && !EnableCloudUpload {
+		r.pdcpUploadErrMsg = "Scan results upload to cloud is disabled."
+		return writer
+	}
+	h := &pdcpauth.PDCPCredHandler{}
+	creds, err := h.GetCreds()
+	if err != nil {
+		if err != pdcpauth.ErrNoCreds && !HideAutoSaveMsg {
+			r.Logger.Verbose().Msgf("Could not get credentials for cloud upload: %s\n", err)
+		}
+		r.pdcpUploadErrMsg = fmt.Sprintf("To view results on Cloud Dashboard, configure API key from %v", pdcpauth.DashBoardURL)
+		return writer
+	}
+	uploadWriter, err := pdcp.NewUploadWriter(context.Background(), r.Logger, creds)
+	if err != nil {
+		r.pdcpUploadErrMsg = fmt.Sprintf("PDCP (%v) Auto-Save Failed: %s\n", pdcpauth.DashBoardURL, err)
+		return writer
+	}
+	if r.options.ScanID != "" {
+		// ignore and use empty scan id if invalid
+		_ = uploadWriter.SetScanID(r.options.ScanID)
+	}
+	if r.options.ScanName != "" {
+		uploadWriter.SetScanName(r.options.ScanName)
+	}
+	if r.options.TeamID != "" {
+		uploadWriter.SetTeamID(r.options.TeamID)
+	}
+	return output.NewMultiWriter(writer, uploadWriter)
+}
+
+// RunEnumeration sets up the input layer for giving input nuclei.
+// binary and runs the actual enumeration
+func (r *Runner) RunEnumeration() error {
+	// If the user has asked for DAST server mode, run the live
+	// DAST fuzzing server.
+	if r.options.DASTServer {
+		execurOpts := &server.NucleiExecutorOptions{
+			Options:            r.options,
+			Output:             r.output,
+			Progress:           r.progress,
+			Catalog:            r.catalog,
+			IssuesClient:       r.issuesClient,
+			RateLimiter:        r.rateLimiter,
+			Interactsh:         r.interactsh,
+			ProjectFile:        r.projectFile,
+			Browser:            r.browser,
+			Colorizer:          r.colorizer,
+			Parser:             r.parser,
+			TemporaryDirectory: r.tmpDir,
+			FuzzStatsDB:        r.fuzzStats,
+			Logger:             r.Logger,
+		}
+		dastServer, err := server.New(&server.Options{
+			Address:               r.options.DASTServerAddress,
+			Templates:             r.options.Templates,
+			OutputWriter:          r.output,
+			Verbose:               r.options.Verbose,
+			Token:                 r.options.DASTServerToken,
+			InScope:               r.options.Scope,
+			OutScope:              r.options.OutOfScope,
+			NucleiExecutorOptions: execurOpts,
+		})
+		if err != nil {
+			return err
+		}
+		r.dastServer = dastServer
+		return dastServer.Start()
+	}
+
+	// If user asked for new templates to be executed, collect the list from the templates' directory.
+	if r.options.NewTemplates {
+		if arr := config.DefaultConfig.GetNewAdditions(); len(arr) > 0 {
+			r.options.Templates = append(r.options.Templates, arr...)
+		}
+	}
+	if len(r.options.NewTemplatesWithVersion) > 0 {
+		if arr := installer.GetNewTemplatesInVersions(r.options.NewTemplatesWithVersion...); len(arr) > 0 {
+			r.options.Templates = append(r.options.Templates, arr...)
+		}
+	}
+	// Exclude ignored file for validation
+	if !r.options.Validate {
+		ignoreFile := config.ReadIgnoreFile()
+		r.options.ExcludeTags = append(r.options.ExcludeTags, ignoreFile.Tags...)
+		r.options.ExcludedTemplates = append(r.options.ExcludedTemplates, ignoreFile.Files...)
+	}
+
+	fuzzFreqCache := frequency.New(frequency.DefaultMaxTrackCount, r.options.FuzzParamFrequency)
+	r.fuzzFrequencyCache = fuzzFreqCache
+
+	// Create the executor options which will be used throughout the execution
+	// stage by the nuclei engine modules.
+	executorOpts := &protocols.ExecutorOptions{
+		Output:              r.output,
+		Options:             r.options,
+		Progress:            r.progress,
+		Catalog:             r.catalog,
+		IssuesClient:        r.issuesClient,
+		RateLimiter:         r.rateLimiter,
+		Interactsh:          r.interactsh,
+		ProjectFile:         r.projectFile,
+		Browser:             r.browser,
+		Colorizer:           r.colorizer,
+		ResumeCfg:           r.resumeCfg,
+		ExcludeMatchers:     excludematchers.New(r.options.ExcludeMatchers),
+		InputHelper:         input.NewHelper(),
+		TemporaryDirectory:  r.tmpDir,
+		Parser:              r.parser,
+		FuzzParamsFrequency: fuzzFreqCache,
+		GlobalMatchers:      globalmatchers.New(),
+		DoNotCache:          r.options.DoNotCacheTemplates,
+		Logger:              r.Logger,
+	}
+
+	if config.DefaultConfig.IsDebugArgEnabled(config.DebugExportURLPattern) {
+		// Go StdLib style experimental/debug feature switch
+		executorOpts.ExportReqURLPattern = true
+	}
+
+	if len(r.options.SecretsFile) > 0 && !r.options.Validate {
+		// Clone options so GetAuthTmplStore can modify them without affecting the original
+		authOptions := r.options.Copy()
+		authTmplStore, err := GetAuthTmplStore(authOptions, r.catalog, executorOpts)
+		if err != nil {
+			return errors.Wrap(err, "failed to load dynamic auth templates")
+		}
+		authOpts := &authprovider.AuthProviderOptions{SecretsFiles: r.options.SecretsFile}
+		authOpts.LazyFetchSecret = GetLazyAuthFetchCallback(&AuthLazyFetchOptions{
+			TemplateStore: authTmplStore,
+			ExecOpts:      executorOpts,
+		})
+		// initialize auth provider
+		provider, err := authprovider.NewAuthProvider(authOpts)
+		if err != nil {
+			return errors.Wrap(err, "could not create auth provider")
+		}
+		executorOpts.AuthProvider = provider
+	}
+
+	if r.options.ShouldUseHostError() {
+		maxHostError := r.options.MaxHostError
+		if r.options.TemplateThreads > maxHostError {
+			r.Logger.Print().Msgf("[%v] The concurrency value is higher than max-host-error", r.colorizer.BrightYellow("WRN"))
+			r.Logger.Info().Msgf("Adjusting max-host-error to the concurrency value: %d", r.options.TemplateThreads)
+
+			maxHostError = r.options.TemplateThreads
+		}
+
+		cache := hosterrorscache.New(maxHostError, hosterrorscache.DefaultMaxHostsCount, r.options.TrackError)
+		cache.SetVerbose(r.options.Verbose)
+
+		r.hostErrors = cache
+		executorOpts.HostErrorsCache = cache
+	}
+
+	executorEngine := core.New(r.options)
+	executorEngine.SetExecuterOptions(executorOpts)
+
+	workflowLoader, err := parsers.NewLoader(executorOpts)
+	if err != nil {
+		return errors.Wrap(err, "Could not create loader.")
+	}
+	executorOpts.WorkflowLoader = workflowLoader
+
+	// If using input-file flags, only load http fuzzing based templates.
+	loaderConfig := loader.NewConfig(r.options, r.catalog, executorOpts)
+	if !strings.EqualFold(r.options.InputFileMode, "list") || r.options.DAST {
+		// if input type is not list (implicitly enable fuzzing)
+		r.options.DAST = true
+	}
+	store, err := loader.New(loaderConfig)
+	if err != nil {
+		return errors.Wrap(err, "Could not create loader.")
+	}
+
+	// list all templates or tags as specified by user.
+	// This uses a separate parser to reduce time taken as
+	// normally nuclei does a lot of compilation and stuff
+	// for templates, which we don't want for these simp
+	if r.options.TemplateList || r.options.TemplateDisplay || r.options.TagList {
+		if err := store.LoadTemplatesOnlyMetadata(); err != nil {
+			return err
+		}
+
+		if r.options.TagList {
+			r.listAvailableStoreTags(store)
+		} else {
+			r.listAvailableStoreTemplates(store)
+		}
+		os.Exit(0)
+	}
+
+	if r.options.Validate {
+		if err := store.ValidateTemplates(); err != nil {
+			return err
+		}
+		if stats.GetValue(templates.SyntaxErrorStats) == 0 && stats.GetValue(templates.SyntaxWarningStats) == 0 && stats.GetValue(templates.RuntimeWarningsStats) == 0 {
+			r.Logger.Info().Msgf("All templates validated successfully")
+		} else {
+			return errors.New("encountered errors while performing template validation")
+		}
+		return nil // exit
+	}
+	if err := store.Load(); err != nil {
+		return errors.Wrap(err, "could not load templates")
+	}
+	// TODO: remove below functions after v3 or update warning messages
+	templates.PrintDeprecatedProtocolNameMsgIfApplicable(r.options.Silent, r.options.Verbose)
+
+	// add the hosts from the metadata queries of loaded templates into input provider
+	if r.options.Uncover && len(r.options.UncoverQuery) == 0 {
+		uncoverOpts := &uncoverlib.Options{
+			Limit:         r.options.UncoverLimit,
+			MaxRetry:      r.options.Retries,
+			Timeout:       r.options.Timeout,
+			RateLimit:     uint(r.options.UncoverRateLimit),
+			RateLimitUnit: time.Minute, // default unit is minute
+		}
+		ret := uncover.GetUncoverTargetsFromMetadata(context.TODO(), store.Templates(), r.options.UncoverField, uncoverOpts)
+		for host := range ret {
+			_ = r.inputProvider.SetWithExclusions(r.options.ExecutionId, host)
+		}
+	}
+	// display execution info like version , templates used etc
+	r.displayExecutionInfo(store)
+
+	// prefetch secrets if enabled
+	if executorOpts.AuthProvider != nil && r.options.PreFetchSecrets {
+		r.Logger.Info().Msgf("Pre-fetching secrets from authprovider[s]")
+		if err := executorOpts.AuthProvider.PreFetchSecrets(); err != nil {
+			return errors.Wrap(err, "could not pre-fetch secrets")
+		}
+	}
+
+	// If not explicitly disabled, check if http based protocols
+	// are used, and if inputs are non-http to pre-perform probing
+	// of urls and storing them for execution.
+	if !r.options.DisableHTTPProbe && loader.IsHTTPBasedProtocolUsed(store) && r.isInputNonHTTP() {
+		inputHelpers, err := r.initializeTemplatesHTTPInput()
+		if err != nil {
+			return errors.Wrap(err, "could not probe http input")
+		}
+		executorOpts.InputHelper.InputsHTTP = inputHelpers
+	}
+
+	// initialize stats worker ( this is no-op unless nuclei is built with stats build tag)
+	// during execution a directory with 2 files will be created in the current directory
+	// config.json - containing below info
+	// events.jsonl - containing all start and end times of all templates
+	events.InitWithConfig(&events.ScanConfig{
+		Name:                "nuclei-stats", // make this configurable
+		TargetCount:         int(r.inputProvider.Count()),
+		TemplatesCount:      len(store.Templates()) + len(store.Workflows()),
+		TemplateConcurrency: r.options.TemplateThreads,
+		PayloadConcurrency:  r.options.PayloadConcurrency,
+		JsConcurrency:       r.options.JsConcurrency,
+		Retries:             r.options.Retries,
+	}, "")
+
+	if r.dastServer != nil {
+		go func() {
+			if err := r.dastServer.Start(); err != nil {
+				r.Logger.Error().Msgf("could not start dast server: %v", err)
+			}
+		}()
+	}
+
+	now := time.Now()
+	enumeration := false
+	var results *atomic.Bool
+	results, err = r.runStandardEnumeration(executorOpts, store, executorEngine)
+	enumeration = true
+
+	if !enumeration {
+		return err
+	}
+
+	if executorOpts.FuzzStatsDB != nil {
+		executorOpts.FuzzStatsDB.Close()
+	}
+	if r.interactsh != nil {
+		matched := r.interactsh.Close()
+		if matched {
+			results.CompareAndSwap(false, true)
+		}
+	}
+	if executorOpts.InputHelper != nil {
+		_ = executorOpts.InputHelper.Close()
+	}
+	r.fuzzFrequencyCache.Close()
+
+	r.progress.Stop()
+	timeTaken := time.Since(now)
+	// todo: error propagation without canonical straight error check is required by cloud?
+	// use safe dereferencing to avoid potential panics in case of previous unchecked errors
+	if v := ptrutil.Safe(results); !v.Load() {
+		r.Logger.Info().Msgf("Scan completed in %s. No results found.", shortDur(timeTaken))
+	} else {
+		matchCount := r.output.ResultCount()
+		r.Logger.Info().Msgf("Scan completed in %s. %d matches found.", shortDur(timeTaken), matchCount)
+	}
+
+	// check if a passive scan was requested but no target was provided
+	if r.options.OfflineHTTP && len(r.options.Targets) == 0 && r.options.TargetsFilePath == "" {
+		return errors.Wrap(err, "missing required input (http response) to run passive templates")
+	}
+
+	return err
+}
+
+func shortDur(d time.Duration) string {
+	if d < time.Minute {
+		return d.String()
+	}
+
+	// Truncate to the nearest minute
+	d = d.Truncate(time.Minute)
+	s := d.String()
+
+	if strings.HasSuffix(s, "m0s") {
+		s = s[:len(s)-2]
+	}
+	if strings.HasSuffix(s, "h0m") {
+		s = s[:len(s)-2]
+	}
+	return s
+}
+
+func (r *Runner) isInputNonHTTP() bool {
+	var nonURLInput bool
+	r.inputProvider.Iterate(func(value *contextargs.MetaInput) bool {
+		if !strings.Contains(value.Input, "://") {
+			nonURLInput = true
+			return false
+		}
+		return true
+	})
+	return nonURLInput
+}
+
+func (r *Runner) executeSmartWorkflowInput(executorOpts *protocols.ExecutorOptions, store *loader.Store, engine *core.Engine) (*atomic.Bool, error) {
+	r.progress.Init(r.inputProvider.Count(), 0, 0)
+
+	service, err := automaticscan.New(automaticscan.Options{
+		ExecuterOpts: executorOpts,
+		Store:        store,
+		Engine:       engine,
+		Target:       r.inputProvider,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "could not create automatic scan service")
+	}
+	if err := service.Execute(); err != nil {
+		return nil, errors.Wrap(err, "could not execute automatic scan")
+	}
+	result := &atomic.Bool{}
+	result.Store(service.Close())
+	return result, nil
+}
+
+func (r *Runner) executeTemplatesInput(store *loader.Store, engine *core.Engine) (*atomic.Bool, error) {
+	if r.options.VerboseVerbose {
+		for _, template := range store.Templates() {
+			r.logAvailableTemplate(template.Path)
+		}
+		for _, template := range store.Workflows() {
+			r.logAvailableTemplate(template.Path)
+		}
+	}
+
+	finalTemplates := []*templates.Template{}
+	finalTemplates = append(finalTemplates, store.Templates()...)
+	finalTemplates = append(finalTemplates, store.Workflows()...)
+
+	if len(finalTemplates) == 0 {
+		return nil, errors.New("no templates provided for scan")
+	}
+
+	// pass input provider to engine
+	// TODO: this should be not necessary after r.hmapInputProvider is removed + refactored
+	if r.inputProvider == nil {
+		return nil, errors.New("no input provider found")
+	}
+	results := engine.ExecuteScanWithOpts(context.Background(), finalTemplates, r.inputProvider, r.options.DisableClustering)
+	return results, nil
+}
+
+// displayExecutionInfo displays misc info about the nuclei engine execution
+func (r *Runner) displayExecutionInfo(store *loader.Store) {
+	// Display stats for any loaded templates' syntax warnings or errors
+	stats.Display(templates.SyntaxWarningStats)
+	stats.Display(templates.SyntaxErrorStats)
+	stats.Display(templates.RuntimeWarningsStats)
+	tmplCount := len(store.Templates())
+	workflowCount := len(store.Workflows())
+	if r.options.Verbose || (tmplCount == 0 && workflowCount == 0) {
+		// only print these stats in verbose mode
+		stats.ForceDisplayWarning(templates.ExcludedHeadlessTmplStats)
+		stats.ForceDisplayWarning(templates.ExcludedCodeTmplStats)
+		stats.ForceDisplayWarning(templates.ExludedDastTmplStats)
+		stats.ForceDisplayWarning(templates.TemplatesExcludedStats)
+		stats.ForceDisplayWarning(templates.ExcludedFileStats)
+		stats.ForceDisplayWarning(templates.ExcludedSelfContainedStats)
+	}
+
+	if tmplCount == 0 && workflowCount == 0 {
+		// if dast flag is used print explicit warning
+		if r.options.DAST {
+			r.Logger.Print().Msgf("[%v] No DAST templates found", aurora.BrightYellow("WRN"))
+		}
+		stats.ForceDisplayWarning(templates.SkippedCodeTmplTamperedStats)
+	} else {
+		stats.DisplayAsWarning(templates.SkippedCodeTmplTamperedStats)
+	}
+	stats.DisplayAsWarning(httpProtocol.SetThreadToCountZero)
+	stats.ForceDisplayWarning(templates.SkippedUnsignedStats)
+	stats.ForceDisplayWarning(templates.SkippedRequestSignatureStats)
+
+	cfg := config.DefaultConfig
+
+	updateutils.Aurora = r.colorizer
+	versionInfo := func(version, latestVersion, versionType string) string {
+		if !cfg.CanCheckForUpdates() {
+			return fmt.Sprintf("Current %s version: %v (%s) - remove '-duc' flag to enable update checks", versionType, version, r.colorizer.BrightYellow("unknown"))
+		}
+		return fmt.Sprintf("Current %s version: %v %v", versionType, version, updateutils.GetVersionDescription(version, latestVersion))
+	}
+
+	gologger.Info().Msg(versionInfo(config.Version, cfg.LatestNucleiVersion, "nuclei"))
+	gologger.Info().Msg(versionInfo(cfg.TemplateVersion, cfg.LatestNucleiTemplatesVersion, "nuclei-templates"))
+	if !HideAutoSaveMsg {
+		if r.pdcpUploadErrMsg != "" {
+			r.Logger.Warning().Msgf("%s", r.pdcpUploadErrMsg)
+		} else {
+			r.Logger.Info().Msgf("To view results on cloud dashboard, visit %v/scans upon scan completion.", pdcpauth.DashBoardURL)
+		}
+	}
+
+	if tmplCount > 0 || workflowCount > 0 {
+		if len(store.Templates()) > 0 {
+			r.Logger.Info().Msgf("New templates added in latest release: %d", len(config.DefaultConfig.GetNewAdditions()))
+			r.Logger.Info().Msgf("Templates loaded for current scan: %d", len(store.Templates()))
+		}
+		if len(store.Workflows()) > 0 {
+			r.Logger.Info().Msgf("Workflows loaded for current scan: %d", len(store.Workflows()))
+		}
+		for k, v := range templates.SignatureStats {
+			value := v.Load()
+			if value > 0 {
+				if k == templates.Unsigned && !r.options.Silent && !config.DefaultConfig.HideTemplateSigWarning {
+					r.Logger.Print().Msgf("[%v] Loading %d unsigned templates for scan. Use with caution.", r.colorizer.BrightYellow("WRN"), value)
+				} else {
+					r.Logger.Info().Msgf("Executing %d signed templates from %s", value, k)
+				}
+			}
+		}
+	}
+
+	if r.inputProvider.Count() > 0 {
+		r.Logger.Info().Msgf("Targets loaded for current scan: %d", r.inputProvider.Count())
+	}
+}
+
+// SaveResumeConfig to file
+func (r *Runner) SaveResumeConfig(path string) error {
+	dir := filepath.Dir(path)
+	if !fileutil.FolderExists(dir) {
+		if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+			return err
+		}
+	}
+	resumeCfgClone := r.resumeCfg.Clone()
+	resumeCfgClone.ResumeFrom = resumeCfgClone.Current
+	data, _ := json.MarshalIndent(resumeCfgClone, "", "\t")
+
+	return os.WriteFile(path, data, permissionutil.ConfigFilePermission)
+}
+
+// upload existing scan results to cloud with progress
+func UploadResultsToCloud(options *types.Options) error {
+	h := &pdcpauth.PDCPCredHandler{}
+	creds, err := h.GetCreds()
+	if err != nil {
+		return errors.Wrap(err, "could not get credentials for cloud upload")
+	}
+	ctx := context.TODO()
+	uploadWriter, err := pdcp.NewUploadWriter(ctx, options.Logger, creds)
+	if err != nil {
+		return errors.Wrap(err, "could not create upload writer")
+	}
+	if options.ScanID != "" {
+		_ = uploadWriter.SetScanID(options.ScanID)
+	}
+	if options.ScanName != "" {
+		uploadWriter.SetScanName(options.ScanName)
+	}
+	if options.TeamID != "" {
+		uploadWriter.SetTeamID(options.TeamID)
+	}
+
+	// Open file to count the number of results first
+	file, err := os.Open(options.ScanUploadFile)
+	if err != nil {
+		return errors.Wrap(err, "could not open scan upload file")
+	}
+	defer func() {
+		_ = file.Close()
+	}()
+
+	options.Logger.Info().Msgf("Uploading scan results to cloud dashboard from %s", options.ScanUploadFile)
+	dec := json.NewDecoder(file)
+	for dec.More() {
+		var r output.ResultEvent
+		err := dec.Decode(&r)
+		if err != nil {
+			options.Logger.Warning().Msgf("Could not decode jsonl: %s\n", err)
+			continue
+		}
+		if err = uploadWriter.Write(&r); err != nil {
+			options.Logger.Warning().Msgf("[%s] failed to upload: %s\n", r.TemplateID, err)
+		}
+	}
+	uploadWriter.Close()
+	return nil
+}
+
+type WalkFunc func(reflect.Value, reflect.StructField)
+
+// Walk traverses a struct and executes a callback function on each value in the struct.
+// The interface{} passed to the function should be a pointer to a struct or a struct.
+// WalkFunc is the callback function used for each value in the struct. It is passed the
+// reflect.Value and reflect.Type properties of the value in the struct.
+func Walk(s interface{}, callback WalkFunc) {
+	structValue := reflect.ValueOf(s)
+	if structValue.Kind() == reflect.Ptr {
+		structValue = structValue.Elem()
+	}
+	if structValue.Kind() != reflect.Struct {
+		return
+	}
+	for i := 0; i < structValue.NumField(); i++ {
+		field := structValue.Field(i)
+		fieldType := structValue.Type().Field(i)
+		if !fieldType.IsExported() {
+			continue
+		}
+		if field.Kind() == reflect.Struct {
+			Walk(field.Addr().Interface(), callback)
+		} else if field.Kind() == reflect.Ptr && field.Elem().Kind() == reflect.Struct {
+			Walk(field.Interface(), callback)
+		} else {
+			callback(field, fieldType)
+		}
+	}
+}
+
+// expandEndVars looks for values in a struct tagged with "yaml" and checks if they are prefixed with '$'.
+// If they are, it will try to retrieve the value from the environment and if it exists, it will set the
+// value of the field to that of the environment variable.
+func expandEndVars(f reflect.Value, fieldType reflect.StructField) {
+	if _, ok := fieldType.Tag.Lookup("yaml"); !ok {
+		return
+	}
+	if f.Kind() == reflect.String {
+		str := f.String()
+		if strings.HasPrefix(str, "$") {
+			env := strings.TrimPrefix(str, "$")
+			retrievedEnv := os.Getenv(env)
+			if retrievedEnv != "" {
+				f.SetString(os.Getenv(env))
+			}
+		}
+	}
+}
+
+func init() {
+	HideAutoSaveMsg = env.GetEnvOrDefault("DISABLE_CLOUD_UPLOAD_WRN", false)
+	EnableCloudUpload = env.GetEnvOrDefault("ENABLE_CLOUD_UPLOAD", false)
+}

--- a/runner.go
+++ b/runner.go
@@ -193,7 +193,7 @@ func New(options *types.Options) (*Runner, error) {
 	runner.catalog = disk.NewCatalog(config.DefaultConfig.TemplatesDirectory)
 
 	var httpclient *retryablehttp.Client
-	if options.ProxyInternal && options.AliveHttpProxy != "" || options.AliveSocksProxy != "" {
+	if options.ProxyInternal && (options.AliveHttpProxy != "" || options.AliveSocksProxy != "") {
 		var err error
 		httpclient, err = httpclientpool.Get(options, &httpclientpool.Configuration{})
 		if err != nil {
@@ -725,12 +725,10 @@ func (r *Runner) RunEnumeration() error {
 	}
 
 	now := time.Now()
-	enumeration := false
 	var results *atomic.Bool
 	results, err = r.runStandardEnumeration(executorOpts, store, executorEngine)
-	enumeration = true
 
-	if !enumeration {
+	if err != nil {
 		return err
 	}
 
@@ -761,7 +759,7 @@ func (r *Runner) RunEnumeration() error {
 
 	// check if a passive scan was requested but no target was provided
 	if r.options.OfflineHTTP && len(r.options.Targets) == 0 && r.options.TargetsFilePath == "" {
-		return errors.Wrap(err, "missing required input (http response) to run passive templates")
+		return errors.New("missing required input (http response) to run passive templates")
 	}
 
 	return err

--- a/util.go
+++ b/util.go
@@ -1,0 +1,83 @@
+package automaticscan
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/config"
+	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/disk"
+	"github.com/projectdiscovery/nuclei/v3/pkg/templates"
+	"github.com/projectdiscovery/nuclei/v3/pkg/types"
+	sliceutil "github.com/projectdiscovery/utils/slice"
+)
+
+// getTemplateDirs returns template directories for given input
+// by default it returns default template directory
+func getTemplateDirs(opts Options) ([]string, error) {
+	defaultTemplatesDirectories := []string{config.DefaultConfig.GetTemplateDir()}
+	// adding custom template path if available
+	if len(opts.ExecuterOpts.Options.Templates) > 0 {
+		defaultTemplatesDirectories = append(defaultTemplatesDirectories, opts.ExecuterOpts.Options.Templates...)
+	}
+	// Collect path for default directories we want to look for templates in
+	var allTemplates []string
+	for _, directory := range defaultTemplatesDirectories {
+		templates, err := opts.ExecuterOpts.Catalog.GetTemplatePath(directory)
+		if err != nil {
+			return nil, errors.Wrap(err, "could not get templates in directory")
+		}
+		allTemplates = append(allTemplates, templates...)
+	}
+	allTemplates = sliceutil.Dedupe(allTemplates)
+	if len(allTemplates) == 0 {
+		return nil, fmt.Errorf("%w for given input", disk.ErrNoTemplatesFound)
+	}
+	return allTemplates, nil
+}
+
+// LoadTemplatesWithTags loads and returns templates with given tags
+func LoadTemplatesWithTags(opts Options, templateDirs []string, tags []string, logInfo bool) ([]*templates.Template, error) {
+	finalTemplates, err := opts.Store.LoadTemplatesWithTags(templateDirs, tags)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not load templates with tags")
+	}
+	if len(finalTemplates) == 0 {
+		return nil, errors.New("could not find any templates with tech tag")
+	}
+
+	if !opts.ExecuterOpts.Options.DisableClustering {
+		// cluster and reduce requests
+		totalReqBeforeCluster := getRequestCount(finalTemplates) * int(opts.Target.Count())
+		finalTemplates, clusterCount := templates.ClusterTemplates(finalTemplates, opts.ExecuterOpts)
+		totalReqAfterClustering := getRequestCount(finalTemplates) * int(opts.Target.Count())
+		if totalReqAfterClustering < totalReqBeforeCluster && logInfo {
+			opts.ExecuterOpts.Logger.Info().Msgf("Automatic scan tech-detect: Templates clustered: %d (Reduced %d Requests)", clusterCount, totalReqBeforeCluster-totalReqAfterClustering)
+		}
+	}
+
+	// log template loaded if VerboseVerbose flag is set
+	if opts.ExecuterOpts.Options.VerboseVerbose {
+		for _, tpl := range finalTemplates {
+			opts.ExecuterOpts.Logger.Print().Msgf("%s\n", templates.TemplateLogMessage(tpl.ID,
+				types.ToString(tpl.Info.Name),
+				tpl.Info.Authors.ToSlice(),
+				tpl.Info.SeverityHolder.Severity))
+		}
+
+	}
+	return finalTemplates, nil
+}
+
+// returns total requests count
+func getRequestCount(templates []*templates.Template) int {
+	count := 0
+	for _, template := range templates {
+		// ignore requests in workflows as total requests in workflow
+		// depends on what templates will be called in workflow
+		if len(template.Workflows) > 0 {
+			continue
+		}
+		count += template.TotalRequests
+	}
+	return count
+}

--- a/util.go
+++ b/util.go
@@ -69,9 +69,9 @@ func LoadTemplatesWithTags(opts Options, templateDirs []string, tags []string, l
 }
 
 // returns total requests count
-func getRequestCount(templates []*templates.Template) int {
+func getRequestCount(tmpls []*templates.Template) int {
 	count := 0
-	for _, template := range templates {
+	for _, template := range tmpls {
 		// ignore requests in workflows as total requests in workflow
 		// depends on what templates will be called in workflow
 		if len(template.Workflows) > 0 {


### PR DESCRIPTION
/claim #6674

### Fix: Replace Panic with Error in Template Loader
Refactored `LoadTemplatesWithTags` and the call chain to properly propagate errors instead of panicking when dialers are missing.

### Changes
- **`pkg/catalog/loader/loader.go`**: Updated `LoadTemplatesWithTags`, `LoadTemplates`, and `Load` to return errors instead of panicking.
- **`internal/runner/runner.go`**: Updated caller to handle error returns from `store.Load()`.
- **`internal/runner/lazy.go`**: Updated `GetLazyAuthFetchCallback` to handle errors.
- **`pkg/protocols/common/automaticscan/util.go`**: Updated helper to handle error returns.
- **`pkg/catalog/loader/loader_bench_test.go`**: Updated benchmark tests to accommodate the new function signatures.

### Verification
- Manual code review confirms error propagation throughout the call stack.
- Benchmark test signatures updated to prevent compilation failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lazy authentication template fetching for dynamic credential retrieval.
  * Full-featured template/workflow loader with advanced filtering, validation, metadata caching, remote/template URI support, and preprocessor hooks.
  * Runner framework for template-based enumeration with lifecycle management, resume support, tracing, and optional cloud result uploads.
  * Utilities to resolve template directories and load templates by tags with clustering and reporting.

* **Tests**
  * Added benchmarks for template loading and validation performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->