### PR TITLE
feat: add honeypot detection capability

### DIFF
--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -437,6 +437,12 @@ on extensive configurability, massive extensibility and ease of use.`)
 		flagSet.BoolVar(&options.DisableStdin, "no-stdin", false, "disable stdin processing"),
 	)
 
+	flagSet.CreateGroup("honeypot", "Honeypot",
+		flagSet.BoolVarP(&options.HoneypotDetection, "honeypot-detection", "hpd", false, "enable honeypot detection for hosts with abnormally high template match count"),
+		flagSet.IntVarP(&options.HoneypotThreshold, "honeypot-threshold", "hpt", 100, "minimum number of unique template matches to flag a host as honeypot"),
+		flagSet.BoolVarP(&options.HoneypotExcludeResults, "honeypot-exclude", "hpe", false, "exclude results from detected honeypot hosts"),
+	)
+
 	flagSet.CreateGroup("headless", "Headless",
 		flagSet.BoolVar(&options.Headless, "headless", false, "enable templates that require headless browser support (root user on Linux will disable sandbox)"),
 		flagSet.IntVar(&options.PageTimeout, "page-timeout", 20, "seconds to wait for each page in headless mode"),

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -275,6 +275,15 @@ func New(options *types.Options) (*Runner, error) {
 	}
 	// setup a proxy writer to automatically upload results to PDCP
 	runner.output = runner.setupPDCPUpload(outputWriter)
+	if options.HoneypotDetection {
+		runner.output = output.NewHoneypotWriter(output.HoneypotWriterOptions{
+			Inner:          runner.output,
+			Threshold:      options.HoneypotThreshold,
+			ExcludeResults: options.HoneypotExcludeResults,
+			Logger:         runner.Logger,
+		})
+		runner.Logger.Info().Msgf("Honeypot detection enabled (threshold: %d unique template matches per host)", options.HoneypotThreshold)
+	}
 	if options.HTTPStats {
 		runner.httpStats = outputstats.NewTracker()
 		runner.output = output.NewMultiWriter(runner.output, output.NewTrackerWriter(runner.httpStats))

--- a/pkg/output/honeypot_writer.go
+++ b/pkg/output/honeypot_writer.go
@@ -1,0 +1,208 @@
+package output
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/logrusorgru/aurora"
+	"github.com/projectdiscovery/gologger"
+)
+
+// DefaultHoneypotThreshold is the default number of unique template matches
+// per host above which the host is flagged as a potential honeypot.
+const DefaultHoneypotThreshold = 100
+
+// HoneypotWriter wraps an output Writer to track the number of unique
+// template matches per host. Hosts exceeding the configured threshold
+// are flagged as potential honeypots in the scan summary.
+//
+// When ExcludeHoneypotResults is true, results for flagged hosts are
+// suppressed from output entirely; otherwise they are written normally
+// but the user is warned at scan completion.
+type HoneypotWriter struct {
+	inner     Writer
+	threshold int
+	exclude   bool
+	logger    *gologger.Logger
+
+	mu sync.Mutex
+	// hostMatches tracks unique template IDs matched per host.
+	hostMatches map[string]map[string]struct{}
+	// hostResults buffers results when exclusion mode is on.
+	hostResults map[string][]*ResultEvent
+}
+
+// HoneypotWriterOptions contains options for honeypot detection.
+type HoneypotWriterOptions struct {
+	// Inner is the underlying writer to delegate to.
+	Inner Writer
+	// Threshold is the minimum number of unique template matches
+	// on a single host that triggers honeypot detection.
+	// A value of 0 means the default threshold is used.
+	Threshold int
+	// ExcludeResults when true suppresses results for detected honeypots.
+	ExcludeResults bool
+	// Logger is the logger instance.
+	Logger *gologger.Logger
+}
+
+var _ Writer = &HoneypotWriter{}
+
+// NewHoneypotWriter creates a new HoneypotWriter wrapping the provided writer.
+func NewHoneypotWriter(opts HoneypotWriterOptions) *HoneypotWriter {
+	threshold := opts.Threshold
+	if threshold <= 0 {
+		threshold = DefaultHoneypotThreshold
+	}
+	return &HoneypotWriter{
+		inner:       opts.Inner,
+		threshold:   threshold,
+		exclude:     opts.ExcludeResults,
+		logger:      opts.Logger,
+		hostMatches: make(map[string]map[string]struct{}),
+		hostResults: make(map[string][]*ResultEvent),
+	}
+}
+
+// Write intercepts result events to track matches per host. If exclusion
+// mode is enabled, results for hosts that already exceed the threshold
+// are dropped. Otherwise, all results are forwarded to the inner writer.
+func (hw *HoneypotWriter) Write(event *ResultEvent) error {
+	if event == nil {
+		return nil
+	}
+	host := extractHost(event)
+	templateID := event.TemplateID
+
+	hw.mu.Lock()
+	if hw.hostMatches[host] == nil {
+		hw.hostMatches[host] = make(map[string]struct{})
+	}
+	hw.hostMatches[host][templateID] = struct{}{}
+	matchCount := len(hw.hostMatches[host])
+
+	if hw.exclude {
+		// Buffer results to potentially drop them if the host turns out
+		// to be a honeypot. Once the threshold is crossed, stop buffering
+		// and silently discard future results for this host.
+		if matchCount > hw.threshold {
+			// Already flagged -- discard silently
+			hw.mu.Unlock()
+			return nil
+		}
+		if matchCount == hw.threshold {
+			// Just crossed the threshold -- discard buffered results and this one
+			hw.logger.Warning().Msgf("[honeypot] Host %s exceeded threshold (%d unique template matches) - dropping results", host, hw.threshold)
+			delete(hw.hostResults, host)
+			hw.mu.Unlock()
+			return nil
+		}
+		// Below threshold -- buffer and forward
+		hw.hostResults[host] = append(hw.hostResults[host], event)
+		hw.mu.Unlock()
+		return hw.inner.Write(event)
+	}
+
+	hw.mu.Unlock()
+	return hw.inner.Write(event)
+}
+
+// WriteFailure forwards failure events to the inner writer.
+func (hw *HoneypotWriter) WriteFailure(event *InternalWrappedEvent) error {
+	return hw.inner.WriteFailure(event)
+}
+
+// Request forwards request logs to the inner writer.
+func (hw *HoneypotWriter) Request(templateID, url, requestType string, err error) {
+	hw.inner.Request(templateID, url, requestType, err)
+}
+
+// RequestStatsLog forwards stats log to the inner writer.
+func (hw *HoneypotWriter) RequestStatsLog(statusCode, response string) {
+	hw.inner.RequestStatsLog(statusCode, response)
+}
+
+// WriteStoreDebugData forwards debug data to the inner writer.
+func (hw *HoneypotWriter) WriteStoreDebugData(host, templateID, eventType string, data string) {
+	hw.inner.WriteStoreDebugData(host, templateID, eventType, data)
+}
+
+// Colorizer returns the colorizer from the inner writer.
+func (hw *HoneypotWriter) Colorizer() aurora.Aurora {
+	return hw.inner.Colorizer()
+}
+
+// ResultCount returns result count from the inner writer.
+func (hw *HoneypotWriter) ResultCount() int {
+	return hw.inner.ResultCount()
+}
+
+// Close prints the honeypot detection summary and closes the inner writer.
+func (hw *HoneypotWriter) Close() {
+	hw.printHoneypotSummary()
+	hw.inner.Close()
+}
+
+// GetDetectedHoneypots returns a map of hosts detected as potential
+// honeypots and the number of unique template matches for each.
+func (hw *HoneypotWriter) GetDetectedHoneypots() map[string]int {
+	hw.mu.Lock()
+	defer hw.mu.Unlock()
+
+	detected := make(map[string]int)
+	for host, templates := range hw.hostMatches {
+		if len(templates) >= hw.threshold {
+			detected[host] = len(templates)
+		}
+	}
+	return detected
+}
+
+// printHoneypotSummary prints detected honeypots at scan completion.
+func (hw *HoneypotWriter) printHoneypotSummary() {
+	detected := hw.GetDetectedHoneypots()
+	if len(detected) == 0 {
+		hw.logger.Info().Msgf("[honeypot] No potential honeypots detected (threshold: %d)", hw.threshold)
+		return
+	}
+
+	// Sort by match count descending for readable output
+	type hostEntry struct {
+		Host  string
+		Count int
+	}
+	entries := make([]hostEntry, 0, len(detected))
+	for host, count := range detected {
+		entries = append(entries, hostEntry{Host: host, Count: count})
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Count > entries[j].Count
+	})
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("[honeypot] Detected %d potential honeypot(s) (threshold: %d unique template matches):\n", len(entries), hw.threshold))
+	for _, e := range entries {
+		action := "results included"
+		if hw.exclude {
+			action = "results excluded"
+		}
+		sb.WriteString(fmt.Sprintf("  - %s: %d unique matches (%s)\n", e.Host, e.Count, action))
+	}
+	hw.logger.Warning().Msgf("%s", sb.String())
+}
+
+// extractHost returns the best available host identifier from a ResultEvent.
+func extractHost(event *ResultEvent) string {
+	if event.Host != "" {
+		return event.Host
+	}
+	if event.IP != "" {
+		return event.IP
+	}
+	if event.URL != "" {
+		return event.URL
+	}
+	return "unknown"
+}

--- a/pkg/output/honeypot_writer_test.go
+++ b/pkg/output/honeypot_writer_test.go
@@ -1,0 +1,174 @@
+package output
+
+import (
+	"testing"
+
+	"github.com/logrusorgru/aurora"
+	"github.com/projectdiscovery/gologger"
+)
+
+type mockWriter struct {
+	events  []*ResultEvent
+	closed  bool
+	results int
+}
+
+func (m *mockWriter) Close()                                                        { m.closed = true }
+func (m *mockWriter) Colorizer() aurora.Aurora                                       { return aurora.NewAurora(false) }
+func (m *mockWriter) Write(event *ResultEvent) error                                 { m.events = append(m.events, event); m.results++; return nil }
+func (m *mockWriter) WriteFailure(event *InternalWrappedEvent) error                 { return nil }
+func (m *mockWriter) Request(templateID, url, requestType string, err error)         {}
+func (m *mockWriter) RequestStatsLog(statusCode, response string)                    {}
+func (m *mockWriter) WriteStoreDebugData(host, templateID, eventType string, d string) {}
+func (m *mockWriter) ResultCount() int                                               { return m.results }
+
+func TestHoneypotWriterDetection(t *testing.T) {
+	mock := &mockWriter{}
+	hw := NewHoneypotWriter(HoneypotWriterOptions{
+		Inner:     mock,
+		Threshold: 3,
+		Logger:    gologger.DefaultLogger,
+	})
+
+	// Write 3 unique template matches for the same host
+	for i := 0; i < 3; i++ {
+		event := &ResultEvent{
+			Host:       "192.168.1.1",
+			TemplateID: "template-" + string(rune('a'+i)),
+		}
+		if err := hw.Write(event); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+
+	detected := hw.GetDetectedHoneypots()
+	if len(detected) != 1 {
+		t.Fatalf("expected 1 detected honeypot, got %d", len(detected))
+	}
+	if detected["192.168.1.1"] != 3 {
+		t.Fatalf("expected 3 matches for host, got %d", detected["192.168.1.1"])
+	}
+
+	// All results should have been written through (exclude=false)
+	if len(mock.events) != 3 {
+		t.Fatalf("expected 3 events written, got %d", len(mock.events))
+	}
+}
+
+func TestHoneypotWriterExclude(t *testing.T) {
+	mock := &mockWriter{}
+	hw := NewHoneypotWriter(HoneypotWriterOptions{
+		Inner:          mock,
+		Threshold:      3,
+		ExcludeResults: true,
+		Logger:         gologger.DefaultLogger,
+	})
+
+	// Write 5 unique template matches for the same host
+	for i := 0; i < 5; i++ {
+		event := &ResultEvent{
+			Host:       "10.0.0.1",
+			TemplateID: "tmpl-" + string(rune('a'+i)),
+		}
+		_ = hw.Write(event)
+	}
+
+	detected := hw.GetDetectedHoneypots()
+	if len(detected) != 1 {
+		t.Fatalf("expected 1 detected honeypot, got %d", len(detected))
+	}
+
+	// When exclude is enabled, results at and above threshold should be dropped.
+	// Templates a, b are written (count 1, 2 -- below threshold 3)
+	// Template c hits threshold exactly (count 3) -- dropped
+	// Templates d, e exceed threshold -- dropped
+	if len(mock.events) != 2 {
+		t.Fatalf("expected 2 events written (below threshold), got %d", len(mock.events))
+	}
+}
+
+func TestHoneypotWriterNoDetection(t *testing.T) {
+	mock := &mockWriter{}
+	hw := NewHoneypotWriter(HoneypotWriterOptions{
+		Inner:     mock,
+		Threshold: 10,
+		Logger:    gologger.DefaultLogger,
+	})
+
+	// Write 3 unique template matches (below threshold)
+	for i := 0; i < 3; i++ {
+		event := &ResultEvent{
+			Host:       "example.com",
+			TemplateID: "t-" + string(rune('a'+i)),
+		}
+		_ = hw.Write(event)
+	}
+
+	detected := hw.GetDetectedHoneypots()
+	if len(detected) != 0 {
+		t.Fatalf("expected no detected honeypots, got %d", len(detected))
+	}
+	if len(mock.events) != 3 {
+		t.Fatalf("expected 3 events, got %d", len(mock.events))
+	}
+}
+
+func TestHoneypotWriterMultipleHosts(t *testing.T) {
+	mock := &mockWriter{}
+	hw := NewHoneypotWriter(HoneypotWriterOptions{
+		Inner:     mock,
+		Threshold: 2,
+		Logger:    gologger.DefaultLogger,
+	})
+
+	// Host A: 3 matches (honeypot)
+	for i := 0; i < 3; i++ {
+		_ = hw.Write(&ResultEvent{Host: "host-a", TemplateID: "t-" + string(rune('a'+i))})
+	}
+	// Host B: 1 match (normal)
+	_ = hw.Write(&ResultEvent{Host: "host-b", TemplateID: "t-x"})
+
+	detected := hw.GetDetectedHoneypots()
+	if len(detected) != 1 {
+		t.Fatalf("expected 1 detected honeypot, got %d", len(detected))
+	}
+	if _, ok := detected["host-a"]; !ok {
+		t.Fatal("expected host-a to be detected as honeypot")
+	}
+	if _, ok := detected["host-b"]; ok {
+		t.Fatal("host-b should not be detected as honeypot")
+	}
+}
+
+func TestHoneypotWriterDuplicateTemplates(t *testing.T) {
+	mock := &mockWriter{}
+	hw := NewHoneypotWriter(HoneypotWriterOptions{
+		Inner:     mock,
+		Threshold: 3,
+		Logger:    gologger.DefaultLogger,
+	})
+
+	// Same template matched multiple times should only count once
+	for i := 0; i < 5; i++ {
+		_ = hw.Write(&ResultEvent{Host: "host-c", TemplateID: "same-template"})
+	}
+
+	detected := hw.GetDetectedHoneypots()
+	if len(detected) != 0 {
+		t.Fatalf("expected no honeypot (same template repeated), got %d", len(detected))
+	}
+}
+
+func TestHoneypotWriterClose(t *testing.T) {
+	mock := &mockWriter{}
+	hw := NewHoneypotWriter(HoneypotWriterOptions{
+		Inner:     mock,
+		Threshold: 5,
+		Logger:    gologger.DefaultLogger,
+	})
+
+	hw.Close()
+	if !mock.closed {
+		t.Fatal("expected inner writer to be closed")
+	}
+}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -406,6 +406,14 @@ type Options struct {
 	EnableGlobalMatchersTemplates bool
 	// EnableFileTemplates enables file templates
 	EnableFileTemplates bool
+	// HoneypotDetection enables detection of potential honeypot hosts
+	// that match an unusually high number of templates
+	HoneypotDetection bool
+	// HoneypotThreshold is the minimum number of unique template matches
+	// per host before flagging it as a potential honeypot (default 100)
+	HoneypotThreshold int
+	// HoneypotExcludeResults when true excludes results from detected honeypot hosts
+	HoneypotExcludeResults bool
 	// Disables cloud upload
 	EnableCloudUpload bool
 	// ScanID is the scan ID to use for cloud upload
@@ -658,6 +666,9 @@ func (options *Options) Copy() *Options {
 		EnableSelfContainedTemplates:   options.EnableSelfContainedTemplates,
 		EnableGlobalMatchersTemplates:  options.EnableGlobalMatchersTemplates,
 		EnableFileTemplates:            options.EnableFileTemplates,
+		HoneypotDetection:              options.HoneypotDetection,
+		HoneypotThreshold:              options.HoneypotThreshold,
+		HoneypotExcludeResults:         options.HoneypotExcludeResults,
 		EnableCloudUpload:              options.EnableCloudUpload,
 		ScanID:                         options.ScanID,
 		ScanName:                       options.ScanName,


### PR DESCRIPTION
## Summary

- Adds post-scan honeypot detection that tracks unique template matches per host and flags hosts exceeding a configurable threshold
- Introduces a `HoneypotWriter` that wraps the existing output writer pipeline, intercepting result events to count unique template matches per host
- Adds three new CLI flags: `--honeypot-detection` (`-hpd`), `--honeypot-threshold` (`-hpt`, default 100), and `--honeypot-exclude` (`-hpe`)
- When a host exceeds the threshold, a warning is printed at scan completion; optionally, results from detected honeypots can be excluded from output entirely

## Motivation

Many hosts on Shodan are configured as honeypots that deliberately return responses matching many nuclei vulnerability templates. This creates noise in scan results and can mislead users. This feature detects such hosts by observing unusually high match rates and warns the user (or optionally drops the results).

## Test plan

- [x] Unit tests added for `HoneypotWriter` covering detection, exclusion, multiple hosts, duplicate template deduplication, and close behavior
- [x] `go build ./...` passes
- [x] `go test ./pkg/output/ -run TestHoneypot` passes (6/6 tests)
- [ ] Manual testing: run nuclei with `-hpd` flag against a known honeypot target and verify warning is printed
- [ ] Manual testing: run with `-hpd -hpe` to verify results from honeypot hosts are excluded

## Usage

```bash
# Enable honeypot detection with default threshold (100 unique template matches)
nuclei -u target.com -hpd

# Custom threshold
nuclei -u target.com -hpd -hpt 50

# Exclude honeypot results from output
nuclei -u target.com -hpd -hpe
```

/claim #6403

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Honeypot detection to flag hosts with unusually many unique template matches.
  * CLI flags: `honeypot-detection`, `honeypot-threshold` (default 100), `honeypot-exclude` to optionally drop results from detected hosts.
  * Options updated to carry honeypot settings across runs.

* **Tests**
  * Added unit tests covering detection, exclusion, duplicates, multiple hosts, and close behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->