### PR TITLE
fix: replace panic with error handling in template loader when dialers are missing

### DIFF
--- a/internal/runner/lazy.go
+++ b/internal/runner/lazy.go
@@ -67,7 +67,10 @@ func GetAuthTmplStore(opts *types.Options, catalog catalog.Catalog, execOpts *pr
 // GetLazyAuthFetchCallback returns a lazy fetch callback for auth secrets
 func GetLazyAuthFetchCallback(opts *AuthLazyFetchOptions) authx.LazyFetchSecret {
 	return func(d *authx.Dynamic) error {
-		tmpls := opts.TemplateStore.LoadTemplates([]string{d.TemplatePath})
+		tmpls, err := opts.TemplateStore.LoadTemplates([]string{d.TemplatePath})
+		if err != nil {
+			return fmt.Errorf("could not load template %s: %w", d.TemplatePath, err)
+		}
 		if len(tmpls) == 0 {
 			return fmt.Errorf("%w for path: %s", disk.ErrNoTemplatesFound, d.TemplatePath)
 		}

--- a/pkg/catalog/loader/loader.go
+++ b/pkg/catalog/loader/loader.go
@@ -334,7 +334,11 @@ func (store *Store) RegisterPreprocessor(preprocessor templates.Preprocessor) {
 // Load loads all the templates from a store, performs filtering and returns
 // the complete compiled templates for a nuclei execution configuration.
 func (store *Store) Load() {
-	store.templates = store.LoadTemplates(store.finalTemplates)
+	var err error
+	store.templates, err = store.LoadTemplates(store.finalTemplates)
+	if err != nil {
+		store.logger.Error().Msgf("Could not load templates: %s", err)
+	}
 	store.workflows = store.LoadWorkflows(store.finalWorkflows)
 }
 
@@ -637,7 +641,7 @@ func isParsingError(store *Store, message string, template string, err error) bo
 }
 
 // LoadTemplates takes a list of templates and returns paths for them
-func (store *Store) LoadTemplates(templatesList []string) []*templates.Template {
+func (store *Store) LoadTemplates(templatesList []string) ([]*templates.Template, error) {
 	return store.LoadTemplatesWithTags(templatesList, nil)
 }
 
@@ -668,7 +672,7 @@ func (store *Store) LoadWorkflows(workflowsList []string) []*templates.Template 
 
 // LoadTemplatesWithTags takes a list of templates and extra tags
 // returning templates that match.
-func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) []*templates.Template {
+func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) ([]*templates.Template, error) {
 	defer store.saveMetadataIndexOnce()
 
 	indexFilter := store.indexFilter
@@ -708,7 +712,7 @@ func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) []*templ
 
 	wgLoadTemplates, errWg := syncutil.New(syncutil.WithSize(concurrency))
 	if errWg != nil {
-		panic("could not create wait group")
+		return nil, fmt.Errorf("could not create wait group: %w", errWg)
 	}
 
 	if typesOpts.ExecutionId == "" {
@@ -717,7 +721,7 @@ func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) []*templ
 
 	dialers := protocolstate.GetDialersWithId(typesOpts.ExecutionId)
 	if dialers == nil {
-		panic("dialers with executionId " + typesOpts.ExecutionId + " not found")
+		return nil, fmt.Errorf("dialers with executionId %s not found", typesOpts.ExecutionId)
 	}
 
 	for _, templatePath := range includedTemplates {
@@ -852,7 +856,7 @@ func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) []*templ
 		return loadedTemplates.Slice[i].Path < loadedTemplates.Slice[j].Path
 	})
 
-	return loadedTemplates.Slice
+	return loadedTemplates.Slice, nil
 }
 
 // IsHTTPBasedProtocolUsed returns true if http/headless protocol is being used for

--- a/pkg/protocols/common/automaticscan/util.go
+++ b/pkg/protocols/common/automaticscan/util.go
@@ -37,7 +37,10 @@ func getTemplateDirs(opts Options) ([]string, error) {
 
 // LoadTemplatesWithTags loads and returns templates with given tags
 func LoadTemplatesWithTags(opts Options, templateDirs []string, tags []string, logInfo bool) ([]*templates.Template, error) {
-	finalTemplates := opts.Store.LoadTemplatesWithTags(templateDirs, tags)
+	finalTemplates, err := opts.Store.LoadTemplatesWithTags(templateDirs, tags)
+	if err != nil {
+		return nil, fmt.Errorf("could not load templates: %w", err)
+	}
 	if len(finalTemplates) == 0 {
 		return nil, errors.New("could not find any templates with tech tag")
 	}


### PR DESCRIPTION
## Description

Replaced `panic()` calls in `LoadTemplatesWithTags` with proper error returns, allowing callers to handle failures gracefully instead of crashing.

/claim #6674

## Changes

### `pkg/catalog/loader/loader.go`
- Changed `LoadTemplates()` signature to return `([]*templates.Template, error)`
- Changed `LoadTemplatesWithTags()` signature to return `([]*templates.Template, error)`
- Replaced `panic("could not create wait group")` with `return nil, fmt.Errorf(...)`
- Replaced `panic("dialers with executionId ... not found")` with `return nil, fmt.Errorf(...)`
- Updated `Load()` to handle error from `LoadTemplates()`

### `internal/runner/lazy.go`
- Updated `GetLazyAuthFetchCallback` to handle error from `LoadTemplates()`

### `pkg/protocols/common/automaticscan/util.go`
- Updated `LoadTemplatesWithTags` wrapper to propagate error from store method

## Testing
- All changes follow the existing codebase pattern of returning `fmt.Errorf` for error conditions
- No behavioral change for success paths; only error paths are improved
- Callers that previously would crash now receive descriptive errors

## Checklist
- [x] PR created against the `dev` branch
- [x] Descriptive commit message with issue reference
- [x] Changes are minimal and focused on the issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling for template loading operations to prevent silent failures and ensure proper error reporting when templates cannot be loaded successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->