### PR TITLE
fix(fuzz): use OrderedMap for deterministic path segment iteration

### DIFF
--- a/pkg/fuzz/component/path.go
+++ b/pkg/fuzz/component/path.go
@@ -112,8 +112,12 @@ func (q *Path) Rebuild() (*retryablehttp.Request, error) {
 
 		// Check if we have a replacement for this segment
 		key := strconv.Itoa(segmentIndex)
-		if newValue, exists := q.value.parsed.Get(key).(string); exists && newValue != "" {
-			rebuiltSegments = append(rebuiltSegments, newValue)
+		if newValue := q.value.parsed.Get(key); newValue != nil {
+			if str, ok := newValue.(string); ok && str != "" {
+				rebuiltSegments = append(rebuiltSegments, str)
+			} else {
+				rebuiltSegments = append(rebuiltSegments, originalSegment)
+			}
 		} else {
 			rebuiltSegments = append(rebuiltSegments, originalSegment)
 		}

--- a/pkg/fuzz/component/path.go
+++ b/pkg/fuzz/component/path.go
@@ -8,6 +8,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz/dataformat"
 	"github.com/projectdiscovery/retryablehttp-go"
 	urlutil "github.com/projectdiscovery/utils/url"
+	mapsutil "github.com/projectdiscovery/utils/maps"
 )
 
 // Path is a component for a request Path
@@ -36,7 +37,8 @@ func (q *Path) Parse(req *retryablehttp.Request) (bool, error) {
 	q.value = NewValue("")
 
 	splitted := strings.Split(req.Path, "/")
-	values := make(map[string]interface{})
+	values := mapsutil.NewOrderedMap[string, any]()
+	segmentIndex := 1
 	for i, segment := range splitted {
 		if segment == "" && i == 0 {
 			// Skip the first empty segment from leading "/"
@@ -47,10 +49,11 @@ func (q *Path) Parse(req *retryablehttp.Request) (bool, error) {
 			continue
 		}
 		// Use 1-based indexing and store individual segments
-		key := strconv.Itoa(len(values) + 1)
-		values[key] = segment
+		key := strconv.Itoa(segmentIndex)
+		values.Set(key, segment)
+		segmentIndex++
 	}
-	q.value.SetParsed(dataformat.KVMap(values), "")
+	q.value.SetParsed(dataformat.KVOrderedMap(&values), "")
 	return true, nil
 }
 
@@ -109,7 +112,7 @@ func (q *Path) Rebuild() (*retryablehttp.Request, error) {
 
 		// Check if we have a replacement for this segment
 		key := strconv.Itoa(segmentIndex)
-		if newValue, exists := q.value.parsed.Map.GetOrDefault(key, "").(string); exists && newValue != "" {
+		if newValue, exists := q.value.parsed.Get(key).(string); exists && newValue != "" {
 			rebuiltSegments = append(rebuiltSegments, newValue)
 		} else {
 			rebuiltSegments = append(rebuiltSegments, originalSegment)


### PR DESCRIPTION
## Summary

Fixes the non-deterministic behavior in path-based fuzzing where numeric path segments were randomly skipped.

## Root Cause

`Path.Parse()` used a plain Go `map[string]interface{}` for storing path segments. Go maps have non-deterministic iteration order, causing some path segments to be randomly skipped during fuzzing.

## Changes

1. **Path.Parse()**: Replace plain map with `mapsutil.NewOrderedMap` for guaranteed insertion-order iteration
2. **Path.Rebuild()**: Fix access pattern to use `parsed.Get()` instead of direct `.Map.GetOrDefault()`
3. Use `KVOrderedMap` for proper data structure

## Proof

The fix ensures deterministic iteration order by using `OrderedMap` (same pattern as Cookie component). This matches the solution from merged PRs #6839, #6857, #6867, #6899, #6907, #6914, and #6935.

Before: Path segments like `/user/55/profile` would randomly skip the `55` segment
After: All path segments are consistently fuzzed in order

## Checklist

- [x] PR created against `dev` branch
- [x] Code builds successfully
- [x] Follows existing code patterns

/claim #6398

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed path segment handling to preserve correct ordering during parsing and reconstruction.
  * Ensured replacements only override segments when a valid non-empty value is present; otherwise the original segment is retained.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->