### PR TITLE
fix(fuzz): use insertion-ordered map for path segments to ensure deterministic fuzzing

### DIFF
--- a/pkg/fuzz/component/path.go
+++ b/pkg/fuzz/component/path.go
@@ -2,11 +2,13 @@ package component
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"strings"
 
 	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz/dataformat"
 	"github.com/projectdiscovery/retryablehttp-go"
+	mapsutil "github.com/projectdiscovery/utils/maps"
 	urlutil "github.com/projectdiscovery/utils/url"
 )
 
@@ -36,7 +38,8 @@ func (q *Path) Parse(req *retryablehttp.Request) (bool, error) {
 	q.value = NewValue("")
 
 	splitted := strings.Split(req.Path, "/")
-	values := make(map[string]interface{})
+	values := mapsutil.NewOrderedMap[string, any]()
+	segmentIndex := 1
 	for i, segment := range splitted {
 		if segment == "" && i == 0 {
 			// Skip the first empty segment from leading "/"
@@ -46,11 +49,12 @@ func (q *Path) Parse(req *retryablehttp.Request) (bool, error) {
 			// Skip any other empty segments
 			continue
 		}
-		// Use 1-based indexing and store individual segments
-		key := strconv.Itoa(len(values) + 1)
-		values[key] = segment
+		// Use 1-based indexing and store individual segments in insertion order
+		key := strconv.Itoa(segmentIndex)
+		values.Set(key, segment)
+		segmentIndex++
 	}
-	q.value.SetParsed(dataformat.KVMap(values), "")
+	q.value.SetParsed(dataformat.KVOrderedMap(&values), "")
 	return true, nil
 }
 
@@ -109,10 +113,20 @@ func (q *Path) Rebuild() (*retryablehttp.Request, error) {
 
 		// Check if we have a replacement for this segment
 		key := strconv.Itoa(segmentIndex)
-		if newValue, exists := q.value.parsed.Map.GetOrDefault(key, "").(string); exists && newValue != "" {
-			rebuiltSegments = append(rebuiltSegments, newValue)
-		} else {
+		replacement := q.value.parsed.Get(key)
+		switch v := replacement.(type) {
+		case string:
+			if v != "" {
+				rebuiltSegments = append(rebuiltSegments, v)
+			} else {
+				rebuiltSegments = append(rebuiltSegments, originalSegment)
+			}
+		case nil:
 			rebuiltSegments = append(rebuiltSegments, originalSegment)
+		default:
+			// Be defensive: in case a non-string sneaks in (shouldn't for Path),
+			// stringify instead of dropping the segment.
+			rebuiltSegments = append(rebuiltSegments, fmt.Sprint(v))
 		}
 		segmentIndex++
 	}

--- a/pkg/fuzz/component/path_test.go
+++ b/pkg/fuzz/component/path_test.go
@@ -59,8 +59,12 @@ func TestURLComponent_NestedPaths(t *testing.T) {
 	}
 
 	isSet := false
+	var keys []string
+	var values []string
 
 	_ = path.Iterate(func(key string, value interface{}) error {
+		keys = append(keys, key)
+		values = append(values, value.(string))
 		t.Logf("Key: %s, Value: %s", key, value.(string))
 		if !isSet && value.(string) == "753" {
 			isSet = true
@@ -70,6 +74,9 @@ func TestURLComponent_NestedPaths(t *testing.T) {
 		}
 		return nil
 	})
+
+	require.Equal(t, []string{"1", "2", "3"}, keys, "unexpected keys")
+	require.Equal(t, []string{"user", "753", "profile"}, values, "unexpected values")
 
 	newReq, err := path.Rebuild()
 	if err != nil {
@@ -97,7 +104,11 @@ func TestPathComponent_SQLInjection(t *testing.T) {
 	t.Logf("Original path: %s", req.Path)
 
 	// Let's see what path segments are available for fuzzing
+	var keys []string
+	var values []string
 	err = path.Iterate(func(key string, value interface{}) error {
+		keys = append(keys, key)
+		values = append(values, value.(string))
 		t.Logf("Key: %s, Value: %s", key, value.(string))
 
 		// Try fuzzing the "55" segment specifically (which should be key "2")
@@ -111,6 +122,9 @@ func TestPathComponent_SQLInjection(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	require.Equal(t, []string{"1", "2", "3"}, keys, "unexpected keys")
+	require.Equal(t, []string{"user", "55", "profile"}, values, "unexpected values")
 
 	newReq, err := path.Rebuild()
 	if err != nil {


### PR DESCRIPTION
Path segments were stored in an unordered map, making iteration order nondeterministic. In fuzzing flows that stop early (eg due to stop-at-first-match or host error short-circuit), this could skip segments such as numeric IDs (eg /55) entirely.

- Store path segments in an insertion-ordered map for stable key order
- Make Rebuild() consume KV via Get() so it works for ordered maps
- Modify tests to assert stable segment order for nested paths

## Proposed changes

This PR addresses an issue where the fuzzing engine could randomly skip certain URL path segments (such as numeric IDs like `/55`) during path-based fuzzing. 

**Root Cause:**
Previously, path segments were stored in a standard Go `map`. Since Go randomizes map iteration order, the sequence in which segments were evaluated was nondeterministic. In scenarios where the fuzzing flow short-circuits or stops early (e.g., due to `stop-at-first-match` or host connection errors), this randomization caused the engine to skip certain segments entirely.

**Modifications:**
- **Deterministic Iteration:** Replaced the unordered map with an insertion-ordered map for storing path segments, ensuring stable and predictable key iteration.
- **Refactored `Rebuild()`:** Updated the `Rebuild()` logic to consume key-value pairs via `Get()` so that the reconstructed paths respect the ordered map sequence.
- **Test Assertions:** Modified existing tests to explicitly assert stable segment ordering for nested paths.

Closes #6398 

## Proof

- [x] **Integration Testing:** Ran the path-based SQLi fuzzing template against a target URL containing a numeric segment (`http://localhost:8080/user/55/profile`).
  ```bash
  go run cmd/nuclei/main.go -dast -t integration_tests/fuzz/fuzz-path-sqli.yaml -u http://localhost:8080/user/55/profile -v -debug -nmhe

- [x] Verification: Verified via -debug logs that HTTP requests are now consistently generated for all path segments in deterministic order (e.g., /user+OR+True/55/profile, /user/55+OR+True/profile, and /user/55/profile+OR+True).

- [x] Unit Tests: Ensured all unit tests pass and properly validate the ordered iteration.

## Checklist
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch

- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes

- [x] I have added tests that prove my fix is effective or that my feature works

- [x] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Path segments now preserve insertion order during fuzzing operations.
  * Improved fallback handling for invalid or missing path replacements.

* **Tests**
  * Added verification for path segment ordering in fuzzing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->