### PR TITLE
Add xss_context analyzer (reflection first pass)

### DIFF
--- a/pkg/fuzz/analyzers/xss/analyzer.go
+++ b/pkg/fuzz/analyzers/xss/analyzer.go
@@ -54,14 +54,17 @@ func init() {
 	analyzers.RegisterAnalyzer(analyzerName, &Analyzer{})
 }
 
+// Name returns the registered analyzer name.
 func (a *Analyzer) Name() string {
 	return analyzerName
 }
 
+// ApplyInitialTransformation applies standard fuzz payload transformations (e.g. [RANDNUM]) to the analyzer input.
 func (a *Analyzer) ApplyInitialTransformation(data string, _ map[string]interface{}) string {
 	return analyzers.ApplyPayloadTransformations(data)
 }
 
+// Analyze replays a fuzz-generated request with the transformed payload injected and reports reflection + rough HTML context.
 func (a *Analyzer) Analyze(options *analyzers.Options) (bool, string, error) {
 	if options == nil || options.FuzzGenerated.Component == nil || options.HttpClient == nil {
 		return false, "", nil

--- a/pkg/fuzz/analyzers/xss/analyzer.go
+++ b/pkg/fuzz/analyzers/xss/analyzer.go
@@ -1,0 +1,66 @@
+package xss
+
+import (
+	"io"
+	"strings"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz/analyzers"
+)
+
+const analyzerName = "xss_context"
+
+// Analyzer is a first-pass XSS analyzer that validates reflection.
+// Context classification is implemented in follow-up steps.
+type Analyzer struct{}
+
+var _ analyzers.Analyzer = &Analyzer{}
+
+func init() {
+	analyzers.RegisterAnalyzer(analyzerName, &Analyzer{})
+}
+
+func (a *Analyzer) Name() string {
+	return analyzerName
+}
+
+func (a *Analyzer) ApplyInitialTransformation(data string, _ map[string]interface{}) string {
+	return analyzers.ApplyPayloadTransformations(data)
+}
+
+func (a *Analyzer) Analyze(options *analyzers.Options) (bool, string, error) {
+	if options == nil || options.FuzzGenerated.Component == nil || options.HttpClient == nil {
+		return false, "", nil
+	}
+
+	gr := options.FuzzGenerated
+	payload := a.ApplyInitialTransformation(gr.OriginalPayload, options.AnalyzerParameters)
+	if payload == "" {
+		return false, "", nil
+	}
+
+	if err := gr.Component.SetValue(gr.Key, payload); err != nil {
+		return false, "", err
+	}
+
+	rebuilt, err := gr.Component.Rebuild()
+	if err != nil {
+		return false, "", err
+	}
+
+	resp, err := options.HttpClient.Do(rebuilt)
+	if err != nil {
+		return false, "", err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return false, "", err
+	}
+
+	if strings.Contains(string(body), payload) {
+		return true, "reflected payload detected (xss_context classifier WIP)", nil
+	}
+
+	return false, "", nil
+}

--- a/pkg/fuzz/analyzers/xss/analyzer.go
+++ b/pkg/fuzz/analyzers/xss/analyzer.go
@@ -7,6 +7,37 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz/analyzers"
 )
 
+// classifyContexts detects whether payload is reflected and tries to infer a rough context.
+// This is intentionally lightweight (no HTML parser) and is meant for fuzzing guidance.
+func classifyContexts(body, payload string) (bool, string) {
+	if payload == "" {
+		return false, ""
+	}
+	idx := strings.Index(body, payload)
+	if idx < 0 {
+		return false, ""
+	}
+
+	before := body[:idx]
+	// comment context
+	if strings.LastIndex(before, "<!--") > strings.LastIndex(before, "-->") {
+		return true, "reflected payload detected in html_comment context"
+	}
+	// script context
+	if strings.LastIndex(strings.ToLower(before), "<script") > strings.LastIndex(strings.ToLower(before), "</script>") {
+		return true, "reflected payload detected in script context"
+	}
+	// tag/attribute context
+	lastLt := strings.LastIndex(before, "<")
+	lastGt := strings.LastIndex(before, ">")
+	if lastLt > lastGt {
+		// inside a tag declaration; assume attribute-ish
+		return true, "reflected payload detected in html_attribute context"
+	}
+
+	return true, "reflected payload detected in html context"
+}
+
 const analyzerName = "xss_context"
 
 // Analyzer is a first-pass XSS analyzer that validates reflection.
@@ -58,8 +89,9 @@ func (a *Analyzer) Analyze(options *analyzers.Options) (bool, string, error) {
 		return false, "", err
 	}
 
-	if strings.Contains(string(body), payload) {
-		return true, "reflected payload detected (xss_context classifier WIP)", nil
+	matched, reason := classifyContexts(string(body), payload)
+	if matched {
+		return true, reason, nil
 	}
 
 	return false, "", nil

--- a/pkg/fuzz/analyzers/xss/analyzer.go
+++ b/pkg/fuzz/analyzers/xss/analyzer.go
@@ -24,7 +24,8 @@ func classifyContexts(body, payload string) (bool, string) {
 		return true, "reflected payload detected in html_comment context"
 	}
 	// script context
-	if strings.LastIndex(strings.ToLower(before), "<script") > strings.LastIndex(strings.ToLower(before), "</script>") {
+	lowerBefore := strings.ToLower(before)
+	if strings.LastIndex(lowerBefore, "<script") > strings.LastIndex(lowerBefore, "</script>") {
 		return true, "reflected payload detected in script context"
 	}
 	// tag/attribute context
@@ -38,7 +39,10 @@ func classifyContexts(body, payload string) (bool, string) {
 	return true, "reflected payload detected in html context"
 }
 
-const analyzerName = "xss_context"
+const (
+	analyzerName        = "xss_context"
+	maxResponseBodySize = 10 << 20 // 10MB
+)
 
 // Analyzer is a first-pass XSS analyzer that validates reflection.
 // Context classification is implemented in follow-up steps.
@@ -64,7 +68,7 @@ func (a *Analyzer) Analyze(options *analyzers.Options) (bool, string, error) {
 	}
 
 	gr := options.FuzzGenerated
-	payload := a.ApplyInitialTransformation(gr.OriginalPayload, options.AnalyzerParameters)
+	payload := a.ApplyInitialTransformation(gr.Value, options.AnalyzerParameters)
 	if payload == "" {
 		return false, "", nil
 	}
@@ -72,6 +76,9 @@ func (a *Analyzer) Analyze(options *analyzers.Options) (bool, string, error) {
 	if err := gr.Component.SetValue(gr.Key, payload); err != nil {
 		return false, "", err
 	}
+	defer func() {
+		_ = gr.Component.SetValue(gr.Key, gr.Value)
+	}()
 
 	rebuilt, err := gr.Component.Rebuild()
 	if err != nil {
@@ -84,7 +91,7 @@ func (a *Analyzer) Analyze(options *analyzers.Options) (bool, string, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBodySize))
 	if err != nil {
 		return false, "", err
 	}

--- a/pkg/fuzz/analyzers/xss/analyzer_test.go
+++ b/pkg/fuzz/analyzers/xss/analyzer_test.go
@@ -1,49 +1,225 @@
 package xss
 
 import (
+	"io"
+	"net/http"
+	"net/url"
 	"strings"
 	"testing"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz"
+	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz/analyzers"
+	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz/component"
+	"github.com/projectdiscovery/retryablehttp-go"
 )
 
 func TestClassifyContexts(t *testing.T) {
-	payload := "PAYLOAD"
-
 	tests := []struct {
-		name   string
-		body   string
-		reason string
+		name      string
+		body      string
+		payload   string
+		wantMatch bool
+		wantIn    string
 	}{
 		{
-			name:   "html",
-			body:   "<html><body>hello PAYLOAD world</body></html>",
-			reason: "html context",
+			name:      "script context",
+			body:      `<html><script>var x = "PAYLOAD";</script></html>`,
+			payload:   "PAYLOAD",
+			wantMatch: true,
+			wantIn:    "script",
 		},
 		{
-			name:   "script",
-			body:   "<script>var a='PAYLOAD';</script>",
-			reason: "script context",
+			name:      "attribute context",
+			body:      `<img src="x" onerror="PAYLOAD">`,
+			payload:   "PAYLOAD",
+			wantMatch: true,
+			wantIn:    "attribute",
 		},
 		{
-			name:   "comment",
-			body:   "<!-- PAYLOAD -->",
-			reason: "html_comment context",
+			name:      "comment context",
+			body:      `<!-- PAYLOAD -->`,
+			payload:   "PAYLOAD",
+			wantMatch: true,
+			wantIn:    "comment",
 		},
 		{
-			name:   "attribute",
-			body:   "<div data-x='PAYLOAD'>x</div>",
-			reason: "html_attribute context",
+			name:      "html context",
+			body:      `<div>hello PAYLOAD world</div>`,
+			payload:   "PAYLOAD",
+			wantMatch: true,
+			wantIn:    "html context",
+		},
+		{
+			name:      "not reflected",
+			body:      `<div>hello world</div>`,
+			payload:   "PAYLOAD",
+			wantMatch: false,
+			wantIn:    "",
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ok, reason := classifyContexts(tt.body, payload)
-			if !ok {
-				t.Fatalf("expected match")
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			matched, reason := classifyContexts(tc.body, tc.payload)
+			if matched != tc.wantMatch {
+				t.Fatalf("matched=%v want=%v reason=%q", matched, tc.wantMatch, reason)
 			}
-			if reason == "" || !strings.Contains(reason, tt.reason) {
-				t.Fatalf("expected reason containing %q, got %q", tt.reason, reason)
+			if tc.wantIn != "" && reason != "" && !strings.Contains(reason, tc.wantIn) {
+				t.Fatalf("reason=%q does not include %q", reason, tc.wantIn)
 			}
 		})
 	}
+}
+
+func TestAnalyze_UsesFinalValueAndRestoresComponent(t *testing.T) {
+	component := &fakeComponent{current: "seed"}
+	analyzer := &Analyzer{}
+
+	matched, reason, err := analyzer.Analyze(&analyzers.Options{
+		FuzzGenerated: fuzz.GeneratedRequest{
+			Component:       component,
+			Key:             "k",
+			Value:           "foo[RANDNUM]",
+			OriginalPayload: "bar[RANDNUM]",
+		},
+		HttpClient: newTestClient(true),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !matched {
+		t.Fatalf("expected reflection match, reason=%q", reason)
+	}
+	if len(component.setCalls) != 2 {
+		t.Fatalf("expected 2 SetValue calls (set + restore), got %d", len(component.setCalls))
+	}
+	if !strings.HasPrefix(component.setCalls[0].value, "foo") {
+		t.Fatalf("expected first SetValue to use transformed gr.Value, got %q", component.setCalls[0].value)
+	}
+	if component.setCalls[1].value != "foo[RANDNUM]" {
+		t.Fatalf("expected restore SetValue to use original gr.Value, got %q", component.setCalls[1].value)
+	}
+	if component.rebuildCalls != 1 {
+		t.Fatalf("expected Rebuild to be called once, got %d", component.rebuildCalls)
+	}
+}
+
+func TestAnalyze_NoReflection(t *testing.T) {
+	component := &fakeComponent{current: "seed"}
+	analyzer := &Analyzer{}
+
+	matched, reason, err := analyzer.Analyze(&analyzers.Options{
+		FuzzGenerated: fuzz.GeneratedRequest{
+			Component:       component,
+			Key:             "k",
+			Value:           "probe",
+			OriginalPayload: "template",
+		},
+		HttpClient: newTestClient(false),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if matched {
+		t.Fatalf("expected no reflection match, reason=%q", reason)
+	}
+	if len(component.setCalls) != 2 {
+		t.Fatalf("expected 2 SetValue calls (set + restore), got %d", len(component.setCalls))
+	}
+}
+
+func TestAnalyze_EmptyPayloadEarlyExit(t *testing.T) {
+	component := &fakeComponent{current: "seed"}
+	analyzer := &Analyzer{}
+
+	matched, reason, err := analyzer.Analyze(&analyzers.Options{
+		FuzzGenerated: fuzz.GeneratedRequest{
+			Component:       component,
+			Key:             "k",
+			Value:           "",
+			OriginalPayload: "ignored",
+		},
+		HttpClient: newTestClient(true),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if matched || reason != "" {
+		t.Fatalf("expected empty early exit, got matched=%v reason=%q", matched, reason)
+	}
+	if len(component.setCalls) != 0 {
+		t.Fatalf("expected no SetValue calls on empty payload, got %d", len(component.setCalls))
+	}
+	if component.rebuildCalls != 0 {
+		t.Fatalf("expected no Rebuild calls on empty payload, got %d", component.rebuildCalls)
+	}
+}
+
+type roundTripFn func(req *http.Request) (*http.Response, error)
+
+func (f roundTripFn) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func newTestClient(reflectPayload bool) *retryablehttp.Client {
+	client := retryablehttp.NewClient(retryablehttp.DefaultOptionsSingle)
+	client.HTTPClient.Transport = roundTripFn(func(req *http.Request) (*http.Response, error) {
+		body := "<html><body>no reflection</body></html>"
+		if reflectPayload {
+			payload := req.URL.Query().Get("k")
+			body = "<html><body>" + payload + "</body></html>"
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Request:    req,
+		}, nil
+	})
+	return client
+}
+
+type setCall struct {
+	key   string
+	value string
+}
+
+type fakeComponent struct {
+	key          string
+	current      string
+	setCalls     []setCall
+	rebuildCalls int
+}
+
+func (f *fakeComponent) Name() string { return "fake" }
+
+func (f *fakeComponent) Parse(_ *retryablehttp.Request) (bool, error) { return true, nil }
+
+func (f *fakeComponent) Iterate(cb func(key string, value interface{}) error) error {
+	if cb == nil {
+		return nil
+	}
+	return cb(f.key, f.current)
+}
+
+func (f *fakeComponent) SetValue(key string, value string) error {
+	f.key = key
+	f.current = value
+	f.setCalls = append(f.setCalls, setCall{key: key, value: value})
+	return nil
+}
+
+func (f *fakeComponent) Delete(_ string) error { return nil }
+
+func (f *fakeComponent) Rebuild() (*retryablehttp.Request, error) {
+	f.rebuildCalls++
+	query := url.Values{}
+	query.Set(f.key, f.current)
+	return retryablehttp.NewRequest(http.MethodGet, "https://example.test/?"+query.Encode(), nil)
+}
+
+func (f *fakeComponent) Clone() component.Component {
+	copied := *f
+	copied.setCalls = append([]setCall(nil), f.setCalls...)
+	return &copied
 }

--- a/pkg/fuzz/analyzers/xss/analyzer_test.go
+++ b/pkg/fuzz/analyzers/xss/analyzer_test.go
@@ -1,0 +1,49 @@
+package xss
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestClassifyContexts(t *testing.T) {
+	payload := "PAYLOAD"
+
+	tests := []struct {
+		name   string
+		body   string
+		reason string
+	}{
+		{
+			name:   "html",
+			body:   "<html><body>hello PAYLOAD world</body></html>",
+			reason: "html context",
+		},
+		{
+			name:   "script",
+			body:   "<script>var a='PAYLOAD';</script>",
+			reason: "script context",
+		},
+		{
+			name:   "comment",
+			body:   "<!-- PAYLOAD -->",
+			reason: "html_comment context",
+		},
+		{
+			name:   "attribute",
+			body:   "<div data-x='PAYLOAD'>x</div>",
+			reason: "html_attribute context",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ok, reason := classifyContexts(tt.body, payload)
+			if !ok {
+				t.Fatalf("expected match")
+			}
+			if reason == "" || !strings.Contains(reason, tt.reason) {
+				t.Fatalf("expected reason containing %q, got %q", tt.reason, reason)
+			}
+		})
+	}
+}

--- a/pkg/protocols/http/http.go
+++ b/pkg/protocols/http/http.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/projectdiscovery/fastdialer/fastdialer"
 	_ "github.com/projectdiscovery/nuclei/v3/pkg/fuzz/analyzers/time"
+	_ "github.com/projectdiscovery/nuclei/v3/pkg/fuzz/analyzers/xss"
 
 	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz"
 	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz/analyzers"


### PR DESCRIPTION
Follow-up implementation for #5838.

## Proposed Changes

- Add new fuzz analyzer `xss_context` that:
  - applies nuclei fuzz payload transformations (e.g. `[RANDNUM]`) before sending
  - replays the rebuilt request via the provided `HttpClient`
  - detects whether the final payload is reflected in the response body
  - returns a rough reflection context hint (`html_comment`, `script`, `html_attribute`, `html`)
- Wire the analyzer into the HTTP fuzz pipeline so it can be used in HTTP-based fuzzing flows.

## Proof

```bash
go test ./pkg/fuzz/... -count=1
ok   	github.com/projectdiscovery/nuclei/v3/pkg/fuzz	0.300s
?    	github.com/projectdiscovery/nuclei/v3/pkg/fuzz/analyzers	[no test files]
ok   	github.com/projectdiscovery/nuclei/v3/pkg/fuzz/analyzers/time	1.079s
ok   	github.com/projectdiscovery/nuclei/v3/pkg/fuzz/analyzers/xss	0.121s
ok   	github.com/projectdiscovery/nuclei/v3/pkg/fuzz/component	0.529s
ok   	github.com/projectdiscovery/nuclei/v3/pkg/fuzz/dataformat	0.499s
?    	github.com/projectdiscovery/nuclei/v3/pkg/fuzz/frequency	[no test files]
ok   	github.com/projectdiscovery/nuclei/v3/pkg/fuzz/stats	0.475s
```

## Checklist

- [x] PR created against the correct branch (`dev`)
- [x] Tests added
- [x] Proof included

/claim #5838


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced XSS (Cross-Site Scripting) vulnerability analyzer for fuzzing workflows
  * Detects reflected payloads with context-aware classification (scripts, attributes, comments, HTML content)
  * Integrates with HTTP protocol analysis

* **Tests**
  * Added comprehensive test coverage for XSS detection and context classification scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->