### PR TITLE
fix(loader): init dialers when missing (Fixes #6674)

### DIFF
--- a/pkg/catalog/loader/loader.go
+++ b/pkg/catalog/loader/loader.go
@@ -717,7 +717,18 @@ func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) []*templ
 
 	dialers := protocolstate.GetDialersWithId(typesOpts.ExecutionId)
 	if dialers == nil {
-		panic("dialers with executionId " + typesOpts.ExecutionId + " not found")
+		// Template parsing/execution relies on protocol dialers being initialized.
+		// Some non-scanning flows (e.g. template listing / lazy auth loading) can
+		// call into the loader without having initialized protocolstate.
+		if err := protocolstate.Init(typesOpts); err != nil {
+			store.logger.Error().Msgf("Could not initialize dialers with executionId %s: %s", typesOpts.ExecutionId, err)
+			return nil
+		}
+		dialers = protocolstate.GetDialersWithId(typesOpts.ExecutionId)
+		if dialers == nil {
+			store.logger.Error().Msgf("Dialers with executionId %s not found", typesOpts.ExecutionId)
+			return nil
+		}
 	}
 
 	for _, templatePath := range includedTemplates {

--- a/pkg/catalog/loader/loader_test.go
+++ b/pkg/catalog/loader/loader_test.go
@@ -1,11 +1,19 @@
 package loader
 
 import (
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 
+	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/config"
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/disk"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
+	"github.com/projectdiscovery/nuclei/v3/pkg/templates"
+	"github.com/projectdiscovery/nuclei/v3/pkg/types"
+	"github.com/rs/xid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -100,4 +108,48 @@ func TestRemoteTemplates(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestLoadTemplatesInitializesDialersWhenMissing(t *testing.T) {
+	// Create a minimal template on disk.
+	tmp := t.TempDir()
+	tmplPath := filepath.Join(tmp, "test.yaml")
+	require.NoError(t, os.WriteFile(tmplPath, []byte(`id: test
+info:
+  name: Test
+  author: test
+  severity: info
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+    matchers:
+      - type: status
+        status:
+          - 200
+`), 0o644))
+
+	execID := xid.New().String()
+	opts := &types.Options{ExecutionId: execID, Timeout: 5, Retries: 1}
+	defer protocolstate.Close(execID)
+
+	execOpts := &protocols.ExecutorOptions{
+		Options: opts,
+		Catalog: disk.NewCatalog(tmp),
+		Parser:  templates.NewParser(),
+		Logger:  gologger.DefaultLogger,
+	}
+
+	store, err := New(&Config{
+		Templates:       []string{tmplPath},
+		Catalog:         disk.NewCatalog(tmp),
+		ExecutorOptions: execOpts,
+		Logger:          gologger.DefaultLogger,
+	})
+	require.NoError(t, err)
+
+	// Historically this could panic if protocolstate.Init wasn't called by the caller.
+	require.NotPanics(t, func() {
+		_ = store.LoadTemplates([]string{tmplPath})
+	})
 }


### PR DESCRIPTION
Fixes #6674

Summary:
- Loader no longer panics when dialers are missing for a given executionId.
- Attempts protocolstate.Init(types.Options) on-demand and returns nil with an error log if initialization fails.
- Adds a regression test to ensure the loader does not panic.

Tests:
- go test ./pkg/catalog/loader -count=1

/claim #6674

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when protocol dialers are unavailable, preventing application crashes. The system now logs errors and gracefully continues instead of panicking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->