### PR TITLE
fix(fuzz): avoid skipping numeric path segment fuzzing

### DIFF
--- a/pkg/fuzz/parts.go
+++ b/pkg/fuzz/parts.go
@@ -162,7 +162,7 @@ func (rule *Rule) execWithInput(input *ExecuteRuleInput, httpReq *retryablehttp.
 	// If the parameter is frequent, skip it if the option is enabled
 	if rule.options.FuzzParamsFrequency != nil {
 		if rule.options.FuzzParamsFrequency.IsParameterFrequent(
-			parameter,
+			actualParameter,
 			httpReq.String(),
 			rule.options.TemplateID,
 		) {

--- a/pkg/fuzz/parts_test.go
+++ b/pkg/fuzz/parts_test.go
@@ -1,2 +1,72 @@
-// TODO: Write tests
 package fuzz
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz/frequency"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols"
+	"github.com/projectdiscovery/retryablehttp-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecWithInput_UsesActualParameterForFrequencyCheck(t *testing.T) {
+	req, err := retryablehttp.NewRequest(http.MethodGet, "http://example.com/user/55/profile", nil)
+	require.NoError(t, err)
+
+	tracker := frequency.New(64, 1)
+	t.Cleanup(tracker.Close)
+
+	// Simulate prior frequency mark on numeric index key (old buggy behavior target).
+	tracker.MarkParameter("2", req.String(), "tpl")
+
+	rule := &Rule{
+		options: &protocols.ExecutorOptions{
+			TemplateID:           "tpl",
+			FuzzParamsFrequency:  tracker,
+		},
+	}
+
+	called := false
+	input := &ExecuteRuleInput{
+		Callback: func(gr GeneratedRequest) bool {
+			called = true
+			require.Equal(t, "55", gr.Parameter)
+			return true
+		},
+	}
+
+	err = rule.execWithInput(input, req, nil, nil, "2", "55", "", "", "", "")
+	require.NoError(t, err)
+	require.True(t, called, "callback should execute because actual parameter '55' is not marked frequent")
+}
+
+func TestExecWithInput_SkipsWhenActualParameterIsFrequent(t *testing.T) {
+	req, err := retryablehttp.NewRequest(http.MethodGet, "http://example.com/user/55/profile", nil)
+	require.NoError(t, err)
+
+	tracker := frequency.New(64, 1)
+	t.Cleanup(tracker.Close)
+
+	// Mark actual path segment value as frequent.
+	tracker.MarkParameter("55", req.String(), "tpl")
+
+	rule := &Rule{
+		options: &protocols.ExecutorOptions{
+			TemplateID:          "tpl",
+			FuzzParamsFrequency: tracker,
+		},
+	}
+
+	called := false
+	input := &ExecuteRuleInput{
+		Callback: func(gr GeneratedRequest) bool {
+			called = true
+			return true
+		},
+	}
+
+	err = rule.execWithInput(input, req, nil, nil, "2", "55", "", "", "", "")
+	require.NoError(t, err)
+	require.False(t, called, "callback should be skipped when actual parameter is frequent")
+}


### PR DESCRIPTION
## Summary
- fix fuzz parameter frequency filtering to use the actual parameter value (e.g. "55") instead of numeric path index key (e.g. "2")
- prevent false frequent-parameter skips that can suppress numeric path-part fuzzing
- add regression tests for both non-skip and skip behavior

## Changes
- pkg/fuzz/parts.go
  - use actualParameter in FuzzParamsFrequency.IsParameterFrequent(...)
- pkg/fuzz/parts_test.go
  - TestExecWithInput_UsesActualParameterForFrequencyCheck
  - TestExecWithInput_SkipsWhenActualParameterIsFrequent

## Verification
- go test ./pkg/fuzz -run 'TestExecWithInput_UsesActualParameterForFrequencyCheck|TestExecWithInput_SkipsWhenActualParameterIsFrequent' -count=1
- go test ./pkg/fuzz/... ./pkg/protocols/http/... -count=1
- from integration_tests/: TESTS='fuzz/fuzz-path-sqli.yaml' PROTO='fuzzing' go run ../cmd/integration-test

This addresses issue behavior reported in #6398.

/claim #6398


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected parameter frequency evaluation to use actual parameter values instead of original references when determining whether to skip fuzzing operations.

* **Tests**
  * Added unit tests verifying frequency-based behavior: one confirming operations execute when parameters are not marked frequent, another confirming operations skip when actual parameters are marked frequent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->