### PR TITLE
fix: fuzzing no longer skips numeric path segments

### DIFF
--- a/pkg/fuzz/component/path.go
+++ b/pkg/fuzz/component/path.go
@@ -2,11 +2,13 @@ package component
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"strings"
 
 	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz/dataformat"
 	"github.com/projectdiscovery/retryablehttp-go"
+	mapsutil "github.com/projectdiscovery/utils/maps"
 	urlutil "github.com/projectdiscovery/utils/url"
 )
 
@@ -36,7 +38,8 @@ func (q *Path) Parse(req *retryablehttp.Request) (bool, error) {
 	q.value = NewValue("")
 
 	splitted := strings.Split(req.Path, "/")
-	values := make(map[string]interface{})
+	values := mapsutil.NewOrderedMap[string, any]()
+	idx := 0
 	for i, segment := range splitted {
 		if segment == "" && i == 0 {
 			// Skip the first empty segment from leading "/"
@@ -47,10 +50,11 @@ func (q *Path) Parse(req *retryablehttp.Request) (bool, error) {
 			continue
 		}
 		// Use 1-based indexing and store individual segments
-		key := strconv.Itoa(len(values) + 1)
-		values[key] = segment
+		idx++
+		key := strconv.Itoa(idx)
+		values.Set(key, segment)
 	}
-	q.value.SetParsed(dataformat.KVMap(values), "")
+	q.value.SetParsed(dataformat.KVOrderedMap(&values), "")
 	return true, nil
 }
 
@@ -109,8 +113,12 @@ func (q *Path) Rebuild() (*retryablehttp.Request, error) {
 
 		// Check if we have a replacement for this segment
 		key := strconv.Itoa(segmentIndex)
-		if newValue, exists := q.value.parsed.Map.GetOrDefault(key, "").(string); exists && newValue != "" {
-			rebuiltSegments = append(rebuiltSegments, newValue)
+		if got := q.value.parsed.Get(key); got != nil {
+			if newValue := fmt.Sprint(got); newValue != "" {
+				rebuiltSegments = append(rebuiltSegments, newValue)
+			} else {
+				rebuiltSegments = append(rebuiltSegments, originalSegment)
+			}
 		} else {
 			rebuiltSegments = append(rebuiltSegments, originalSegment)
 		}

--- a/pkg/fuzz/component/path_test.go
+++ b/pkg/fuzz/component/path_test.go
@@ -1,6 +1,7 @@
 package component
 
 import (
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -126,4 +127,81 @@ func TestPathComponent_SQLInjection(t *testing.T) {
 
 	// Let's also test what the actual URL looks like
 	t.Logf("Full URL: %s", newReq.String())
+}
+
+// TestPathComponent_DeterministicIteration verifies that path segments are
+// iterated in insertion order (1, 2, 3, ...) every time, not in random map
+// order. This is the regression test for issue #6398 where numeric path
+// parts like "55" in /user/55/profile were non-deterministically skipped
+// during fuzzing because the underlying storage was a plain Go map.
+func TestPathComponent_DeterministicIteration(t *testing.T) {
+	const url = "https://example.com/user/55/profile/edit"
+	expectedKeys := []string{"1", "2", "3", "4"}
+	expectedVals := []string{"user", "55", "profile", "edit"}
+
+	// Run enough iterations to surface random map ordering if present.
+	// With 4 keys a plain map produces the correct order ~1/24 of the
+	// time, so 100 iterations gives >99.99% chance of catching it.
+	for i := 0; i < 100; i++ {
+		req, err := retryablehttp.NewRequest(http.MethodGet, url, nil)
+		require.NoError(t, err)
+
+		p := NewPath()
+		found, err := p.Parse(req)
+		require.NoError(t, err)
+		require.True(t, found)
+
+		var keys, vals []string
+		_ = p.Iterate(func(key string, value interface{}) error {
+			keys = append(keys, key)
+			vals = append(vals, fmt.Sprint(value))
+			return nil
+		})
+
+		require.Equal(t, expectedKeys, keys, "iteration %d: keys out of order", i)
+		require.Equal(t, expectedVals, vals, "iteration %d: values out of order", i)
+	}
+}
+
+// TestPathComponent_NumericSegmentFuzz verifies that every path segment,
+// including purely numeric ones, gets fuzzed when iterating in single mode.
+// This directly reproduces the scenario from issue #6398.
+func TestPathComponent_NumericSegmentFuzz(t *testing.T) {
+	for iter := 0; iter < 50; iter++ {
+		req, err := retryablehttp.NewRequest(http.MethodGet, "https://example.com/user/55/profile", nil)
+		require.NoError(t, err)
+
+		p := NewPath()
+		found, err := p.Parse(req)
+		require.NoError(t, err)
+		require.True(t, found)
+
+		// Simulate single-mode fuzzing: iterate, fuzz one segment, rebuild, restore.
+		var rebuiltPaths []string
+		var allKeys []string
+		_ = p.Iterate(func(key string, value interface{}) error {
+			allKeys = append(allKeys, key)
+			orig := fmt.Sprint(value)
+			err := p.SetValue(key, orig+" OR True")
+			require.NoError(t, err)
+
+			rebuilt, err := p.Rebuild()
+			require.NoError(t, err)
+			rebuiltPaths = append(rebuiltPaths, rebuilt.Path)
+
+			// restore original
+			err = p.SetValue(key, orig)
+			require.NoError(t, err)
+			return nil
+		})
+
+		require.Equal(t, []string{"1", "2", "3"}, allKeys,
+			"iteration %d: not all segments iterated", iter)
+		require.Contains(t, rebuiltPaths, "/user OR True/55/profile",
+			"iteration %d: segment 'user' not fuzzed", iter)
+		require.Contains(t, rebuiltPaths, "/user/55 OR True/profile",
+			"iteration %d: numeric segment '55' not fuzzed", iter)
+		require.Contains(t, rebuiltPaths, "/user/55/profile OR True",
+			"iteration %d: segment 'profile' not fuzzed", iter)
+	}
 }


### PR DESCRIPTION
/claim #6398

## Proposed Changes

Fixes the non-deterministic path segment skipping during fuzz runs, which was particularly visible with numeric path parts (e.g. `/user/55/profile`).

**Root cause:** `Path.Parse()` stored path segments in a plain Go `map[string]interface{}`. Go maps have randomized iteration order, so when the fuzzing engine iterated over path segments in single mode, the order was non-deterministic. This meant that on some runs, certain segments (often numeric ones like `55`) would be iterated before or after others in unpredictable ways, leading to fuzzed requests being generated for the wrong segment position or segments being skipped entirely.

The bug was intermittent -- @dwisiswant0's testing showed only 3 out of 10 runs correctly fuzzed the `/user/55` segment -- which is consistent with random map ordering for a 3-key map (correct order ~1/6 of the time).

**Fix:** Switch `Path.Parse()` from a plain `map` to `mapsutil.OrderedMap`, which preserves insertion order. This matches the pattern already used by the cookie component. Also update `Rebuild()` to use the `KV.Get()` accessor instead of directly accessing the `Map` field (which is `nil` when using `OrderedMap`).

## Proof

**Before (plain map, non-deterministic):** Running the test 10 times shows random iteration order -- segments processed in different orders each run, causing some segments to be skipped in the rebuilt path.

**After (ordered map, deterministic):** New regression tests run 50-100 iterations and verify that:
1. Path segments are always iterated in insertion order (1, 2, 3, ...)
2. Every segment, including numeric ones, produces a correctly fuzzed rebuilt path

```
=== RUN   TestPathComponent_DeterministicIteration
--- PASS: TestPathComponent_DeterministicIteration (0.00s)
=== RUN   TestPathComponent_NumericSegmentFuzz
--- PASS: TestPathComponent_NumericSegmentFuzz (0.00s)
```

All existing tests continue to pass:

```
ok  github.com/projectdiscovery/nuclei/v3/pkg/fuzz                    0.094s
ok  github.com/projectdiscovery/nuclei/v3/pkg/fuzz/analyzers/time     0.956s
ok  github.com/projectdiscovery/nuclei/v3/pkg/fuzz/component          0.018s
ok  github.com/projectdiscovery/nuclei/v3/pkg/fuzz/dataformat         0.007s
ok  github.com/projectdiscovery/nuclei/v3/pkg/fuzz/stats              0.004s
```

## Checklist

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced path segment handling to preserve insertion order during fuzzing and retrieval operations with improved empty value handling.
* **Tests**
  * Added deterministic iteration tests verifying consistent segment ordering across multiple iterations.
  * Added numeric segment fuzzing tests to validate behavior across different segment types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->