### PR TITLE
ci: integrate typos spell checker

### DIFF
--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -1,0 +1,18 @@
+name: 🔤 Typos
+
+on:
+  push:
+    branches: ["dev"]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  typos:
+    name: "Spell Check"
+    if: ${{ !endsWith(github.actor, '[bot]') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: crate-ci/typos@v1
+        with:
+          config: ./_typos.toml

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,7 +1,5 @@
 [files]
 extend-exclude = [
-    # Filename contains legacy typo (renaming would be breaking)
-    "pkg/model/worflow_loader.go",
     # Non-English README translations
     "README_CN.md",
     "README_ES.md",
@@ -54,7 +52,6 @@ Reuests = "Reuests"
 PostReuestsHandlerRequest = "PostReuestsHandlerRequest"
 MisMatched = "MisMatched"
 fo = "fo"
-Fo = "Fo"
 ExludedDastTmplStats = "ExludedDastTmplStats"
 AllowdTypes = "AllowdTypes"
 worflow = "worflow"

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,61 @@
+[files]
+extend-exclude = [
+    # Filename contains legacy typo (renaming would be breaking)
+    "pkg/model/worflow_loader.go",
+    # Non-English README translations
+    "README_CN.md",
+    "README_ES.md",
+    "README_ID.md",
+    "README_JP.md",
+    "README_KR.md",
+    "README_PT-BR.md",
+    "README_TR.md",
+    # WAF regex patterns
+    "pkg/output/stats/waf/regexes.json",
+    # Test fixtures with binary/encoded content
+    "pkg/testutils/integration.go",
+    "pkg/protocols/common/helpers/deserialization/testdata/",
+    "pkg/input/formats/testdata/",
+    # Integration test templates (SQL error messages, URL paths, etc.)
+    "integration_tests/",
+]
+
+[default]
+extend-ignore-re = [
+    # Base64 encoded strings
+    "[A-Za-z0-9+/]{40,}={0,2}",
+    # JSONL(ines) format is intentional CLI output description
+    "JSONL\\(ines?\\)",
+]
+
+[default.extend-words]
+# CLI flag short names
+hae = "hae"
+ot = "ot"
+ue = "ue"
+# Intentional identifiers/words
+NooP = "NooP"
+Noo = "Noo"
+splitted = "splitted"
+alo = "alo"
+ser = "ser"
+# Spanish content in test data
+algoritmos = "algoritmos"
+cliente = "cliente"
+# Timezone abbreviation (Indian Standard Time)
+IST = "IST"
+
+[default.extend-identifiers]
+# Existing Go identifiers (renaming would be a breaking change)
+formated = "formated"
+isFormated = "isFormated"
+formatedTemplateData = "formatedTemplateData"
+Reuests = "Reuests"
+PostReuestsHandlerRequest = "PostReuestsHandlerRequest"
+MisMatched = "MisMatched"
+fo = "fo"
+Fo = "Fo"
+ExludedDastTmplStats = "ExludedDastTmplStats"
+AllowdTypes = "AllowdTypes"
+worflow = "worflow"
+inFo = "inFo"

--- a/lib/config.go
+++ b/lib/config.go
@@ -52,7 +52,7 @@ type TemplateFilters struct {
 	ExcludeSeverities    string   // filter by excluding severities (accepts CSV values of info, low, medium, high, critical)
 	ProtocolTypes        string   // filter by protocol types
 	ExcludeProtocolTypes string   // filter by excluding protocol types
-	Authors              []string // fiter by author
+	Authors              []string // filter by author
 	Tags                 []string // filter by tags present in template
 	ExcludeTags          []string // filter by excluding tags present in template
 	IncludeTags          []string // filter by including tags present in template

--- a/lib/tests/sdk_test.go
+++ b/lib/tests/sdk_test.go
@@ -42,7 +42,7 @@ func TestSimpleNuclei(t *testing.T) {
 		defer ne.Close()
 	}
 
-	// this is shared test so needs to be run as seperate process
+	// this is shared test so needs to be run as separate process
 	if env.GetEnvOrDefault("TestSimpleNuclei", false) {
 		// run as new process
 		cmd := exec.Command(os.Args[0], "-test.run=TestSimpleNuclei")
@@ -81,7 +81,7 @@ func TestSimpleNucleiRemote(t *testing.T) {
 		require.Nil(t, err)
 		defer ne.Close()
 	}
-	// this is shared test so needs to be run as seperate process
+	// this is shared test so needs to be run as separate process
 	if env.GetEnvOrDefault("TestSimpleNucleiRemote", false) {
 		cmd := exec.Command(os.Args[0], "-test.run=TestSimpleNucleiRemote")
 		cmd.Env = append(os.Environ(), "TestSimpleNucleiRemote=true")
@@ -155,7 +155,7 @@ func TestWithVarsNuclei(t *testing.T) {
 		require.Nil(t, err)
 		defer ne.Close()
 	}
-	// this is shared test so needs to be run as seperate process
+	// this is shared test so needs to be run as separate process
 	if env.GetEnvOrDefault("TestWithVarsNuclei", false) {
 		cmd := exec.Command(os.Args[0], "-test.run=TestWithVarsNuclei")
 		cmd.Env = append(os.Environ(), "TestWithVarsNuclei=true")

--- a/pkg/tmplexec/flow/flow_executor_test.go
+++ b/pkg/tmplexec/flow/flow_executor_test.go
@@ -118,7 +118,7 @@ func TestFlowWithConditionNegative(t *testing.T) {
 
 	input := contextargs.NewWithInput(context.Background(), "scanme.sh")
 	ctx := scan.NewScanContext(context.Background(), input)
-	// expect no results and verify thant dns request is executed and http is not
+	// expect no results and verify that dns request is executed and http is not
 	gotresults, err := Template.Executer.Execute(ctx)
 	require.Nil(t, err, "could not execute template")
 	require.False(t, gotresults)


### PR DESCRIPTION
Fixes #6532

Adds the [crate-ci/typos](https://github.com/crate-ci/typos) GitHub Action to CI to automatically catch spelling errors in future PRs.

## Changes
- Added `.github/workflows/typos.yml` — runs typos spell checker on push to dev, PRs, and manual dispatch
- Added `_typos.toml` — configuration to exclude non-English READMEs, test fixtures, and known false positives from intentional identifiers
- Fixed a few remaining typos in comments (`fiter` → `filter`, `seperate` → `separate`, `thant` → `that`)

Ref: #6521

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added typo-checker configuration to expand ignored paths, recognize additional words and identifiers, and reduce false positives.
  * Fixed spelling and wording in comments across tests and libraries to improve clarity and documentation quality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->