### PR TITLE
fix(js): prevent pool slot starvation under load

### DIFF
--- a/pkg/js/compiler/compiler.go
+++ b/pkg/js/compiler/compiler.go
@@ -135,6 +135,11 @@ func (c *Compiler) ExecuteWithOptions(program *goja.Program, args *ExecuteArgs, 
 			}
 		}()
 
+		// Propagate the deadline context so that ExecuteProgram (and both
+		// the pooled and non-pooled paths) can use it for slot acquisition
+		// and watchdog goroutines. Without this, opts.Context carries no
+		// deadline and pool slots are held indefinitely by zombie goroutines.
+		opts.Context = ctx
 		return ExecuteProgram(program, args, opts)
 	})
 	if err != nil {

--- a/pkg/js/compiler/non-pool.go
+++ b/pkg/js/compiler/non-pool.go
@@ -2,6 +2,7 @@ package compiler
 
 import (
 	"sync"
+	"sync/atomic"
 
 	"github.com/Mzack9999/goja"
 	syncutil "github.com/projectdiscovery/utils/sync"
@@ -16,8 +17,32 @@ var (
 
 func executeWithoutPooling(p *goja.Program, args *ExecuteArgs, opts *ExecuteOptions) (result goja.Value, err error) {
 	lazyFixedSgInit()
-	ephemeraljsc.Add()
-	defer ephemeraljsc.Done()
+	// Acquire a pool slot, respecting the execution deadline. Returns
+	// immediately if the context has already expired.
+	if err := ephemeraljsc.AddWithContext(opts.Context); err != nil {
+		return nil, err
+	}
+	// Watchdog: release the pool slot if the deadline expires while the
+	// goroutine is still running (zombie). See executeWithPoolingProgram
+	// for the full explanation. The atomic.Bool guarantees exactly one
+	// Done() call between the watchdog and the normal defer path.
+	var slotReleased atomic.Bool
+	done := make(chan struct{})
+	go func() {
+		select {
+		case <-opts.Context.Done():
+			if slotReleased.CompareAndSwap(false, true) {
+				ephemeraljsc.Done()
+			}
+		case <-done:
+		}
+	}()
+	defer func() {
+		close(done)
+		if slotReleased.CompareAndSwap(false, true) {
+			ephemeraljsc.Done()
+		}
+	}()
 	runtime := createNewRuntime()
 	return executeWithRuntime(runtime, p, args, opts)
 }

--- a/pkg/js/compiler/pool.go
+++ b/pkg/js/compiler/pool.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"reflect"
 	"sync"
+	"sync/atomic"
 
 	"github.com/Mzack9999/goja"
 	"github.com/Mzack9999/goja_nodejs/console"
@@ -85,6 +86,7 @@ func executeWithRuntime(runtime *goja.Runtime, p *goja.Program, args *ExecuteArg
 			opts.Cleanup(runtime)
 		}
 		runtime.RemoveContextValue("executionId")
+		runtime.RemoveContextValue("ctx")
 	}()
 
 	// TODO(dwisiswant0): remove this once we get the RCA.
@@ -113,6 +115,7 @@ func executeWithRuntime(runtime *goja.Runtime, p *goja.Program, args *ExecuteArg
 
 	// inject execution id and context
 	runtime.SetContextValue("executionId", opts.ExecutionId)
+	runtime.SetContextValue("ctx", opts.Context)
 
 	// execute the script
 	return runtime.RunProgram(p)
@@ -139,8 +142,34 @@ func executeWithPoolingProgram(p *goja.Program, args *ExecuteArgs, opts *Execute
 	lazySgInit()
 	sgResizeCheck(opts.Context)
 
-	pooljsc.Add()
-	defer pooljsc.Done()
+	// Acquire a pool slot, respecting the execution deadline. Returns
+	// immediately if the context has already expired.
+	if err := pooljsc.AddWithContext(opts.Context); err != nil {
+		return nil, err
+	}
+	// Watchdog: release the pool slot if the deadline expires while the
+	// goroutine is still running (zombie). ExecFuncWithTwoReturns abandons
+	// the caller on timeout, but the goroutine keeps running and holds its
+	// slot via defer. The watchdog ensures the slot is freed at the deadline
+	// so the pool doesn't starve. The atomic.Bool guarantees exactly one
+	// Done() call between the watchdog and the normal defer path.
+	var slotReleased atomic.Bool
+	done := make(chan struct{})
+	go func() {
+		select {
+		case <-opts.Context.Done():
+			if slotReleased.CompareAndSwap(false, true) {
+				pooljsc.Done()
+			}
+		case <-done:
+		}
+	}()
+	defer func() {
+		close(done)
+		if slotReleased.CompareAndSwap(false, true) {
+			pooljsc.Done()
+		}
+	}()
 	runtime := gojapool.Get().(*goja.Runtime)
 	defer gojapool.Put(runtime)
 	var buff bytes.Buffer

--- a/pkg/js/compiler/pool_test.go
+++ b/pkg/js/compiler/pool_test.go
@@ -1,0 +1,141 @@
+package compiler
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	syncutil "github.com/projectdiscovery/utils/sync"
+)
+
+// TestAddWithContextRespectsDeadline verifies that AddWithContext returns an
+// error when the context deadline expires while waiting for a pool slot.
+// Before the fix, Add() used context.Background() and would block indefinitely.
+func TestAddWithContextRespectsDeadline(t *testing.T) {
+	pool, err := syncutil.New(syncutil.WithSize(1))
+	require.NoError(t, err)
+
+	// Fill the only slot.
+	pool.Add()
+	defer pool.Done()
+
+	// Try to acquire with a short deadline — should fail fast, not hang.
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	err = pool.AddWithContext(ctx)
+	elapsed := time.Since(start)
+
+	require.Error(t, err, "AddWithContext should fail when pool is full and deadline expires")
+	require.Less(t, elapsed, 200*time.Millisecond, "AddWithContext should fail fast after deadline")
+}
+
+// TestWatchdogReleasesSlotOnDeadline verifies that the watchdog goroutine
+// releases a pool slot when the execution deadline expires, even if the
+// worker goroutine is still running (zombie). This is the core fix for
+// pool slot starvation: without the watchdog, a zombie goroutine holds its
+// slot via defer Done() until its network call eventually times out (or never).
+func TestWatchdogReleasesSlotOnDeadline(t *testing.T) {
+	pool, err := syncutil.New(syncutil.WithSize(1))
+	require.NoError(t, err)
+
+	// Acquire the only slot (simulates a JS execution starting).
+	pool.Add()
+
+	// Set up the watchdog pattern (same as our fix in pool.go / non-pool.go).
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	var slotReleased atomic.Bool
+	watchdogDone := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			if slotReleased.CompareAndSwap(false, true) {
+				pool.Done()
+			}
+		case <-watchdogDone:
+		}
+	}()
+	defer func() {
+		close(watchdogDone)
+		if slotReleased.CompareAndSwap(false, true) {
+			pool.Done()
+		}
+	}()
+
+	// Wait for the deadline to fire and the watchdog to release the slot.
+	<-ctx.Done()
+	time.Sleep(20 * time.Millisecond)
+
+	// A new execution should be able to acquire the slot, even though the
+	// "zombie" never called Done() itself.
+	freshCtx, freshCancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer freshCancel()
+	require.NoError(t, pool.AddWithContext(freshCtx),
+		"slot acquisition should succeed after watchdog release")
+	pool.Done()
+}
+
+// TestPoolExhaustionRecovery demonstrates the complete starvation/recovery
+// cycle. All pool slots are filled with zombie goroutines that block well
+// beyond their deadline. The watchdog pattern frees the slots when the
+// deadlines expire, allowing subsequent executions to proceed.
+//
+// Without the fix, the pool stays permanently exhausted and every subsequent
+// AddWithContext call fails (or Add() blocks forever).
+func TestPoolExhaustionRecovery(t *testing.T) {
+	const poolSize = 3
+	pool, err := syncutil.New(syncutil.WithSize(poolSize))
+	require.NoError(t, err)
+
+	// Fill every slot with a "zombie" that blocks for 10s but has a 100ms
+	// deadline. The watchdog should free each slot after ~100ms.
+	for i := range poolSize {
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+
+		require.NoError(t, pool.AddWithContext(ctx), "initial slot acquisition %d", i)
+
+		var released atomic.Bool
+		done := make(chan struct{})
+
+		// Watchdog: release slot when deadline expires.
+		go func() {
+			select {
+			case <-ctx.Done():
+				if released.CompareAndSwap(false, true) {
+					pool.Done()
+				}
+			case <-done:
+			}
+		}()
+
+		// Zombie worker: blocks for 10s simulating a hung network call.
+		go func() {
+			defer func() {
+				close(done)
+				if released.CompareAndSwap(false, true) {
+					pool.Done()
+				}
+			}()
+			time.Sleep(10 * time.Second)
+		}()
+	}
+
+	// Pool is fully saturated. Wait for all deadlines to expire.
+	time.Sleep(200 * time.Millisecond)
+
+	// All slots should now be free. Acquire and release each one.
+	for i := range poolSize {
+		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		defer cancel()
+		require.NoError(t, pool.AddWithContext(ctx),
+			"post-recovery slot acquisition %d/%d (pool still starved)", i+1, poolSize)
+		pool.Done()
+	}
+}


### PR DESCRIPTION
## Proposed changes

Partially addresses #6894 — JS protocol templates silently drop all matches
under load. This PR fixes pool slot starvation (the primary cause); a follow-up
is needed to propagate execution contexts into JS library network calls.

**Root cause:** zombie goroutines from timed-out JS executions hold pool slots
indefinitely. `compiler.go` creates a 20s deadline context but passes the
original (no-deadline) context to `ExecuteProgram`. Both `pooljsc.Add()` and
`ephemeraljsc.Add()` block with `context.Background()`, so goroutines waiting
for a slot never fail fast. Once a slot is acquired, JS library network calls
use `context.TODO()` — they hang on non-matching targets with no deadline.
`ExecFuncWithTwoReturns` abandons the caller after 20s, but the goroutine
continues holding its pool slot via `defer Done()`. Both pools (80 pooled + 20
non-pooled slots) fill with zombies; subsequent executions time out waiting for
slots.

**Three changes fix slot lifecycle management:**

1. **Propagate the deadline context** (`compiler.go`): set `opts.Context = ctx`
   before calling `ExecuteProgram` so the 20s deadline flows through to both
   execution paths.

2. **Fail-fast slot acquisition** (`pool.go`, `non-pool.go`): replace `Add()`
   with `AddWithContext(ctx)`. Goroutines waiting for a slot return immediately
   when the deadline expires instead of blocking indefinitely.

3. **Watchdog goroutine** (`pool.go`, `non-pool.go`): a background goroutine
   listens on `ctx.Done()` and releases the pool slot when the deadline expires,
   even if the zombie is still running. An `atomic.Bool` ensures exactly one
   `Done()` call between the watchdog and the normal defer path.

**Note:** this PR does not address `context.TODO()` usage in the 16 JS library
files. That is a follow-up concern. The watchdog already prevents permanent pool
starvation; context propagation into JS libraries would make zombies exit faster.

### Proof

#### Setup

**1. Start a Redis container (no password):**

```shell
docker run -d --name redis-repro -p 6379:6379 redis:latest
```

**2. Save as `listeners.py` and start 25 TCP listeners (15s response delay):**

Each listener accepts a connection, waits 15 seconds, then responds with
garbage. The 15s delay is within Nuclei's default JS execution timeout (20s)
but long enough to hold pool slots. Open ports cause `isPortOpen` pre-conditions
to pass, so JS templates execute against all listeners and consume pool slots.

<details>
<summary>listeners.py</summary>

```python
#!/usr/bin/env python3
"""Start TCP listeners that accept connections but don't speak Redis."""
import socket
import threading
import signal
import sys
import time

PORT_START = 20000
COUNT = int(sys.argv[1]) if len(sys.argv) > 1 else 25
DELAY = 15

def handle_conn(conn):
    try:
        conn.recv(1024)
        time.sleep(DELAY)
        conn.sendall(b"-ERR not redis\r\n")
    except Exception:
        pass
    finally:
        conn.close()

def listener(port):
    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
    s.bind(('127.0.0.1', port))
    s.listen(5)
    while True:
        try:
            conn, _ = s.accept()
            threading.Thread(target=handle_conn, args=(conn,), daemon=True).start()
        except OSError:
            break

for p in range(PORT_START, PORT_START + COUNT):
    threading.Thread(target=listener, args=(p,), daemon=True).start()

print(f"Listening on {COUNT} ports ({PORT_START}-{PORT_START + COUNT - 1}), delay={DELAY}s")
signal.pause()
```

</details>

```shell
python3 listeners.py 25
```

**3. Generate target list (25 haystack + 1 Redis last):**

```shell
python3 -c "
for i in range(20000, 20025):
    print(f'localhost:{i}')
print('localhost:6379')
" > targets.txt
```

#### Baseline — single target (identical on both dev and fix)

```
$ nuclei -t ~/nuclei-templates/javascript/ -target localhost:6379 -no-mhe -silent
[redis-default-logins] [javascript] [high] localhost:6379 [passwords=""]
[redis-default-logins] [javascript] [high] localhost:6379 [passwords="iamadmin"]
[redis-default-logins] [javascript] [high] localhost:6379 [passwords="root"]
[redis-default-logins] [javascript] [high] localhost:6379 [passwords="password"]
[redis-default-logins] [javascript] [high] localhost:6379 [passwords="admin"]
[redis-info] [javascript] [info] localhost:6379
[snmpv3-detect] [javascript] [info] localhost:6379
```

7 matches.

#### Under load — dev branch (567794f7), 3 consecutive runs

```
$ nuclei -t ~/nuclei-templates/javascript/ -l targets.txt -no-mhe -silent | wc -l
0
$ nuclei -t ~/nuclei-templates/javascript/ -l targets.txt -no-mhe -silent | wc -l
0
$ nuclei -t ~/nuclei-templates/javascript/ -l targets.txt -no-mhe -silent | wc -l
0
```

**0 matches every time.** All results silently dropped.

#### Under load — this branch, 3 consecutive runs

```
$ nuclei -t ~/nuclei-templates/javascript/ -l targets.txt -no-mhe -silent | wc -l
15
$ nuclei -t ~/nuclei-templates/javascript/ -l targets.txt -no-mhe -silent | wc -l
33
$ nuclei -t ~/nuclei-templates/javascript/ -l targets.txt -no-mhe -silent | wc -l
9
```

**9–33 matches per run** (vs 0 on dev). All three runs find `redis-info`
(Export, pooled path). `redis-default-logins` (non-Export, 20-slot path)
recovered in 2 of 3 runs. The remaining variance is caused by `context.TODO()`
in JS library network calls — zombie goroutines still hold slots for up to 15s
(the listener delay) before completing, limiting throughput on the crowded
20-slot non-pooled path. That is a follow-up fix.

#### Unit tests

Three new tests in `pkg/js/compiler/pool_test.go` verify the fix mechanics:

- `TestAddWithContextRespectsDeadline` — slot acquisition fails fast when
  deadline expires (vs blocking indefinitely with `Add()`)
- `TestWatchdogReleasesSlotOnDeadline` — watchdog frees a slot held by a zombie,
  allowing a new execution to acquire it
- `TestPoolExhaustionRecovery` — full starvation/recovery cycle: all slots
  filled with zombies, deadlines expire, subsequent acquisitions succeed

```
$ go test -race -v -run 'TestAddWithContext|TestWatchdog|TestPoolExhaustion' ./pkg/js/compiler/...
=== RUN   TestAddWithContextRespectsDeadline
--- PASS: TestAddWithContextRespectsDeadline (0.05s)
=== RUN   TestWatchdogReleasesSlotOnDeadline
--- PASS: TestWatchdogReleasesSlotOnDeadline (0.07s)
=== RUN   TestPoolExhaustionRecovery
--- PASS: TestPoolExhaustionRecovery (0.20s)
PASS
```

## Checklist

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Script execution now respects outer cancellation and deadlines, making timeouts more predictable.
  * Resource pool handling and cleanup are more robust, ensuring slots are reliably released when executions are cancelled or time out.

* **Tests**
  * Added tests validating deadline-aware acquisitions, watchdog-driven slot release on deadline, and pool exhaustion recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->