### PR TITLE
feat(output): optional honeypot-style match-density detection

### DIFF
--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -421,6 +421,8 @@ on extensive configurability, massive extensibility and ease of use.`)
 		flagSet.IntVar(&options.Retries, "retries", 1, "number of times to retry a failed request"),
 		flagSet.BoolVarP(&options.LeaveDefaultPorts, "leave-default-ports", "ldp", false, "leave default HTTP/HTTPS ports (eg. host:80,host:443)"),
 		flagSet.IntVarP(&options.MaxHostError, "max-host-error", "mhe", 30, "max errors for a host before skipping from scan"),
+		flagSet.IntVarP(&options.HoneypotThreshold, "honeypot-threshold", "hpt", 0, "flag hosts as potential honeypots when this many unique template ids match (0 disables)"),
+		flagSet.BoolVar(&options.HoneypotSuppressResults, "honeypot-suppress", false, "suppress findings from hosts flagged by honeypot-threshold"),
 		flagSet.StringSliceVarP(&options.TrackError, "track-error", "te", nil, "adds given error to max-host-error watchlist (standard, file)", goflags.FileStringSliceOptions),
 		flagSet.BoolVarP(&options.NoHostErrors, "no-mhe", "nmhe", false, "disable skipping host from scan based on errors"),
 		flagSet.BoolVar(&options.Project, "project", false, "use a project folder to avoid sending same request multiple times"),

--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -421,7 +421,7 @@ on extensive configurability, massive extensibility and ease of use.`)
 		flagSet.IntVar(&options.Retries, "retries", 1, "number of times to retry a failed request"),
 		flagSet.BoolVarP(&options.LeaveDefaultPorts, "leave-default-ports", "ldp", false, "leave default HTTP/HTTPS ports (eg. host:80,host:443)"),
 		flagSet.IntVarP(&options.MaxHostError, "max-host-error", "mhe", 30, "max errors for a host before skipping from scan"),
-		flagSet.IntVarP(&options.HoneypotThreshold, "honeypot-threshold", "hpt", 0, "flag hosts as potential honeypots when this many unique template ids match (0 disables)"),
+		flagSet.IntVarP(&options.HoneypotThreshold, "honeypot-threshold", "hpt", 0, "flag hosts as potential honeypots when this many unique template ids match (0 disables; higher values may increase memory on large host sets)"),
 		flagSet.BoolVar(&options.HoneypotSuppressResults, "honeypot-suppress", false, "suppress findings from hosts flagged by honeypot-threshold"),
 		flagSet.StringSliceVarP(&options.TrackError, "track-error", "te", nil, "adds given error to max-host-error watchlist (standard, file)", goflags.FileStringSliceOptions),
 		flagSet.BoolVarP(&options.NoHostErrors, "no-mhe", "nmhe", false, "disable skipping host from scan based on errors"),

--- a/pkg/output/honeypot.go
+++ b/pkg/output/honeypot.go
@@ -100,8 +100,9 @@ func normalizeHostCandidate(candidate string) string {
 		}
 	}
 
-	value = strings.TrimPrefix(value, "http://")
-	value = strings.TrimPrefix(value, "https://")
+	if schemeIdx := strings.Index(value, "://"); schemeIdx != -1 {
+		value = value[schemeIdx+3:]
+	}
 	if idx := strings.IndexAny(value, "/?#"); idx != -1 {
 		value = value[:idx]
 	}

--- a/pkg/output/honeypot.go
+++ b/pkg/output/honeypot.go
@@ -1,0 +1,114 @@
+package output
+
+import (
+	"net"
+	"strings"
+	"sync"
+
+	urlutil "github.com/projectdiscovery/utils/url"
+)
+
+type honeypotDecision struct {
+	host         string
+	count        int
+	newlyFlagged bool
+	suppress     bool
+}
+
+type honeypotDetector struct {
+	threshold int
+	suppress  bool
+
+	mu          sync.Mutex
+	hostMatches map[string]map[string]struct{}
+	flagged     map[string]struct{}
+}
+
+func newHoneypotDetector(threshold int, suppress bool) *honeypotDetector {
+	if threshold <= 0 {
+		return nil
+	}
+	return &honeypotDetector{
+		threshold:   threshold,
+		suppress:    suppress,
+		hostMatches: make(map[string]map[string]struct{}),
+		flagged:     make(map[string]struct{}),
+	}
+}
+
+func (d *honeypotDetector) evaluate(event *ResultEvent) honeypotDecision {
+	if d == nil || event == nil || event.TemplateID == "" {
+		return honeypotDecision{}
+	}
+
+	host := normalizeHoneypotHost(event)
+	if host == "" {
+		return honeypotDecision{}
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	templates, ok := d.hostMatches[host]
+	if !ok {
+		templates = make(map[string]struct{})
+		d.hostMatches[host] = templates
+	}
+	templates[event.TemplateID] = struct{}{}
+
+	count := len(templates)
+	if count < d.threshold {
+		return honeypotDecision{host: host, count: count}
+	}
+
+	_, alreadyFlagged := d.flagged[host]
+	if !alreadyFlagged {
+		d.flagged[host] = struct{}{}
+	}
+
+	return honeypotDecision{
+		host:         host,
+		count:        count,
+		newlyFlagged: !alreadyFlagged,
+		suppress:     d.suppress,
+	}
+}
+
+func normalizeHoneypotHost(event *ResultEvent) string {
+	for _, candidate := range []string{event.Host, event.URL, event.Matched} {
+		host := normalizeHostCandidate(candidate)
+		if host != "" {
+			return host
+		}
+	}
+	return ""
+}
+
+func normalizeHostCandidate(candidate string) string {
+	value := strings.TrimSpace(candidate)
+	if value == "" {
+		return ""
+	}
+
+	if parsed, err := urlutil.ParseAbsoluteURL(value, false); err == nil && parsed != nil {
+		host := strings.ToLower(parsed.Hostname())
+		if host != "" {
+			return host
+		}
+	}
+
+	value = strings.TrimPrefix(value, "http://")
+	value = strings.TrimPrefix(value, "https://")
+	if idx := strings.IndexAny(value, "/?#"); idx != -1 {
+		value = value[:idx]
+	}
+	if host, _, err := net.SplitHostPort(value); err == nil {
+		value = host
+	}
+
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	return strings.ToLower(value)
+}

--- a/pkg/output/honeypot.go
+++ b/pkg/output/honeypot.go
@@ -49,6 +49,10 @@ func (d *honeypotDetector) evaluate(event *ResultEvent) honeypotDecision {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
+	if _, alreadyFlagged := d.flagged[host]; alreadyFlagged {
+		return honeypotDecision{host: host, suppress: d.suppress}
+	}
+
 	templates, ok := d.hostMatches[host]
 	if !ok {
 		templates = make(map[string]struct{})
@@ -61,16 +65,15 @@ func (d *honeypotDetector) evaluate(event *ResultEvent) honeypotDecision {
 		return honeypotDecision{host: host, count: count}
 	}
 
-	_, alreadyFlagged := d.flagged[host]
-	if !alreadyFlagged {
-		d.flagged[host] = struct{}{}
-	}
+	d.flagged[host] = struct{}{}
+	delete(d.hostMatches, host)
 
+	// The event that crosses threshold should still be emitted.
 	return honeypotDecision{
 		host:         host,
 		count:        count,
-		newlyFlagged: !alreadyFlagged,
-		suppress:     d.suppress,
+		newlyFlagged: true,
+		suppress:     false,
 	}
 }
 

--- a/pkg/output/honeypot.go
+++ b/pkg/output/honeypot.go
@@ -78,7 +78,7 @@ func (d *honeypotDetector) evaluate(event *ResultEvent) honeypotDecision {
 }
 
 func normalizeHoneypotHost(event *ResultEvent) string {
-	for _, candidate := range []string{event.Host, event.URL, event.Matched} {
+	for _, candidate := range []string{event.Host, event.URL} {
 		host := normalizeHostCandidate(candidate)
 		if host != "" {
 			return host
@@ -107,6 +107,8 @@ func normalizeHostCandidate(candidate string) string {
 	}
 	if host, _, err := net.SplitHostPort(value); err == nil {
 		value = host
+	} else if strings.HasPrefix(value, "[") && strings.HasSuffix(value, "]") {
+		value = strings.TrimPrefix(strings.TrimSuffix(value, "]"), "[")
 	}
 
 	value = strings.TrimSpace(value)

--- a/pkg/output/honeypot_test.go
+++ b/pkg/output/honeypot_test.go
@@ -70,6 +70,45 @@ func TestHoneypotDetectorPrunesHostMatchesAfterThreshold(t *testing.T) {
 	require.True(t, flaggedExists)
 }
 
+func TestHoneypotDetectorDeduplicatesSameTemplateID(t *testing.T) {
+	detector := newHoneypotDetector(2, false)
+	require.NotNil(t, detector)
+
+	decision1 := detector.evaluate(&ResultEvent{TemplateID: "tpl-1", Host: "https://example.com", Type: "http"})
+	require.Equal(t, "example.com", decision1.host)
+	require.Equal(t, 1, decision1.count)
+	require.False(t, decision1.newlyFlagged)
+	require.False(t, decision1.suppress)
+
+	decision2 := detector.evaluate(&ResultEvent{TemplateID: "tpl-1", Host: "https://example.com", Type: "http"})
+	require.Equal(t, "example.com", decision2.host)
+	require.Equal(t, 1, decision2.count)
+	require.False(t, decision2.newlyFlagged)
+	require.False(t, decision2.suppress)
+
+	detector.mu.Lock()
+	defer detector.mu.Unlock()
+	_, flaggedExists := detector.flagged["example.com"]
+	require.False(t, flaggedExists)
+}
+
+func TestStandardWriterHoneypotDisabledThresholdZero(t *testing.T) {
+	writer, err := NewStandardWriter(&types.Options{JSONL: true, HoneypotThreshold: 0, HoneypotSuppressResults: true})
+	require.NoError(t, err)
+	writer.DisableStdout = true
+	output := &testWriteCloser{}
+	writer.outputFile = output
+
+	require.NoError(t, writer.Write(&ResultEvent{TemplateID: "tpl-1", Host: "https://example.com", Type: "http"}))
+	require.NoError(t, writer.Write(&ResultEvent{TemplateID: "tpl-2", Host: "https://example.com", Type: "http"}))
+	require.NoError(t, writer.Write(&ResultEvent{TemplateID: "tpl-3", Host: "https://example.com", Type: "http"}))
+
+	require.Equal(t, 3, writer.ResultCount())
+	require.Contains(t, output.String(), `"template-id":"tpl-1"`)
+	require.Contains(t, output.String(), `"template-id":"tpl-2"`)
+	require.Contains(t, output.String(), `"template-id":"tpl-3"`)
+}
+
 func TestStandardWriterHoneypotThresholdWarnOnly(t *testing.T) {
 	writer, err := NewStandardWriter(&types.Options{JSONL: true, HoneypotThreshold: 2})
 	require.NoError(t, err)

--- a/pkg/output/honeypot_test.go
+++ b/pkg/output/honeypot_test.go
@@ -28,9 +28,18 @@ func TestNormalizeHostCandidate(t *testing.T) {
 		require.Equal(t, "::1", normalizeHostCandidate("[::1]:8080"))
 	})
 
+	t.Run("IPv6BracketOnly", func(t *testing.T) {
+		require.Equal(t, "::1", normalizeHostCandidate("[::1]"))
+	})
+
 	t.Run("IPv4Host", func(t *testing.T) {
 		require.Equal(t, "192.168.1.1", normalizeHostCandidate("192.168.1.1"))
 	})
+}
+
+func TestNormalizeHoneypotHostIgnoresMatchedFallback(t *testing.T) {
+	host := normalizeHoneypotHost(&ResultEvent{Matched: "example.com", Type: "file"})
+	require.Equal(t, "", host)
 }
 
 func TestStandardWriterHoneypotThresholdWarnOnly(t *testing.T) {

--- a/pkg/output/honeypot_test.go
+++ b/pkg/output/honeypot_test.go
@@ -19,6 +19,18 @@ func TestNormalizeHostCandidate(t *testing.T) {
 	t.Run("HostOnly", func(t *testing.T) {
 		require.Equal(t, "example.com", normalizeHostCandidate("EXAMPLE.COM"))
 	})
+
+	t.Run("Empty", func(t *testing.T) {
+		require.Equal(t, "", normalizeHostCandidate(""))
+	})
+
+	t.Run("IPv6WithPort", func(t *testing.T) {
+		require.Equal(t, "::1", normalizeHostCandidate("[::1]:8080"))
+	})
+
+	t.Run("IPv4Host", func(t *testing.T) {
+		require.Equal(t, "192.168.1.1", normalizeHostCandidate("192.168.1.1"))
+	})
 }
 
 func TestStandardWriterHoneypotThresholdWarnOnly(t *testing.T) {
@@ -45,8 +57,10 @@ func TestStandardWriterHoneypotThresholdSuppress(t *testing.T) {
 
 	require.NoError(t, writer.Write(&ResultEvent{TemplateID: "tpl-1", URL: "https://example.com", Type: "http"}))
 	require.NoError(t, writer.Write(&ResultEvent{TemplateID: "tpl-2", URL: "https://example.com", Type: "http"}))
+	require.NoError(t, writer.Write(&ResultEvent{TemplateID: "tpl-3", URL: "https://example.com", Type: "http"}))
 
-	require.Equal(t, 1, writer.ResultCount())
+	require.Equal(t, 2, writer.ResultCount())
 	require.Contains(t, output.String(), `"template-id":"tpl-1"`)
-	require.NotContains(t, output.String(), `"template-id":"tpl-2"`)
+	require.Contains(t, output.String(), `"template-id":"tpl-2"`)
+	require.NotContains(t, output.String(), `"template-id":"tpl-3"`)
 }

--- a/pkg/output/honeypot_test.go
+++ b/pkg/output/honeypot_test.go
@@ -35,11 +35,39 @@ func TestNormalizeHostCandidate(t *testing.T) {
 	t.Run("IPv4Host", func(t *testing.T) {
 		require.Equal(t, "192.168.1.1", normalizeHostCandidate("192.168.1.1"))
 	})
+
+	t.Run("UppercaseHTTPScheme", func(t *testing.T) {
+		require.Equal(t, "example.com", normalizeHostCandidate("HTTPS://EXAMPLE.COM/path"))
+	})
+
+	t.Run("NonHTTPScheme", func(t *testing.T) {
+		require.Equal(t, "example.com", normalizeHostCandidate("tcp://example.com:4444/path"))
+	})
 }
 
 func TestNormalizeHoneypotHostIgnoresMatchedFallback(t *testing.T) {
 	host := normalizeHoneypotHost(&ResultEvent{Matched: "example.com", Type: "file"})
 	require.Equal(t, "", host)
+}
+
+func TestHoneypotDetectorPrunesHostMatchesAfterThreshold(t *testing.T) {
+	detector := newHoneypotDetector(2, false)
+	require.NotNil(t, detector)
+
+	decision1 := detector.evaluate(&ResultEvent{TemplateID: "tpl-1", Host: "https://example.com", Type: "http"})
+	require.Equal(t, "example.com", decision1.host)
+	require.False(t, decision1.newlyFlagged)
+
+	decision2 := detector.evaluate(&ResultEvent{TemplateID: "tpl-2", Host: "https://example.com", Type: "http"})
+	require.Equal(t, "example.com", decision2.host)
+	require.True(t, decision2.newlyFlagged)
+
+	detector.mu.Lock()
+	defer detector.mu.Unlock()
+	_, hostMatchesExists := detector.hostMatches["example.com"]
+	_, flaggedExists := detector.flagged["example.com"]
+	require.False(t, hostMatchesExists)
+	require.True(t, flaggedExists)
 }
 
 func TestStandardWriterHoneypotThresholdWarnOnly(t *testing.T) {

--- a/pkg/output/honeypot_test.go
+++ b/pkg/output/honeypot_test.go
@@ -1,0 +1,52 @@
+package output
+
+import (
+	"testing"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeHostCandidate(t *testing.T) {
+	t.Run("URL", func(t *testing.T) {
+		require.Equal(t, "example.com", normalizeHostCandidate("https://example.com/test?q=1"))
+	})
+
+	t.Run("HostPort", func(t *testing.T) {
+		require.Equal(t, "example.com", normalizeHostCandidate("example.com:8443"))
+	})
+
+	t.Run("HostOnly", func(t *testing.T) {
+		require.Equal(t, "example.com", normalizeHostCandidate("EXAMPLE.COM"))
+	})
+}
+
+func TestStandardWriterHoneypotThresholdWarnOnly(t *testing.T) {
+	writer, err := NewStandardWriter(&types.Options{JSONL: true, HoneypotThreshold: 2})
+	require.NoError(t, err)
+	writer.DisableStdout = true
+	output := &testWriteCloser{}
+	writer.outputFile = output
+
+	require.NoError(t, writer.Write(&ResultEvent{TemplateID: "tpl-1", Host: "https://example.com", Type: "http"}))
+	require.NoError(t, writer.Write(&ResultEvent{TemplateID: "tpl-2", Host: "https://example.com", Type: "http"}))
+
+	require.Equal(t, 2, writer.ResultCount())
+	require.Contains(t, output.String(), `"template-id":"tpl-1"`)
+	require.Contains(t, output.String(), `"template-id":"tpl-2"`)
+}
+
+func TestStandardWriterHoneypotThresholdSuppress(t *testing.T) {
+	writer, err := NewStandardWriter(&types.Options{JSONL: true, HoneypotThreshold: 2, HoneypotSuppressResults: true})
+	require.NoError(t, err)
+	writer.DisableStdout = true
+	output := &testWriteCloser{}
+	writer.outputFile = output
+
+	require.NoError(t, writer.Write(&ResultEvent{TemplateID: "tpl-1", URL: "https://example.com", Type: "http"}))
+	require.NoError(t, writer.Write(&ResultEvent{TemplateID: "tpl-2", URL: "https://example.com", Type: "http"}))
+
+	require.Equal(t, 1, writer.ResultCount())
+	require.Contains(t, output.String(), `"template-id":"tpl-1"`)
+	require.NotContains(t, output.String(), `"template-id":"tpl-2"`)
+}

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -82,7 +82,8 @@ type StandardWriter struct {
 	// when using custom server code with output
 	JSONLogRequestHook func(*JSONLogRequest)
 
-	resultCount atomic.Int32
+	honeypotDetector *honeypotDetector
+	resultCount      atomic.Int32
 }
 
 var _ Writer = &StandardWriter{}
@@ -280,6 +281,7 @@ func NewStandardWriter(options *types.Options) (*StandardWriter, error) {
 		storeResponseDir: options.StoreResponseDir,
 		omitTemplate:     options.OmitTemplate,
 		KeysToRedact:     options.Redact,
+		honeypotDetector: newHoneypotDetector(options.HoneypotThreshold, options.HoneypotSuppressResults),
 	}
 
 	if v := os.Getenv("DISABLE_STDOUT"); v == "true" || v == "1" {
@@ -297,6 +299,15 @@ func (w *StandardWriter) ResultCount() int {
 func (w *StandardWriter) Write(event *ResultEvent) error {
 	if event.Error != "" && !w.matcherStatus {
 		return nil
+	}
+
+	if decision := w.honeypotDetector.evaluate(event); decision.host != "" {
+		if decision.newlyFlagged {
+			gologger.Warning().Msgf("Potential honeypot-like target detected (%s): matched %d unique template ids (threshold=%d)", decision.host, decision.count, w.honeypotDetector.threshold)
+		}
+		if decision.suppress {
+			return nil
+		}
 	}
 
 	// Enrich the result event with extra metadata on the template-path and url.

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -580,6 +580,8 @@ func (options *Options) Copy() *Options {
 		OmitRawRequests:                options.OmitRawRequests,
 		HTTPStats:                      options.HTTPStats,
 		OmitTemplate:                   options.OmitTemplate,
+		HoneypotThreshold:              options.HoneypotThreshold,
+		HoneypotSuppressResults:        options.HoneypotSuppressResults,
 		JSONExport:                     options.JSONExport,
 		JSONLExport:                    options.JSONLExport,
 		Redact:                         options.Redact,

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -236,6 +236,13 @@ type Options struct {
 	HTTPStats bool
 	// OmitTemplate omits encoded template from JSON output
 	OmitTemplate bool
+	// HoneypotThreshold is the number of unique matched templates per host
+	// after which the host is marked as a potential honeypot.
+	// 0 disables detection.
+	HoneypotThreshold int
+	// HoneypotSuppressResults suppresses subsequent results from hosts flagged
+	// as potential honeypots when HoneypotThreshold is set.
+	HoneypotSuppressResults bool
 	// JSONExport is the file to export JSON output format to
 	JSONExport string
 	// JSONLExport is the file to export JSONL output format to

--- a/pkg/types/types_test.go
+++ b/pkg/types/types_test.go
@@ -1,0 +1,19 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOptionsCopyIncludesHoneypotFields(t *testing.T) {
+	original := &Options{
+		HoneypotThreshold:       7,
+		HoneypotSuppressResults: true,
+	}
+
+	copied := original.Copy()
+	require.NotNil(t, copied)
+	require.Equal(t, 7, copied.HoneypotThreshold)
+	require.True(t, copied.HoneypotSuppressResults)
+}


### PR DESCRIPTION
Implements an opt-in detection path for likely honeypot/noise targets that match many unrelated templates on the same host.

### Proposed Changes

- add `-honeypot-threshold` / `-hpt` (default `0`, disabled)
- add `-honeypot-suppress` to suppress findings from flagged hosts
- introduce host-level unique-template tracking in output writer
- emit one warning when a host crosses threshold
- add unit tests for host normalization and suppress/warn behavior

### Behavior

- When threshold is disabled (`0`): no overhead / no behavior changes
- When enabled:
  - each result updates a per-host set of distinct `template-id`
  - once count reaches threshold, host is marked as potential honeypot
  - warning is printed once per host
  - if `-honeypot-suppress` is enabled, subsequent results for that host are skipped

### Proof

```bash
go test ./pkg/output -count=1
go test ./cmd/nuclei -run TestNonExistent -count=1
```

### Checklist

- [x] PR created against `dev`
- [x] Tests added for the new logic
- [x] Existing touched packages compile and tests pass locally

/claim #6403


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added honeypot detection to identify and flag hosts that match multiple unique templates.
  * New CLI options to set the per-host match threshold and optionally suppress findings from flagged hosts.
  * Flagged hosts emit a warning the first time they are detected; suppression prevents subsequent outputs when enabled.

* **Tests**
  * Added tests for host normalization, threshold-triggered flagging, deduplication, pruning behavior, and suppression handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->