### PR TITLE
feat(profile): allow metadata fields + inline list in template profiles

### DIFF
--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -656,8 +656,18 @@ Additional documentation is available at: https://docs.nuclei.sh/getting-started
 		if !fileutil.FileExists(templateProfile) {
 			options.Logger.Fatal().Msgf("given template profile file '%s' does not exist", templateProfile)
 		}
-		if err := flagSet.MergeConfigFile(templateProfile); err != nil {
+		templateProfileForMerge, cleanupProfile, err := sanitizeTemplateProfileForMerge(templateProfile)
+		if err != nil {
+			options.Logger.Fatal().Msgf("Could not preprocess template profile: %s\n", err)
+		}
+		if cleanupProfile != nil {
+			defer cleanupProfile()
+		}
+		if err := flagSet.MergeConfigFile(templateProfileForMerge); err != nil {
 			options.Logger.Fatal().Msgf("Could not read template profile: %s\n", err)
+		}
+		if err := materializeInlineListTargets(); err != nil {
+			options.Logger.Fatal().Msgf("Could not process inline profile list targets: %s\n", err)
 		}
 	}
 
@@ -805,4 +815,78 @@ func findProfilePathById(profileId, templatesDir string) string {
 		options.Logger.Error().Msgf("%s\n", err)
 	}
 	return profilePath
+}
+
+func sanitizeTemplateProfileForMerge(profilePath string) (string, func(), error) {
+	data, err := os.ReadFile(profilePath)
+	if err != nil {
+		return "", nil, err
+	}
+
+	var parsed map[string]interface{}
+	if err := yaml.Unmarshal(data, &parsed); err != nil {
+		return profilePath, nil, nil
+	}
+	if len(parsed) == 0 {
+		return profilePath, nil, nil
+	}
+
+	ignoredFields := []string{"id", "name", "purpose", "description"}
+	changed := false
+	for _, field := range ignoredFields {
+		if _, ok := parsed[field]; ok {
+			delete(parsed, field)
+			changed = true
+		}
+	}
+	if !changed {
+		return profilePath, nil, nil
+	}
+
+	normalized, err := yaml.Marshal(parsed)
+	if err != nil {
+		return "", nil, err
+	}
+	tmpFile, err := os.CreateTemp("", "nuclei-profile-*.yaml")
+	if err != nil {
+		return "", nil, err
+	}
+	if _, err := tmpFile.Write(normalized); err != nil {
+		_ = tmpFile.Close()
+		_ = os.Remove(tmpFile.Name())
+		return "", nil, err
+	}
+	if err := tmpFile.Close(); err != nil {
+		_ = os.Remove(tmpFile.Name())
+		return "", nil, err
+	}
+
+	cleanup := func() {
+		_ = os.Remove(tmpFile.Name())
+	}
+	return tmpFile.Name(), cleanup, nil
+}
+
+func materializeInlineListTargets() error {
+	if options.TargetsFilePath == "" || !strings.Contains(options.TargetsFilePath, "\n") {
+		return nil
+	}
+	inlineTargets := strings.TrimSpace(options.TargetsFilePath)
+	if inlineTargets == "" {
+		return nil
+	}
+
+	tmpFile, err := os.CreateTemp("", "nuclei-inline-targets-*.txt")
+	if err != nil {
+		return err
+	}
+	if _, err := tmpFile.WriteString(inlineTargets + "\n"); err != nil {
+		_ = tmpFile.Close()
+		return err
+	}
+	if err := tmpFile.Close(); err != nil {
+		return err
+	}
+	options.TargetsFilePath = tmpFile.Name()
+	return nil
 }

--- a/cmd/nuclei/main_profile_test.go
+++ b/cmd/nuclei/main_profile_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSanitizeTemplateProfileForMerge(t *testing.T) {
+	dir := t.TempDir()
+	profilePath := filepath.Join(dir, "profile.yaml")
+	content := `id: demo
+name: Demo Profile
+purpose: test
+list: hosts.txt
+tags: ["cve"]
+`
+	require.NoError(t, os.WriteFile(profilePath, []byte(content), 0o644))
+
+	newPath, cleanup, err := sanitizeTemplateProfileForMerge(profilePath)
+	require.NoError(t, err)
+	if cleanup != nil {
+		defer cleanup()
+	}
+	require.NotEqual(t, profilePath, newPath)
+
+	data, err := os.ReadFile(newPath)
+	require.NoError(t, err)
+	text := string(data)
+	require.NotContains(t, text, "id:")
+	require.NotContains(t, text, "name:")
+	require.Contains(t, text, "list: hosts.txt")
+}
+
+func TestMaterializeInlineListTargets(t *testing.T) {
+	prev := options
+	options = &types.Options{}
+	defer func() { options = prev }()
+
+	options.TargetsFilePath = "https://a.example\nhttps://b.example"
+	require.NoError(t, materializeInlineListTargets())
+	require.NotContains(t, options.TargetsFilePath, "\n")
+
+	data, err := os.ReadFile(options.TargetsFilePath)
+	require.NoError(t, err)
+	require.Contains(t, string(data), "https://a.example")
+	require.Contains(t, string(data), "https://b.example")
+}


### PR DESCRIPTION
## Proposed Changes
This PR addresses two practical profile usability gaps from #5567:

1. **Ignore profile metadata keys**
   - Allows `id`, `name`, `purpose`, and `description` in template profile YAML without failing config merge.
   - These keys are stripped before passing data to goflags merge.

2. **Support inline `list:` values in profile YAML**
   - If `list` contains multiline content, nuclei now materializes it to a temp file and uses it as `TargetsFilePath`.
   - This enables profile-local target lists without external host files.

## Proof
```bash
go test ./cmd/nuclei -run 'TestSanitizeTemplateProfileForMerge|TestMaterializeInlineListTargets' -count=1
ok  github.com/projectdiscovery/nuclei/v3/cmd/nuclei  0.737s
```

## Checklist
- [x] PR created against `dev`
- [x] Tests added for the new behavior
- [x] Test command included
- [ ] Docs update (can add after maintainer preference)

/claim #5567


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
- Inline target lists can now be passed directly in commands as newline-separated values without requiring separate files

**Bug Fixes**
- Configuration merging now properly excludes non-essential profile metadata to prevent merge conflicts

**Tests**
- Added test coverage for profile sanitization and inline target list processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->