### PR TITLE
fix(fuzz): prevent concurrent map writes in MultiPartForm.Decode

### DIFF
--- a/pkg/fuzz/component/body.go
+++ b/pkg/fuzz/component/body.go
@@ -77,18 +77,27 @@ func (b *Body) Parse(req *retryablehttp.Request) (bool, error) {
 
 // parseBody parses a body with a custom decoder
 func (b *Body) parseBody(decoderName string, req *retryablehttp.Request) (bool, error) {
-	decoder := dataformat.Get(decoderName)
+	var decoder dataformat.DataFormat
 	if decoderName == dataformat.MultiPartFormDataFormat {
-		// set content type to extract boundary
-		if err := decoder.(*dataformat.MultiPartForm).ParseBoundary(req.Header.Get("Content-Type")); err != nil {
+		// MultiPartForm is stateful (boundary, filesMetadata) so a fresh
+		// instance is required to avoid concurrent map writes when multiple
+		// goroutines fuzz in parallel.
+		mpf := dataformat.NewMultiPartForm()
+		if err := mpf.ParseBoundary(req.Header.Get("Content-Type")); err != nil {
 			return false, errors.Wrap(err, "could not parse boundary")
 		}
+		decoder = mpf
+	} else {
+		decoder = dataformat.Get(decoderName)
 	}
 	decoded, err := decoder.Decode(b.value.String())
 	if err != nil {
 		return false, errors.Wrap(err, "could not decode raw")
 	}
 	b.value.SetParsed(decoded, decoder.Name())
+	if decoderName == dataformat.MultiPartFormDataFormat {
+		b.value.encoder = decoder
+	}
 	return true, nil
 }
 

--- a/pkg/fuzz/component/value.go
+++ b/pkg/fuzz/component/value.go
@@ -19,6 +19,7 @@ type Value struct {
 	data       string
 	parsed     dataformat.KV
 	dataFormat string
+	encoder    dataformat.DataFormat
 }
 
 // NewValue returns a new value component
@@ -42,6 +43,7 @@ func (v *Value) Clone() *Value {
 		data:       v.data,
 		parsed:     v.parsed.Clone(),
 		dataFormat: v.dataFormat,
+		encoder:    v.encoder,
 	}
 }
 
@@ -138,9 +140,8 @@ func (v *Value) Delete(key string) bool {
 func (v *Value) Encode() (string, error) {
 	toEncodeStr := v.data
 	if v.parsed.OrderedMap != nil {
-		// flattening orderedmap not supported
 		if v.dataFormat != "" {
-			dataformatStr, err := dataformat.Encode(v.parsed, v.dataFormat)
+			dataformatStr, err := v.encode(v.parsed)
 			if err != nil {
 				return "", err
 			}
@@ -154,13 +155,20 @@ func (v *Value) Encode() (string, error) {
 		return "", err
 	}
 	if v.dataFormat != "" {
-		dataformatStr, err := dataformat.Encode(dataformat.KVMap(nested), v.dataFormat)
+		dataformatStr, err := v.encode(dataformat.KVMap(nested))
 		if err != nil {
 			return "", err
 		}
 		toEncodeStr = dataformatStr
 	}
 	return toEncodeStr, nil
+}
+
+func (v *Value) encode(data dataformat.KV) (string, error) {
+	if v.encoder != nil {
+		return v.encoder.Encode(data)
+	}
+	return dataformat.Encode(data, v.dataFormat)
 }
 
 // In go, []int, []string are not implictily converted to []interface{}

--- a/pkg/fuzz/dataformat/multipart_test.go
+++ b/pkg/fuzz/dataformat/multipart_test.go
@@ -1,6 +1,7 @@
 package dataformat
 
 import (
+	"sync"
 	"testing"
 
 	mapsutil "github.com/projectdiscovery/utils/maps"
@@ -367,4 +368,27 @@ func TestMultiPartForm_GetFileMetadataWithNilMap(t *testing.T) {
 	// GetFileMetadata should handle nil filesMetadata gracefully
 	_, exists := form.GetFileMetadata("anything")
 	assert.False(t, exists)
+}
+
+func TestMultiPartFormDecode_ConcurrentWithSeparateInstances(t *testing.T) {
+	boundary := "boundary123"
+	body := "--" + boundary + "\r\n" +
+		"Content-Disposition: form-data; name=\"file\"; filename=\"test.txt\"\r\n" +
+		"Content-Type: text/plain\r\n\r\n" +
+		"file content\r\n" +
+		"--" + boundary + "--\r\n"
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			mpf := NewMultiPartForm()
+			require.NoError(t, mpf.ParseBoundary("multipart/form-data; boundary="+boundary))
+			kv, err := mpf.Decode(body)
+			require.NoError(t, err)
+			require.NotNil(t, kv)
+		}()
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
## Proposed changes

Closes #6947

`MultiPartForm` is registered as a singleton in `dataformat.init()` and shared across all goroutines via `dataformat.Get()`. When multiple goroutines fuzz `multipart/form-data` bodies in parallel, concurrent writes to `filesMetadata` map in `Decode()` and `boundary` field in `ParseBoundary()` cause `fatal error: concurrent map writes` (unrecoverable).

This fix creates a fresh `MultiPartForm` instance per parse in `Body.parseBody` instead of reusing the singleton. The instance is also stored on `Value` so it remains available for re-encoding during `Rebuild()`.

Other `DataFormat` implementations (JSON, XML, Form, Raw) are stateless and remain as singletons.

This is similar to the approach in #6828 which addressed concurrent map writes in `evaluateVarsWithInteractsh`.

### Proof

Race condition test added and verified:

```
$ go test -race -run TestMultiPartFormDecode_ConcurrentWithSeparateInstances ./pkg/fuzz/dataformat/...
ok  github.com/projectdiscovery/nuclei/v3/pkg/fuzz/dataformat

$ go test -race ./pkg/fuzz/...
ok  github.com/projectdiscovery/nuclei/v3/pkg/fuzz
ok  github.com/projectdiscovery/nuclei/v3/pkg/fuzz/analyzers/time
ok  github.com/projectdiscovery/nuclei/v3/pkg/fuzz/component
ok  github.com/projectdiscovery/nuclei/v3/pkg/fuzz/dataformat
ok  github.com/projectdiscovery/nuclei/v3/pkg/fuzz/stats
```

## Checklist

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread-safety for multipart form data handling during concurrent operations.

* **Tests**
  * Added concurrent execution tests to verify thread-safe multipart form data processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->