### PR TITLE
fix: replace panic with error handling in template loader when dialers are missing

### DIFF
--- a/cmd/integration-test/library.go
+++ b/cmd/integration-test/library.go
@@ -132,7 +132,9 @@ func executeNucleiAsLibrary(templatePath, templateURL string) ([]string, error) 
 	if err != nil {
 		return nil, errors.Wrap(err, "could not create loader")
 	}
-	store.Load()
+	if err := store.Load(); err != nil {
+		return nil, errors.Wrap(err, "could not load templates")
+	}
 
 	_ = engine.Execute(context.Background(), store.Templates(), provider.NewSimpleInputProviderWithUrls(defaultOpts.ExecutionId, templateURL))
 	engine.WorkPool().Wait() // Wait for the scan to finish

--- a/internal/runner/lazy.go
+++ b/internal/runner/lazy.go
@@ -67,7 +67,10 @@ func GetAuthTmplStore(opts *types.Options, catalog catalog.Catalog, execOpts *pr
 // GetLazyAuthFetchCallback returns a lazy fetch callback for auth secrets
 func GetLazyAuthFetchCallback(opts *AuthLazyFetchOptions) authx.LazyFetchSecret {
 	return func(d *authx.Dynamic) error {
-		tmpls := opts.TemplateStore.LoadTemplates([]string{d.TemplatePath})
+		tmpls, err := opts.TemplateStore.LoadTemplates([]string{d.TemplatePath})
+		if err != nil {
+			return fmt.Errorf("could not load templates for path %s: %w", d.TemplatePath, err)
+		}
 		if len(tmpls) == 0 {
 			return fmt.Errorf("%w for path: %s", disk.ErrNoTemplatesFound, d.TemplatePath)
 		}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -660,7 +660,9 @@ func (r *Runner) RunEnumeration() error {
 		}
 		return nil // exit
 	}
-	store.Load()
+	if err := store.Load(); err != nil {
+		return err
+	}
 	// TODO: remove below functions after v3 or update warning messages
 	templates.PrintDeprecatedProtocolNameMsgIfApplicable(r.options.Silent, r.options.Verbose)
 

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -661,7 +661,7 @@ func (r *Runner) RunEnumeration() error {
 		return nil // exit
 	}
 	if err := store.Load(); err != nil {
-		return err
+		return errors.Wrap(err, "could not load templates")
 	}
 	// TODO: remove below functions after v3 or update warning messages
 	templates.PrintDeprecatedProtocolNameMsgIfApplicable(r.options.Silent, r.options.Verbose)

--- a/internal/server/nuclei_sdk.go
+++ b/internal/server/nuclei_sdk.go
@@ -125,7 +125,9 @@ func newNucleiExecutor(opts *NucleiExecutorOptions) (*nucleiExecutor, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "Could not create loader options.")
 	}
-	store.Load()
+	if err := store.Load(); err != nil {
+		return nil, errors.Wrap(err, "could not load templates")
+	}
 
 	return &nucleiExecutor{
 		engine:       executorEngine,

--- a/lib/multi.go
+++ b/lib/multi.go
@@ -150,7 +150,9 @@ func (e *ThreadSafeNucleiEngine) ExecuteNucleiWithOptsCtx(ctx context.Context, t
 	if err != nil {
 		return errkit.Wrapf(err, "Could not create loader client: %s", err)
 	}
-	store.Load()
+	if err := store.Load(); err != nil {
+		return errkit.Wrapf(err, "could not load templates")
+	}
 
 	inputProvider := provider.NewSimpleInputProviderWithUrls(e.eng.opts.ExecutionId, targets...)
 

--- a/lib/sdk.go
+++ b/lib/sdk.go
@@ -120,7 +120,9 @@ func (e *NucleiEngine) LoadAllTemplates() error {
 // GetTemplates returns all nuclei templates that are loaded
 func (e *NucleiEngine) GetTemplates() []*templates.Template {
 	if !e.templatesLoaded {
-		_ = e.LoadAllTemplates()
+		if err := e.LoadAllTemplates(); err != nil {
+			gologger.Warning().Msgf("could not load templates: %s", err)
+		}
 	}
 	return e.store.Templates()
 }
@@ -128,7 +130,9 @@ func (e *NucleiEngine) GetTemplates() []*templates.Template {
 // GetWorkflows returns all nuclei workflows that are loaded
 func (e *NucleiEngine) GetWorkflows() []*templates.Template {
 	if !e.templatesLoaded {
-		_ = e.LoadAllTemplates()
+		if err := e.LoadAllTemplates(); err != nil {
+			gologger.Warning().Msgf("could not load workflows: %s", err)
+		}
 	}
 	return e.store.Workflows()
 }

--- a/lib/sdk.go
+++ b/lib/sdk.go
@@ -265,7 +265,12 @@ func (e *NucleiEngine) Close() {
 // enable matcher-status option if you expect this callback to be called for all results regardless if it matched or not
 func (e *NucleiEngine) ExecuteCallbackWithCtx(ctx context.Context, callback ...func(event *output.ResultEvent)) error {
 	if !e.templatesLoaded {
-		_ = e.LoadAllTemplates()
+		if err := e.LoadAllTemplates(); err != nil {
+			gologger.Warning().Msgf("could not load templates: %s", err)
+		}
+	}
+	if e.store == nil {
+		return ErrNoTemplatesAvailable
 	}
 	if len(e.store.Templates()) == 0 && len(e.store.Workflows()) == 0 {
 		return ErrNoTemplatesAvailable

--- a/lib/sdk.go
+++ b/lib/sdk.go
@@ -124,6 +124,9 @@ func (e *NucleiEngine) GetTemplates() []*templates.Template {
 			gologger.Warning().Msgf("could not load templates: %s", err)
 		}
 	}
+	if e.store == nil {
+		return nil
+	}
 	return e.store.Templates()
 }
 
@@ -133,6 +136,9 @@ func (e *NucleiEngine) GetWorkflows() []*templates.Template {
 		if err := e.LoadAllTemplates(); err != nil {
 			gologger.Warning().Msgf("could not load workflows: %s", err)
 		}
+	}
+	if e.store == nil {
+		return nil
 	}
 	return e.store.Workflows()
 }

--- a/lib/sdk.go
+++ b/lib/sdk.go
@@ -110,7 +110,9 @@ func (e *NucleiEngine) LoadAllTemplates() error {
 	if err != nil {
 		return errkit.Wrapf(err, "Could not create loader client: %s", err)
 	}
-	e.store.Load()
+	if err := e.store.Load(); err != nil {
+		return errkit.Wrapf(err, "could not load templates")
+	}
 	e.templatesLoaded = true
 	return nil
 }

--- a/pkg/catalog/loader/loader.go
+++ b/pkg/catalog/loader/loader.go
@@ -333,9 +333,14 @@ func (store *Store) RegisterPreprocessor(preprocessor templates.Preprocessor) {
 
 // Load loads all the templates from a store, performs filtering and returns
 // the complete compiled templates for a nuclei execution configuration.
-func (store *Store) Load() {
-	store.templates = store.LoadTemplates(store.finalTemplates)
+func (store *Store) Load() error {
+	loadedTemplates, err := store.LoadTemplates(store.finalTemplates)
+	if err != nil {
+		return fmt.Errorf("could not load templates: %w", err)
+	}
+	store.templates = loadedTemplates
 	store.workflows = store.LoadWorkflows(store.finalWorkflows)
+	return nil
 }
 
 var templateIDPathMap map[string]string
@@ -637,7 +642,7 @@ func isParsingError(store *Store, message string, template string, err error) bo
 }
 
 // LoadTemplates takes a list of templates and returns paths for them
-func (store *Store) LoadTemplates(templatesList []string) []*templates.Template {
+func (store *Store) LoadTemplates(templatesList []string) ([]*templates.Template, error) {
 	return store.LoadTemplatesWithTags(templatesList, nil)
 }
 
@@ -668,7 +673,7 @@ func (store *Store) LoadWorkflows(workflowsList []string) []*templates.Template 
 
 // LoadTemplatesWithTags takes a list of templates and extra tags
 // returning templates that match.
-func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) []*templates.Template {
+func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) ([]*templates.Template, error) {
 	defer store.saveMetadataIndexOnce()
 
 	indexFilter := store.indexFilter
@@ -708,7 +713,7 @@ func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) []*templ
 
 	wgLoadTemplates, errWg := syncutil.New(syncutil.WithSize(concurrency))
 	if errWg != nil {
-		panic("could not create wait group")
+		return nil, fmt.Errorf("could not create wait group: %w", errWg)
 	}
 
 	if typesOpts.ExecutionId == "" {
@@ -717,7 +722,7 @@ func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) []*templ
 
 	dialers := protocolstate.GetDialersWithId(typesOpts.ExecutionId)
 	if dialers == nil {
-		panic("dialers with executionId " + typesOpts.ExecutionId + " not found")
+		return nil, fmt.Errorf("dialers with executionId %s not found", typesOpts.ExecutionId)
 	}
 
 	for _, templatePath := range includedTemplates {
@@ -852,7 +857,7 @@ func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) []*templ
 		return loadedTemplates.Slice[i].Path < loadedTemplates.Slice[j].Path
 	})
 
-	return loadedTemplates.Slice
+	return loadedTemplates.Slice, nil
 }
 
 // IsHTTPBasedProtocolUsed returns true if http/headless protocol is being used for

--- a/pkg/catalog/loader/loader_bench_test.go
+++ b/pkg/catalog/loader/loader_bench_test.go
@@ -71,7 +71,7 @@ func BenchmarkLoadTemplates(b *testing.B) {
 		b.ReportAllocs()
 
 		for b.Loop() {
-			_ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
+			_, _ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
 		}
 	})
 
@@ -89,7 +89,7 @@ func BenchmarkLoadTemplates(b *testing.B) {
 		b.ReportAllocs()
 
 		for b.Loop() {
-			_ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
+			_, _ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
 		}
 	})
 
@@ -107,7 +107,7 @@ func BenchmarkLoadTemplates(b *testing.B) {
 		b.ReportAllocs()
 
 		for b.Loop() {
-			_ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
+			_, _ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
 		}
 	})
 
@@ -125,7 +125,7 @@ func BenchmarkLoadTemplates(b *testing.B) {
 		b.ReportAllocs()
 
 		for b.Loop() {
-			_ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
+			_, _ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
 		}
 	})
 
@@ -143,7 +143,7 @@ func BenchmarkLoadTemplates(b *testing.B) {
 		b.ReportAllocs()
 
 		for b.Loop() {
-			_ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
+			_, _ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
 		}
 	})
 
@@ -161,7 +161,7 @@ func BenchmarkLoadTemplates(b *testing.B) {
 		b.ReportAllocs()
 
 		for b.Loop() {
-			_ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
+			_, _ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
 		}
 	})
 
@@ -181,7 +181,7 @@ func BenchmarkLoadTemplates(b *testing.B) {
 		b.ReportAllocs()
 
 		for b.Loop() {
-			_ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
+			_, _ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
 		}
 	})
 }

--- a/pkg/catalog/loader/loader_bench_test.go
+++ b/pkg/catalog/loader/loader_bench_test.go
@@ -71,7 +71,9 @@ func BenchmarkLoadTemplates(b *testing.B) {
 		b.ReportAllocs()
 
 		for b.Loop() {
-			_, _ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
+			if _, err := store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory}); err != nil {
+				b.Fatalf("could not load templates: %s", err)
+			}
 		}
 	})
 
@@ -89,7 +91,9 @@ func BenchmarkLoadTemplates(b *testing.B) {
 		b.ReportAllocs()
 
 		for b.Loop() {
-			_, _ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
+			if _, err := store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory}); err != nil {
+				b.Fatalf("could not load templates: %s", err)
+			}
 		}
 	})
 
@@ -107,7 +111,9 @@ func BenchmarkLoadTemplates(b *testing.B) {
 		b.ReportAllocs()
 
 		for b.Loop() {
-			_, _ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
+			if _, err := store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory}); err != nil {
+				b.Fatalf("could not load templates: %s", err)
+			}
 		}
 	})
 
@@ -125,7 +131,9 @@ func BenchmarkLoadTemplates(b *testing.B) {
 		b.ReportAllocs()
 
 		for b.Loop() {
-			_, _ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
+			if _, err := store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory}); err != nil {
+				b.Fatalf("could not load templates: %s", err)
+			}
 		}
 	})
 
@@ -143,7 +151,9 @@ func BenchmarkLoadTemplates(b *testing.B) {
 		b.ReportAllocs()
 
 		for b.Loop() {
-			_, _ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
+			if _, err := store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory}); err != nil {
+				b.Fatalf("could not load templates: %s", err)
+			}
 		}
 	})
 
@@ -161,7 +171,9 @@ func BenchmarkLoadTemplates(b *testing.B) {
 		b.ReportAllocs()
 
 		for b.Loop() {
-			_, _ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
+			if _, err := store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory}); err != nil {
+				b.Fatalf("could not load templates: %s", err)
+			}
 		}
 	})
 
@@ -181,7 +193,9 @@ func BenchmarkLoadTemplates(b *testing.B) {
 		b.ReportAllocs()
 
 		for b.Loop() {
-			_, _ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
+			if _, err := store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory}); err != nil {
+				b.Fatalf("could not load templates: %s", err)
+			}
 		}
 	})
 }

--- a/pkg/protocols/common/automaticscan/util.go
+++ b/pkg/protocols/common/automaticscan/util.go
@@ -37,7 +37,10 @@ func getTemplateDirs(opts Options) ([]string, error) {
 
 // LoadTemplatesWithTags loads and returns templates with given tags
 func LoadTemplatesWithTags(opts Options, templateDirs []string, tags []string, logInfo bool) ([]*templates.Template, error) {
-	finalTemplates := opts.Store.LoadTemplatesWithTags(templateDirs, tags)
+	finalTemplates, err := opts.Store.LoadTemplatesWithTags(templateDirs, tags)
+	if err != nil {
+		return nil, fmt.Errorf("could not load templates with tags: %w", err)
+	}
 	if len(finalTemplates) == 0 {
 		return nil, errors.New("could not find any templates with tech tag")
 	}


### PR DESCRIPTION
## Proposed Changes

Replaces two `panic()` calls in `LoadTemplatesWithTags` (`pkg/catalog/loader/loader.go`, lines ~714 and ~722) with proper error returns using `fmt.Errorf`, allowing callers to handle failures gracefully instead of crashing.

/claim #6674

### What changed

| File | Change |
|------|--------|
| `pkg/catalog/loader/loader.go` | `LoadTemplatesWithTags` returns `([]*templates.Template, error)`; `LoadTemplates` returns `([]*templates.Template, error)`; `Load()` returns `error`; both `panic()` calls replaced with `return nil, fmt.Errorf(...)` |
| `internal/runner/runner.go` | `Load()` error check added |
| `internal/runner/lazy.go` | `LoadTemplates` error handling added |
| `internal/server/nuclei_sdk.go` | `Load()` error check added |
| `lib/sdk.go` | `Load()` error check added |
| `lib/multi.go` | `Load()` error check added |
| `cmd/integration-test/library.go` | `Load()` error check added |
| `pkg/protocols/common/automaticscan/util.go` | `LoadTemplatesWithTags` error handling added |
| `pkg/catalog/loader/loader_bench_test.go` | Updated to handle `(_, error)` return |

### Why these changes

The current code panics when:
1. `syncutil.New()` fails to create a wait group
2. `protocolstate.GetDialersWithId()` returns nil (dialers not initialized)

This is too harsh for a public API that may be exercised in non-scanning flows. The broader codebase pattern returns `fmt.Errorf` when encountering missing resources rather than panicking.

## Proof

- No behavioral change for success paths; only error paths are improved
- Callers that previously would crash now receive descriptive errors
- Error messages include context (execution ID, original error) for debugging
- All changes follow existing codebase conventions (`errors.Wrap`, `errkit.Wrapf`, `fmt.Errorf`)

## Checklist

- [x] PR created against the `dev` branch
- [x] All changes are minimal and focused on the issue
- [x] Callers updated to handle errors appropriately
- [x] Documentation: error conditions are self-documenting via `fmt.Errorf` messages

Fixes #6674

:robot: Built with AI assistance (Claude)
Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Template loading now surfaces and wraps load errors instead of ignoring them, preventing silent failures.
  * Loading aborts early on failures and logs warnings where appropriate instead of continuing with invalid state.
  * Detects and errors when multiple templates are found for a single path to avoid ambiguous results.

* **Refactor**
  * Replaced panic/ignore patterns with explicit error returns and propagation across the template loading pipeline.

* **Tests**
  * Benchmarks updated to check and fail on template load errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->