### PR TITLE
feat: add honeypot detection to reduce false positives

### DIFF
--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -423,6 +423,8 @@ on extensive configurability, massive extensibility and ease of use.`)
 		flagSet.IntVarP(&options.MaxHostError, "max-host-error", "mhe", 30, "max errors for a host before skipping from scan"),
 		flagSet.StringSliceVarP(&options.TrackError, "track-error", "te", nil, "adds given error to max-host-error watchlist (standard, file)", goflags.FileStringSliceOptions),
 		flagSet.BoolVarP(&options.NoHostErrors, "no-mhe", "nmhe", false, "disable skipping host from scan based on errors"),
+		flagSet.IntVarP(&options.HoneypotThreshold, "honeypot-threshold", "hpt", 0, "minimum unique template matches before flagging a host as honeypot (0 = disabled)"),
+		flagSet.BoolVarP(&options.HoneypotSuppressResults, "honeypot-suppress", "hpq", false, "suppress results from hosts flagged as honeypots (default: warn only)"),
 		flagSet.BoolVar(&options.Project, "project", false, "use a project folder to avoid sending same request multiple times"),
 		flagSet.StringVar(&options.ProjectPath, "project-path", os.TempDir(), "set a specific project path"),
 		flagSet.BoolVarP(&options.StopAtFirstMatch, "stop-at-first-match", "spm", false, "stop processing HTTP requests after the first match (may break template/workflow logic)"),

--- a/pkg/honeypot/detector.go
+++ b/pkg/honeypot/detector.go
@@ -1,0 +1,166 @@
+package honeypot
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+	"sync"
+
+	"github.com/projectdiscovery/gologger"
+)
+
+// Detector tracks unique template matches per host to identify potential honeypots.
+// Honeypots are hosts that respond positively to an unusually high number of vulnerability
+// checks, indicating they are deliberately mirroring scanner signatures to produce false positives.
+type Detector struct {
+	// threshold is the minimum number of unique template matches to flag a host as a honeypot.
+	// A value of 0 means detection is disabled.
+	threshold int
+	// suppress controls whether results from flagged hosts are suppressed (true) or only warned (false).
+	suppress bool
+	// matches tracks unique template IDs matched per normalized host.
+	matches map[string]map[string]struct{}
+	// flagged tracks hosts that have been flagged as honeypots.
+	flagged map[string]bool
+	// mu protects concurrent access to matches and flagged maps.
+	mu sync.Mutex
+}
+
+// New creates a new honeypot Detector with the given threshold and suppression mode.
+// A threshold of 0 disables detection entirely.
+func New(threshold int, suppress bool) *Detector {
+	return &Detector{
+		threshold: threshold,
+		suppress:  suppress,
+		matches:   make(map[string]map[string]struct{}),
+		flagged:   make(map[string]bool),
+	}
+}
+
+// Enabled returns true if honeypot detection is active.
+func (d *Detector) Enabled() bool {
+	return d != nil && d.threshold > 0
+}
+
+// Record registers a template match for a host and returns whether the result
+// should be suppressed. It returns (isFlagged, shouldSuppress).
+//
+// isFlagged is true if the host has been identified as a potential honeypot.
+// shouldSuppress is true only if isFlagged is true AND suppress mode is enabled.
+func (d *Detector) Record(host, templateID string) (isFlagged, shouldSuppress bool) {
+	if !d.Enabled() {
+		return false, false
+	}
+	if host == "" || templateID == "" {
+		return false, false
+	}
+
+	normalizedHost := normalizeHost(host)
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	// If already flagged, skip counting
+	if d.flagged[normalizedHost] {
+		return true, d.suppress
+	}
+
+	templates, ok := d.matches[normalizedHost]
+	if !ok {
+		templates = make(map[string]struct{})
+		d.matches[normalizedHost] = templates
+	}
+	templates[templateID] = struct{}{}
+
+	if len(templates) >= d.threshold {
+		d.flagged[normalizedHost] = true
+		gologger.Warning().Msgf("[honeypot] %s matched %d unique templates (threshold: %d) — likely honeypot", normalizedHost, len(templates), d.threshold)
+		return true, d.suppress
+	}
+
+	return false, false
+}
+
+// IsFlagged returns whether a host has been flagged as a honeypot.
+func (d *Detector) IsFlagged(host string) bool {
+	if !d.Enabled() {
+		return false
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.flagged[normalizeHost(host)]
+}
+
+// FlaggedHosts returns a list of all hosts flagged as honeypots with their match counts.
+func (d *Detector) FlaggedHosts() map[string]int {
+	if !d.Enabled() {
+		return nil
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	result := make(map[string]int, len(d.flagged))
+	for host := range d.flagged {
+		result[host] = len(d.matches[host])
+	}
+	return result
+}
+
+// Summary returns a human-readable summary of flagged hosts, or an empty string if none.
+func (d *Detector) Summary() string {
+	flagged := d.FlaggedHosts()
+	if len(flagged) == 0 {
+		return ""
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("[honeypot] %d host(s) flagged as potential honeypot(s):\n", len(flagged)))
+	for host, count := range flagged {
+		sb.WriteString(fmt.Sprintf("  - %s (%d unique template matches)\n", host, count))
+	}
+	return sb.String()
+}
+
+// normalizeHost extracts a consistent host identifier from various URL/host formats.
+// It strips scheme, path, query, fragment, and userinfo, keeping only host:port.
+func normalizeHost(input string) string {
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return ""
+	}
+
+	// If it looks like a URL, parse it
+	if strings.Contains(input, "://") {
+		if u, err := url.Parse(input); err == nil {
+			host := u.Hostname()
+			port := u.Port()
+			if port != "" {
+				return host + ":" + port
+			}
+			return host
+		}
+	}
+
+	// Strip any path component
+	if idx := strings.Index(input, "/"); idx != -1 {
+		input = input[:idx]
+	}
+
+	// Strip userinfo if present (user:pass@host)
+	if idx := strings.LastIndex(input, "@"); idx != -1 {
+		input = input[idx+1:]
+	}
+
+	// Normalize IPv6 addresses in bracket notation: [::1]:8080 → ::1:8080
+	if strings.HasPrefix(input, "[") {
+		if closeBracket := strings.Index(input, "]"); closeBracket != -1 {
+			host := input[1:closeBracket]
+			if closeBracket+1 < len(input) && input[closeBracket+1] == ':' {
+				return host + ":" + input[closeBracket+2:]
+			}
+			return host
+		}
+	}
+
+	return input
+}

--- a/pkg/honeypot/detector.go
+++ b/pkg/honeypot/detector.go
@@ -23,7 +23,7 @@ type Detector struct {
 	// flagged tracks hosts that have been flagged as honeypots.
 	flagged map[string]bool
 	// mu protects concurrent access to matches and flagged maps.
-	mu sync.Mutex
+	mu sync.RWMutex
 }
 
 // New creates a new honeypot Detector with the given threshold and suppression mode.
@@ -58,10 +58,10 @@ func (d *Detector) Record(host, templateID string) (isFlagged, shouldSuppress bo
 	normalizedHost := normalizeHost(host)
 
 	d.mu.Lock()
-	defer d.mu.Unlock()
 
 	// If already flagged, skip counting
 	if d.flagged[normalizedHost] {
+		d.mu.Unlock()
 		return true, d.suppress
 	}
 
@@ -74,10 +74,14 @@ func (d *Detector) Record(host, templateID string) (isFlagged, shouldSuppress bo
 
 	if len(templates) >= d.threshold {
 		d.flagged[normalizedHost] = true
-		gologger.Warning().Msgf("[honeypot] %s matched %d unique templates (threshold: %d) — likely honeypot", normalizedHost, len(templates), d.threshold)
+		matchCount := len(templates)
+		d.mu.Unlock()
+		// Log outside the lock to avoid stalling concurrent writers
+		gologger.Warning().Msgf("[honeypot] %s matched %d unique templates (threshold: %d) — likely honeypot", normalizedHost, matchCount, d.threshold)
 		return true, d.suppress
 	}
 
+	d.mu.Unlock()
 	return false, false
 }
 
@@ -86,8 +90,8 @@ func (d *Detector) IsFlagged(host string) bool {
 	if !d.Enabled() {
 		return false
 	}
-	d.mu.Lock()
-	defer d.mu.Unlock()
+	d.mu.RLock()
+	defer d.mu.RUnlock()
 	return d.flagged[normalizeHost(host)]
 }
 
@@ -96,8 +100,8 @@ func (d *Detector) FlaggedHosts() map[string]int {
 	if !d.Enabled() {
 		return nil
 	}
-	d.mu.Lock()
-	defer d.mu.Unlock()
+	d.mu.RLock()
+	defer d.mu.RUnlock()
 
 	result := make(map[string]int, len(d.flagged))
 	for host := range d.flagged {
@@ -135,6 +139,10 @@ func normalizeHost(input string) string {
 			host := u.Hostname()
 			port := u.Port()
 			if port != "" {
+				// Preserve bracket notation for IPv6 to avoid ambiguity
+				if strings.Contains(host, ":") {
+					return "[" + host + "]:" + port
+				}
 				return host + ":" + port
 			}
 			return host
@@ -151,14 +159,14 @@ func normalizeHost(input string) string {
 		input = input[idx+1:]
 	}
 
-	// Normalize IPv6 addresses in bracket notation: [::1]:8080 → ::1:8080
+	// Preserve IPv6 bracket notation: [::1]:8080 stays as [::1]:8080
 	if strings.HasPrefix(input, "[") {
 		if closeBracket := strings.Index(input, "]"); closeBracket != -1 {
 			host := input[1:closeBracket]
 			if closeBracket+1 < len(input) && input[closeBracket+1] == ':' {
-				return host + ":" + input[closeBracket+2:]
+				return "[" + host + "]:" + input[closeBracket+2:]
 			}
-			return host
+			return "[" + host + "]"
 		}
 	}
 

--- a/pkg/honeypot/detector.go
+++ b/pkg/honeypot/detector.go
@@ -20,7 +20,9 @@ type Detector struct {
 	// suppress controls whether results from flagged hosts are suppressed (true) or only warned (false).
 	suppress bool
 	// matches tracks unique template IDs matched per normalized host.
-	// Entries are pruned once a host is flagged to bound memory growth.
+	// Each host's set is naturally bounded at threshold entries: once the set
+	// reaches threshold, the host is flagged and the entry is pruned entirely.
+	// Total memory is therefore O(uniqueHosts × threshold).
 	matches map[string]map[string]struct{}
 	// flagged tracks hosts that have been flagged as honeypots, storing the match count
 	// at the time of flagging. This allows matches to be pruned while preserving counts.
@@ -75,6 +77,9 @@ func (d *Detector) Record(host, templateID string) (isFlagged, shouldSuppress bo
 	}
 	templates[templateID] = struct{}{}
 
+	// Cap check: once the per-host set reaches threshold, flag and prune.
+	// This bounds each host's set to at most threshold entries; combined
+	// with pruning on flag, total memory is O(uniqueHosts × threshold).
 	if len(templates) >= d.threshold {
 		matchCount := len(templates)
 		// Store the match count in flagged map and prune the per-template set:
@@ -189,6 +194,13 @@ func normalizeHost(input string) string {
 			}
 			return "[" + host + "]"
 		}
+	}
+
+	// Detect bare IPv6 without brackets (e.g., "::1", "fe80::1").
+	// Two or more colons distinguishes IPv6 from host:port (which has exactly one).
+	// Wrap in brackets for consistency with all other IPv6 code paths above.
+	if strings.Count(input, ":") >= 2 {
+		return "[" + input + "]"
 	}
 
 	return input

--- a/pkg/honeypot/detector.go
+++ b/pkg/honeypot/detector.go
@@ -3,6 +3,7 @@ package honeypot
 import (
 	"fmt"
 	"net/url"
+	"sort"
 	"strings"
 	"sync"
 
@@ -125,10 +126,17 @@ func (d *Detector) Summary() string {
 		return ""
 	}
 
+	// Sort hosts for deterministic output across runs
+	hosts := make([]string, 0, len(flagged))
+	for host := range flagged {
+		hosts = append(hosts, host)
+	}
+	sort.Strings(hosts)
+
 	var sb strings.Builder
 	sb.WriteString(fmt.Sprintf("[honeypot] %d host(s) flagged as potential honeypot(s):\n", len(flagged)))
-	for host, count := range flagged {
-		sb.WriteString(fmt.Sprintf("  - %s (%d unique template matches)\n", host, count))
+	for _, host := range hosts {
+		sb.WriteString(fmt.Sprintf("  - %s (%d unique template matches)\n", host, flagged[host]))
 	}
 	return sb.String()
 }
@@ -146,12 +154,17 @@ func normalizeHost(input string) string {
 		if u, err := url.Parse(input); err == nil {
 			host := u.Hostname()
 			port := u.Port()
+			isIPv6 := strings.Contains(host, ":")
 			if port != "" {
 				// Preserve bracket notation for IPv6 to avoid ambiguity
-				if strings.Contains(host, ":") {
+				if isIPv6 {
 					return "[" + host + "]:" + port
 				}
 				return host + ":" + port
+			}
+			// Wrap bare IPv6 in brackets for consistency with non-URL input "[::1]"
+			if isIPv6 {
+				return "[" + host + "]"
 			}
 			return host
 		}

--- a/pkg/honeypot/detector.go
+++ b/pkg/honeypot/detector.go
@@ -19,9 +19,11 @@ type Detector struct {
 	// suppress controls whether results from flagged hosts are suppressed (true) or only warned (false).
 	suppress bool
 	// matches tracks unique template IDs matched per normalized host.
+	// Entries are pruned once a host is flagged to bound memory growth.
 	matches map[string]map[string]struct{}
-	// flagged tracks hosts that have been flagged as honeypots.
-	flagged map[string]bool
+	// flagged tracks hosts that have been flagged as honeypots, storing the match count
+	// at the time of flagging. This allows matches to be pruned while preserving counts.
+	flagged map[string]int
 	// mu protects concurrent access to matches and flagged maps.
 	mu sync.RWMutex
 }
@@ -33,7 +35,7 @@ func New(threshold int, suppress bool) *Detector {
 		threshold: threshold,
 		suppress:  suppress,
 		matches:   make(map[string]map[string]struct{}),
-		flagged:   make(map[string]bool),
+		flagged:   make(map[string]int),
 	}
 }
 
@@ -60,7 +62,7 @@ func (d *Detector) Record(host, templateID string) (isFlagged, shouldSuppress bo
 	d.mu.Lock()
 
 	// If already flagged, skip counting
-	if d.flagged[normalizedHost] {
+	if _, ok := d.flagged[normalizedHost]; ok {
 		d.mu.Unlock()
 		return true, d.suppress
 	}
@@ -73,8 +75,13 @@ func (d *Detector) Record(host, templateID string) (isFlagged, shouldSuppress bo
 	templates[templateID] = struct{}{}
 
 	if len(templates) >= d.threshold {
-		d.flagged[normalizedHost] = true
 		matchCount := len(templates)
+		// Store the match count in flagged map and prune the per-template set:
+		// once flagged, Record() short-circuits on the flagged check above,
+		// so these entries would never be read again. This bounds memory growth
+		// for scans with many flagged hosts.
+		d.flagged[normalizedHost] = matchCount
+		delete(d.matches, normalizedHost)
 		d.mu.Unlock()
 		// Log outside the lock to avoid stalling concurrent writers
 		gologger.Warning().Msgf("[honeypot] %s matched %d unique templates (threshold: %d) — likely honeypot", normalizedHost, matchCount, d.threshold)
@@ -92,7 +99,8 @@ func (d *Detector) IsFlagged(host string) bool {
 	}
 	d.mu.RLock()
 	defer d.mu.RUnlock()
-	return d.flagged[normalizeHost(host)]
+	_, ok := d.flagged[normalizeHost(host)]
+	return ok
 }
 
 // FlaggedHosts returns a list of all hosts flagged as honeypots with their match counts.
@@ -104,8 +112,8 @@ func (d *Detector) FlaggedHosts() map[string]int {
 	defer d.mu.RUnlock()
 
 	result := make(map[string]int, len(d.flagged))
-	for host := range d.flagged {
-		result[host] = len(d.matches[host])
+	for host, count := range d.flagged {
+		result[host] = count
 	}
 	return result
 }

--- a/pkg/honeypot/detector_test.go
+++ b/pkg/honeypot/detector_test.go
@@ -114,6 +114,10 @@ func TestNormalizeHost(t *testing.T) {
 		{"http://[::1]", "[::1]"},
 		{"[::1]:8080", "[::1]:8080"},
 		{"[::1]", "[::1]"},
+		// Bare IPv6 without brackets (wrapped for consistency)
+		{"::1", "[::1]"},
+		{"fe80::1", "[fe80::1]"},
+		{"2001:db8::1", "[2001:db8::1]"},
 	}
 
 	for _, tt := range tests {

--- a/pkg/honeypot/detector_test.go
+++ b/pkg/honeypot/detector_test.go
@@ -111,6 +111,7 @@ func TestNormalizeHost(t *testing.T) {
 		{"  https://example.com  ", "example.com"},
 		// IPv6 bracket notation (preserved to avoid ambiguity)
 		{"https://[::1]:8080/path", "[::1]:8080"},
+		{"http://[::1]", "[::1]"},
 		{"[::1]:8080", "[::1]:8080"},
 		{"[::1]", "[::1]"},
 	}

--- a/pkg/honeypot/detector_test.go
+++ b/pkg/honeypot/detector_test.go
@@ -1,0 +1,185 @@
+package honeypot
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetectorDisabledByDefault(t *testing.T) {
+	d := New(0, false)
+	require.False(t, d.Enabled())
+	flagged, suppress := d.Record("host1", "template1")
+	require.False(t, flagged)
+	require.False(t, suppress)
+}
+
+func TestDetectorNilSafe(t *testing.T) {
+	var d *Detector
+	require.False(t, d.Enabled())
+	require.False(t, d.IsFlagged("host1"))
+	require.Nil(t, d.FlaggedHosts())
+	require.Empty(t, d.Summary())
+}
+
+func TestDetectorThresholdTriggered(t *testing.T) {
+	d := New(3, false)
+	require.True(t, d.Enabled())
+
+	// Below threshold
+	flagged, _ := d.Record("host1", "cve-2021-001")
+	require.False(t, flagged)
+	flagged, _ = d.Record("host1", "cve-2021-002")
+	require.False(t, flagged)
+
+	// Hits threshold
+	flagged, suppress := d.Record("host1", "cve-2021-003")
+	require.True(t, flagged)
+	require.False(t, suppress) // suppress is false in warn-only mode
+}
+
+func TestDetectorSuppressMode(t *testing.T) {
+	d := New(2, true)
+
+	d.Record("host1", "t1")
+	flagged, suppress := d.Record("host1", "t2")
+	require.True(t, flagged)
+	require.True(t, suppress)
+
+	// Subsequent records for flagged host should also suppress
+	flagged, suppress = d.Record("host1", "t3")
+	require.True(t, flagged)
+	require.True(t, suppress)
+}
+
+func TestDetectorWarnOnlyMode(t *testing.T) {
+	d := New(2, false)
+
+	d.Record("host1", "t1")
+	flagged, suppress := d.Record("host1", "t2")
+	require.True(t, flagged)
+	require.False(t, suppress) // warn only, never suppress
+}
+
+func TestDetectorDuplicateTemplateNotCounted(t *testing.T) {
+	d := New(3, false)
+
+	// Same template ID should not be counted multiple times
+	d.Record("host1", "cve-2021-001")
+	d.Record("host1", "cve-2021-001")
+	d.Record("host1", "cve-2021-001")
+
+	require.False(t, d.IsFlagged("host1"))
+}
+
+func TestDetectorMultipleHosts(t *testing.T) {
+	d := New(2, true)
+
+	// Host1 gets flagged
+	d.Record("host1", "t1")
+	d.Record("host1", "t2")
+	require.True(t, d.IsFlagged("host1"))
+
+	// Host2 should not be affected
+	d.Record("host2", "t1")
+	require.False(t, d.IsFlagged("host2"))
+}
+
+func TestDetectorEmptyInputs(t *testing.T) {
+	d := New(2, false)
+	flagged, _ := d.Record("", "t1")
+	require.False(t, flagged)
+	flagged, _ = d.Record("host1", "")
+	require.False(t, flagged)
+}
+
+func TestNormalizeHost(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"https://example.com/path", "example.com"},
+		{"https://example.com:8443/path?q=1", "example.com:8443"},
+		{"http://user:pass@example.com", "example.com"},
+		{"example.com", "example.com"},
+		{"example.com:8080", "example.com:8080"},
+		{"example.com/path/to/resource", "example.com"},
+		{"user:pass@example.com:22", "example.com:22"},
+		{"", ""},
+		{"  https://example.com  ", "example.com"},
+		// IPv6 bracket notation
+		{"https://[::1]:8080/path", "::1:8080"},
+		{"[::1]:8080", "::1:8080"},
+		{"[::1]", "::1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := normalizeHost(tt.input)
+			require.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestDetectorFlaggedHosts(t *testing.T) {
+	d := New(2, false)
+
+	d.Record("host1", "t1")
+	d.Record("host1", "t2")
+	d.Record("host2", "t1")
+	d.Record("host2", "t2")
+
+	flagged := d.FlaggedHosts()
+	require.Len(t, flagged, 2)
+	require.Equal(t, 2, flagged["host1"])
+	require.Equal(t, 2, flagged["host2"])
+}
+
+func TestDetectorSummary(t *testing.T) {
+	d := New(2, false)
+
+	// No flagged hosts
+	require.Empty(t, d.Summary())
+
+	// Flag a host
+	d.Record("host1", "t1")
+	d.Record("host1", "t2")
+
+	summary := d.Summary()
+	require.Contains(t, summary, "1 host(s) flagged")
+	require.Contains(t, summary, "host1")
+}
+
+func TestDetectorHostNormalization(t *testing.T) {
+	d := New(2, false)
+
+	// Different URL forms of same host should be normalized
+	d.Record("https://example.com/path1", "t1")
+	d.Record("https://example.com/path2", "t2")
+
+	require.True(t, d.IsFlagged("example.com"))
+}
+
+func TestDetectorConcurrentAccess(t *testing.T) {
+	d := New(10, false)
+	var wg sync.WaitGroup
+
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			host := fmt.Sprintf("host%d", i%5)
+			templateID := fmt.Sprintf("template-%d", i)
+			d.Record(host, templateID)
+		}(i)
+	}
+	wg.Wait()
+
+	// Should not panic and flagged hosts should be consistent
+	flagged := d.FlaggedHosts()
+	for _, count := range flagged {
+		require.GreaterOrEqual(t, count, 10)
+	}
+}

--- a/pkg/honeypot/detector_test.go
+++ b/pkg/honeypot/detector_test.go
@@ -109,10 +109,10 @@ func TestNormalizeHost(t *testing.T) {
 		{"user:pass@example.com:22", "example.com:22"},
 		{"", ""},
 		{"  https://example.com  ", "example.com"},
-		// IPv6 bracket notation
-		{"https://[::1]:8080/path", "::1:8080"},
-		{"[::1]:8080", "::1:8080"},
-		{"[::1]", "::1"},
+		// IPv6 bracket notation (preserved to avoid ambiguity)
+		{"https://[::1]:8080/path", "[::1]:8080"},
+		{"[::1]:8080", "[::1]:8080"},
+		{"[::1]", "[::1]"},
 	}
 
 	for _, tt := range tests {
@@ -179,6 +179,8 @@ func TestDetectorConcurrentAccess(t *testing.T) {
 
 	// Should not panic and flagged hosts should be consistent
 	flagged := d.FlaggedHosts()
+	// All 5 hosts (host0-host4) should be flagged: 100 goroutines / 5 hosts = 20 templates each > threshold 10
+	require.Len(t, flagged, 5)
 	for _, count := range flagged {
 		require.GreaterOrEqual(t, count, 10)
 	}

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -24,6 +24,7 @@ import (
 	"github.com/projectdiscovery/interactsh/pkg/server"
 	"github.com/projectdiscovery/nuclei/v3/internal/colorizer"
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/config"
+	"github.com/projectdiscovery/nuclei/v3/pkg/honeypot"
 	"github.com/projectdiscovery/nuclei/v3/pkg/model"
 	"github.com/projectdiscovery/nuclei/v3/pkg/model/types/severity"
 	"github.com/projectdiscovery/nuclei/v3/pkg/operators"
@@ -81,6 +82,9 @@ type StandardWriter struct {
 	// JSONLogRequestHook is a hook that can be used to log request/response
 	// when using custom server code with output
 	JSONLogRequestHook func(*JSONLogRequest)
+
+	// honeypotDetector tracks template match density per host to identify honeypots.
+	honeypotDetector *honeypot.Detector
 
 	resultCount atomic.Int32
 }
@@ -218,6 +222,9 @@ type ResultEvent struct {
 	FileToIndexPosition map[string]int `json:"-"`
 	TemplateVerifier    string         `json:"-"`
 	Error               string         `json:"error,omitempty"`
+	// HoneypotDetected indicates the host was flagged as a potential honeypot
+	// due to an unusually high number of unique template matches.
+	HoneypotDetected bool `json:"honeypot_detected,omitempty"`
 }
 
 type IssueTrackerMetadata struct {
@@ -280,6 +287,7 @@ func NewStandardWriter(options *types.Options) (*StandardWriter, error) {
 		storeResponseDir: options.StoreResponseDir,
 		omitTemplate:     options.OmitTemplate,
 		KeysToRedact:     options.Redact,
+		honeypotDetector: honeypot.New(options.HoneypotThreshold, options.HoneypotSuppressResults),
 	}
 
 	if v := os.Getenv("DISABLE_STDOUT"); v == "true" || v == "1" {
@@ -297,6 +305,21 @@ func (w *StandardWriter) ResultCount() int {
 func (w *StandardWriter) Write(event *ResultEvent) error {
 	if event.Error != "" && !w.matcherStatus {
 		return nil
+	}
+
+	// Check honeypot detection: track unique template matches per host
+	if w.honeypotDetector.Enabled() {
+		host := event.Host
+		if host == "" {
+			host = event.URL
+		}
+		isFlagged, shouldSuppress := w.honeypotDetector.Record(host, event.TemplateID)
+		if isFlagged {
+			event.HoneypotDetected = true
+			if shouldSuppress {
+				return nil
+			}
+		}
 	}
 
 	// Enrich the result event with extra metadata on the template-path and url.
@@ -451,8 +474,18 @@ func (w *StandardWriter) Colorizer() aurora.Aurora {
 	return w.aurora
 }
 
+// HoneypotDetector returns the honeypot detector instance for the writer.
+func (w *StandardWriter) HoneypotDetector() *honeypot.Detector {
+	return w.honeypotDetector
+}
+
 // Close closes the output writing interface
 func (w *StandardWriter) Close() {
+	// Print honeypot detection summary if any hosts were flagged
+	if summary := w.honeypotDetector.Summary(); summary != "" {
+		gologger.Warning().Msgf("\n%s", summary)
+	}
+
 	if w.outputFile != nil {
 		_ = w.outputFile.Close()
 	}

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -307,7 +307,15 @@ func (w *StandardWriter) Write(event *ResultEvent) error {
 		return nil
 	}
 
-	// Check honeypot detection: track unique template matches per host
+	// Check honeypot detection: track unique template matches per host.
+	// When a host is flagged and suppress mode is enabled, the result is dropped here
+	// without incrementing resultCount. This is intentional: suppressed honeypot results
+	// should not appear in scan summaries, progress bars, exit codes, or cloud uploads.
+	//
+	// Note: this is a streaming design — results written *before* a host crosses the
+	// honeypot threshold will not have HoneypotDetected set retroactively. Users relying
+	// on JSON output post-processing should filter by host using the honeypot summary
+	// rather than solely by this per-event field.
 	if w.honeypotDetector.Enabled() {
 		host := event.Host
 		if host == "" {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -133,6 +133,12 @@ type Options struct {
 	TrackError goflags.StringSlice
 	// NoHostErrors disables host skipping after maximum number of errors
 	NoHostErrors bool
+	// HoneypotThreshold is the minimum number of unique template matches for a host
+	// to be flagged as a potential honeypot. A value of 0 disables detection.
+	HoneypotThreshold int
+	// HoneypotSuppressResults controls whether results from honeypot-flagged hosts
+	// are suppressed (true) or only warned about (false).
+	HoneypotSuppressResults bool
 	// BulkSize is the of targets analyzed in parallel for each template
 	BulkSize int
 	// TemplateThreads is the number of templates executed in parallel
@@ -525,6 +531,8 @@ func (options *Options) Copy() *Options {
 		MaxHostError:                   options.MaxHostError,
 		TrackError:                     options.TrackError,
 		NoHostErrors:                   options.NoHostErrors,
+		HoneypotThreshold:              options.HoneypotThreshold,
+		HoneypotSuppressResults:        options.HoneypotSuppressResults,
 		BulkSize:                       options.BulkSize,
 		TemplateThreads:                options.TemplateThreads,
 		HeadlessBulkSize:               options.HeadlessBulkSize,


### PR DESCRIPTION
## Proposed changes

Implements honeypot detection for Nuclei to address the issue where certain Shodan-exposed hosts deliberately serve responses matching a large number of vulnerability templates, producing massive amounts of false positive results. When a host matches an unusually high number of unique template signatures, this PR flags it as a likely honeypot, warns the user, and optionally suppresses results from that host.

/claim #6403

### Changes

- **`pkg/honeypot/detector.go`** - New `Detector` type that tracks unique template IDs matched per normalized host. When the match count crosses a configurable threshold, the host is flagged and a warning is logged. Thread-safe via `sync.Mutex`. Handles all host/URL forms via `normalizeHost` (strips scheme, path, query, fragment, userinfo, IPv6 brackets).

- **`pkg/honeypot/detector_test.go`** - 13 unit tests covering: disabled-by-default, nil-safety, threshold triggering, suppress mode, warn-only mode, duplicate template deduplication, multi-host isolation, empty inputs, host normalization (including IPv6 bracket notation), flagged-host listing, summary output, URL normalization, and concurrent access.

- **`pkg/output/output.go`** - Integration into `StandardWriter.Write()`: records each match with the detector, sets `HoneypotDetected: true` on the `ResultEvent`, and optionally returns early to suppress output. Adds `HoneypotDetected bool` field to `ResultEvent` (`json:"honeypot_detected,omitempty"`). Summary printed in `Close()`.

- **`pkg/types/types.go`** - Two new options fields: `HoneypotThreshold int` and `HoneypotSuppressResults bool`. Both included in `Options.Copy()`.

- **`cmd/nuclei/main.go`** - Two new CLI flags in the optimization group:
  - `-honeypot-threshold` / `-hpt` (int, default 0 = disabled)
  - `-honeypot-suppress` / `-hpq` (bool, default false = warn only)

### Proof

Since this feature requires scanning actual honeypot hosts, here is the expected behavior based on the implementation and tests:

**Warn-only mode** (default when detection enabled):
```bash
nuclei -target 120.26.237.211 -hpt 10

# When a host matches 10+ unique templates:
[WRN] [honeypot] 120.26.237.211 matched 10 unique templates (threshold: 10) - likely honeypot

# Results still written but tagged in JSON:
{"template-id":"cve-2024-50379","host":"120.26.237.211","honeypot_detected":true,...}
```

**Suppress mode:**
```bash
nuclei -target 120.26.237.211 -hpt 10 -hpq

# Warning appears, subsequent results silently dropped. Summary at close:
[WRN]
[honeypot] 1 host(s) flagged as potential honeypot(s):
  - 120.26.237.211 (10 unique template matches)
```

### Design Rationale

- **Minimal footprint**: 155 lines in core detector, no external dependencies beyond stdlib + gologger
- **Disabled by default** (`-hpt 0`): opt-in, no behavior change for existing users
- **Warn vs suppress**: two-stage approach - users run with warn first, then enable suppression
- **Host normalization**: HTTP/HTTPS URLs, bare host:port, IPv4, IPv6 `[::1]`, userinfo stripping
- **Integration point**: `StandardWriter.Write()` is the natural chokepoint, no middleware wrapper needed

## Checklist

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate) - flags documented via CLI help text

*This PR was developed with AI assistance (Claude/Anthropic). All changes reviewed against codebase conventions.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Honeypot detection to flag hosts with many unique template matches, configurable threshold.
  * New CLI options to set threshold and optionally suppress results from detected honeypots.
  * Output integration: events are marked when a host is flagged, suppressed when configured, and a summary printed on close.

* **Tests**
  * Comprehensive tests covering threshold behavior, host normalization, duplicate handling, multi-host isolation, summaries, and concurrency safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->