### PR TITLE
feat(profile): inline secrets + safe profile materialization

### DIFF
--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -46,11 +46,18 @@ import (
 	updateutils "github.com/projectdiscovery/utils/update"
 )
 
+const (
+	maxTemplateProfileSizeBytes = 5 * 1024 * 1024
+	maxInlineTargetsSizeBytes   = 10 * 1024 * 1024
+	maxInlineSecretsSizeBytes   = 2 * 1024 * 1024
+)
+
 var (
-	cfgFile         string
-	templateProfile string
-	memProfile      string // optional profile file path
-	options         = &types.Options{}
+	cfgFile           string
+	templateProfile   string
+	memProfile        string // optional profile file path
+	options           = &types.Options{}
+	runtimeCleanupFns []func()
 )
 
 func main() {
@@ -63,6 +70,7 @@ func main() {
 		options.Logger.Fatal().Msgf("Could not initialize options: %s\n", err)
 	}
 	_ = readConfig()
+	defer runRuntimeCleanups()
 
 	if options.ListDslSignatures {
 		options.Logger.Info().Msgf("The available custom DSL functions are:")
@@ -656,8 +664,39 @@ Additional documentation is available at: https://docs.nuclei.sh/getting-started
 		if !fileutil.FileExists(templateProfile) {
 			options.Logger.Fatal().Msgf("given template profile file '%s' does not exist", templateProfile)
 		}
-		if err := flagSet.MergeConfigFile(templateProfile); err != nil {
+
+		targetsFromCLI := options.TargetsFilePath
+		secretsFromCLI := append(goflags.StringSlice{}, options.SecretsFile...)
+
+		sanitizedProfilePath, cleanup, err := sanitizeTemplateProfileForMerge(templateProfile)
+		if err != nil {
 			options.Logger.Fatal().Msgf("Could not read template profile: %s\n", err)
+		}
+		registerRuntimeCleanup(cleanup)
+
+		if err := flagSet.MergeConfigFile(sanitizedProfilePath); err != nil {
+			options.Logger.Fatal().Msgf("Could not read template profile: %s\n", err)
+		}
+
+		// Preserve explicit CLI inputs over profile values.
+		if targetsFromCLI != "" {
+			options.TargetsFilePath = targetsFromCLI
+		} else {
+			cleanup, err = materializeInlineListTargets(templateProfile)
+			if err != nil {
+				options.Logger.Fatal().Msgf("Could not process template profile list field: %s\n", err)
+			}
+			registerRuntimeCleanup(cleanup)
+		}
+
+		if len(secretsFromCLI) > 0 {
+			options.SecretsFile = secretsFromCLI
+		} else {
+			cleanup, err = materializeInlineSecretsFromProfile(templateProfile)
+			if err != nil {
+				options.Logger.Fatal().Msgf("Could not process template profile secrets field: %s\n", err)
+			}
+			registerRuntimeCleanup(cleanup)
 		}
 	}
 
@@ -805,4 +844,227 @@ func findProfilePathById(profileId, templatesDir string) string {
 		options.Logger.Error().Msgf("%s\n", err)
 	}
 	return profilePath
+}
+
+func registerRuntimeCleanup(cleanup func()) {
+	if cleanup != nil {
+		runtimeCleanupFns = append(runtimeCleanupFns, cleanup)
+	}
+}
+
+func runRuntimeCleanups() {
+	for i := len(runtimeCleanupFns) - 1; i >= 0; i-- {
+		runtimeCleanupFns[i]()
+	}
+	runtimeCleanupFns = nil
+}
+
+func sanitizeTemplateProfileForMerge(profilePath string) (string, func(), error) {
+	profileData, err := readTemplateProfileData(profilePath)
+	if err != nil {
+		return "", nil, err
+	}
+
+	ignoreFields := map[string]struct{}{
+		"id":          {},
+		"name":        {},
+		"purpose":     {},
+		"description": {},
+		"secrets":     {},
+	}
+	changed := false
+	for field := range ignoreFields {
+		if _, ok := profileData[field]; ok {
+			delete(profileData, field)
+			changed = true
+		}
+	}
+	if !changed {
+		return profilePath, nil, nil
+	}
+
+	sanitizedData, err := yaml.Marshal(profileData)
+	if err != nil {
+		return "", nil, fmt.Errorf("could not marshal sanitized profile: %w", err)
+	}
+
+	tmpFile, err := os.CreateTemp("", "nuclei-profile-sanitized-*.yaml")
+	if err != nil {
+		return "", nil, fmt.Errorf("could not create temp profile file: %w", err)
+	}
+
+	cleanup := func() { _ = os.Remove(tmpFile.Name()) }
+	if _, err := tmpFile.Write(sanitizedData); err != nil {
+		_ = tmpFile.Close()
+		cleanup()
+		return "", nil, fmt.Errorf("could not write temp profile file: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("could not close temp profile file: %w", err)
+	}
+	return tmpFile.Name(), cleanup, nil
+}
+
+func materializeInlineListTargets(profilePath string) (func(), error) {
+	profileData, err := readTemplateProfileData(profilePath)
+	if err != nil {
+		return nil, err
+	}
+
+	listValue, hasList := profileData["list"]
+	if !hasList {
+		return nil, nil
+	}
+
+	inlineTargets, err := normalizeInlineTargets(listValue)
+	if err != nil {
+		return nil, err
+	}
+	if inlineTargets == "" {
+		return nil, nil
+	}
+
+	if len(inlineTargets) > maxInlineTargetsSizeBytes {
+		return nil, fmt.Errorf("inline target list exceeds %d bytes", maxInlineTargetsSizeBytes)
+	}
+
+	tmpFile, err := os.CreateTemp("", "nuclei-inline-targets-*.txt")
+	if err != nil {
+		return nil, fmt.Errorf("could not create temp targets file: %w", err)
+	}
+
+	cleanup := func() { _ = os.Remove(tmpFile.Name()) }
+	if _, err := tmpFile.WriteString(inlineTargets); err != nil {
+		_ = tmpFile.Close()
+		cleanup()
+		return nil, fmt.Errorf("could not write temp targets file: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		cleanup()
+		return nil, fmt.Errorf("could not close temp targets file: %w", err)
+	}
+
+	options.TargetsFilePath = tmpFile.Name()
+	return cleanup, nil
+}
+
+func materializeInlineSecretsFromProfile(profilePath string) (func(), error) {
+	profileData, err := readTemplateProfileData(profilePath)
+	if err != nil {
+		return nil, err
+	}
+
+	secretsValue, hasSecrets := profileData["secrets"]
+	if !hasSecrets {
+		return nil, nil
+	}
+
+	secretsData, err := normalizeInlineSecrets(secretsValue)
+	if err != nil {
+		return nil, err
+	}
+	if len(secretsData) == 0 {
+		return nil, nil
+	}
+
+	if len(secretsData) > maxInlineSecretsSizeBytes {
+		return nil, fmt.Errorf("inline secrets exceed %d bytes", maxInlineSecretsSizeBytes)
+	}
+
+	tmpFile, err := os.CreateTemp("", "nuclei-inline-secrets-*.yaml")
+	if err != nil {
+		return nil, fmt.Errorf("could not create temp secrets file: %w", err)
+	}
+
+	cleanup := func() { _ = os.Remove(tmpFile.Name()) }
+	if _, err := tmpFile.Write(secretsData); err != nil {
+		_ = tmpFile.Close()
+		cleanup()
+		return nil, fmt.Errorf("could not write temp secrets file: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		cleanup()
+		return nil, fmt.Errorf("could not close temp secrets file: %w", err)
+	}
+
+	options.SecretsFile = append(options.SecretsFile, tmpFile.Name())
+	return cleanup, nil
+}
+
+func readTemplateProfileData(profilePath string) (map[string]interface{}, error) {
+	fileInfo, err := os.Stat(profilePath)
+	if err != nil {
+		return nil, fmt.Errorf("could not stat template profile %q: %w", profilePath, err)
+	}
+	if fileInfo.Size() > maxTemplateProfileSizeBytes {
+		return nil, fmt.Errorf("template profile exceeds %d bytes", maxTemplateProfileSizeBytes)
+	}
+
+	data, err := os.ReadFile(profilePath)
+	if err != nil {
+		return nil, fmt.Errorf("could not read template profile %q: %w", profilePath, err)
+	}
+
+	profileData := make(map[string]interface{})
+	if err := yaml.Unmarshal(data, &profileData); err != nil {
+		return nil, fmt.Errorf("could not parse template profile %q: %w", profilePath, err)
+	}
+	return profileData, nil
+}
+
+func normalizeInlineTargets(value interface{}) (string, error) {
+	switch typed := value.(type) {
+	case string:
+		trimmed := strings.TrimSpace(typed)
+		if trimmed == "" || !strings.Contains(trimmed, "\n") {
+			return "", nil
+		}
+		if !strings.HasSuffix(trimmed, "\n") {
+			trimmed += "\n"
+		}
+		return trimmed, nil
+	case []interface{}:
+		if len(typed) == 0 {
+			return "", nil
+		}
+		lines := make([]string, 0, len(typed))
+		for _, item := range typed {
+			str, ok := item.(string)
+			if !ok {
+				return "", fmt.Errorf("inline list contains non-string value: %T", item)
+			}
+			if line := strings.TrimSpace(str); line != "" {
+				lines = append(lines, line)
+			}
+		}
+		if len(lines) == 0 {
+			return "", nil
+		}
+		return strings.Join(lines, "\n") + "\n", nil
+	default:
+		return "", nil
+	}
+}
+
+func normalizeInlineSecrets(value interface{}) ([]byte, error) {
+	switch typed := value.(type) {
+	case nil:
+		return nil, nil
+	case string:
+		trimmed := strings.TrimSpace(typed)
+		if trimmed == "" {
+			return nil, nil
+		}
+		if !strings.HasSuffix(trimmed, "\n") {
+			trimmed += "\n"
+		}
+		return []byte(trimmed), nil
+	default:
+		secretBytes, err := yaml.Marshal(typed)
+		if err != nil {
+			return nil, fmt.Errorf("could not marshal inline secrets: %w", err)
+		}
+		return secretBytes, nil
+	}
 }

--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -11,6 +11,7 @@ import (
 	"runtime/pprof"
 	"runtime/trace"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/projectdiscovery/gologger"
@@ -58,6 +59,7 @@ var (
 	memProfile        string // optional profile file path
 	options           = &types.Options{}
 	runtimeCleanupFns []func()
+	runtimeCleanupMu  sync.Mutex
 )
 
 func main() {
@@ -677,7 +679,7 @@ Additional documentation is available at: https://docs.nuclei.sh/getting-started
 
 		sanitizedProfilePath, cleanup, err := sanitizeTemplateProfileForMerge(templateProfile, profileData)
 		if err != nil {
-			options.Logger.Fatal().Msgf("Could not read template profile: %s\n", err)
+			options.Logger.Fatal().Msgf("Could not sanitize template profile for merge: %s\n", err)
 		}
 		registerRuntimeCleanup(cleanup)
 
@@ -854,23 +856,31 @@ func findProfilePathById(profileId, templatesDir string) string {
 }
 
 func registerRuntimeCleanup(cleanup func()) {
-	if cleanup != nil {
-		runtimeCleanupFns = append(runtimeCleanupFns, cleanup)
+	if cleanup == nil {
+		return
 	}
+
+	runtimeCleanupMu.Lock()
+	runtimeCleanupFns = append(runtimeCleanupFns, cleanup)
+	runtimeCleanupMu.Unlock()
 }
 
 func runRuntimeCleanups() {
-	for i := len(runtimeCleanupFns) - 1; i >= 0; i-- {
+	runtimeCleanupMu.Lock()
+	pendingCleanups := runtimeCleanupFns
+	runtimeCleanupFns = nil
+	runtimeCleanupMu.Unlock()
+
+	for i := len(pendingCleanups) - 1; i >= 0; i-- {
 		func(cleanupIndex int) {
 			defer func() {
 				if recovered := recover(); recovered != nil {
 					options.Logger.Warning().Msgf("runtime cleanup panic recovered at index %d: %v", cleanupIndex, recovered)
 				}
 			}()
-			runtimeCleanupFns[cleanupIndex]()
+			pendingCleanups[cleanupIndex]()
 		}(i)
 	}
-	runtimeCleanupFns = nil
 }
 
 func sanitizeTemplateProfileForMerge(profilePath string, profileData map[string]interface{}) (string, func(), error) {
@@ -884,6 +894,7 @@ func sanitizeTemplateProfileForMerge(profilePath string, profileData map[string]
 		"name":        {},
 		"purpose":     {},
 		"description": {},
+		"list":        {},
 		"secrets":     {},
 	}
 	changed := false

--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -1086,11 +1086,13 @@ func normalizeInlineSecrets(value interface{}) ([]byte, error) {
 			trimmed += "\n"
 		}
 		return []byte(trimmed), nil
-	default:
+	case map[interface{}]interface{}, map[string]interface{}:
 		secretBytes, err := yaml.Marshal(typed)
 		if err != nil {
 			return nil, fmt.Errorf("could not marshal inline secrets: %w", err)
 		}
 		return secretBytes, nil
+	default:
+		return nil, fmt.Errorf("unsupported inline secrets type: %T", value)
 	}
 }

--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -49,7 +49,7 @@ import (
 
 const (
 	maxTemplateProfileSizeBytes = 5 * 1024 * 1024
-	maxInlineTargetsSizeBytes   = 10 * 1024 * 1024
+	maxInlineTargetsSizeBytes   = 5 * 1024 * 1024
 	maxInlineSecretsSizeBytes   = 2 * 1024 * 1024
 )
 
@@ -179,6 +179,7 @@ func main() {
 
 	nucleiRunner, err := runner.New(options)
 	if err != nil {
+		runRuntimeCleanups()
 		options.Logger.Fatal().Msgf("Could not create runner: %s\n", err)
 	}
 	if nucleiRunner == nil {
@@ -237,6 +238,7 @@ func main() {
 	}()
 
 	if err := nucleiRunner.RunEnumeration(); err != nil {
+		runRuntimeCleanups()
 		if options.Validate {
 			options.Logger.Fatal().Msgf("Could not validate templates: %s\n", err)
 		} else {
@@ -715,6 +717,7 @@ Additional documentation is available at: https://docs.nuclei.sh/getting-started
 	if len(options.SecretsFile) > 0 {
 		for _, secretFile := range options.SecretsFile {
 			if !fileutil.FileExists(secretFile) {
+				runRuntimeCleanups()
 				options.Logger.Fatal().Msgf("given secrets file '%s' does not exist", secretFile)
 			}
 		}

--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -684,6 +684,7 @@ Additional documentation is available at: https://docs.nuclei.sh/getting-started
 		registerRuntimeCleanup(cleanup)
 
 		if err := flagSet.MergeConfigFile(sanitizedProfilePath); err != nil {
+			runRuntimeCleanups()
 			options.Logger.Fatal().Msgf("Could not read template profile: %s\n", err)
 		}
 
@@ -693,6 +694,7 @@ Additional documentation is available at: https://docs.nuclei.sh/getting-started
 		} else {
 			cleanup, err = materializeInlineListTargets(profileData)
 			if err != nil {
+				runRuntimeCleanups()
 				options.Logger.Fatal().Msgf("Could not process template profile list field: %s\n", err)
 			}
 			registerRuntimeCleanup(cleanup)
@@ -703,6 +705,7 @@ Additional documentation is available at: https://docs.nuclei.sh/getting-started
 		} else {
 			cleanup, err = materializeInlineSecretsFromProfile(profileData)
 			if err != nil {
+				runRuntimeCleanups()
 				options.Logger.Fatal().Msgf("Could not process template profile secrets field: %s\n", err)
 			}
 			registerRuntimeCleanup(cleanup)
@@ -1063,7 +1066,7 @@ func normalizeInlineTargets(value interface{}) (string, error) {
 		}
 		return strings.Join(lines, "\n") + "\n", nil
 	default:
-		return "", nil
+		return "", fmt.Errorf("unsupported list value type: %T", value)
 	}
 }
 

--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -214,6 +214,7 @@ func main() {
 		options.Logger.Info().Msgf("CTRL+C pressed: Exiting\n")
 		if options.DASTServer {
 			nucleiRunner.Close()
+			runRuntimeCleanups()
 			os.Exit(1)
 		}
 
@@ -229,6 +230,7 @@ func main() {
 				options.Logger.Error().Msgf("Couldn't create resume file: %s\n", err)
 			}
 		}
+		runRuntimeCleanups()
 		os.Exit(1)
 	}()
 
@@ -668,7 +670,12 @@ Additional documentation is available at: https://docs.nuclei.sh/getting-started
 		targetsFromCLI := options.TargetsFilePath
 		secretsFromCLI := append(goflags.StringSlice{}, options.SecretsFile...)
 
-		sanitizedProfilePath, cleanup, err := sanitizeTemplateProfileForMerge(templateProfile)
+		profileData, err := readTemplateProfileData(templateProfile)
+		if err != nil {
+			options.Logger.Fatal().Msgf("Could not read template profile: %s\n", err)
+		}
+
+		sanitizedProfilePath, cleanup, err := sanitizeTemplateProfileForMerge(templateProfile, profileData)
 		if err != nil {
 			options.Logger.Fatal().Msgf("Could not read template profile: %s\n", err)
 		}
@@ -682,7 +689,7 @@ Additional documentation is available at: https://docs.nuclei.sh/getting-started
 		if targetsFromCLI != "" {
 			options.TargetsFilePath = targetsFromCLI
 		} else {
-			cleanup, err = materializeInlineListTargets(templateProfile)
+			cleanup, err = materializeInlineListTargets(profileData)
 			if err != nil {
 				options.Logger.Fatal().Msgf("Could not process template profile list field: %s\n", err)
 			}
@@ -692,7 +699,7 @@ Additional documentation is available at: https://docs.nuclei.sh/getting-started
 		if len(secretsFromCLI) > 0 {
 			options.SecretsFile = secretsFromCLI
 		} else {
-			cleanup, err = materializeInlineSecretsFromProfile(templateProfile)
+			cleanup, err = materializeInlineSecretsFromProfile(profileData)
 			if err != nil {
 				options.Logger.Fatal().Msgf("Could not process template profile secrets field: %s\n", err)
 			}
@@ -854,15 +861,22 @@ func registerRuntimeCleanup(cleanup func()) {
 
 func runRuntimeCleanups() {
 	for i := len(runtimeCleanupFns) - 1; i >= 0; i-- {
-		runtimeCleanupFns[i]()
+		func(cleanupIndex int) {
+			defer func() {
+				if recovered := recover(); recovered != nil {
+					options.Logger.Warning().Msgf("runtime cleanup panic recovered at index %d: %v", cleanupIndex, recovered)
+				}
+			}()
+			runtimeCleanupFns[cleanupIndex]()
+		}(i)
 	}
 	runtimeCleanupFns = nil
 }
 
-func sanitizeTemplateProfileForMerge(profilePath string) (string, func(), error) {
-	profileData, err := readTemplateProfileData(profilePath)
-	if err != nil {
-		return "", nil, err
+func sanitizeTemplateProfileForMerge(profilePath string, profileData map[string]interface{}) (string, func(), error) {
+	sanitizedProfileData := make(map[string]interface{}, len(profileData))
+	for key, value := range profileData {
+		sanitizedProfileData[key] = value
 	}
 
 	ignoreFields := map[string]struct{}{
@@ -874,8 +888,8 @@ func sanitizeTemplateProfileForMerge(profilePath string) (string, func(), error)
 	}
 	changed := false
 	for field := range ignoreFields {
-		if _, ok := profileData[field]; ok {
-			delete(profileData, field)
+		if _, ok := sanitizedProfileData[field]; ok {
+			delete(sanitizedProfileData, field)
 			changed = true
 		}
 	}
@@ -883,7 +897,7 @@ func sanitizeTemplateProfileForMerge(profilePath string) (string, func(), error)
 		return profilePath, nil, nil
 	}
 
-	sanitizedData, err := yaml.Marshal(profileData)
+	sanitizedData, err := yaml.Marshal(sanitizedProfileData)
 	if err != nil {
 		return "", nil, fmt.Errorf("could not marshal sanitized profile: %w", err)
 	}
@@ -906,12 +920,7 @@ func sanitizeTemplateProfileForMerge(profilePath string) (string, func(), error)
 	return tmpFile.Name(), cleanup, nil
 }
 
-func materializeInlineListTargets(profilePath string) (func(), error) {
-	profileData, err := readTemplateProfileData(profilePath)
-	if err != nil {
-		return nil, err
-	}
-
+func materializeInlineListTargets(profileData map[string]interface{}) (func(), error) {
 	listValue, hasList := profileData["list"]
 	if !hasList {
 		return nil, nil
@@ -949,12 +958,7 @@ func materializeInlineListTargets(profilePath string) (func(), error) {
 	return cleanup, nil
 }
 
-func materializeInlineSecretsFromProfile(profilePath string) (func(), error) {
-	profileData, err := readTemplateProfileData(profilePath)
-	if err != nil {
-		return nil, err
-	}
-
+func materializeInlineSecretsFromProfile(profileData map[string]interface{}) (func(), error) {
 	secretsValue, hasSecrets := profileData["secrets"]
 	if !hasSecrets {
 		return nil, nil
@@ -993,6 +997,11 @@ func materializeInlineSecretsFromProfile(profilePath string) (func(), error) {
 }
 
 func readTemplateProfileData(profilePath string) (map[string]interface{}, error) {
+	resolvedProfilePath, err := filepath.EvalSymlinks(profilePath)
+	if err == nil {
+		profilePath = resolvedProfilePath
+	}
+
 	fileInfo, err := os.Stat(profilePath)
 	if err != nil {
 		return nil, fmt.Errorf("could not stat template profile %q: %w", profilePath, err)
@@ -1008,7 +1017,7 @@ func readTemplateProfileData(profilePath string) (map[string]interface{}, error)
 
 	profileData := make(map[string]interface{})
 	if err := yaml.Unmarshal(data, &profileData); err != nil {
-		return nil, fmt.Errorf("could not parse template profile %q: %w", profilePath, err)
+		return nil, fmt.Errorf("could not parse template profile %q: invalid yaml syntax", profilePath)
 	}
 	return profileData, nil
 }
@@ -1017,7 +1026,7 @@ func normalizeInlineTargets(value interface{}) (string, error) {
 	switch typed := value.(type) {
 	case string:
 		trimmed := strings.TrimSpace(typed)
-		if trimmed == "" || !strings.Contains(trimmed, "\n") {
+		if trimmed == "" {
 			return "", nil
 		}
 		if !strings.HasSuffix(trimmed, "\n") {

--- a/cmd/nuclei/main_profile_test.go
+++ b/cmd/nuclei/main_profile_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestSanitizeTemplateProfileForMerge(t *testing.T) {
+	// NOTE: These tests mutate package-level globals (options, runtimeCleanupFns);
+	// keep them non-parallel unless the shared state is refactored.
 	options = &types.Options{}
 	runtimeCleanupFns = nil
 
@@ -47,8 +49,8 @@ tags:
 	require.NotContains(t, text, "purpose:")
 	require.NotContains(t, text, "description:")
 	require.NotContains(t, text, "secrets:")
+	require.NotContains(t, text, "list:")
 	require.Contains(t, text, "tags:")
-	require.Contains(t, text, "list:")
 }
 
 func TestMaterializeInlineListTargets(t *testing.T) {

--- a/cmd/nuclei/main_profile_test.go
+++ b/cmd/nuclei/main_profile_test.go
@@ -155,3 +155,21 @@ func TestMaterializeInlineSecretsFromProfile(t *testing.T) {
 	require.Contains(t, string(data), "static:")
 	require.Contains(t, string(data), "X-API-Key")
 }
+
+func TestMaterializeInlineSecretsRejectsUnsupportedType(t *testing.T) {
+	// NOTE: These tests mutate package-level globals (options, runtimeCleanupFns);
+	// keep them non-parallel unless the shared state is refactored.
+	options = &types.Options{}
+	runtimeCleanupFns = nil
+
+	profilePath := filepath.Join(t.TempDir(), "profile.yaml")
+	require.NoError(t, os.WriteFile(profilePath, []byte("secrets: true\n"), 0o600))
+
+	profileData, err := readTemplateProfileData(profilePath)
+	require.NoError(t, err)
+
+	cleanup, err := materializeInlineSecretsFromProfile(profileData)
+	require.Error(t, err)
+	require.Nil(t, cleanup)
+	require.Contains(t, err.Error(), "unsupported inline secrets type")
+}

--- a/cmd/nuclei/main_profile_test.go
+++ b/cmd/nuclei/main_profile_test.go
@@ -29,7 +29,10 @@ tags:
   - kev
 `), 0o600))
 
-	sanitizedPath, cleanup, err := sanitizeTemplateProfileForMerge(profilePath)
+	profileData, err := readTemplateProfileData(profilePath)
+	require.NoError(t, err)
+
+	sanitizedPath, cleanup, err := sanitizeTemplateProfileForMerge(profilePath, profileData)
 	require.NoError(t, err)
 	require.NotEmpty(t, sanitizedPath)
 	if cleanup != nil {
@@ -58,7 +61,10 @@ func TestMaterializeInlineListTargets(t *testing.T) {
   https://two.example
 `), 0o600))
 
-	cleanup, err := materializeInlineListTargets(profilePath)
+	profileData, err := readTemplateProfileData(profilePath)
+	require.NoError(t, err)
+
+	cleanup, err := materializeInlineListTargets(profileData)
 	require.NoError(t, err)
 	require.NotEmpty(t, options.TargetsFilePath)
 	if cleanup != nil {
@@ -69,6 +75,28 @@ func TestMaterializeInlineListTargets(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, string(data), "https://one.example")
 	require.Contains(t, string(data), "https://two.example")
+}
+
+func TestMaterializeSingleLineInlineTarget(t *testing.T) {
+	options = &types.Options{}
+	runtimeCleanupFns = nil
+
+	profilePath := filepath.Join(t.TempDir(), "profile.yaml")
+	require.NoError(t, os.WriteFile(profilePath, []byte("list: https://single.example\n"), 0o600))
+
+	profileData, err := readTemplateProfileData(profilePath)
+	require.NoError(t, err)
+
+	cleanup, err := materializeInlineListTargets(profileData)
+	require.NoError(t, err)
+	require.NotEmpty(t, options.TargetsFilePath)
+	if cleanup != nil {
+		t.Cleanup(cleanup)
+	}
+
+	data, err := os.ReadFile(options.TargetsFilePath)
+	require.NoError(t, err)
+	require.Equal(t, "https://single.example\n", string(data))
 }
 
 func TestMaterializeInlineSecretsFromProfile(t *testing.T) {
@@ -86,7 +114,10 @@ func TestMaterializeInlineSecretsFromProfile(t *testing.T) {
           value: abc
 `), 0o600))
 
-	cleanup, err := materializeInlineSecretsFromProfile(profilePath)
+	profileData, err := readTemplateProfileData(profilePath)
+	require.NoError(t, err)
+
+	cleanup, err := materializeInlineSecretsFromProfile(profileData)
 	require.NoError(t, err)
 	require.Len(t, options.SecretsFile, 1)
 	if cleanup != nil {

--- a/cmd/nuclei/main_profile_test.go
+++ b/cmd/nuclei/main_profile_test.go
@@ -54,6 +54,8 @@ tags:
 }
 
 func TestMaterializeInlineListTargets(t *testing.T) {
+	// NOTE: These tests mutate package-level globals (options, runtimeCleanupFns);
+	// keep them non-parallel unless the shared state is refactored.
 	options = &types.Options{}
 	runtimeCleanupFns = nil
 
@@ -80,6 +82,8 @@ func TestMaterializeInlineListTargets(t *testing.T) {
 }
 
 func TestMaterializeSingleLineInlineTarget(t *testing.T) {
+	// NOTE: These tests mutate package-level globals (options, runtimeCleanupFns);
+	// keep them non-parallel unless the shared state is refactored.
 	options = &types.Options{}
 	runtimeCleanupFns = nil
 
@@ -101,7 +105,27 @@ func TestMaterializeSingleLineInlineTarget(t *testing.T) {
 	require.Equal(t, "https://single.example\n", string(data))
 }
 
+func TestMaterializeInlineListTargetsRejectsUnsupportedType(t *testing.T) {
+	// NOTE: These tests mutate package-level globals (options, runtimeCleanupFns);
+	// keep them non-parallel unless the shared state is refactored.
+	options = &types.Options{}
+	runtimeCleanupFns = nil
+
+	profilePath := filepath.Join(t.TempDir(), "profile.yaml")
+	require.NoError(t, os.WriteFile(profilePath, []byte("list: 42\n"), 0o600))
+
+	profileData, err := readTemplateProfileData(profilePath)
+	require.NoError(t, err)
+
+	cleanup, err := materializeInlineListTargets(profileData)
+	require.Error(t, err)
+	require.Nil(t, cleanup)
+	require.Contains(t, err.Error(), "unsupported list value type")
+}
+
 func TestMaterializeInlineSecretsFromProfile(t *testing.T) {
+	// NOTE: These tests mutate package-level globals (options, runtimeCleanupFns);
+	// keep them non-parallel unless the shared state is refactored.
 	options = &types.Options{}
 	runtimeCleanupFns = nil
 

--- a/cmd/nuclei/main_profile_test.go
+++ b/cmd/nuclei/main_profile_test.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSanitizeTemplateProfileForMerge(t *testing.T) {
+	options = &types.Options{}
+	runtimeCleanupFns = nil
+
+	profilePath := filepath.Join(t.TempDir(), "profile.yaml")
+	require.NoError(t, os.WriteFile(profilePath, []byte(`id: demo
+name: Demo Profile
+purpose: Test
+description: should-be-removed
+list: |
+  https://example.com
+secrets:
+  static:
+    - type: header
+      domains:
+        - example.com
+tags:
+  - kev
+`), 0o600))
+
+	sanitizedPath, cleanup, err := sanitizeTemplateProfileForMerge(profilePath)
+	require.NoError(t, err)
+	require.NotEmpty(t, sanitizedPath)
+	if cleanup != nil {
+		t.Cleanup(cleanup)
+	}
+
+	data, err := os.ReadFile(sanitizedPath)
+	require.NoError(t, err)
+	text := string(data)
+	require.NotContains(t, text, "id:")
+	require.NotContains(t, text, "name:")
+	require.NotContains(t, text, "purpose:")
+	require.NotContains(t, text, "description:")
+	require.NotContains(t, text, "secrets:")
+	require.Contains(t, text, "tags:")
+	require.Contains(t, text, "list:")
+}
+
+func TestMaterializeInlineListTargets(t *testing.T) {
+	options = &types.Options{}
+	runtimeCleanupFns = nil
+
+	profilePath := filepath.Join(t.TempDir(), "profile.yaml")
+	require.NoError(t, os.WriteFile(profilePath, []byte(`list: |
+  https://one.example
+  https://two.example
+`), 0o600))
+
+	cleanup, err := materializeInlineListTargets(profilePath)
+	require.NoError(t, err)
+	require.NotEmpty(t, options.TargetsFilePath)
+	if cleanup != nil {
+		t.Cleanup(cleanup)
+	}
+
+	data, err := os.ReadFile(options.TargetsFilePath)
+	require.NoError(t, err)
+	require.Contains(t, string(data), "https://one.example")
+	require.Contains(t, string(data), "https://two.example")
+}
+
+func TestMaterializeInlineSecretsFromProfile(t *testing.T) {
+	options = &types.Options{}
+	runtimeCleanupFns = nil
+
+	profilePath := filepath.Join(t.TempDir(), "profile.yaml")
+	require.NoError(t, os.WriteFile(profilePath, []byte(`secrets:
+  static:
+    - type: header
+      domains:
+        - example.com
+      headers:
+        - key: X-API-Key
+          value: abc
+`), 0o600))
+
+	cleanup, err := materializeInlineSecretsFromProfile(profilePath)
+	require.NoError(t, err)
+	require.Len(t, options.SecretsFile, 1)
+	if cleanup != nil {
+		t.Cleanup(cleanup)
+	}
+
+	data, err := os.ReadFile(options.SecretsFile[0])
+	require.NoError(t, err)
+	require.Contains(t, string(data), "static:")
+	require.Contains(t, string(data), "X-API-Key")
+}


### PR DESCRIPTION
Follow-up for #5567 focused on secure, practical profile materialization.

## Proposed Changes

- sanitize profile metadata before goflags merge (ignore: `id`, `name`, `purpose`, `description`)
- add inline `secrets` support from profile YAML:
  - `secrets` map/string is written to a temp secrets file
  - temp secrets file is appended to `options.SecretsFile`
- improve inline `list` materialization:
  - supports multiline string and string-array forms
  - writes to temp target list file
- add runtime cleanup registry for temp files created from profile materialization
- add guardrails:
  - max template profile size limit
  - max inline targets size limit
  - max inline secrets size limit
- preserve explicit CLI `-l/--list` and `-sf/--secret-file` precedence over profile values

## Proof

```bash
go test ./cmd/nuclei -run 'TestSanitizeTemplateProfileForMerge|TestMaterializeInlineListTargets|TestMaterializeInlineSecretsFromProfile' -count=1
go test ./cmd/nuclei -run TestNonExistent -count=1
```

## Checklist

- [x] PR created against `dev`
- [x] Tests added for new behavior
- [x] Proof commands included

/claim #5567


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Materialize inline targets and secrets from template profiles into CLI options, while preserving any CLI-provided values.

* **Bug Fixes / Reliability**
  * Register and run runtime cleanup for temporary artifacts on exit, errors, and interrupt (CTRL+C).

* **Chores**
  * Sanitize sensitive profile fields and enforce size limits for profiles, inline targets, and inline secrets.

* **Tests**
  * Added tests covering profile sanitization, inline targets/secrets materialization, and related error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->