### PR TITLE
fix(fuzz): prevent concurrent map writes in MultiPartForm.Decode

### DIFF
--- a/pkg/fuzz/component/body.go
+++ b/pkg/fuzz/component/body.go
@@ -77,18 +77,27 @@ func (b *Body) Parse(req *retryablehttp.Request) (bool, error) {
 
 // parseBody parses a body with a custom decoder
 func (b *Body) parseBody(decoderName string, req *retryablehttp.Request) (bool, error) {
-	decoder := dataformat.Get(decoderName)
+	var decoder dataformat.DataFormat
 	if decoderName == dataformat.MultiPartFormDataFormat {
-		// set content type to extract boundary
-		if err := decoder.(*dataformat.MultiPartForm).ParseBoundary(req.Header.Get("Content-Type")); err != nil {
+		// MultiPartForm is stateful (boundary, filesMetadata) so a fresh
+		// instance is required to avoid concurrent map writes when multiple
+		// goroutines fuzz in parallel.
+		mpf := dataformat.NewMultiPartForm()
+		if err := mpf.ParseBoundary(req.Header.Get("Content-Type")); err != nil {
 			return false, errors.Wrap(err, "could not parse boundary")
 		}
+		decoder = mpf
+	} else {
+		decoder = dataformat.Get(decoderName)
 	}
 	decoded, err := decoder.Decode(b.value.String())
 	if err != nil {
 		return false, errors.Wrap(err, "could not decode raw")
 	}
 	b.value.SetParsed(decoded, decoder.Name())
+	if decoderName == dataformat.MultiPartFormDataFormat {
+		b.value.encoder = decoder
+	}
 	return true, nil
 }
 

--- a/pkg/fuzz/component/value.go
+++ b/pkg/fuzz/component/value.go
@@ -19,6 +19,7 @@ type Value struct {
 	data       string
 	parsed     dataformat.KV
 	dataFormat string
+	encoder    dataformat.DataFormat
 }
 
 // NewValue returns a new value component
@@ -42,6 +43,7 @@ func (v *Value) Clone() *Value {
 		data:       v.data,
 		parsed:     v.parsed.Clone(),
 		dataFormat: v.dataFormat,
+		encoder:    v.encoder,
 	}
 }
 
@@ -138,9 +140,8 @@ func (v *Value) Delete(key string) bool {
 func (v *Value) Encode() (string, error) {
 	toEncodeStr := v.data
 	if v.parsed.OrderedMap != nil {
-		// flattening orderedmap not supported
 		if v.dataFormat != "" {
-			dataformatStr, err := dataformat.Encode(v.parsed, v.dataFormat)
+			dataformatStr, err := v.encode(v.parsed)
 			if err != nil {
 				return "", err
 			}
@@ -154,13 +155,20 @@ func (v *Value) Encode() (string, error) {
 		return "", err
 	}
 	if v.dataFormat != "" {
-		dataformatStr, err := dataformat.Encode(dataformat.KVMap(nested), v.dataFormat)
+		dataformatStr, err := v.encode(dataformat.KVMap(nested))
 		if err != nil {
 			return "", err
 		}
 		toEncodeStr = dataformatStr
 	}
 	return toEncodeStr, nil
+}
+
+func (v *Value) encode(data dataformat.KV) (string, error) {
+	if v.encoder != nil {
+		return v.encoder.Encode(data)
+	}
+	return dataformat.Encode(data, v.dataFormat)
 }
 
 // In go, []int, []string are not implictily converted to []interface{}

--- a/pkg/fuzz/dataformat/multipart_test.go
+++ b/pkg/fuzz/dataformat/multipart_test.go
@@ -384,10 +384,10 @@ func TestMultiPartFormDecode_ConcurrentWithSeparateInstances(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			mpf := NewMultiPartForm()
-			require.NoError(t, mpf.ParseBoundary("multipart/form-data; boundary="+boundary))
+			assert.NoError(t, mpf.ParseBoundary("multipart/form-data; boundary="+boundary))
 			kv, err := mpf.Decode(body)
-			require.NoError(t, err)
-			require.NotNil(t, kv)
+			assert.NoError(t, err)
+			assert.NotNil(t, kv)
 		}()
 	}
 	wg.Wait()

--- a/pkg/fuzz/dataformat/multipart_test.go
+++ b/pkg/fuzz/dataformat/multipart_test.go
@@ -1,6 +1,7 @@
 package dataformat
 
 import (
+	"sync"
 	"testing"
 
 	mapsutil "github.com/projectdiscovery/utils/maps"
@@ -367,4 +368,27 @@ func TestMultiPartForm_GetFileMetadataWithNilMap(t *testing.T) {
 	// GetFileMetadata should handle nil filesMetadata gracefully
 	_, exists := form.GetFileMetadata("anything")
 	assert.False(t, exists)
+}
+
+func TestMultiPartFormDecode_ConcurrentWithSeparateInstances(t *testing.T) {
+	boundary := "boundary123"
+	body := "--" + boundary + "\r\n" +
+		"Content-Disposition: form-data; name=\"file\"; filename=\"test.txt\"\r\n" +
+		"Content-Type: text/plain\r\n\r\n" +
+		"file content\r\n" +
+		"--" + boundary + "--\r\n"
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			mpf := NewMultiPartForm()
+			require.NoError(t, mpf.ParseBoundary("multipart/form-data; boundary="+boundary))
+			kv, err := mpf.Decode(body)
+			require.NoError(t, err)
+			require.NotNil(t, kv)
+		}()
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
## Summary

Fixes #6947

`MultiPartForm` is registered as a singleton via `dataformat.init()` and shared across all goroutines through `dataformat.Get()`. Unlike other `DataFormat` implementations, `MultiPartForm` stores mutable per-request state (`boundary` and `filesMetadata`), so concurrent fuzzing goroutines trigger `fatal error: concurrent map writes` — an unrecoverable crash.

**Fix:** Create a fresh `MultiPartForm` instance per `parseBody` call instead of reusing the singleton.

## Changes

- **`pkg/fuzz/component/body.go`** — When `decoderName` is `multipart/form-data`, instantiate a new `MultiPartForm` and call `ParseBoundary` on it rather than mutating the shared singleton.
- **`pkg/fuzz/component/value.go`** — Preserve the per-request `MultiPartForm` instance (with its `boundary` and `filesMetadata`) so that `Encode` round-trips correctly.
- **`pkg/fuzz/dataformat/multipart_test.go`** — Add `TestMultiPartFormDecode_ConcurrentWithSeparateInstances` to verify that separate instances are safe under `-race`.

## Root cause

```
ExecuteCallbackWithCtx
  → engine.ExecuteScanWithOpts (concurrent goroutines)
    → Body.Parse()
      → parseBody("multipart/form-data", req)
        → dataformat.Get("multipart/form-data")  // returns singleton
        → singleton.ParseBoundary(...)            // writes to singleton.boundary  ← race
        → singleton.Decode(...)                   // writes to singleton.filesMetadata map
                                                  // ← fatal error: concurrent map writes
```

## Test plan

- [x] `go test -race -count=1 ./pkg/fuzz/dataformat/` — all pass (concurrent test included)
- [x] `go test -race -count=1 ./pkg/fuzz/...` — verifies no regressions in fuzz package
- [x] Shared-instance test confirms race is detected by `-race` (before fix pattern)
- [x] Separate-instance test confirms no race (after fix pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread-safety of multipart form-data parsing to handle concurrent processing reliably.

* **New Features**
  * Added optional encoder support enabling custom data encoding logic for values.

* **Tests**
  * Added concurrent operation tests to verify multipart form decoding reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->