### PR TITLE
fix(authx): make concurrent secret fetch wait instead of skip

### DIFF
--- a/pkg/authprovider/authx/dynamic.go
+++ b/pkg/authprovider/authx/dynamic.go
@@ -3,6 +3,7 @@ package authx
 import (
 	"fmt"
 	"strings"
+	"sync"
 	"sync/atomic"
 
 	"github.com/projectdiscovery/gologger"
@@ -32,6 +33,7 @@ type Dynamic struct {
 	fetchCallback LazyFetchSecret        `json:"-" yaml:"-"`
 	fetched       *atomic.Bool           `json:"-" yaml:"-"` // atomic flag to check if the secret has been fetched
 	fetching      *atomic.Bool           `json:"-" yaml:"-"` // atomic flag to prevent recursive fetch calls
+	fetchOnce     sync.Once              `json:"-" yaml:"-"` // ensures fetch runs exactly once and concurrent callers wait
 	error         error                  `json:"-" yaml:"-"` // error if any
 }
 
@@ -212,18 +214,20 @@ func (d *Dynamic) Fetch(isFatal bool) error {
 		return d.error
 	}
 
-	// Try to set fetching flag atomically
-	if !d.fetching.CompareAndSwap(false, true) {
-		// Already fetching, return current error
+	// If we're inside a recursive fetch call (e.g. the fetch callback itself
+	// triggers another fetch for the same dynamic), skip to avoid deadlock.
+	if d.fetching.Load() {
 		return d.error
 	}
 
-	// We're the only one fetching, call the callback
-	d.error = d.fetchCallback(d)
-
-	// Mark as fetched and clear fetching flag
-	d.fetched.Store(true)
-	d.fetching.Store(false)
+	// Use sync.Once to ensure the fetch callback runs exactly once.
+	// Concurrent callers will block here until the first caller completes.
+	d.fetchOnce.Do(func() {
+		d.fetching.Store(true)
+		d.error = d.fetchCallback(d)
+		d.fetched.Store(true)
+		d.fetching.Store(false)
+	})
 
 	if d.error != nil && isFatal {
 		gologger.Fatal().Msgf("Could not fetch dynamic secret: %s\n", d.error)

--- a/pkg/authprovider/authx/file.go
+++ b/pkg/authprovider/authx/file.go
@@ -227,6 +227,9 @@ func GetTemplatePathsFromSecretFile(file string) ([]string, error) {
 	}
 	var paths []string
 	for _, dynamic := range auth.Dynamic {
+		if dynamic == nil {
+			continue
+		}
 		paths = append(paths, dynamic.TemplatePath)
 	}
 	return paths, nil

--- a/pkg/authprovider/authx/file.go
+++ b/pkg/authprovider/authx/file.go
@@ -40,7 +40,7 @@ type Authx struct {
 	ID      string       `json:"id" yaml:"id"`
 	Info    AuthFileInfo `json:"info" yaml:"info"`
 	Secrets []Secret     `json:"static" yaml:"static"`
-	Dynamic []Dynamic    `json:"dynamic" yaml:"dynamic"`
+	Dynamic []*Dynamic   `json:"dynamic" yaml:"dynamic"`
 }
 
 type AuthFileInfo struct {

--- a/pkg/authprovider/authx/strategy.go
+++ b/pkg/authprovider/authx/strategy.go
@@ -19,7 +19,7 @@ type AuthStrategy interface {
 // it implements the AuthStrategy interface
 type DynamicAuthStrategy struct {
 	// Dynamic is the dynamic secret to use
-	Dynamic Dynamic
+	Dynamic *Dynamic
 }
 
 // Apply applies the strategy to the request

--- a/pkg/authprovider/authx/strategy.go
+++ b/pkg/authprovider/authx/strategy.go
@@ -24,6 +24,9 @@ type DynamicAuthStrategy struct {
 
 // Apply applies the strategy to the request
 func (d *DynamicAuthStrategy) Apply(req *http.Request) {
+	if d.Dynamic == nil {
+		return
+	}
 	strategies := d.Dynamic.GetStrategies()
 	if strategies == nil {
 		return
@@ -38,8 +41,17 @@ func (d *DynamicAuthStrategy) Apply(req *http.Request) {
 
 // ApplyOnRR applies the strategy to the retryable request
 func (d *DynamicAuthStrategy) ApplyOnRR(req *retryablehttp.Request) {
+	if d.Dynamic == nil {
+		return
+	}
 	strategy := d.Dynamic.GetStrategies()
+	if strategy == nil {
+		return
+	}
 	for _, s := range strategy {
+		if s == nil {
+			continue
+		}
 		s.ApplyOnRR(req)
 	}
 }


### PR DESCRIPTION
## Description

Fixes #6592

When multiple goroutines call `Dynamic.Fetch()` concurrently (which happens during template execution with `-secret-file`), the previous implementation using `atomic.CompareAndSwap` would cause non-fetching goroutines to return immediately with a nil error, even though the fetch hadn't completed yet. This caused templates to execute **without authentication**.

## Root Cause

In `Dynamic.Fetch()`:
1. Goroutine A starts fetching → `fetching.CompareAndSwap(false, true)` succeeds
2. Goroutine B calls `Fetch()` → `CompareAndSwap` fails → returns `d.error` which is **nil** (fetch not done)
3. Goroutine B proceeds with no auth since `GetStrategies()` sees nil error and builds strategies from unpopulated `Extracted` data

## Fix

Replace the atomic-based concurrency control with `sync.Once`, which:
- Runs the fetch callback **exactly once**
- **Blocks** all concurrent callers until the first caller completes
- Retains the recursive-fetch guard via `d.fetching` to avoid deadlocks

This restores the pre-3.4.8 behavior where all templates wait for authentication to finish before executing.

## Testing

- `go build ./...` passes
- `go test ./pkg/authprovider/...` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures dynamic authentication fetch runs once; concurrent requests wait for completion.
  * Prevents recursive fetch re-entry to avoid instability under load.
  * Adds guards against nil entries to reduce panics and crashes.

* **Refactor**
  * Internal representation of dynamic auth entries adjusted for safer lifetime management (no public API changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->