### PR TITLE
fix(loader): return dialer-missing as errors across loader call chain

### DIFF
--- a/cmd/integration-test/library.go
+++ b/cmd/integration-test/library.go
@@ -132,7 +132,9 @@ func executeNucleiAsLibrary(templatePath, templateURL string) ([]string, error) 
 	if err != nil {
 		return nil, errors.Wrap(err, "could not create loader")
 	}
-	store.Load()
+	if err := store.Load(); err != nil {
+		return nil, errors.Wrap(err, "could not load templates")
+	}
 
 	_ = engine.Execute(context.Background(), store.Templates(), provider.NewSimpleInputProviderWithUrls(defaultOpts.ExecutionId, templateURL))
 	engine.WorkPool().Wait() // Wait for the scan to finish

--- a/internal/runner/lazy.go
+++ b/internal/runner/lazy.go
@@ -67,7 +67,10 @@ func GetAuthTmplStore(opts *types.Options, catalog catalog.Catalog, execOpts *pr
 // GetLazyAuthFetchCallback returns a lazy fetch callback for auth secrets
 func GetLazyAuthFetchCallback(opts *AuthLazyFetchOptions) authx.LazyFetchSecret {
 	return func(d *authx.Dynamic) error {
-		tmpls := opts.TemplateStore.LoadTemplates([]string{d.TemplatePath})
+		tmpls, err := opts.TemplateStore.LoadTemplates([]string{d.TemplatePath})
+		if err != nil {
+			return errkit.Wrap(err, "failed to load template")
+		}
 		if len(tmpls) == 0 {
 			return fmt.Errorf("%w for path: %s", disk.ErrNoTemplatesFound, d.TemplatePath)
 		}

--- a/internal/runner/lazy.go
+++ b/internal/runner/lazy.go
@@ -143,7 +143,7 @@ func GetLazyAuthFetchCallback(opts *AuthLazyFetchOptions) authx.LazyFetchSecret 
 			// log result of template in result file/screen
 			_ = writer.WriteResult(e, opts.ExecOpts.Output, opts.ExecOpts.Progress, opts.ExecOpts.IssuesClient)
 		}
-		_, err := tmpl.Executer.ExecuteWithResults(ctx)
+		_, err = tmpl.Executer.ExecuteWithResults(ctx)
 		if err != nil {
 			finalErr = err
 		}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -660,7 +660,9 @@ func (r *Runner) RunEnumeration() error {
 		}
 		return nil // exit
 	}
-	store.Load()
+	if err := store.Load(); err != nil {
+		return errors.Wrap(err, "could not load templates")
+	}
 	// TODO: remove below functions after v3 or update warning messages
 	templates.PrintDeprecatedProtocolNameMsgIfApplicable(r.options.Silent, r.options.Verbose)
 

--- a/internal/server/nuclei_sdk.go
+++ b/internal/server/nuclei_sdk.go
@@ -125,7 +125,9 @@ func newNucleiExecutor(opts *NucleiExecutorOptions) (*nucleiExecutor, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "Could not create loader options.")
 	}
-	store.Load()
+	if err := store.Load(); err != nil {
+		return nil, errors.Wrap(err, "Could not load templates.")
+	}
 
 	return &nucleiExecutor{
 		engine:       executorEngine,

--- a/internal/server/nuclei_sdk.go
+++ b/internal/server/nuclei_sdk.go
@@ -111,7 +111,7 @@ func newNucleiExecutor(opts *NucleiExecutorOptions) (*nucleiExecutor, error) {
 
 	workflowLoader, err := parsers.NewLoader(executorOpts)
 	if err != nil {
-		return nil, errors.Wrap(err, "Could not create loader options.")
+		return nil, errors.Wrap(err, "could not create loader options")
 	}
 	executorOpts.WorkflowLoader = workflowLoader
 
@@ -123,10 +123,10 @@ func newNucleiExecutor(opts *NucleiExecutorOptions) (*nucleiExecutor, error) {
 	}
 	store, err := loader.New(loaderConfig)
 	if err != nil {
-		return nil, errors.Wrap(err, "Could not create loader options.")
+		return nil, errors.Wrap(err, "could not create loader options")
 	}
 	if err := store.Load(); err != nil {
-		return nil, errors.Wrap(err, "Could not load templates.")
+		return nil, errors.Wrap(err, "could not load templates")
 	}
 
 	return &nucleiExecutor{

--- a/lib/multi.go
+++ b/lib/multi.go
@@ -150,7 +150,9 @@ func (e *ThreadSafeNucleiEngine) ExecuteNucleiWithOptsCtx(ctx context.Context, t
 	if err != nil {
 		return errkit.Wrapf(err, "Could not create loader client: %s", err)
 	}
-	store.Load()
+	if err := store.Load(); err != nil {
+		return errkit.Wrapf(err, "Could not load templates: %s", err)
+	}
 
 	inputProvider := provider.NewSimpleInputProviderWithUrls(e.eng.opts.ExecutionId, targets...)
 

--- a/lib/multi.go
+++ b/lib/multi.go
@@ -151,7 +151,7 @@ func (e *ThreadSafeNucleiEngine) ExecuteNucleiWithOptsCtx(ctx context.Context, t
 		return errkit.Wrap(err, "could not create loader client")
 	}
 	if err := store.Load(); err != nil {
-		return errkit.Wrap(err, "Could not load templates")
+		return errkit.Wrap(err, "could not load templates")
 	}
 
 	inputProvider := provider.NewSimpleInputProviderWithUrls(e.eng.opts.ExecutionId, targets...)

--- a/lib/multi.go
+++ b/lib/multi.go
@@ -151,7 +151,7 @@ func (e *ThreadSafeNucleiEngine) ExecuteNucleiWithOptsCtx(ctx context.Context, t
 		return errkit.Wrapf(err, "Could not create loader client: %s", err)
 	}
 	if err := store.Load(); err != nil {
-		return errkit.Wrapf(err, "Could not load templates: %s", err)
+		return errkit.Wrap(err, "Could not load templates")
 	}
 
 	inputProvider := provider.NewSimpleInputProviderWithUrls(e.eng.opts.ExecutionId, targets...)

--- a/lib/multi.go
+++ b/lib/multi.go
@@ -142,13 +142,13 @@ func (e *ThreadSafeNucleiEngine) ExecuteNucleiWithOptsCtx(ctx context.Context, t
 	// load templates
 	workflowLoader, err := workflow.NewLoader(unsafeOpts.executerOpts)
 	if err != nil {
-		return errkit.Wrapf(err, "Could not create workflow loader: %s", err)
+		return errkit.Wrap(err, "could not create workflow loader")
 	}
 	unsafeOpts.executerOpts.WorkflowLoader = workflowLoader
 
 	store, err := loader.New(loader.NewConfig(tmpEngine.opts, e.eng.catalog, unsafeOpts.executerOpts))
 	if err != nil {
-		return errkit.Wrapf(err, "Could not create loader client: %s", err)
+		return errkit.Wrap(err, "could not create loader client")
 	}
 	if err := store.Load(); err != nil {
 		return errkit.Wrap(err, "Could not load templates")

--- a/lib/sdk.go
+++ b/lib/sdk.go
@@ -110,7 +110,9 @@ func (e *NucleiEngine) LoadAllTemplates() error {
 	if err != nil {
 		return errkit.Wrapf(err, "Could not create loader client: %s", err)
 	}
-	e.store.Load()
+	if err := e.store.Load(); err != nil {
+		return errkit.Wrapf(err, "Could not load templates: %s", err)
+	}
 	e.templatesLoaded = true
 	return nil
 }

--- a/lib/sdk.go
+++ b/lib/sdk.go
@@ -111,7 +111,7 @@ func (e *NucleiEngine) LoadAllTemplates() error {
 		return errkit.Wrap(err, "could not create loader client")
 	}
 	if err := e.store.Load(); err != nil {
-		return errkit.Wrap(err, "Could not load templates")
+		return errkit.Wrap(err, "could not load templates")
 	}
 	e.templatesLoaded = true
 	return nil
@@ -120,7 +120,15 @@ func (e *NucleiEngine) LoadAllTemplates() error {
 // GetTemplates returns all nuclei templates that are loaded
 func (e *NucleiEngine) GetTemplates() []*templates.Template {
 	if !e.templatesLoaded {
-		_ = e.LoadAllTemplates()
+		if err := e.LoadAllTemplates(); err != nil {
+			if e.Logger != nil {
+				e.Logger.Warning().Msgf("could not load templates: %s", err)
+			}
+			return []*templates.Template{}
+		}
+	}
+	if e.store == nil {
+		return []*templates.Template{}
 	}
 	return e.store.Templates()
 }
@@ -128,7 +136,15 @@ func (e *NucleiEngine) GetTemplates() []*templates.Template {
 // GetWorkflows returns all nuclei workflows that are loaded
 func (e *NucleiEngine) GetWorkflows() []*templates.Template {
 	if !e.templatesLoaded {
-		_ = e.LoadAllTemplates()
+		if err := e.LoadAllTemplates(); err != nil {
+			if e.Logger != nil {
+				e.Logger.Warning().Msgf("could not load templates: %s", err)
+			}
+			return []*templates.Template{}
+		}
+	}
+	if e.store == nil {
+		return []*templates.Template{}
 	}
 	return e.store.Workflows()
 }

--- a/lib/sdk.go
+++ b/lib/sdk.go
@@ -111,7 +111,7 @@ func (e *NucleiEngine) LoadAllTemplates() error {
 		return errkit.Wrapf(err, "Could not create loader client: %s", err)
 	}
 	if err := e.store.Load(); err != nil {
-		return errkit.Wrapf(err, "Could not load templates: %s", err)
+		return errkit.Wrap(err, "Could not load templates")
 	}
 	e.templatesLoaded = true
 	return nil

--- a/lib/sdk.go
+++ b/lib/sdk.go
@@ -102,13 +102,13 @@ type NucleiEngine struct {
 func (e *NucleiEngine) LoadAllTemplates() error {
 	workflowLoader, err := workflow.NewLoader(e.executerOpts)
 	if err != nil {
-		return errkit.Wrapf(err, "Could not create workflow loader: %s", err)
+		return errkit.Wrap(err, "could not create workflow loader")
 	}
 	e.executerOpts.WorkflowLoader = workflowLoader
 
 	e.store, err = loader.New(loader.NewConfig(e.opts, e.catalog, e.executerOpts))
 	if err != nil {
-		return errkit.Wrapf(err, "Could not create loader client: %s", err)
+		return errkit.Wrap(err, "could not create loader client")
 	}
 	if err := e.store.Load(); err != nil {
 		return errkit.Wrap(err, "Could not load templates")
@@ -255,7 +255,9 @@ func (e *NucleiEngine) Close() {
 // enable matcher-status option if you expect this callback to be called for all results regardless if it matched or not
 func (e *NucleiEngine) ExecuteCallbackWithCtx(ctx context.Context, callback ...func(event *output.ResultEvent)) error {
 	if !e.templatesLoaded {
-		_ = e.LoadAllTemplates()
+		if err := e.LoadAllTemplates(); err != nil {
+			return err
+		}
 	}
 	if len(e.store.Templates()) == 0 && len(e.store.Workflows()) == 0 {
 		return ErrNoTemplatesAvailable

--- a/pkg/catalog/loader/loader.go
+++ b/pkg/catalog/loader/loader.go
@@ -723,7 +723,7 @@ func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) ([]*temp
 	}
 
 	if protocolstate.GetDialersWithId(typesOpts.ExecutionId) == nil {
-		return nil, fmt.Errorf("%w for %s", ErrDialersNotInitialized, typesOpts.ExecutionId)
+		return nil, fmt.Errorf("%w for execution ID %s", ErrDialersNotInitialized, typesOpts.ExecutionId)
 	}
 
 	for _, templatePath := range includedTemplates {

--- a/pkg/catalog/loader/loader.go
+++ b/pkg/catalog/loader/loader.go
@@ -333,9 +333,14 @@ func (store *Store) RegisterPreprocessor(preprocessor templates.Preprocessor) {
 
 // Load loads all the templates from a store, performs filtering and returns
 // the complete compiled templates for a nuclei execution configuration.
-func (store *Store) Load() {
-	store.templates = store.LoadTemplates(store.finalTemplates)
+func (store *Store) Load() error {
+	loadedTemplates, err := store.LoadTemplates(store.finalTemplates)
+	if err != nil {
+		return err
+	}
+	store.templates = loadedTemplates
 	store.workflows = store.LoadWorkflows(store.finalWorkflows)
+	return nil
 }
 
 var templateIDPathMap map[string]string
@@ -637,7 +642,7 @@ func isParsingError(store *Store, message string, template string, err error) bo
 }
 
 // LoadTemplates takes a list of templates and returns paths for them
-func (store *Store) LoadTemplates(templatesList []string) []*templates.Template {
+func (store *Store) LoadTemplates(templatesList []string) ([]*templates.Template, error) {
 	return store.LoadTemplatesWithTags(templatesList, nil)
 }
 
@@ -668,7 +673,7 @@ func (store *Store) LoadWorkflows(workflowsList []string) []*templates.Template 
 
 // LoadTemplatesWithTags takes a list of templates and extra tags
 // returning templates that match.
-func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) []*templates.Template {
+func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) ([]*templates.Template, error) {
 	defer store.saveMetadataIndexOnce()
 
 	indexFilter := store.indexFilter
@@ -708,7 +713,7 @@ func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) []*templ
 
 	wgLoadTemplates, errWg := syncutil.New(syncutil.WithSize(concurrency))
 	if errWg != nil {
-		panic("could not create wait group")
+		return nil, errors.Wrap(errWg, "could not create wait group")
 	}
 
 	if typesOpts.ExecutionId == "" {
@@ -717,7 +722,7 @@ func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) []*templ
 
 	dialers := protocolstate.GetDialersWithId(typesOpts.ExecutionId)
 	if dialers == nil {
-		panic("dialers with executionId " + typesOpts.ExecutionId + " not found")
+		return nil, fmt.Errorf("dialers not initialized for %s", typesOpts.ExecutionId)
 	}
 
 	for _, templatePath := range includedTemplates {
@@ -852,7 +857,7 @@ func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) []*templ
 		return loadedTemplates.Slice[i].Path < loadedTemplates.Slice[j].Path
 	})
 
-	return loadedTemplates.Slice
+	return loadedTemplates.Slice, nil
 }
 
 // IsHTTPBasedProtocolUsed returns true if http/headless protocol is being used for

--- a/pkg/catalog/loader/loader.go
+++ b/pkg/catalog/loader/loader.go
@@ -1,6 +1,7 @@
 package loader
 
 import (
+	stderrors "errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -41,7 +42,8 @@ const (
 )
 
 var (
-	TrustedTemplateDomains = []string{"cloud.projectdiscovery.io"}
+	TrustedTemplateDomains   = []string{"cloud.projectdiscovery.io"}
+	ErrDialersNotInitialized = stderrors.New("dialers not initialized")
 )
 
 // Config contains the configuration options for the loader
@@ -722,7 +724,7 @@ func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) ([]*temp
 
 	dialers := protocolstate.GetDialersWithId(typesOpts.ExecutionId)
 	if dialers == nil {
-		return nil, fmt.Errorf("dialers not initialized for %s", typesOpts.ExecutionId)
+		return nil, fmt.Errorf("%w for %s", ErrDialersNotInitialized, typesOpts.ExecutionId)
 	}
 
 	for _, templatePath := range includedTemplates {

--- a/pkg/catalog/loader/loader.go
+++ b/pkg/catalog/loader/loader.go
@@ -722,8 +722,7 @@ func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) ([]*temp
 		typesOpts.ExecutionId = xid.New().String()
 	}
 
-	dialers := protocolstate.GetDialersWithId(typesOpts.ExecutionId)
-	if dialers == nil {
+	if protocolstate.GetDialersWithId(typesOpts.ExecutionId) == nil {
 		return nil, fmt.Errorf("%w for %s", ErrDialersNotInitialized, typesOpts.ExecutionId)
 	}
 

--- a/pkg/catalog/loader/loader.go
+++ b/pkg/catalog/loader/loader.go
@@ -715,7 +715,7 @@ func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) ([]*temp
 
 	wgLoadTemplates, errWg := syncutil.New(syncutil.WithSize(concurrency))
 	if errWg != nil {
-		return nil, errors.Wrap(errWg, "could not create wait group")
+		return nil, fmt.Errorf("could not create wait group: %w", errWg)
 	}
 
 	if typesOpts.ExecutionId == "" {

--- a/pkg/catalog/loader/loader_bench_test.go
+++ b/pkg/catalog/loader/loader_bench_test.go
@@ -71,7 +71,7 @@ func BenchmarkLoadTemplates(b *testing.B) {
 		b.ReportAllocs()
 
 		for b.Loop() {
-			_ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
+			_, _ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
 		}
 	})
 
@@ -89,7 +89,7 @@ func BenchmarkLoadTemplates(b *testing.B) {
 		b.ReportAllocs()
 
 		for b.Loop() {
-			_ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
+			_, _ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
 		}
 	})
 
@@ -107,7 +107,7 @@ func BenchmarkLoadTemplates(b *testing.B) {
 		b.ReportAllocs()
 
 		for b.Loop() {
-			_ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
+			_, _ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
 		}
 	})
 
@@ -125,7 +125,7 @@ func BenchmarkLoadTemplates(b *testing.B) {
 		b.ReportAllocs()
 
 		for b.Loop() {
-			_ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
+			_, _ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
 		}
 	})
 
@@ -143,7 +143,7 @@ func BenchmarkLoadTemplates(b *testing.B) {
 		b.ReportAllocs()
 
 		for b.Loop() {
-			_ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
+			_, _ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
 		}
 	})
 
@@ -161,7 +161,7 @@ func BenchmarkLoadTemplates(b *testing.B) {
 		b.ReportAllocs()
 
 		for b.Loop() {
-			_ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
+			_, _ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
 		}
 	})
 
@@ -181,7 +181,7 @@ func BenchmarkLoadTemplates(b *testing.B) {
 		b.ReportAllocs()
 
 		for b.Loop() {
-			_ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
+			_, _ = store.LoadTemplates([]string{config.DefaultConfig.TemplatesDirectory})
 		}
 	})
 }

--- a/pkg/catalog/loader/loader_test.go
+++ b/pkg/catalog/loader/loader_test.go
@@ -2,7 +2,6 @@ package loader
 
 import (
 	"reflect"
-	"strings"
 	"testing"
 
 	"github.com/projectdiscovery/gologger"
@@ -118,6 +117,5 @@ func TestLoadTemplatesWithTags_MissingDialersReturnsError(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = store.LoadTemplatesWithTags([]string{}, nil)
-	require.Error(t, err)
-	require.True(t, strings.Contains(err.Error(), "dialers not initialized for "+options.ExecutionId))
+	require.ErrorContains(t, err, "dialers not initialized for "+options.ExecutionId)
 }

--- a/pkg/catalog/loader/loader_test.go
+++ b/pkg/catalog/loader/loader_test.go
@@ -2,10 +2,15 @@ package loader
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
+	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/config"
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/disk"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols"
+	"github.com/projectdiscovery/nuclei/v3/pkg/types"
+	"github.com/rs/xid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -100,4 +105,19 @@ func TestRemoteTemplates(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestLoadTemplatesWithTags_MissingDialersReturnsError(t *testing.T) {
+	options := types.DefaultOptions()
+	options.ExecutionId = xid.New().String()
+	options.Logger = gologger.DefaultLogger
+	catalog := disk.NewCatalog("")
+	executorOpts := &protocols.ExecutorOptions{Options: options}
+
+	store, err := New(NewConfig(options, catalog, executorOpts))
+	require.NoError(t, err)
+
+	_, err = store.LoadTemplatesWithTags([]string{}, nil)
+	require.Error(t, err)
+	require.True(t, strings.Contains(err.Error(), "dialers not initialized for "+options.ExecutionId))
 }

--- a/pkg/catalog/loader/loader_test.go
+++ b/pkg/catalog/loader/loader_test.go
@@ -117,5 +117,6 @@ func TestLoadTemplatesWithTags_MissingDialersReturnsError(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = store.LoadTemplatesWithTags([]string{}, nil)
-	require.ErrorContains(t, err, "dialers not initialized for "+options.ExecutionId)
+	require.ErrorIs(t, err, ErrDialersNotInitialized)
+	require.ErrorContains(t, err, options.ExecutionId)
 }

--- a/pkg/protocols/common/automaticscan/util.go
+++ b/pkg/protocols/common/automaticscan/util.go
@@ -37,7 +37,10 @@ func getTemplateDirs(opts Options) ([]string, error) {
 
 // LoadTemplatesWithTags loads and returns templates with given tags
 func LoadTemplatesWithTags(opts Options, templateDirs []string, tags []string, logInfo bool) ([]*templates.Template, error) {
-	finalTemplates := opts.Store.LoadTemplatesWithTags(templateDirs, tags)
+	finalTemplates, err := opts.Store.LoadTemplatesWithTags(templateDirs, tags)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not load templates")
+	}
 	if len(finalTemplates) == 0 {
 		return nil, errors.New("could not find any templates with tech tag")
 	}


### PR DESCRIPTION
Follow-up implementation for #6674.

## Proposed Changes

- replace panic paths in loader with proper error returns:
  - missing dialers by execution id
  - nil waitgroup in template loading path
- update function signatures to propagate errors:
  - `Store.Load`
  - `Store.LoadTemplates`
  - `Store.LoadTemplatesWithTags`
- update all affected callers to handle and propagate returned errors:
  - runner, lazy auth path, sdk/multi-sdk, integration test entry, server sdk, automaticscan
- include regression test for missing dialers error path
- include benchmark/test call-site updates for new return signatures
- include nitpick cleanup from review pass:
  - avoid redundant `Wrapf(..., "%s", err)` wrapping in SDK entry points
  - use `require.ErrorContains` in loader tests

## Proof

```bash
# compile-check for touched integration/sdks paths
go test ./lib ./internal/server ./cmd/integration-test -run TestNonExistent -count=1

# behavioral/unit checks for modified runtime paths
go test ./pkg/catalog/loader ./pkg/protocols/common/automaticscan ./internal/runner -count=1
```

## Checklist

- [x] PR created against `dev`
- [x] Tests/compile checks provided for touched paths
- [x] Regression assertion added for dialer-missing error behavior

/claim #6674


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Template-loading failures now surface clear, propagated errors; missing or duplicate templates are detected and reported.
  * Missing connectors/dialers now produce explicit errors instead of silent failures.

* **Refactor**
  * Template-loading APIs and execution paths updated to return and propagate load errors so callers halt or handle failures gracefully.
  * Error messages standardized and simplified for clearer reporting.

* **Tests**
  * Added a test verifying error reporting when required dialers/connectors are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->