### PR TITLE
fix(fuzz): implement deterministic path iteration to prevent skipping segments

### DIFF
--- a/pkg/fuzz/component/path.go
+++ b/pkg/fuzz/component/path.go
@@ -2,6 +2,7 @@ package component
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -10,7 +11,7 @@ import (
 	urlutil "github.com/projectdiscovery/utils/url"
 )
 
-// Path is a component for a request Path
+// Path is a component for a request URL Path that supports deterministic iteration.
 type Path struct {
 	value *Value
 
@@ -24,17 +25,18 @@ type Path struct {
 
 var _ Component = &Path{}
 
-// NewPath creates a new URL component
+// NewPath creates a new Path component instance.
 func NewPath() *Path {
 	return &Path{}
 }
 
-// Name returns the name of the component
+// Name returns the identifier for the Path component.
 func (q *Path) Name() string {
 	return RequestPathComponent
 }
 
-// Parse parses the component and returns the parsed component
+// Parse dissects the request path into individual segments and stores them internally.
+// It returns true if the path was successfully parsed.
 func (q *Path) Parse(req *retryablehttp.Request) (bool, error) {
 	q.req = req
 	q.value = NewValue("")
@@ -65,7 +67,8 @@ func (q *Path) Parse(req *retryablehttp.Request) (bool, error) {
 	return true, nil
 }
 
-// Iterate iterates through the component segments in a deterministic order
+// Iterate traverses the path segments in the exact order they appear in the URL.
+// This ensures predictable behavior for fuzzing engines.
 func (q *Path) Iterate(callback func(key string, value interface{}) error) (err error) {
 	// Instead of iterating over the random map, we iterate over our ordered keys.
 	// This ensures numeric path parts like "/55/" are always processed correctly.
@@ -73,7 +76,9 @@ func (q *Path) Iterate(callback func(key string, value interface{}) error) (err 
 		// Get the value from the parsed map using the deterministic key
 		val := q.value.parsed.Map.GetOrDefault(key, nil)
 		if val == nil {
-			continue
+			// Defensive check: if a key exists in q.keys but not in the map,
+			// we return an error to avoid silent bugs.
+			return fmt.Errorf("path component: key %q present in keys slice but missing from parsed map", key)
 		}
 
 		if errx := callback(key, val); errx != nil {
@@ -83,7 +88,7 @@ func (q *Path) Iterate(callback func(key string, value interface{}) error) (err 
 	return nil
 }
 
-// SetValue sets a value in the component for a key
+// SetValue replaces a specific path segment identified by its key with a new value.
 func (q *Path) SetValue(key string, value string) error {
 	escaped := urlutil.PathEncode(value)
 	if !q.value.SetParsedValue(key, escaped) {
@@ -92,13 +97,13 @@ func (q *Path) SetValue(key string, value string) error {
 	return nil
 }
 
-// Delete deletes a key from the component
+// Delete removes a path segment from the component and updates the order tracking.
 func (q *Path) Delete(key string) error {
 	if !q.value.Delete(key) {
 		return ErrKeyNotFound
 	}
 
-	// Remove the key from our ordered slice as well
+	// Remove the key from our ordered slice as well to keep them in sync
 	for i, v := range q.keys {
 		if v == key {
 			q.keys = append(q.keys[:i], q.keys[i+1:]...)
@@ -108,7 +113,7 @@ func (q *Path) Delete(key string) error {
 	return nil
 }
 
-// Rebuild returns a new request with the component rebuilt
+// Rebuild constructs a new HTTP request with the modified path segments.
 func (q *Path) Rebuild() (*retryablehttp.Request, error) {
 	// Get the original path segments
 	originalSplitted := strings.Split(q.req.Path, "/")
@@ -152,7 +157,7 @@ func (q *Path) Rebuild() (*retryablehttp.Request, error) {
 	return cloned, nil
 }
 
-// Clone clones current state to a new component
+// Clone creates a deep copy of the Path component, including the deterministic keys.
 func (q *Path) Clone() Component {
 	// Ensure we deep copy the keys slice to maintain determinism in the clone
 	newKeys := make([]string, len(q.keys))

--- a/pkg/fuzz/component/path.go
+++ b/pkg/fuzz/component/path.go
@@ -139,8 +139,9 @@ func (q *Path) Rebuild() (*retryablehttp.Request, error) {
 			continue
 		}
 
-		// Retrieve the value (it might have been changed by the fuzzer)
-		if newValue, exists := q.value.parsed.Map.GetOrDefault(key, "").(string); exists && newValue != "" {
+		// Type-assert to string; fall back to the original segment
+		// when the value is not a string or is empty to prevent broken paths.
+		if newValue, ok := q.value.parsed.Map.GetOrDefault(key, "").(string); ok && newValue != "" {
 			rebuiltSegments = append(rebuiltSegments, newValue)
 		} else {
 			rebuiltSegments = append(rebuiltSegments, originalSegment)

--- a/pkg/fuzz/component/path.go
+++ b/pkg/fuzz/component/path.go
@@ -15,6 +15,11 @@ type Path struct {
 	value *Value
 
 	req *retryablehttp.Request
+
+	// keys stores the order of path segments to ensure deterministic iteration.
+	// This fixes issue #6398 where numeric segments were skipped due to
+	// random map iteration in Go.
+	keys []string
 }
 
 var _ Component = &Path{}
@@ -29,14 +34,15 @@ func (q *Path) Name() string {
 	return RequestPathComponent
 }
 
-// Parse parses the component and returns the
-// parsed component
+// Parse parses the component and returns the parsed component
 func (q *Path) Parse(req *retryablehttp.Request) (bool, error) {
 	q.req = req
 	q.value = NewValue("")
+	q.keys = []string{} // Reset keys
 
 	splitted := strings.Split(req.Path, "/")
 	values := make(map[string]interface{})
+
 	for i, segment := range splitted {
 		if segment == "" && i == 0 {
 			// Skip the first empty segment from leading "/"
@@ -46,28 +52,38 @@ func (q *Path) Parse(req *retryablehttp.Request) (bool, error) {
 			// Skip any other empty segments
 			continue
 		}
-		// Use 1-based indexing and store individual segments
+
+		// Create a 1-based index key
 		key := strconv.Itoa(len(values) + 1)
 		values[key] = segment
+
+		// Store the key in our slice to preserve insertion order
+		q.keys = append(q.keys, key)
 	}
+
 	q.value.SetParsed(dataformat.KVMap(values), "")
 	return true, nil
 }
 
-// Iterate iterates through the component
+// Iterate iterates through the component segments in a deterministic order
 func (q *Path) Iterate(callback func(key string, value interface{}) error) (err error) {
-	q.value.parsed.Iterate(func(key string, value any) bool {
-		if errx := callback(key, value); errx != nil {
-			err = errx
-			return false
+	// Instead of iterating over the random map, we iterate over our ordered keys.
+	// This ensures numeric path parts like "/55/" are always processed correctly.
+	for _, key := range q.keys {
+		// Get the value from the parsed map using the deterministic key
+		val := q.value.parsed.Map.GetOrDefault(key, nil)
+		if val == nil {
+			continue
 		}
-		return true
-	})
-	return
+
+		if errx := callback(key, val); errx != nil {
+			return errx
+		}
+	}
+	return nil
 }
 
-// SetValue sets a value in the component
-// for a key
+// SetValue sets a value in the component for a key
 func (q *Path) SetValue(key string, value string) error {
 	escaped := urlutil.PathEncode(value)
 	if !q.value.SetParsedValue(key, escaped) {
@@ -81,11 +97,18 @@ func (q *Path) Delete(key string) error {
 	if !q.value.Delete(key) {
 		return ErrKeyNotFound
 	}
+
+	// Remove the key from our ordered slice as well
+	for i, v := range q.keys {
+		if v == key {
+			q.keys = append(q.keys[:i], q.keys[i+1:]...)
+			break
+		}
+	}
 	return nil
 }
 
-// Rebuild returns a new request with the
-// component rebuilt
+// Rebuild returns a new request with the component rebuilt
 func (q *Path) Rebuild() (*retryablehttp.Request, error) {
 	// Get the original path segments
 	originalSplitted := strings.Split(q.req.Path, "/")
@@ -98,17 +121,16 @@ func (q *Path) Rebuild() (*retryablehttp.Request, error) {
 		rebuiltSegments = append(rebuiltSegments, "")
 	}
 
-	// Process each segment
-	segmentIndex := 1 // 1-based indexing for our stored values
+	// Process each segment using 1-based indexing
+	segmentIndex := 1
 	for i := 1; i < len(originalSplitted); i++ {
 		originalSegment := originalSplitted[i]
 		if originalSegment == "" {
-			// Skip empty segments
 			continue
 		}
 
-		// Check if we have a replacement for this segment
 		key := strconv.Itoa(segmentIndex)
+		// Retrieve the value (it might have been changed by the fuzzer)
 		if newValue, exists := q.value.parsed.Map.GetOrDefault(key, "").(string); exists && newValue != "" {
 			rebuiltSegments = append(rebuiltSegments, newValue)
 		} else {
@@ -117,20 +139,12 @@ func (q *Path) Rebuild() (*retryablehttp.Request, error) {
 		segmentIndex++
 	}
 
-	// Join the segments back into a path
 	rebuiltPath := strings.Join(rebuiltSegments, "/")
 
 	if unescaped, err := urlutil.PathDecode(rebuiltPath); err == nil {
-		// this is handle the case where anyportion of path has url encoded data
-		// by default the http/request official library will escape/encode special characters in path
-		// to avoid double encoding we unescape/decode already encoded value
-		//
-		// if there is a invalid url encoded value like %99 then it will still be encoded as %2599 and not %99
-		// the only way to make sure it stays as %99 is to implement raw request and unsafe for fuzzing as well
 		rebuiltPath = unescaped
 	}
 
-	// Clone the request and update the path
 	cloned := q.req.Clone(context.Background())
 	if err := cloned.UpdateRelPath(rebuiltPath, true); err != nil {
 		cloned.RawPath = rebuiltPath
@@ -138,10 +152,15 @@ func (q *Path) Rebuild() (*retryablehttp.Request, error) {
 	return cloned, nil
 }
 
-// Clones current state to a new component
+// Clone clones current state to a new component
 func (q *Path) Clone() Component {
+	// Ensure we deep copy the keys slice to maintain determinism in the clone
+	newKeys := make([]string, len(q.keys))
+	copy(newKeys, q.keys)
+
 	return &Path{
 		value: q.value.Clone(),
 		req:   q.req.Clone(context.Background()),
+		keys:  newKeys,
 	}
 }

--- a/pkg/fuzz/component/path.go
+++ b/pkg/fuzz/component/path.go
@@ -68,19 +68,15 @@ func (q *Path) Parse(req *retryablehttp.Request) (bool, error) {
 }
 
 // Iterate traverses the path segments in the exact order they appear in the URL.
-// This ensures predictable behavior for fuzzing engines.
+// It uses an ordered slice to guarantee deterministic behavior.
 func (q *Path) Iterate(callback func(key string, value interface{}) error) (err error) {
-	// Instead of iterating over the random map, we iterate over our ordered keys.
-	// This ensures numeric path parts like "/55/" are always processed correctly.
 	for _, key := range q.keys {
-		// Get the value from the parsed map using the deterministic key
-		val := q.value.parsed.Map.GetOrDefault(key, nil)
-		if val == nil {
-			// Defensive check: if a key exists in q.keys but not in the map,
-			// we return an error to avoid silent bugs.
+		// Use Has() for a precise existence check as suggested by review
+		if !q.value.parsed.Map.Has(key) {
 			return fmt.Errorf("path component: key %q present in keys slice but missing from parsed map", key)
 		}
 
+		val := q.value.parsed.Map.GetOrDefault(key, nil)
 		if errx := callback(key, val); errx != nil {
 			return errx
 		}
@@ -113,7 +109,8 @@ func (q *Path) Delete(key string) error {
 	return nil
 }
 
-// Rebuild constructs a new HTTP request with the modified path segments.
+// Rebuild constructs a new HTTP request with the modified path segments,
+// strictly respecting deletions and modifications.
 func (q *Path) Rebuild() (*retryablehttp.Request, error) {
 	// Get the original path segments
 	originalSplitted := strings.Split(q.req.Path, "/")
@@ -135,6 +132,13 @@ func (q *Path) Rebuild() (*retryablehttp.Request, error) {
 		}
 
 		key := strconv.Itoa(segmentIndex)
+
+		// Respect explicit deletions by checking if the key still exists in the map
+		if !q.value.parsed.Map.Has(key) {
+			segmentIndex++
+			continue
+		}
+
 		// Retrieve the value (it might have been changed by the fuzzer)
 		if newValue, exists := q.value.parsed.Map.GetOrDefault(key, "").(string); exists && newValue != "" {
 			rebuiltSegments = append(rebuiltSegments, newValue)

--- a/pkg/fuzz/component/path_test.go
+++ b/pkg/fuzz/component/path_test.go
@@ -8,137 +8,102 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestURLComponent verifies basic path parsing, iteration, and rebuilding logic.
 func TestURLComponent(t *testing.T) {
 	req, err := retryablehttp.NewRequest(http.MethodGet, "https://example.com/testpath", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	urlComponent := NewPath()
 	_, err = urlComponent.Parse(req)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	var keys []string
 	var values []string
-	_ = urlComponent.Iterate(func(key string, value interface{}) error {
+	err = urlComponent.Iterate(func(key string, value interface{}) error {
 		keys = append(keys, key)
 		values = append(values, value.(string))
 		return nil
 	})
+	require.NoError(t, err)
 
 	require.Equal(t, []string{"1"}, keys, "unexpected keys")
 	require.Equal(t, []string{"testpath"}, values, "unexpected values")
 
 	err = urlComponent.SetValue("1", "newpath")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	rebuilt, err := urlComponent.Rebuild()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	require.Equal(t, "/newpath", rebuilt.Path, "unexpected URL path")
 	require.Equal(t, "https://example.com/newpath", rebuilt.String(), "unexpected full URL")
 }
 
+// TestURLComponent_NestedPaths validates the component's ability to handle and modify
+// multiple nested path segments.
 func TestURLComponent_NestedPaths(t *testing.T) {
 	path := NewPath()
 	req, err := retryablehttp.NewRequest(http.MethodGet, "https://example.com/user/753/profile", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	found, err := path.Parse(req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !found {
-		t.Fatal("expected path to be found")
-	}
+	require.NoError(t, err)
+	require.True(t, found, "expected path to be found")
 
 	isSet := false
-
-	_ = path.Iterate(func(key string, value interface{}) error {
+	err = path.Iterate(func(key string, value interface{}) error {
 		t.Logf("Key: %s, Value: %s", key, value.(string))
 		if !isSet && value.(string) == "753" {
 			isSet = true
 			if setErr := path.SetValue(key, "753'"); setErr != nil {
-				t.Fatal(setErr)
+				return setErr
 			}
 		}
 		return nil
 	})
+	require.NoError(t, err)
 
 	newReq, err := path.Rebuild()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if newReq.Path != "/user/753'/profile" {
-		t.Fatalf("expected path to be '/user/753'/profile', got '%s'", newReq.Path)
-	}
+	require.NoError(t, err)
+	require.Equal(t, "/user/753'/profile", newReq.Path, "expected modified path mismatch")
 }
 
+// TestPathComponent_SQLInjection ensures that spaces and special characters used in
+// SQL injection payloads are correctly preserved in the rebuilt path.
 func TestPathComponent_SQLInjection(t *testing.T) {
 	path := NewPath()
 	req, err := retryablehttp.NewRequest(http.MethodGet, "https://example.com/user/55/profile", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	found, err := path.Parse(req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !found {
-		t.Fatal("expected path to be found")
-	}
+	require.NoError(t, err)
+	require.True(t, found, "expected path to be found")
 
-	t.Logf("Original path: %s", req.Path)
-
-	// Let's see what path segments are available for fuzzing
 	err = path.Iterate(func(key string, value interface{}) error {
-		t.Logf("Key: %s, Value: %s", key, value.(string))
-
-		// Try fuzzing the "55" segment specifically (which should be key "2")
 		if value.(string) == "55" {
 			if setErr := path.SetValue(key, "55 OR True"); setErr != nil {
-				t.Fatal(setErr)
+				return setErr
 			}
 		}
 		return nil
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	newReq, err := path.Rebuild()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	t.Logf("Modified path: %s", newReq.Path)
-
-	// Now with PathEncode, spaces are preserved correctly for SQL injection
-	if newReq.Path != "/user/55 OR True/profile" {
-		t.Fatalf("expected path to be '/user/55 OR True/profile', got '%s'", newReq.Path)
-	}
-
-	// Let's also test what the actual URL looks like
-	t.Logf("Full URL: %s", newReq.String())
+	require.NoError(t, err)
+	require.Equal(t, "/user/55 OR True/profile", newReq.Path, "SQL injection payload corruption")
 }
 
+// TestPathComponent_Determinism addresses issue #6398 by verifying that path
+// iteration remains 100% deterministic across multiple parsing cycles.
 func TestPathComponent_Determinism(t *testing.T) {
-	// Testing for non-deterministic behavior as reported in issue #6398.
-	// We use a path with mixed string and numeric segments.
 	pathStr := "/user/55/profile/settings/12345"
-	req, _ := retryablehttp.NewRequest(http.MethodGet, "https://example.com"+pathStr, nil)
+	// Fix: Captured and validated error from NewRequest
+	req, err := retryablehttp.NewRequest(http.MethodGet, "https://example.com"+pathStr, nil)
+	require.NoError(t, err)
 
-	// Expected deterministic order of segments
 	expected := []string{"user", "55", "profile", "settings", "12345"}
 
-	// Run the parse and iteration 100 times to ensure the order is stable.
-	// Standard Go maps iterate in random order, but our fix must remain consistent.
+	// Run multiple times to ensure Go's map randomization doesn't affect the order
 	for i := 0; i < 100; i++ {
 		p := NewPath()
 		found, err := p.Parse(req)
@@ -146,11 +111,13 @@ func TestPathComponent_Determinism(t *testing.T) {
 		require.True(t, found)
 
 		var results []string
-		_ = p.Iterate(func(key string, value interface{}) error {
+		// Fix: Captured and validated error from Iterate
+		err = p.Iterate(func(key string, value interface{}) error {
 			results = append(results, value.(string))
 			return nil
 		})
+		require.NoError(t, err)
 
-		require.Equal(t, expected, results, "Order mismatch detected at iteration %d", i)
+		require.Equal(t, expected, results, "Non-deterministic order at iteration %d", i)
 	}
 }

--- a/pkg/fuzz/component/path_test.go
+++ b/pkg/fuzz/component/path_test.go
@@ -127,3 +127,30 @@ func TestPathComponent_SQLInjection(t *testing.T) {
 	// Let's also test what the actual URL looks like
 	t.Logf("Full URL: %s", newReq.String())
 }
+
+func TestPathComponent_Determinism(t *testing.T) {
+	// Testing for non-deterministic behavior as reported in issue #6398.
+	// We use a path with mixed string and numeric segments.
+	pathStr := "/user/55/profile/settings/12345"
+	req, _ := retryablehttp.NewRequest(http.MethodGet, "https://example.com"+pathStr, nil)
+
+	// Expected deterministic order of segments
+	expected := []string{"user", "55", "profile", "settings", "12345"}
+
+	// Run the parse and iteration 100 times to ensure the order is stable.
+	// Standard Go maps iterate in random order, but our fix must remain consistent.
+	for i := 0; i < 100; i++ {
+		p := NewPath()
+		found, err := p.Parse(req)
+		require.NoError(t, err)
+		require.True(t, found)
+
+		var results []string
+		_ = p.Iterate(func(key string, value interface{}) error {
+			results = append(results, value.(string))
+			return nil
+		})
+
+		require.Equal(t, expected, results, "Order mismatch detected at iteration %d", i)
+	}
+}

--- a/pkg/fuzz/component/path_test.go
+++ b/pkg/fuzz/component/path_test.go
@@ -51,7 +51,6 @@ func TestURLComponent_NestedPaths(t *testing.T) {
 
 	isSet := false
 	err = path.Iterate(func(key string, value interface{}) error {
-		t.Logf("Key: %s, Value: %s", key, value.(string))
 		if !isSet && value.(string) == "753" {
 			isSet = true
 			if setErr := path.SetValue(key, "753'"); setErr != nil {
@@ -94,16 +93,14 @@ func TestPathComponent_SQLInjection(t *testing.T) {
 }
 
 // TestPathComponent_Determinism addresses issue #6398 by verifying that path
-// iteration remains 100% deterministic across multiple parsing cycles.
+// iteration remains 100% deterministic across 100 repeated cycles.
 func TestPathComponent_Determinism(t *testing.T) {
 	pathStr := "/user/55/profile/settings/12345"
-	// Fix: Captured and validated error from NewRequest
 	req, err := retryablehttp.NewRequest(http.MethodGet, "https://example.com"+pathStr, nil)
 	require.NoError(t, err)
 
 	expected := []string{"user", "55", "profile", "settings", "12345"}
 
-	// Run multiple times to ensure Go's map randomization doesn't affect the order
 	for i := 0; i < 100; i++ {
 		p := NewPath()
 		found, err := p.Parse(req)
@@ -111,13 +108,12 @@ func TestPathComponent_Determinism(t *testing.T) {
 		require.True(t, found)
 
 		var results []string
-		// Fix: Captured and validated error from Iterate
 		err = p.Iterate(func(key string, value interface{}) error {
 			results = append(results, value.(string))
 			return nil
 		})
 		require.NoError(t, err)
 
-		require.Equal(t, expected, results, "Non-deterministic order at iteration %d", i)
+		require.Equal(t, expected, results, "Non-deterministic order detected at iteration %d", i)
 	}
 }


### PR DESCRIPTION
I've been looking into the issue where the fuzzing engine was intermittently skipping path segments, specifically numeric IDs like /55/. It turned out to be a classic case of Go's map randomization. Since path segments were being stored and iterated over using a standard map, the order was non-deterministic, leading to inconsistent fuzzing results and flaky integration tests.

The Fix:
Instead of relying on the map's random iteration, I updated the Path component to track the original sequence of segments using an internal keys slice.

During Parse(), we now record the keys in the order they appear in the URL.

The Iterate() method now follows this slice, ensuring that every segment—including numeric ones—is consistently targeted every single time.

This approach keeps the implementation "Pure Go" and doesn't introduce any new external dependencies. I also made sure that Clone() handles the deep copy of these keys to keep parallel scans stable.

Verification:
To make sure this stays fixed, I added a regression test (TestPathComponent_Determinism) that runs the iteration logic 100 times to catch any potential non-determinism.

You can see the test passing below:

<img width="983" height="130" alt="image" src="https://github.com/user-attachments/assets/a7bfb665-8ac2-400f-9f7d-9efa4a1d88c6" />

/claim #6398

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Iteration and rebuilding of paths are now deterministic; deletions and clones preserve order and skip removed segments. Rebuilt paths retain injected values and special characters exactly.

* **Tests**
  * Added tests for nested path updates, payload preservation with special characters, and deterministic iteration across repeated parses; improved error assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->