### PR TITLE
feat: add honeypot-threshold suppression for noisy hosts

### DIFF
--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -421,6 +421,7 @@ on extensive configurability, massive extensibility and ease of use.`)
 		flagSet.IntVar(&options.Retries, "retries", 1, "number of times to retry a failed request"),
 		flagSet.BoolVarP(&options.LeaveDefaultPorts, "leave-default-ports", "ldp", false, "leave default HTTP/HTTPS ports (eg. host:80,host:443)"),
 		flagSet.IntVarP(&options.MaxHostError, "max-host-error", "mhe", 30, "max errors for a host before skipping from scan"),
+		flagSet.IntVar(&options.HoneypotThreshold, "honeypot-threshold", 0, "suppress hosts matching too many distinct templates (0 disables)"),
 		flagSet.StringSliceVarP(&options.TrackError, "track-error", "te", nil, "adds given error to max-host-error watchlist (standard, file)", goflags.FileStringSliceOptions),
 		flagSet.BoolVarP(&options.NoHostErrors, "no-mhe", "nmhe", false, "disable skipping host from scan based on errors"),
 		flagSet.BoolVar(&options.Project, "project", false, "use a project folder to avoid sending same request multiple times"),

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -77,6 +77,9 @@ type StandardWriter struct {
 	DisableStdout         bool
 	AddNewLinesOutputFile bool // by default this is only done for stdout
 	KeysToRedact          []string
+	honeypotThreshold     int
+	hostTemplateMatches   map[string]map[string]struct{}
+	flaggedHoneypotHosts  map[string]struct{}
 
 	// JSONLogRequestHook is a hook that can be used to log request/response
 	// when using custom server code with output
@@ -265,21 +268,24 @@ func NewStandardWriter(options *types.Options) (*StandardWriter, error) {
 	}
 
 	writer := &StandardWriter{
-		json:             options.JSONL,
-		jsonReqResp:      !options.OmitRawRequests,
-		noMetadata:       options.NoMeta,
-		matcherStatus:    options.MatcherStatus,
-		timestamp:        options.Timestamp,
-		aurora:           auroraColorizer,
-		mutex:            &sync.Mutex{},
-		outputFile:       outputFile,
-		traceFile:        traceOutput,
-		errorFile:        errorOutput,
-		severityColors:   colorizer.New(auroraColorizer),
-		storeResponse:    options.StoreResponse,
-		storeResponseDir: options.StoreResponseDir,
-		omitTemplate:     options.OmitTemplate,
-		KeysToRedact:     options.Redact,
+		json:                 options.JSONL,
+		jsonReqResp:          !options.OmitRawRequests,
+		noMetadata:           options.NoMeta,
+		matcherStatus:        options.MatcherStatus,
+		timestamp:            options.Timestamp,
+		aurora:               auroraColorizer,
+		mutex:                &sync.Mutex{},
+		outputFile:           outputFile,
+		traceFile:            traceOutput,
+		errorFile:            errorOutput,
+		severityColors:       colorizer.New(auroraColorizer),
+		storeResponse:        options.StoreResponse,
+		storeResponseDir:     options.StoreResponseDir,
+		omitTemplate:         options.OmitTemplate,
+		KeysToRedact:         options.Redact,
+		honeypotThreshold:    options.HoneypotThreshold,
+		hostTemplateMatches:  make(map[string]map[string]struct{}),
+		flaggedHoneypotHosts: make(map[string]struct{}),
 	}
 
 	if v := os.Getenv("DISABLE_STDOUT"); v == "true" || v == "1" {
@@ -296,6 +302,13 @@ func (w *StandardWriter) ResultCount() int {
 // Write writes the event to file and/or screen.
 func (w *StandardWriter) Write(event *ResultEvent) error {
 	if event.Error != "" && !w.matcherStatus {
+		return nil
+	}
+
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
+
+	if w.isLikelyHoneypot(event) {
 		return nil
 	}
 
@@ -327,8 +340,6 @@ func (w *StandardWriter) Write(event *ResultEvent) error {
 	if len(data) == 0 {
 		return nil
 	}
-	w.mutex.Lock()
-	defer w.mutex.Unlock()
 
 	if !w.DisableStdout {
 		_, _ = os.Stdout.Write(data)
@@ -348,6 +359,61 @@ func (w *StandardWriter) Write(event *ResultEvent) error {
 	}
 	w.resultCount.Add(1)
 	return nil
+}
+
+func (w *StandardWriter) isLikelyHoneypot(event *ResultEvent) bool {
+	if w.honeypotThreshold <= 0 || event == nil {
+		return false
+	}
+
+	host := normalizeResultHost(event)
+	if host == "" {
+		return false
+	}
+
+	if _, ok := w.flaggedHoneypotHosts[host]; ok {
+		return true
+	}
+
+	if event.TemplateID == "" {
+		return false
+	}
+
+	templates, ok := w.hostTemplateMatches[host]
+	if !ok {
+		templates = make(map[string]struct{})
+		w.hostTemplateMatches[host] = templates
+	}
+	templates[event.TemplateID] = struct{}{}
+
+	if len(templates) > w.honeypotThreshold {
+		w.flaggedHoneypotHosts[host] = struct{}{}
+		gologger.Warning().Msgf("[honeypot] suppressing host %s after %d distinct template matches (threshold=%d)", host, len(templates), w.honeypotThreshold)
+		return true
+	}
+
+	return false
+}
+
+func normalizeResultHost(event *ResultEvent) string {
+	if event == nil {
+		return ""
+	}
+	if event.URL != "" {
+		if parsed, err := urlutil.ParseAbsoluteURL(event.URL, false); err == nil && parsed != nil {
+			if parsed.Host != "" {
+				return strings.ToLower(parsed.Host)
+			}
+		}
+	}
+	if event.Host != "" {
+		host := strings.TrimSpace(strings.ToLower(event.Host))
+		host = strings.TrimPrefix(host, "http://")
+		host = strings.TrimPrefix(host, "https://")
+		host = strings.TrimSuffix(host, "/")
+		return host
+	}
+	return ""
 }
 
 func redactKeys(data string, keysToRedact []string) string {

--- a/pkg/output/output_test.go
+++ b/pkg/output/output_test.go
@@ -51,6 +51,25 @@ func TestStandardWriterRequest(t *testing.T) {
 	})
 }
 
+func TestHoneypotThresholdSuppressesHostAfterDistinctTemplateLimit(t *testing.T) {
+	w, err := NewStandardWriter(&types.Options{HoneypotThreshold: 1})
+	require.NoError(t, err)
+	w.DisableStdout = true
+
+	err = w.Write(&ResultEvent{Host: "http://example.com", TemplateID: "t1", Type: "http"})
+	require.NoError(t, err)
+	require.Equal(t, 1, w.ResultCount())
+
+	err = w.Write(&ResultEvent{Host: "https://example.com", TemplateID: "t2", Type: "http"})
+	require.NoError(t, err)
+	require.Equal(t, 1, w.ResultCount())
+}
+
+func TestNormalizeResultHostFromURL(t *testing.T) {
+	host := normalizeResultHost(&ResultEvent{URL: "https://Sub.EXAMPLE.com:8443/path", Host: "ignored"})
+	require.Equal(t, "sub.example.com:8443", host)
+}
+
 type testWriteCloser struct {
 	strings.Builder
 }

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -129,6 +129,9 @@ type Options struct {
 	MetricsPort int
 	// MaxHostError is the maximum number of errors allowed for a host
 	MaxHostError int
+	// HoneypotThreshold suppresses results for hosts matching too many distinct templates
+	// (0 disables honeypot detection).
+	HoneypotThreshold int
 	// TrackError contains additional error messages that count towards the maximum number of errors allowed for a host
 	TrackError goflags.StringSlice
 	// NoHostErrors disables host skipping after maximum number of errors


### PR DESCRIPTION
## Proposed Changes
- add new CLI option: `--honeypot-threshold` (default `0`, disabled)
- when enabled, nuclei tracks distinct matched template IDs per host
- once a host exceeds the threshold, subsequent findings for that host are suppressed
- emit a warning when host suppression is triggered
- add output-layer tests covering host normalization and suppression behavior

This gives users a practical anti-noise control for likely honeypot hosts while keeping default behavior unchanged.

## Proof
```bash
go test ./pkg/output -run 'TestHoneypotThresholdSuppressesHostAfterDistinctTemplateLimit|TestNormalizeResultHostFromURL|TestStandardWriterRequest' -count=1
ok  github.com/projectdiscovery/nuclei/v3/pkg/output  0.325s

go test ./cmd/nuclei -run TestNonExistent -count=1
ok  github.com/projectdiscovery/nuclei/v3/cmd/nuclei  0.731s [no tests to run]
```

## Checklist
- [x] PR created against the correct branch (`dev`)
- [x] Relevant tests passed
- [x] Tests added for new behavior
- [ ] Documentation updated (can add if maintainers want this flag in README/help docs)

/claim #6403


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--honeypot-threshold` CLI flag and configuration option to filter results from hosts matching multiple distinct templates; set to 0 to disable honeypot detection

* **Tests**
  * Added tests validating honeypot suppression behavior and host normalization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->