### PR TITLE
fix: preserve numeric path segments in fuzzing template analysis

### DIFF
--- a/pkg/fuzz/component/path_test.go
+++ b/pkg/fuzz/component/path_test.go
@@ -127,3 +127,54 @@ func TestPathComponent_SQLInjection(t *testing.T) {
 	// Let's also test what the actual URL looks like
 	t.Logf("Full URL: %s", newReq.String())
 }
+
+// TestPathComponent_NumericSegmentFuzzing tests that numeric path segments
+// can be fuzzed with non-numeric payloads. This is a regression test for
+// https://github.com/projectdiscovery/nuclei/issues/6398
+func TestPathComponent_NumericSegmentFuzzing(t *testing.T) {
+	// Test that all path segments including numeric ones can be fuzzed
+	path := NewPath()
+	req, err := retryablehttp.NewRequest(http.MethodGet, "https://example.com/user/55/profile", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found, err := path.Parse(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found {
+		t.Fatal("expected path to be found")
+	}
+
+	// Count the number of path segments
+	segmentCount := 0
+	_ = path.Iterate(func(key string, value interface{}) error {
+		segmentCount++
+		return nil
+	})
+	if segmentCount != 3 {
+		t.Fatalf("expected 3 path segments, got %d", segmentCount)
+	}
+
+	// Test setting a fuzzing payload on each segment including the numeric one
+	// This verifies that numeric segments (like "55") can be replaced with
+	// non-numeric fuzzing payloads (like "55 OR True")
+	_ = path.Iterate(func(key string, value interface{}) error {
+		// Clone the path for this test
+		cloned := path.Clone()
+
+		// Set a fuzzing payload that is NOT a valid number
+		// This should succeed even for originally numeric segments
+		err := cloned.SetValue(key, value.(string)+" OR True")
+		if err != nil {
+			t.Fatalf("failed to set fuzzing payload on segment %s (value: %s): %v", key, value.(string), err)
+		}
+
+		_, err = cloned.Rebuild()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		return nil
+	})
+}

--- a/pkg/fuzz/component/value.go
+++ b/pkg/fuzz/component/value.go
@@ -112,9 +112,12 @@ func (v *Value) SetParsedValue(key, value string) bool {
 	case bool:
 		parsed, err := strconv.ParseBool(value)
 		if err != nil {
-			return false
+			// If the new value can't be parsed as a bool, store it as a string
+			// This allows fuzzing payloads to be set on boolean-typed path segments
+			origValue = value
+		} else {
+			origValue = parsed
 		}
-		origValue = parsed
 	default:
 		// explicitly check for typed slice
 		if val, ok := IsTypedSlice(v); ok {

--- a/pkg/fuzz/component/value.go
+++ b/pkg/fuzz/component/value.go
@@ -103,9 +103,12 @@ func (v *Value) SetParsedValue(key, value string) bool {
 	case int, int32, int64, float32, float64:
 		parsed, err := strconv.ParseInt(value, 10, 64)
 		if err != nil {
-			return false
+			// If the new value can't be parsed as a number, store it as a string
+			// This allows fuzzing payloads like "55%20OR%20True" to be set on numeric values
+			origValue = value
+		} else {
+			origValue = parsed
 		}
-		origValue = parsed
 	case bool:
 		parsed, err := strconv.ParseBool(value)
 		if err != nil {

--- a/pkg/fuzz/component/value_test.go
+++ b/pkg/fuzz/component/value_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/leslie-qiwa/flat"
+	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz/dataformat"
 	"github.com/stretchr/testify/require"
 )
 
@@ -36,6 +37,23 @@ func TestFlatMap_FlattenUnflatten(t *testing.T) {
 		t.Fatal(err)
 	}
 	require.Equal(t, data, nested, "unexpected data")
+}
+
+// TestSetParsedValue_BoolFallback tests that boolean-typed values accept
+// arbitrary fuzzing payloads instead of silently dropping them (regression
+// for https://github.com/projectdiscovery/nuclei/issues/6398)
+func TestSetParsedValue_BoolFallback(t *testing.T) {
+	v := &Value{}
+	v.parsed = dataformat.KVMap(map[string]interface{}{
+		"enabled": true,
+	})
+
+	// Setting a non-bool fuzzing payload should succeed
+	ok := v.SetParsedValue("enabled", "true OR 1=1")
+	require.True(t, ok, "expected SetParsedValue to return true for bool field with non-bool payload")
+
+	got := v.parsed.Get("enabled")
+	require.Equal(t, "true OR 1=1", got, "expected string fallback value to be stored")
 }
 
 func TestAnySlice(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #6398

Fuzzing templates were silently skipping numeric path segments (e.g. `/user/55/profile`) on the dev branch. The `55` would not get fuzzed because the payload couldn't be set on a numeric-typed value.

## Root Cause

In `pkg/fuzz/component/value.go`, the `SetParsedValue` function has a type switch. For numeric types (`int`, `int32`, `int64`, `float32`, `float64`), it attempted to parse the new value as an integer via `strconv.ParseInt`. When a fuzzing payload like `55%20OR%20True` couldn't be parsed as int, it returned `false` — silently dropping the mutation.

The `flat.Flatten` function converts string path segments like `"55"` into actual numeric types, so any non-numeric fuzzing payload would fail to set on those segments.

## Fix

Modified the numeric type case: when `strconv.ParseInt` fails (i.e. the new value is a fuzzing payload, not a plain number), store the value as a string instead of returning `false`. This allows all payloads to be applied to numeric path segments.

## Changes

- `pkg/fuzz/component/value.go` — fixed numeric type case in `SetParsedValue` to fall back to string storage
- `pkg/fuzz/component/path_test.go` — added `TestPathComponent_NumericSegmentFuzzing` regression test

## Test

The new test verifies that `/user/55/profile` correctly fuzzes the `55` segment with non-numeric payloads, matching the behavior of `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added fuzzing test for numeric segment handling in path operations.
  * Added a test ensuring boolean fields accept invalid fuzz payloads and store the fallback string.

* **Bug Fixes**
  * Numeric parsing now gracefully stores invalid inputs as fallback values instead of rejecting them.
  * Boolean parsing now falls back to storing the raw string when parsing fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->