### PR TITLE
fix: use ordered map for deterministic path segment fuzzing

### DIFF
--- a/pkg/fuzz/component/path.go
+++ b/pkg/fuzz/component/path.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz/dataformat"
 	"github.com/projectdiscovery/retryablehttp-go"
+	mapsutil "github.com/projectdiscovery/utils/maps"
 	urlutil "github.com/projectdiscovery/utils/url"
 )
 
@@ -36,7 +37,8 @@ func (q *Path) Parse(req *retryablehttp.Request) (bool, error) {
 	q.value = NewValue("")
 
 	splitted := strings.Split(req.Path, "/")
-	values := make(map[string]interface{})
+	values := mapsutil.NewOrderedMap[string, any]()
+	count := 0
 	for i, segment := range splitted {
 		if segment == "" && i == 0 {
 			// Skip the first empty segment from leading "/"
@@ -47,10 +49,11 @@ func (q *Path) Parse(req *retryablehttp.Request) (bool, error) {
 			continue
 		}
 		// Use 1-based indexing and store individual segments
-		key := strconv.Itoa(len(values) + 1)
-		values[key] = segment
+		count++
+		key := strconv.Itoa(count)
+		values.Set(key, segment)
 	}
-	q.value.SetParsed(dataformat.KVMap(values), "")
+	q.value.SetParsed(dataformat.KVOrderedMap(&values), "")
 	return true, nil
 }
 
@@ -109,8 +112,12 @@ func (q *Path) Rebuild() (*retryablehttp.Request, error) {
 
 		// Check if we have a replacement for this segment
 		key := strconv.Itoa(segmentIndex)
-		if newValue, exists := q.value.parsed.Map.GetOrDefault(key, "").(string); exists && newValue != "" {
-			rebuiltSegments = append(rebuiltSegments, newValue)
+		if val := q.value.parsed.Get(key); val != nil {
+			if newValue, ok := val.(string); ok && newValue != "" {
+				rebuiltSegments = append(rebuiltSegments, newValue)
+			} else {
+				rebuiltSegments = append(rebuiltSegments, originalSegment)
+			}
 		} else {
 			rebuiltSegments = append(rebuiltSegments, originalSegment)
 		}

--- a/pkg/fuzz/component/path_test.go
+++ b/pkg/fuzz/component/path_test.go
@@ -80,6 +80,31 @@ func TestURLComponent_NestedPaths(t *testing.T) {
 	}
 }
 
+// TestPathComponent_DeterministicOrder verifies that path segments are always
+// iterated in insertion order, not random map order. This was the root cause of
+// https://github.com/projectdiscovery/nuclei/issues/6398.
+func TestPathComponent_DeterministicOrder(t *testing.T) {
+	for i := 0; i < 50; i++ {
+		path := NewPath()
+		req, err := retryablehttp.NewRequest(http.MethodGet, "https://example.com/blog/post/123/comments/456/replies", nil)
+		require.NoError(t, err)
+		found, err := path.Parse(req)
+		require.NoError(t, err)
+		require.True(t, found)
+
+		var keys []string
+		var values []string
+		_ = path.Iterate(func(key string, value interface{}) error {
+			keys = append(keys, key)
+			values = append(values, value.(string))
+			return nil
+		})
+
+		require.Equal(t, []string{"1", "2", "3", "4", "5", "6"}, keys, "iteration %d: keys must be in insertion order", i)
+		require.Equal(t, []string{"blog", "post", "123", "comments", "456", "replies"}, values, "iteration %d: values must be in insertion order", i)
+	}
+}
+
 func TestPathComponent_SQLInjection(t *testing.T) {
 	path := NewPath()
 	req, err := retryablehttp.NewRequest(http.MethodGet, "https://example.com/user/55/profile", nil)


### PR DESCRIPTION
### Summary

Fix non-deterministic path segment iteration that caused some segments (especially numeric parts like `55` in `/user/55/profile`) to be skipped during path-based fuzzing.

**Root cause:** `Path.Parse()` stored segments in a plain Go `map[string]interface{}`, which has [non-deterministic iteration order](https://go.dev/ref/spec#For_range). When `Path.Iterate()` was called during fuzzing, segments could be visited in any order, leading to inconsistent results across runs.

**Fix:** Switch to `OrderedMap` to guarantee insertion-order iteration, ensuring all path segments are consistently fuzzed in every run.

### Changes

| File | Change |
|------|--------|
| `pkg/fuzz/component/path.go` | Use `mapsutil.OrderedMap` in `Parse()`, use `KVOrderedMap()` instead of `KVMap()`, fix `Rebuild()` to use `KV.Get()` accessor |
| `pkg/fuzz/component/path_test.go` | Add `TestPathComponent_DeterministicOrder` (50 iterations verifying order) |

### Before / After

**Before (non-deterministic):** Running fuzzing on `/user/55/profile` sometimes skips the `55` segment:
```
[path-based-sqli] Sent HTTP request to http://127.0.0.1:8082/user/55/profile   ← "55" NOT fuzzed
```

**After (deterministic):** All segments are always fuzzed in order:
```
Key: 1, Value: user
Key: 2, Value: 55      ← always visited
Key: 3, Value: profile
Modified path: /user/55 OR True/profile
```

### Proof

All fuzz package tests pass:
```
ok  github.com/projectdiscovery/nuclei/v3/pkg/fuzz                0.092s
ok  github.com/projectdiscovery/nuclei/v3/pkg/fuzz/component      0.017s
ok  github.com/projectdiscovery/nuclei/v3/pkg/fuzz/dataformat      0.008s
```

Full `go build ./...` — no errors.

Closes #6398

/attempt #6398

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path segment handling to ensure consistent ordering throughout parsing and reconstruction operations.

* **Tests**
  * Added test verifying that path segments maintain insertion order across multiple iterations, confirming deterministic behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->