### PR TITLE
fix: isolate project cache by scheme to prevent cross-protocol cache hits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,4 +52,4 @@ vendor
 *.pprof
 *.trace
 *.mem
-*.cpu.github/workflows/typos.yaml
+*.cpu

--- a/.gitignore
+++ b/.gitignore
@@ -52,4 +52,4 @@ vendor
 *.pprof
 *.trace
 *.mem
-*.cpu
+*.cpu.github/workflows/typos.yaml

--- a/pkg/projectfile/project.go
+++ b/pkg/projectfile/project.go
@@ -2,7 +2,9 @@ package projectfile
 
 import (
 	"net/http"
+	"net/url"
 	"regexp"
+	"strings"
 
 	"github.com/pkg/errors"
 
@@ -46,6 +48,32 @@ func (pf *ProjectFile) cleanupData(data []byte) []byte {
 	return regexDefaultInteract.ReplaceAll(data, []byte(""))
 }
 
+// normalizeURL canonicalizes a URL for use as a cache key prefix.
+// It lowercases scheme and host, strips default ports (80/443),
+// and ensures a trailing slash on bare-host URLs.
+func normalizeURL(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return raw
+	}
+	u.Scheme = strings.ToLower(u.Scheme)
+	u.Host = strings.ToLower(u.Host)
+
+	// Strip default ports
+	hostname := u.Hostname()
+	port := u.Port()
+	if (u.Scheme == "http" && port == "80") || (u.Scheme == "https" && port == "443") {
+		u.Host = hostname
+	}
+
+	// Ensure root path has trailing slash for consistency
+	if u.Path == "" {
+		u.Path = "/"
+	}
+
+	return u.String()
+}
+
 // cacheKey builds a unique cache key from the request data and optional URL.
 // Including the URL ensures requests to different schemes (http vs https)
 // or ports produce distinct cache entries.
@@ -54,7 +82,7 @@ func (pf *ProjectFile) cacheKey(req []byte, reqURL string) []byte {
 	if reqURL == "" {
 		return cleaned
 	}
-	return append([]byte(reqURL+"\n"), cleaned...)
+	return append([]byte(normalizeURL(reqURL)+"\n"), cleaned...)
 }
 
 // Get retrieves a cached response. The reqURL parameter is included in the

--- a/pkg/projectfile/project.go
+++ b/pkg/projectfile/project.go
@@ -39,6 +39,18 @@ func New(options *Options) (*ProjectFile, error) {
 	return &p, nil
 }
 
+// cacheKey combines the cleaned request data with the URL to create a unique cache key.
+// Including the URL ensures that requests to the same path but different schemes (http vs https)
+// or different ports produce different cache entries.
+func (pf *ProjectFile) cacheKey(req []byte, reqURL string) []byte {
+	cleaned := pf.cleanupData(req)
+	if reqURL == "" {
+		return cleaned
+	}
+	// Prepend URL as a prefix to ensure scheme+host+port differentiation
+	return append([]byte(reqURL+"\n"), cleaned...)
+}
+
 func (pf *ProjectFile) cleanupData(data []byte) []byte {
 	// ignore all user agents
 	data = regexUserAgent.ReplaceAll(data, []byte("\r\n"))
@@ -47,7 +59,13 @@ func (pf *ProjectFile) cleanupData(data []byte) []byte {
 }
 
 func (pf *ProjectFile) Get(req []byte) (*http.Response, error) {
-	reqHash, err := hash(pf.cleanupData(req))
+	return pf.GetWithURL(req, "")
+}
+
+// GetWithURL retrieves a cached response using both the request data and URL as cache key.
+// The URL ensures scheme and port isolation (e.g., http:// vs https:// requests are cached separately).
+func (pf *ProjectFile) GetWithURL(req []byte, reqURL string) (*http.Response, error) {
+	reqHash, err := hash(pf.cacheKey(req, reqURL))
 	if err != nil {
 		return nil, err
 	}
@@ -67,7 +85,13 @@ func (pf *ProjectFile) Get(req []byte) (*http.Response, error) {
 }
 
 func (pf *ProjectFile) Set(req []byte, resp *http.Response, data []byte) error {
-	reqHash, err := hash(pf.cleanupData(req))
+	return pf.SetWithURL(req, "", resp, data)
+}
+
+// SetWithURL stores a response using both the request data and URL as cache key.
+// The URL ensures scheme and port isolation (e.g., http:// vs https:// requests are cached separately).
+func (pf *ProjectFile) SetWithURL(req []byte, reqURL string, resp *http.Response, data []byte) error {
+	reqHash, err := hash(pf.cacheKey(req, reqURL))
 	if err != nil {
 		return err
 	}

--- a/pkg/projectfile/project.go
+++ b/pkg/projectfile/project.go
@@ -39,18 +39,6 @@ func New(options *Options) (*ProjectFile, error) {
 	return &p, nil
 }
 
-// cacheKey combines the cleaned request data with the URL to create a unique cache key.
-// Including the URL ensures that requests to the same path but different schemes (http vs https)
-// or different ports produce different cache entries.
-func (pf *ProjectFile) cacheKey(req []byte, reqURL string) []byte {
-	cleaned := pf.cleanupData(req)
-	if reqURL == "" {
-		return cleaned
-	}
-	// Prepend URL as a prefix to ensure scheme+host+port differentiation
-	return append([]byte(reqURL+"\n"), cleaned...)
-}
-
 func (pf *ProjectFile) cleanupData(data []byte) []byte {
 	// ignore all user agents
 	data = regexUserAgent.ReplaceAll(data, []byte("\r\n"))
@@ -58,13 +46,20 @@ func (pf *ProjectFile) cleanupData(data []byte) []byte {
 	return regexDefaultInteract.ReplaceAll(data, []byte(""))
 }
 
-func (pf *ProjectFile) Get(req []byte) (*http.Response, error) {
-	return pf.GetWithURL(req, "")
+// cacheKey builds a unique cache key from the request data and optional URL.
+// Including the URL ensures requests to different schemes (http vs https)
+// or ports produce distinct cache entries.
+func (pf *ProjectFile) cacheKey(req []byte, reqURL string) []byte {
+	cleaned := pf.cleanupData(req)
+	if reqURL == "" {
+		return cleaned
+	}
+	return append([]byte(reqURL+"\n"), cleaned...)
 }
 
-// GetWithURL retrieves a cached response using both the request data and URL as cache key.
-// The URL ensures scheme and port isolation (e.g., http:// vs https:// requests are cached separately).
-func (pf *ProjectFile) GetWithURL(req []byte, reqURL string) (*http.Response, error) {
+// Get retrieves a cached response. The reqURL parameter is included in the
+// cache key to isolate entries by scheme and port (e.g. http vs https).
+func (pf *ProjectFile) Get(req []byte, reqURL string) (*http.Response, error) {
 	reqHash, err := hash(pf.cacheKey(req, reqURL))
 	if err != nil {
 		return nil, err
@@ -84,13 +79,9 @@ func (pf *ProjectFile) GetWithURL(req []byte, reqURL string) (*http.Response, er
 	return fromInternalResponse(httpRecord.Response), nil
 }
 
-func (pf *ProjectFile) Set(req []byte, resp *http.Response, data []byte) error {
-	return pf.SetWithURL(req, "", resp, data)
-}
-
-// SetWithURL stores a response using both the request data and URL as cache key.
-// The URL ensures scheme and port isolation (e.g., http:// vs https:// requests are cached separately).
-func (pf *ProjectFile) SetWithURL(req []byte, reqURL string, resp *http.Response, data []byte) error {
+// Set stores a response in the cache. The reqURL parameter is included in the
+// cache key to isolate entries by scheme and port (e.g. http vs https).
+func (pf *ProjectFile) Set(req []byte, reqURL string, resp *http.Response, data []byte) error {
 	reqHash, err := hash(pf.cacheKey(req, reqURL))
 	if err != nil {
 		return err

--- a/pkg/projectfile/project_scheme_test.go
+++ b/pkg/projectfile/project_scheme_test.go
@@ -1,6 +1,7 @@
 package projectfile
 
 import (
+	"errors"
 	"net/http"
 	"os"
 	"testing"
@@ -29,12 +30,18 @@ func TestSchemeNormalization(t *testing.T) {
 		Header:     http.Header{},
 	}
 
+	// Assert cache miss before any Set — confirms key doesn't pre-exist
+	_, err = pf.Get(reqData, "https://example.com")
+	if err == nil || !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound before any Set, got: %v", err)
+	}
+
 	// Store with trailing slash
 	if err := pf.Set(reqData, "https://example.com/", resp, []byte("body")); err != nil {
 		t.Fatal(err)
 	}
 
-	// Retrieve without trailing slash - should hit same cache entry
+	// Retrieve without trailing slash - should hit same cache entry (normalization)
 	got, err := pf.Get(reqData, "https://example.com")
 	if err != nil {
 		t.Fatalf("expected cache hit for normalized URL, got error: %v", err)
@@ -43,12 +50,18 @@ func TestSchemeNormalization(t *testing.T) {
 		t.Errorf("expected status 200, got %d", got.StatusCode)
 	}
 
-	// Store with default port
+	// Assert cache miss before next Set
+	_, err = pf.Get(reqData, "https://other.com/path")
+	if err == nil || !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound before Set on other.com, got: %v", err)
+	}
+
+	// Store with explicit default port (443)
 	if err := pf.Set(reqData, "https://other.com:443/path", resp, []byte("body2")); err != nil {
 		t.Fatal(err)
 	}
 
-	// Retrieve without port - should hit same cache entry
+	// Retrieve without port - should hit same cache entry (default port stripped)
 	got, err = pf.Get(reqData, "https://other.com/path")
 	if err != nil {
 		t.Fatalf("expected cache hit for URL without default port, got error: %v", err)
@@ -88,6 +101,16 @@ func TestSchemeIsolation(t *testing.T) {
 		Header:     http.Header{"X-Test": []string{"http"}},
 	}
 
+	// Assert cache misses before any Set — confirms keys don't pre-exist
+	_, err = pf.Get(reqData, "https://example.com")
+	if err == nil || !errors.Is(err, ErrNotFound) {
+		t.Fatalf("HTTPS: expected ErrNotFound before Set, got: %v", err)
+	}
+	_, err = pf.Get(reqData, "http://example.com")
+	if err == nil || !errors.Is(err, ErrNotFound) {
+		t.Fatalf("HTTP: expected ErrNotFound before Set, got: %v", err)
+	}
+
 	// Store HTTPS response
 	if err := pf.Set(reqData, "https://example.com", httpsResp, []byte("https body")); err != nil {
 		t.Fatal(err)
@@ -120,5 +143,78 @@ func TestSchemeIsolation(t *testing.T) {
 	}
 	if got.StatusCode != 404 {
 		t.Errorf("HTTP cache: expected status 404, got %d", got.StatusCode)
+	}
+}
+
+func TestPortIsolation(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "nuclei-project-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	pf, err := New(&Options{Path: tmpDir, Cleanup: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pf.Close()
+
+	reqData := []byte("GET /api HTTP/1.1\r\nHost: target.internal\r\n\r\n")
+
+	resp8080 := &http.Response{
+		StatusCode: 200,
+		Status:     "200 OK",
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+		Header:     http.Header{"X-Port": []string{"8080"}},
+	}
+	resp8443 := &http.Response{
+		StatusCode: 403,
+		Status:     "403 Forbidden",
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+		Header:     http.Header{"X-Port": []string{"8443"}},
+	}
+
+	// Assert cache misses before any Set
+	_, err = pf.Get(reqData, "http://target.internal:8080/api")
+	if err == nil || !errors.Is(err, ErrNotFound) {
+		t.Fatalf(":8080: expected ErrNotFound before Set, got: %v", err)
+	}
+	_, err = pf.Get(reqData, "https://target.internal:8443/api")
+	if err == nil || !errors.Is(err, ErrNotFound) {
+		t.Fatalf(":8443: expected ErrNotFound before Set, got: %v", err)
+	}
+
+	// Store responses for non-default ports
+	if err := pf.Set(reqData, "http://target.internal:8080/api", resp8080, []byte("body8080")); err != nil {
+		t.Fatal(err)
+	}
+	if err := pf.Set(reqData, "https://target.internal:8443/api", resp8443, []byte("body8443")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Port :8080 should return 200
+	got, err := pf.Get(reqData, "http://target.internal:8080/api")
+	if err != nil {
+		t.Fatalf(":8080 lookup failed: %v", err)
+	}
+	if got.StatusCode != 200 {
+		t.Errorf(":8080 expected 200, got %d", got.StatusCode)
+	}
+
+	// Port :8443 should return 403 (isolated from :8080)
+	got, err = pf.Get(reqData, "https://target.internal:8443/api")
+	if err != nil {
+		t.Fatalf(":8443 lookup failed: %v", err)
+	}
+	if got.StatusCode != 403 {
+		t.Errorf(":8443 expected 403, got %d", got.StatusCode)
+	}
+
+	// Cross-port lookup should miss — :8080 entry should NOT be retrievable via :8443 key
+	_, err = pf.Get(reqData, "http://target.internal:8443/api")
+	if err == nil || !errors.Is(err, ErrNotFound) {
+		t.Errorf("cross-port lookup should miss, got: %v", err)
 	}
 }

--- a/pkg/projectfile/project_scheme_test.go
+++ b/pkg/projectfile/project_scheme_test.go
@@ -6,6 +6,58 @@ import (
 	"testing"
 )
 
+func TestSchemeNormalization(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "nuclei-project-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	pf, err := New(&Options{Path: tmpDir, Cleanup: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pf.Close()
+
+	reqData := []byte("GET / HTTP/1.1\r\nHost: example.com\r\n\r\n")
+
+	resp := &http.Response{
+		StatusCode: 200,
+		Status:     "200 OK",
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+		Header:     http.Header{},
+	}
+
+	// Store with trailing slash
+	if err := pf.Set(reqData, "https://example.com/", resp, []byte("body")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Retrieve without trailing slash - should hit same cache entry
+	got, err := pf.Get(reqData, "https://example.com")
+	if err != nil {
+		t.Fatalf("expected cache hit for normalized URL, got error: %v", err)
+	}
+	if got.StatusCode != 200 {
+		t.Errorf("expected status 200, got %d", got.StatusCode)
+	}
+
+	// Store with default port
+	if err := pf.Set(reqData, "https://other.com:443/path", resp, []byte("body2")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Retrieve without port - should hit same cache entry
+	got, err = pf.Get(reqData, "https://other.com/path")
+	if err != nil {
+		t.Fatalf("expected cache hit for URL without default port, got error: %v", err)
+	}
+	if got.StatusCode != 200 {
+		t.Errorf("expected status 200, got %d", got.StatusCode)
+	}
+}
+
 func TestSchemeIsolation(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "nuclei-project-test")
 	if err != nil {

--- a/pkg/projectfile/project_scheme_test.go
+++ b/pkg/projectfile/project_scheme_test.go
@@ -51,6 +51,9 @@ func TestSchemeIsolation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if got == nil {
+		t.Fatal("HTTPS cache: expected non-nil response")
+	}
 	if got.StatusCode != 200 {
 		t.Errorf("HTTPS cache: expected status 200, got %d", got.StatusCode)
 	}
@@ -59,6 +62,9 @@ func TestSchemeIsolation(t *testing.T) {
 	got, err = pf.Get(reqData, "http://example.com")
 	if err != nil {
 		t.Fatal(err)
+	}
+	if got == nil {
+		t.Fatal("HTTP cache: expected non-nil response")
 	}
 	if got.StatusCode != 404 {
 		t.Errorf("HTTP cache: expected status 404, got %d", got.StatusCode)

--- a/pkg/projectfile/project_scheme_test.go
+++ b/pkg/projectfile/project_scheme_test.go
@@ -37,17 +37,17 @@ func TestSchemeIsolation(t *testing.T) {
 	}
 
 	// Store HTTPS response
-	if err := pf.SetWithURL(reqData, "https://example.com", httpsResp, []byte("https body")); err != nil {
+	if err := pf.Set(reqData, "https://example.com", httpsResp, []byte("https body")); err != nil {
 		t.Fatal(err)
 	}
 
 	// Store HTTP response (different scheme, same host+path)
-	if err := pf.SetWithURL(reqData, "http://example.com", httpResp, []byte("http body")); err != nil {
+	if err := pf.Set(reqData, "http://example.com", httpResp, []byte("http body")); err != nil {
 		t.Fatal(err)
 	}
 
 	// Retrieve HTTPS - should get 200
-	got, err := pf.GetWithURL(reqData, "https://example.com")
+	got, err := pf.Get(reqData, "https://example.com")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -56,7 +56,7 @@ func TestSchemeIsolation(t *testing.T) {
 	}
 
 	// Retrieve HTTP - should get 404
-	got, err = pf.GetWithURL(reqData, "http://example.com")
+	got, err = pf.Get(reqData, "http://example.com")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/projectfile/project_scheme_test.go
+++ b/pkg/projectfile/project_scheme_test.go
@@ -1,0 +1,66 @@
+package projectfile
+
+import (
+	"net/http"
+	"os"
+	"testing"
+)
+
+func TestSchemeIsolation(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "nuclei-project-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	pf, err := New(&Options{Path: tmpDir, Cleanup: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pf.Close()
+
+	reqData := []byte("GET / HTTP/1.1\r\nHost: example.com\r\n\r\n")
+
+	httpsResp := &http.Response{
+		StatusCode: 200,
+		Status:     "200 OK",
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+		Header:     http.Header{"X-Test": []string{"https"}},
+	}
+	httpResp := &http.Response{
+		StatusCode: 404,
+		Status:     "404 Not Found",
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+		Header:     http.Header{"X-Test": []string{"http"}},
+	}
+
+	// Store HTTPS response
+	if err := pf.SetWithURL(reqData, "https://example.com", httpsResp, []byte("https body")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Store HTTP response (different scheme, same host+path)
+	if err := pf.SetWithURL(reqData, "http://example.com", httpResp, []byte("http body")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Retrieve HTTPS - should get 200
+	got, err := pf.GetWithURL(reqData, "https://example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.StatusCode != 200 {
+		t.Errorf("HTTPS cache: expected status 200, got %d", got.StatusCode)
+	}
+
+	// Retrieve HTTP - should get 404
+	got, err = pf.GetWithURL(reqData, "http://example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.StatusCode != 404 {
+		t.Errorf("HTTP cache: expected status 404, got %d", got.StatusCode)
+	}
+}

--- a/pkg/protocols/http/request.go
+++ b/pkg/protocols/http/request.go
@@ -88,6 +88,10 @@ func (request *Request) executeRaceRequest(input *contextargs.Context, previous 
 	if err != nil {
 		return err
 	}
+	if input.MetaInput.Input == "" {
+		input.MetaInput.Input = requestForDump.URL()
+	}
+	reqURL = input.MetaInput.Input
 	request.setCustomHeaders(requestForDump)
 	dumpedRequest, err := dump(requestForDump, reqURL)
 	if err != nil {

--- a/pkg/protocols/http/request.go
+++ b/pkg/protocols/http/request.go
@@ -812,7 +812,7 @@ func (request *Request) executeRequest(input *contextargs.Context, generatedRequ
 		if request.options.ProjectFile != nil {
 			// if unavailable fail silently
 			fromCache = true
-			resp, err = request.options.ProjectFile.Get(dumpedRequest)
+			resp, err = request.options.ProjectFile.GetWithURL(dumpedRequest, input.MetaInput.Input)
 			if err != nil {
 				fromCache = false
 			}
@@ -962,7 +962,7 @@ func (request *Request) executeRequest(input *contextargs.Context, generatedRequ
 	onceFunc := sync.OnceFunc(func() {
 		// if nuclei-project is enabled store the response if not previously done
 		if request.options.ProjectFile != nil && !fromCache {
-			if err := request.options.ProjectFile.Set(dumpedRequest, resp, respChain.BodyBytes()); err != nil {
+			if err := request.options.ProjectFile.SetWithURL(dumpedRequest, input.MetaInput.Input, resp, respChain.BodyBytes()); err != nil {
 				errx = errors.Wrap(err, "could not store in project file")
 			}
 		}

--- a/pkg/protocols/http/request.go
+++ b/pkg/protocols/http/request.go
@@ -812,7 +812,7 @@ func (request *Request) executeRequest(input *contextargs.Context, generatedRequ
 		if request.options.ProjectFile != nil {
 			// if unavailable fail silently
 			fromCache = true
-			resp, err = request.options.ProjectFile.GetWithURL(dumpedRequest, input.MetaInput.Input)
+			resp, err = request.options.ProjectFile.Get(dumpedRequest, input.MetaInput.Input)
 			if err != nil {
 				fromCache = false
 			}
@@ -962,7 +962,7 @@ func (request *Request) executeRequest(input *contextargs.Context, generatedRequ
 	onceFunc := sync.OnceFunc(func() {
 		// if nuclei-project is enabled store the response if not previously done
 		if request.options.ProjectFile != nil && !fromCache {
-			if err := request.options.ProjectFile.SetWithURL(dumpedRequest, input.MetaInput.Input, resp, respChain.BodyBytes()); err != nil {
+			if err := request.options.ProjectFile.Set(dumpedRequest, input.MetaInput.Input, resp, respChain.BodyBytes()); err != nil {
 				errx = errors.Wrap(err, "could not store in project file")
 			}
 		}


### PR DESCRIPTION
## Description

Fixes #6866

When using the `-project` flag, HTTP and HTTPS requests to the same host/path produced identical cache keys because only the raw HTTP request bytes were hashed (which don't include the URL scheme). This caused HTTPS cached responses to be incorrectly served for HTTP targets and vice versa.

## Root Cause

`ProjectFile.Get/Set` hashes only the raw HTTP request dump (e.g., `GET / HTTP/1.1\r\nHost: example.com`). Since this dump is identical for both `http://example.com` and `https://example.com`, they share the same cache entry.

## Changes

- **`pkg/projectfile/project.go`**: Patched existing `Get`/`Set` signatures to accept a `reqURL string` parameter. Scheme isolation logic is baked into the original methods via a `cacheKey` helper — no new methods added.
- **`pkg/protocols/http/request.go`**: Updated call sites to pass `input.MetaInput.Input` as the URL.
- **`pkg/projectfile/project_scheme_test.go`**: Added test verifying HTTP and HTTPS responses are cached and retrieved independently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * HTTP response caching now properly isolates requests by URL, with normalization of URLs (lowercased scheme/host, stripped default ports) for consistency.

* **Tests**
  * Added test coverage for URL scheme normalization and isolation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->