### PR TITLE
Feat: add flag to allow duplicate tempalte IDs

### DIFF
--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -346,6 +346,7 @@ on extensive configurability, massive extensibility and ease of use.`)
 		flagSet.StringVarP(&options.ResolversFile, "resolvers", "r", "", "file containing resolver list for nuclei"),
 		flagSet.BoolVarP(&options.SystemResolvers, "system-resolvers", "sr", false, "use system DNS resolving as error fallback"),
 		flagSet.BoolVarP(&options.DisableClustering, "disable-clustering", "dc", false, "disable clustering of requests"),
+		flagSet.BoolVarP(&options.AllowDuplicateTemplateIDs, "allow-duplicate-template-ids", "adt", false, "allow loading templates with duplicate IDs"),
 		flagSet.BoolVar(&options.OfflineHTTP, "passive", false, "enable passive HTTP response processing mode"),
 		flagSet.BoolVarP(&options.ForceAttemptHTTP2, "force-http2", "fh2", false, "force http2 connection on requests"),
 		flagSet.BoolVarP(&options.EnvironmentVariables, "env-vars", "ev", false, "enable environment variables to be used in template"),

--- a/pkg/catalog/loader/loader.go
+++ b/pkg/catalog/loader/loader.go
@@ -484,8 +484,10 @@ func (store *Store) LoadTemplatesOnlyMetadata() error {
 		}
 
 		if loadedTemplateIDs.Has(template.ID) {
-			store.logger.Debug().Msgf("Skipping duplicate template ID '%s' from path '%s'", template.ID, templatePath)
-			continue
+			if !store.config.ExecutorOptions.Options.AllowDuplicateTemplateIDs {
+				store.logger.Debug().Msgf("Skipping duplicate template ID '%s' from path '%s'", template.ID, templatePath)
+				continue
+			}
 		}
 
 		_ = loadedTemplateIDs.Set(template.ID, struct{}{})
@@ -681,8 +683,10 @@ func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) []*templ
 
 	loadTemplate := func(tmpl *templates.Template) {
 		if loadedTemplateIDs.Has(tmpl.ID) {
-			store.logger.Debug().Msgf("Skipping duplicate template ID '%s' from path '%s'", tmpl.ID, tmpl.Path)
-			return
+			if !store.config.ExecutorOptions.Options.AllowDuplicateTemplateIDs {
+				store.logger.Debug().Msgf("Skipping duplicate template ID '%s' from path '%s'", tmpl.ID, tmpl.Path)
+				return
+			}
 		}
 
 		_ = loadedTemplateIDs.Set(tmpl.ID, struct{}{})

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -188,6 +188,8 @@ type Options struct {
 	HeadlessOptionalArguments goflags.StringSlice
 	// DisableClustering disables clustering of templates
 	DisableClustering bool
+	// AllowDuplicateTemplateIDs allows loading multiple templates with the same ID
+	AllowDuplicateTemplateIDs bool
 	// UseInstalledChrome skips chrome install and use local instance
 	UseInstalledChrome bool
 	// SystemResolvers enables override of nuclei's DNS client opting to use system resolver stack.
@@ -549,6 +551,7 @@ func (options *Options) Copy() *Options {
 		ShowBrowser:                    options.ShowBrowser,
 		HeadlessOptionalArguments:      options.HeadlessOptionalArguments,
 		DisableClustering:              options.DisableClustering,
+		AllowDuplicateTemplateIDs:      options.AllowDuplicateTemplateIDs,
 		UseInstalledChrome:             options.UseInstalledChrome,
 		SystemResolvers:                options.SystemResolvers,
 		ShowActions:                    options.ShowActions,


### PR DESCRIPTION
## Proposed changes

Related issue that was created for this PR: https://github.com/projectdiscovery/nuclei/issues/6921

The proposed change is a flag to allow duplicate template IDs. Default behavior stays the same but with the `--allow-duplicate-template-ids` or `-adt` flag, the duplicate id skip is skipped. 

Modifications are minimal:
- `main.go` the new cli flag is created. False by default
- `pkg/types/types.go` bool is registered
- `pkg/catalog/loader/loader.go` in the two locations where the debug message about skipping duplicate template IDs is printed, they are wrapped by an if statement to check if the new flag is false. If false, it skips the duplicate like normal; if true, it doesn't. 

### Proof

Tests from the contribution docs:

```
 $ make vet
go mod download
go mod verify
all modules verified
go vet ./...
```

I also ran `make build` and `make test` but the output is very long so I'm not including it all:
```
 $ make test
...
--- PASS: TestWorkflowMatchAndCompile (0.00s)
    --- PASS: TestWorkflowMatchAndCompile/name (0.00s)
    --- PASS: TestWorkflowMatchAndCompile/name-negative (0.00s)
    --- PASS: TestWorkflowMatchAndCompile/names-or (0.00s)
    --- PASS: TestWorkflowMatchAndCompile/names-and (0.00s)
PASS
ok      github.com/projectdiscovery/nuclei/v3/pkg/workflows     2.079s
```

```
 $ make build
...
github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/automaticscan
github.com/projectdiscovery/nuclei/v3/internal/server
github.com/projectdiscovery/nuclei/v3/internal/runner
command-line-arguments
```

And then to test it I created 4 duplicate templates in the same directory which have the same template ID. This is the result with no -adt flag, 1 template loaded:

```
 $ ./nuclei -target "https://example.com" -templates ../nuclei-templates/rnd -id "hello-world" -debug

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.7.0

                projectdiscovery.io

[DBG] Skipping duplicate template ID 'hello-world' from path '{redacted}/nuclei-templates/rnd/hello-world4.yaml'
[DBG] Skipping duplicate template ID 'hello-world' from path '{redacted}/nuclei-templates/rnd/hello-world2.yaml'
[DBG] Skipping duplicate template ID 'hello-world' from path '{redacted}/nuclei-templates/rnd/hello-world3.yaml'
[INF] Current nuclei version: v3.7.0 (latest)
[INF] Current nuclei-templates version: v10.3.9 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 182
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] [hello-world] Dumped HTTP request for https://example.com/hello-world.txt
...
```

Then running with the new -adt flag which loads all tempaltes:

```
 $ ./nuclei -target "https://example.com" -templates ../nuclei-templates/rnd -id "hello-world" -debug -adt

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.7.0

                projectdiscovery.io

[INF] Current nuclei version: v3.7.0 (latest)
[INF] Current nuclei-templates version: v10.3.9 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 182
[INF] Templates loaded for current scan: 4
[WRN] Loading 4 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] Templates clustered: 4 (Reduced 3 Requests)
[INF] [cluster-7154f17e4cdcdefc1537d47ac54fd22564396c03ab69345ee7e172b5e67ee097] Dumped HTTP request for https://example.com/hello-world.txt
...
```

And with the long version of the flag:
```
 $ ./nuclei -target "https://example.com" -templates ../nuclei-templates/rnd -id "hello-world" -debug --allow-duplicate-template-ids

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.7.0

                projectdiscovery.io

[INF] Current nuclei version: v3.7.0 (latest)
[INF] Current nuclei-templates version: v10.3.9 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 182
[INF] Templates loaded for current scan: 4
[WRN] Loading 4 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] Templates clustered: 4 (Reduced 3 Requests)
[INF] [cluster-7154f17e4cdcdefc1537d47ac54fd22564396c03ab69345ee7e172b5e67ee097] Dumped HTTP request for https://example.com/hello-world.txt
```

Help menu showing the flag:
```
 $ ./nuclei --help
...
CONFIGURATIONS:
   -config string                        path to the nuclei configuration file
   -tp, -profile string                  template profile config file to run
   -tpl, -profile-list                   list community template profiles
   -fr, -follow-redirects                enable following redirects for http templates
   -fhr, -follow-host-redirects          follow redirects on the same host
   -mr, -max-redirects int               max number of redirects to follow for http templates (default 10)
   -dr, -disable-redirects               disable redirects for http templates
   -rc, -report-config string            nuclei reporting module configuration file
   -H, -header string[]                  custom header/cookie to include in all http request in header:value format (cli, file)
   -V, -var value                        custom vars in key=value format
   -r, -resolvers string                 file containing resolver list for nuclei
   -sr, -system-resolvers                use system DNS resolving as error fallback
   -dc, -disable-clustering              disable clustering of requests
   -adt, -allow-duplicate-template-ids   allow loading templates with duplicate IDs
...
```

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--allow-duplicate-template-ids` CLI flag (short: `-adt`) to permit loading templates that share the same ID, providing greater flexibility in template management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->