### PR TITLE
fix(fuzz): use actual parameter value for frequency checks

### DIFF
--- a/pkg/fuzz/component/path.go
+++ b/pkg/fuzz/component/path.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz/dataformat"
 	"github.com/projectdiscovery/retryablehttp-go"
+	mapsutil "github.com/projectdiscovery/utils/maps"
 	urlutil "github.com/projectdiscovery/utils/url"
 )
 
@@ -36,7 +37,8 @@ func (q *Path) Parse(req *retryablehttp.Request) (bool, error) {
 	q.value = NewValue("")
 
 	splitted := strings.Split(req.Path, "/")
-	values := make(map[string]interface{})
+	values := mapsutil.NewOrderedMap[string, any]()
+	segmentIndex := 1
 	for i, segment := range splitted {
 		if segment == "" && i == 0 {
 			// Skip the first empty segment from leading "/"
@@ -47,10 +49,11 @@ func (q *Path) Parse(req *retryablehttp.Request) (bool, error) {
 			continue
 		}
 		// Use 1-based indexing and store individual segments
-		key := strconv.Itoa(len(values) + 1)
-		values[key] = segment
+		key := strconv.Itoa(segmentIndex)
+		values.Set(key, segment)
+		segmentIndex++
 	}
-	q.value.SetParsed(dataformat.KVMap(values), "")
+	q.value.SetParsed(dataformat.KVOrderedMap(&values), "")
 	return true, nil
 }
 
@@ -109,7 +112,7 @@ func (q *Path) Rebuild() (*retryablehttp.Request, error) {
 
 		// Check if we have a replacement for this segment
 		key := strconv.Itoa(segmentIndex)
-		if newValue, exists := q.value.parsed.Map.GetOrDefault(key, "").(string); exists && newValue != "" {
+		if newValue, ok := q.value.parsed.Get(key).(string); ok && newValue != "" {
 			rebuiltSegments = append(rebuiltSegments, newValue)
 		} else {
 			rebuiltSegments = append(rebuiltSegments, originalSegment)

--- a/pkg/fuzz/component/path_test.go
+++ b/pkg/fuzz/component/path_test.go
@@ -80,6 +80,26 @@ func TestURLComponent_NestedPaths(t *testing.T) {
 	}
 }
 
+func TestPathComponent_PreservesSegmentOrderWithNumericSegment(t *testing.T) {
+	for i := 0; i < 20; i++ {
+		path := NewPath()
+		req, err := retryablehttp.NewRequest(http.MethodGet, "https://example.com/user/55/profile", nil)
+		require.NoError(t, err)
+
+		found, err := path.Parse(req)
+		require.NoError(t, err)
+		require.True(t, found)
+
+		var values []string
+		err = path.Iterate(func(_ string, value interface{}) error {
+			values = append(values, value.(string))
+			return nil
+		})
+		require.NoError(t, err)
+		require.Equal(t, []string{"user", "55", "profile"}, values)
+	}
+}
+
 func TestPathComponent_SQLInjection(t *testing.T) {
 	path := NewPath()
 	req, err := retryablehttp.NewRequest(http.MethodGet, "https://example.com/user/55/profile", nil)

--- a/pkg/fuzz/parts.go
+++ b/pkg/fuzz/parts.go
@@ -162,7 +162,7 @@ func (rule *Rule) execWithInput(input *ExecuteRuleInput, httpReq *retryablehttp.
 	// If the parameter is frequent, skip it if the option is enabled
 	if rule.options.FuzzParamsFrequency != nil {
 		if rule.options.FuzzParamsFrequency.IsParameterFrequent(
-			parameter,
+			actualParameter,
 			httpReq.String(),
 			rule.options.TemplateID,
 		) {

--- a/pkg/fuzz/parts_exec_test.go
+++ b/pkg/fuzz/parts_exec_test.go
@@ -1,0 +1,52 @@
+package fuzz
+
+import (
+	"testing"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz/frequency"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols"
+	"github.com/projectdiscovery/retryablehttp-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecWithInput_DoesNotUseNumericParameterIndexForFrequency(t *testing.T) {
+	tracker := frequency.New(128, 1)
+	defer tracker.Close()
+
+	req, err := retryablehttp.NewRequest("GET", "https://example.com/users/55", nil)
+	require.NoError(t, err)
+
+	tracker.MarkParameter("2", req.String(), "tmpl-6398")
+
+	callbackCalled := false
+	rule := &Rule{options: &protocols.ExecutorOptions{TemplateID: "tmpl-6398", FuzzParamsFrequency: tracker}}
+	input := &ExecuteRuleInput{Callback: func(_ GeneratedRequest) bool {
+		callbackCalled = true
+		return true
+	}}
+
+	err = rule.execWithInput(input, req, nil, nil, "2", "55", "", "", "", "")
+	require.NoError(t, err)
+	require.True(t, callbackCalled, "numeric parameter index should not be used as frequency key")
+}
+
+func TestExecWithInput_SkipsWhenActualParameterIsFrequent(t *testing.T) {
+	tracker := frequency.New(128, 1)
+	defer tracker.Close()
+
+	req, err := retryablehttp.NewRequest("GET", "https://example.com/users/55", nil)
+	require.NoError(t, err)
+
+	tracker.MarkParameter("55", req.String(), "tmpl-6398")
+
+	callbackCalled := false
+	rule := &Rule{options: &protocols.ExecutorOptions{TemplateID: "tmpl-6398", FuzzParamsFrequency: tracker}}
+	input := &ExecuteRuleInput{Callback: func(_ GeneratedRequest) bool {
+		callbackCalled = true
+		return true
+	}}
+
+	err = rule.execWithInput(input, req, nil, nil, "2", "55", "", "", "", "")
+	require.NoError(t, err)
+	require.False(t, callbackCalled, "frequent actual parameter should be skipped")
+}


### PR DESCRIPTION
Follow-up for #6398.

## What this fixes

Numeric path fuzz points were still being frequency-checked by the index-like key (`parameter`, e.g. `"2"`) instead of the effective path value (`actualParameter`, e.g. `"55"`).

This caused cross-target collisions on the same path index and could suppress valid numeric path-part fuzzing.

## Changes

- `pkg/fuzz/parts.go`
  - in `execWithInput`, changed frequency lookup key from `parameter` to `actualParameter`
- `pkg/fuzz/parts_exec_test.go`
  - `TestExecWithInput_DoesNotUseNumericParameterIndexForFrequency`
  - `TestExecWithInput_SkipsWhenActualParameterIsFrequent`

## Verification

```bash
go test ./pkg/fuzz -run 'TestExecWithInput_DoesNotUseNumericParameterIndexForFrequency|TestExecWithInput_SkipsWhenActualParameterIsFrequent' -count=1
go test ./pkg/fuzz/... ./pkg/protocols/http/... -count=1
```

/claim #6398


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved frequency tracking to use the substituted actual parameter value when deciding whether to skip parameters during fuzzing.

* **Refactor**
  * Preserved path segment ordering by switching the internal path segment container to an ordered structure, ensuring numeric segments keep their original position.

* **Tests**
  * Added tests covering numeric parameter handling and skipping behavior when parameters are marked frequent, and validating preserved path segment order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->