### PR TITLE
feat: add honeypot detection mechanism

### DIFF
--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -330,6 +330,8 @@ on extensive configurability, massive extensibility and ease of use.`)
 		flagSet.StringVarP(&options.JSONExport, "json-export", "je", "", "file to export results in JSON format"),
 		flagSet.StringVarP(&options.JSONLExport, "jsonl-export", "jle", "", "file to export results in JSONL(ine) format"),
 		flagSet.StringSliceVarP(&options.Redact, "redact", "rd", nil, "redact given list of keys from query parameter, request header and body", goflags.CommaSeparatedStringSliceOptions),
+		flagSet.IntVarP(&options.HoneypotThreshold, "honeypot-threshold", "hpt", 0, "number of distinct templates a host must match before being flagged as a potential honeypot (0 disables detection; higher values increase memory usage)"),
+		flagSet.BoolVar(&options.HoneypotSuppressResults, "honeypot-suppress", false, "suppress output for hosts flagged as honeypots (events after threshold crossing)"),
 	)
 
 	flagSet.CreateGroup("configs", "Configurations",

--- a/pkg/output/honeypot.go
+++ b/pkg/output/honeypot.go
@@ -1,0 +1,140 @@
+package output
+
+import (
+	"net"
+	"strings"
+	"sync"
+
+	urlutil "github.com/projectdiscovery/utils/url"
+)
+
+// honeypotDetector tracks per-host template matches and flags hosts that
+// respond positively to an unusual number of distinct templates, which may
+// indicate a honeypot or deceptive scanning environment.
+type honeypotDetector struct {
+	threshold   int                       // number of distinct templates before flagging
+	suppress    bool                      // whether to suppress output for flagged hosts
+	mu          sync.Mutex                // protects hostMatches and flagged
+	hostMatches map[string]map[string]struct{} // host -> set of template IDs
+	flagged     map[string]struct{}       // hosts that have crossed the threshold
+}
+
+// honeypotDecision holds the detector's evaluation result for a single event.
+type honeypotDecision struct {
+	host         string
+	count        int
+	newlyFlagged bool
+	suppress     bool
+}
+
+// newHoneypotDetector creates a new honeypot detector with the given threshold and suppression flag.
+// A threshold <= 0 disables detection entirely.
+func newHoneypotDetector(threshold int, suppress bool) *honeypotDetector {
+	if threshold <= 0 {
+		return nil
+	}
+	return &honeypotDetector{
+		threshold:   threshold,
+		suppress:    suppress,
+		hostMatches: make(map[string]map[string]struct{}),
+		flagged:     make(map[string]struct{}),
+	}
+}
+
+// evaluate processes a ResultEvent and returns a decision indicating whether the host
+// is newly flagged, the current match count, and whether output should be suppressed.
+func (d *honeypotDetector) evaluate(event *ResultEvent) honeypotDecision {
+	if d == nil {
+		return honeypotDecision{}
+	}
+
+	host := normalizeHoneypotHost(event)
+	if host == "" {
+		return honeypotDecision{}
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	// If already flagged, return suppression decision immediately
+	_, alreadyFlagged := d.flagged[host]
+	if alreadyFlagged {
+		return honeypotDecision{
+			host:     host,
+			suppress: d.suppress,
+		}
+	}
+
+	// Track unique template IDs for this host
+	templates, exists := d.hostMatches[host]
+	if !exists {
+		templates = make(map[string]struct{})
+		d.hostMatches[host] = templates
+	}
+	templates[event.TemplateID] = struct{}{}
+	count := len(templates)
+
+	// Check if threshold crossed
+	if count >= d.threshold {
+		d.flagged[host] = struct{}{}
+		// Free memory for this host's matches once flagged
+		delete(d.hostMatches, host)
+		return honeypotDecision{
+			host:         host,
+			count:        count,
+			newlyFlagged: true,
+			suppress:     false, // threshold-triggering event is visible
+		}
+	}
+
+	return honeypotDecision{
+		host:  host,
+		count: count,
+	}
+}
+
+// normalizeHoneypotHost extracts and normalizes a canonical host identifier from the event.
+// It tries event.Host, event.URL, falling back to empty string if none are present.
+func normalizeHoneypotHost(event *ResultEvent) string {
+	for _, candidate := range []string{event.Host, event.URL} {
+		host := normalizeHostCandidate(candidate)
+		if host != "" {
+			return host
+		}
+	}
+	return ""
+}
+
+// normalizeHostCandidate attempts to extract a clean host from a candidate string
+// (which may be a bare host, host:port, or URL) and normalizes it to lowercase.
+func normalizeHostCandidate(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+
+	// Fallback: strip any scheme prefix generically first (e.g., HTTPS://host, tcp://host)
+	// This handles uppercase schemes and non-HTTP schemes
+	if idx := strings.Index(value, "://"); idx >= 0 {
+		value = value[idx+3:]
+	}
+
+	// Try parsing as URL (handles http://host:port/path)
+	if parsed, err := urlutil.ParseAbsoluteURL(value, false); err == nil && parsed.Hostname() != "" {
+		return strings.ToLower(parsed.Hostname())
+	}
+
+	// Try stripping port (handles host:port or [::1]:port)
+	if host, _, err := net.SplitHostPort(value); err == nil {
+		value = host
+	} else if strings.HasPrefix(value, "[") && strings.HasSuffix(value, "]") {
+		// Handle bare IPv6 with brackets: [::1] -> ::1
+		value = strings.TrimPrefix(value, "[")
+		value = strings.TrimSuffix(value, "]")
+	}
+
+	value = strings.TrimSpace(value)
+	value = strings.ToLower(value)
+
+	return value
+}

--- a/pkg/output/honeypot_test.go
+++ b/pkg/output/honeypot_test.go
@@ -1,0 +1,138 @@
+package output
+
+import (
+	"testing"
+)
+
+// TestNormalizeHostCandidate verifies host normalization from various input formats.
+func TestNormalizeHostCandidate(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"URL", "https://example.com:443/path", "example.com"},
+		{"HostPort", "example.com:8080", "example.com"},
+		{"HostOnly", "example.com", "example.com"},
+		{"Empty", "", ""},
+		{"IPv6WithPort", "[::1]:8080", "::1"},
+		{"IPv6BracketOnly", "[::1]", "::1"},
+		{"BareIPv4", "192.168.1.1", "192.168.1.1"},
+		{"UppercaseScheme", "HTTPS://Example.COM", "example.com"},
+		{"NonHTTPScheme", "tcp://host.local:4444", "host.local"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := normalizeHostCandidate(tt.input)
+			if result != tt.expected {
+				t.Errorf("normalizeHostCandidate(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+// TestNormalizeHoneypotHostIgnoresMatchedFallback verifies that event.Matched is NOT used as a fallback.
+func TestNormalizeHoneypotHostIgnoresMatchedFallback(t *testing.T) {
+	event := &ResultEvent{
+		Host:    "",
+		URL:     "",
+		Matched: "arbitrary-content-not-a-host",
+	}
+	result := normalizeHoneypotHost(event)
+	if result != "" {
+		t.Errorf("normalizeHoneypotHost should ignore Matched fallback, got %q", result)
+	}
+}
+
+// TestHoneypotDetectorThresholdBehavior verifies threshold-crossing logic:
+// - Distinct templates increment count
+// - Threshold-crossing event is NOT suppressed (visible)
+// - Subsequent events ARE suppressed if suppress=true
+func TestHoneypotDetectorThresholdBehavior(t *testing.T) {
+	detector := newHoneypotDetector(3, true)
+
+	events := []*ResultEvent{
+		{TemplateID: "tpl-1", Host: "host-a"},
+		{TemplateID: "tpl-2", Host: "host-a"},
+		{TemplateID: "tpl-3", Host: "host-a"}, // crosses threshold
+		{TemplateID: "tpl-4", Host: "host-a"}, // should be suppressed
+	}
+
+	// Event 1
+	decision := detector.evaluate(events[0])
+	if decision.suppress {
+		t.Errorf("Event 1 should not be suppressed")
+	}
+	if decision.newlyFlagged {
+		t.Errorf("Event 1 should not flag host")
+	}
+
+	// Event 2
+	decision = detector.evaluate(events[1])
+	if decision.suppress {
+		t.Errorf("Event 2 should not be suppressed")
+	}
+	if decision.newlyFlagged {
+		t.Errorf("Event 2 should not flag host")
+	}
+
+	// Event 3 (threshold crossing)
+	decision = detector.evaluate(events[2])
+	if decision.suppress {
+		t.Errorf("Threshold-crossing event should NOT be suppressed")
+	}
+	if !decision.newlyFlagged {
+		t.Errorf("Event 3 should flag host")
+	}
+	if decision.count != 3 {
+		t.Errorf("Event 3 count = %d, want 3", decision.count)
+	}
+
+	// Event 4 (after flagging)
+	decision = detector.evaluate(events[3])
+	if !decision.suppress {
+		t.Errorf("Event 4 should be suppressed")
+	}
+	if decision.newlyFlagged {
+		t.Errorf("Event 4 should not newly flag (already flagged)")
+	}
+}
+
+// TestHoneypotDetectorDeduplicatesSameTemplateID verifies same template-id on the same host
+// is deduplicated (count stays at 1, host not flagged).
+func TestHoneypotDetectorDeduplicatesSameTemplateID(t *testing.T) {
+	detector := newHoneypotDetector(3, true)
+
+	event := &ResultEvent{TemplateID: "tpl-1", Host: "host-a"}
+	decision1 := detector.evaluate(event)
+	decision2 := detector.evaluate(event) // duplicate
+
+	if decision1.count != 1 {
+		t.Errorf("First evaluation count = %d, want 1", decision1.count)
+	}
+	if decision2.count != 1 {
+		t.Errorf("Second evaluation count = %d, want 1", decision2.count)
+	}
+	if decision1.newlyFlagged || decision2.newlyFlagged {
+		t.Errorf("Host should not be flagged with duplicate template")
+	}
+}
+
+// TestHoneypotDetectorPrunesHostMatchesAfterThreshold verifies memory is freed after flagging.
+func TestHoneypotDetectorPrunesHostMatchesAfterThreshold(t *testing.T) {
+	detector := newHoneypotDetector(2, true)
+
+	detector.evaluate(&ResultEvent{TemplateID: "tpl-1", Host: "host-a"})
+	detector.evaluate(&ResultEvent{TemplateID: "tpl-2", Host: "host-a"}) // crosses threshold
+
+	detector.mu.Lock()
+	defer detector.mu.Unlock()
+
+	if _, exists := detector.hostMatches["host-a"]; exists {
+		t.Errorf("hostMatches['host-a'] should be pruned after flagging")
+	}
+	if _, flagged := detector.flagged["host-a"]; !flagged {
+		t.Errorf("host-a should remain in flagged map")
+	}
+}

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -82,7 +82,8 @@ type StandardWriter struct {
 	// when using custom server code with output
 	JSONLogRequestHook func(*JSONLogRequest)
 
-	resultCount atomic.Int32
+	honeypotDetector *honeypotDetector
+	resultCount      atomic.Int32
 }
 
 var _ Writer = &StandardWriter{}
@@ -280,6 +281,7 @@ func NewStandardWriter(options *types.Options) (*StandardWriter, error) {
 		storeResponseDir: options.StoreResponseDir,
 		omitTemplate:     options.OmitTemplate,
 		KeysToRedact:     options.Redact,
+		honeypotDetector: newHoneypotDetector(options.HoneypotThreshold, options.HoneypotSuppressResults),
 	}
 
 	if v := os.Getenv("DISABLE_STDOUT"); v == "true" || v == "1" {
@@ -297,6 +299,17 @@ func (w *StandardWriter) ResultCount() int {
 func (w *StandardWriter) Write(event *ResultEvent) error {
 	if event.Error != "" && !w.matcherStatus {
 		return nil
+	}
+
+	// Evaluate honeypot detection
+	if w.honeypotDetector != nil {
+		decision := w.honeypotDetector.evaluate(event)
+		if decision.newlyFlagged {
+			gologger.Warning().Msgf("[honeypot-detection] Host %s flagged as potential honeypot after matching %d distinct templates", decision.host, decision.count)
+		}
+		if decision.suppress {
+			return nil
+		}
 	}
 
 	// Enrich the result event with extra metadata on the template-path and url.

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -472,6 +472,12 @@ type Options struct {
 	timeouts *Timeouts
 	// m is a mutex to protect timeouts from concurrent access
 	m sync.Mutex
+	// HoneypotThreshold is the number of distinct templates a host must match before being
+	// flagged as a potential honeypot. Set to 0 to disable honeypot detection. Higher values
+	// track more template IDs per host, increasing memory usage on large scans with many unique hosts.
+	HoneypotThreshold int
+	// HoneypotSuppressResults suppresses output for hosts flagged as honeypots (events after threshold crossing)
+	HoneypotSuppressResults bool
 }
 
 func (options *Options) Copy() *Options {
@@ -684,6 +690,8 @@ func (options *Options) Copy() *Options {
 		DoNotCacheTemplates:            options.DoNotCacheTemplates,
 		ExecutionId:                    options.ExecutionId,
 		Parser:                         options.Parser,
+		HoneypotThreshold:              options.HoneypotThreshold,
+		HoneypotSuppressResults:        options.HoneypotSuppressResults,
 	}
 	optCopy.SetTimeouts(options.timeouts)
 	return optCopy

--- a/pkg/types/types_test.go
+++ b/pkg/types/types_test.go
@@ -1,0 +1,22 @@
+package types
+
+import (
+	"testing"
+)
+
+// TestOptionsCopyHoneypotFields verifies that Options.Copy() propagates honeypot fields.
+func TestOptionsCopyHoneypotFields(t *testing.T) {
+	original := &Options{
+		HoneypotThreshold:       50,
+		HoneypotSuppressResults: true,
+	}
+
+	copied := original.Copy()
+
+	if copied.HoneypotThreshold != original.HoneypotThreshold {
+		t.Errorf("Copy() did not preserve HoneypotThreshold: got %d, want %d", copied.HoneypotThreshold, original.HoneypotThreshold)
+	}
+	if copied.HoneypotSuppressResults != original.HoneypotSuppressResults {
+		t.Errorf("Copy() did not preserve HoneypotSuppressResults: got %v, want %v", copied.HoneypotSuppressResults, original.HoneypotSuppressResults)
+	}
+}


### PR DESCRIPTION
## Proposed Changes

Implements honeypot detection to identify and flag hosts that respond positively to an unusually high number of distinct templates, which may indicate a honeypot or deceptive scanning environment.

### Key Features
- **Per-host template tracking**: Tracks unique template IDs matched by each host
- **Configurable threshold**: `--honeypot-threshold` (-hpt) flag (default: 0/disabled)
- **Automatic warnings**: Logs warning when host crosses threshold
- **Optional suppression**: `--honeypot-suppress` flag to suppress output for flagged hosts
- **Memory efficient**: Prunes per-host data after flagging to prevent memory bloat
- **Comprehensive tests**: Full test coverage for detection logic and host normalization

### Implementation Details
- New `honeypotDetector` in `pkg/output/honeypot.go` with thread-safe per-host tracking
- Host normalization handles URLs, host:port, IPv6, and various schemes
- Integration with `StandardWriter.Write()` for transparent detection
- Threshold-crossing event remains visible; subsequent events can be suppressed

### Example Usage
```bash
# Enable detection with threshold of 50 distinct templates
nuclei -u https://example.com -hpt 50

# Enable detection and suppress flagged hosts
nuclei -u https://example.com -hpt 50 --honeypot-suppress
```

### Testing
```bash
go test ./pkg/output ./pkg/types -count=1
# All tests pass
```

Closes #6403

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added honeypot detection to identify targets with multiple distinct template matches
  * New `--honeypot-threshold` CLI flag to configure the detection threshold
  * New `--honeypot-suppress` CLI flag to suppress results from detected honeypot targets

* **Tests**
  * Added comprehensive tests for honeypot detection and host normalization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->