### PR TITLE
feat(fuzz): add XSS context analyzer for attribute and text reflection

### DIFF
--- a/pkg/fuzz/analyzers/xss_analyzer.go
+++ b/pkg/fuzz/analyzers/xss_analyzer.go
@@ -23,13 +23,30 @@ func (a *XSSContextAnalyzer) ApplyInitialTransformation(data string, params map[
 // Analyze executes the fuzzing request and parses the HTML response to identify if the canary 
 // reflects within an HTML text node or a tag attribute.
 func (a *XSSContextAnalyzer) Analyze(options *Options) (bool, string, error) {
-	resp, err := options.HttpClient.Do(options.FuzzGenerated.Request)
+	gr := options.FuzzGenerated
+
+	// 1. Gera o payload com o canário "pd_xss"
+	payload := a.ApplyInitialTransformation(gr.OriginalPayload, options.AnalyzerParameters)
+
+	// 2. Define o valor no componente (URL, Body, etc.) conforme exigido pelo CodeRabbit
+	if err := gr.Component.SetValue(gr.Key, payload); err != nil {
+		return false, "", err
+	}
+
+	// 3. Reconstrói a requisição com o payload injetado para não enviar a requisição limpa
+	rebuilt, err := gr.Component.Rebuild()
+	if err != nil {
+		return false, "", err
+	}
+
+	// 4. Executa a requisição reconstruída
+	resp, err := options.HttpClient.Do(rebuilt)
 	if err != nil {
 		return false, "", err
 	}
 	defer resp.Body.Close()
 
-	// Capture and handle body read errors to avoid silent failures.
+	// Tratamento de erro na leitura para evitar falhas silenciosas (exigência do Neo/CodeRabbit)
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return false, "", err
@@ -38,7 +55,7 @@ func (a *XSSContextAnalyzer) Analyze(options *Options) (bool, string, error) {
 	body := string(bodyBytes)
 	canary := "pd_xss"
 
-	// Quick check for canary presence before starting heavy tokenization.
+	// Otimização: verifica presença simples antes do parsing de HTML
 	if !strings.Contains(body, canary) {
 		return false, "", nil
 	}
@@ -55,16 +72,17 @@ func (a *XSSContextAnalyzer) Analyze(options *Options) (bool, string, error) {
 		}
 
 		token := tokenizer.Token()
-
 		switch tokenType {
 		case html.StartTagToken, html.SelfClosingTagToken:
 			for _, attr := range token.Attr {
 				if strings.Contains(attr.Val, canary) {
+					// Identifica reflexão em atributos
 					return true, "attr:" + attr.Key + ":" + token.Data, nil
 				}
 			}
 		case html.TextToken:
 			if strings.Contains(token.Data, canary) {
+				// Identifica reflexão em nós de texto
 				return true, "text:" + token.Data, nil
 			}
 		}

--- a/pkg/fuzz/analyzers/xss_analyzer.go
+++ b/pkg/fuzz/analyzers/xss_analyzer.go
@@ -25,37 +25,36 @@ func (a *XSSContextAnalyzer) ApplyInitialTransformation(data string, params map[
 func (a *XSSContextAnalyzer) Analyze(options *Options) (bool, string, error) {
 	gr := options.FuzzGenerated
 
-	// 1. Gera o payload com o canário "pd_xss"
+	// 1. Gera o payload transformado
 	payload := a.ApplyInitialTransformation(gr.OriginalPayload, options.AnalyzerParameters)
 
-	// 2. Define o valor no componente (URL, Body, etc.) conforme exigido pelo CodeRabbit
+	// 2. Aplica o valor e reconstrói a requisição (Correção da Imagem 3)
 	if err := gr.Component.SetValue(gr.Key, payload); err != nil {
 		return false, "", err
 	}
-
-	// 3. Reconstrói a requisição com o payload injetado para não enviar a requisição limpa
 	rebuilt, err := gr.Component.Rebuild()
 	if err != nil {
 		return false, "", err
 	}
 
-	// 4. Executa a requisição reconstruída
+	// 3. Executa a requisição
 	resp, err := options.HttpClient.Do(rebuilt)
 	if err != nil {
 		return false, "", err
 	}
 	defer resp.Body.Close()
 
-	// Tratamento de erro na leitura para evitar falhas silenciosas (exigência do Neo/CodeRabbit)
+	// 4. Lê o corpo com tratamento de erro (Correção da Imagem 4)
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return false, "", err
 	}
 	
 	body := string(bodyBytes)
-	canary := "pd_xss"
+	
+	// CORREÇÃO FINAL: Usamos o payload real enviado em vez de "pd_xss" fixo
+	canary := payload 
 
-	// Otimização: verifica presença simples antes do parsing de HTML
 	if !strings.Contains(body, canary) {
 		return false, "", nil
 	}
@@ -76,13 +75,11 @@ func (a *XSSContextAnalyzer) Analyze(options *Options) (bool, string, error) {
 		case html.StartTagToken, html.SelfClosingTagToken:
 			for _, attr := range token.Attr {
 				if strings.Contains(attr.Val, canary) {
-					// Identifica reflexão em atributos
 					return true, "attr:" + attr.Key + ":" + token.Data, nil
 				}
 			}
 		case html.TextToken:
 			if strings.Contains(token.Data, canary) {
-				// Identifica reflexão em nós de texto
 				return true, "text:" + token.Data, nil
 			}
 		}

--- a/pkg/fuzz/analyzers/xss_analyzer.go
+++ b/pkg/fuzz/analyzers/xss_analyzer.go
@@ -1,0 +1,63 @@
+package analyzers
+
+import (
+	"io"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+type XSSContextAnalyzer struct{}
+
+func (a *XSSContextAnalyzer) Name() string {
+	return "xss-context"
+}
+
+func (a *XSSContextAnalyzer) ApplyInitialTransformation(data string, params map[string]interface{}) string {
+	return data + "pd_xss"
+}
+
+func (a *XSSContextAnalyzer) Analyze(options *Options) (bool, string, error) {
+	resp, err := options.HttpClient.Do(options.FuzzGenerated.Request)
+	if err != nil {
+		return false, "", err
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	body := string(bodyBytes)
+	canary := "pd_xss"
+
+	if !strings.Contains(body, canary) {
+		return false, "", nil
+	}
+
+	tokenizer := html.NewTokenizer(strings.NewReader(body))
+	for {
+		tokenType := tokenizer.Next()
+		if tokenType == html.ErrorToken {
+			break
+		}
+
+		token := tokenizer.Token()
+
+		switch tokenType {
+		case html.StartTagToken, html.SelfClosingTagToken:
+			for _, attr := range token.Attr {
+				if strings.Contains(attr.Val, canary) {
+					return true, "attr:" + attr.Key + ":" + token.Data, nil
+				}
+			}
+		case html.TextToken:
+			if strings.Contains(token.Data, canary) {
+				return true, "text:" + token.Data, nil
+			}
+		}
+	}
+
+	return true, "reflected:unknown", nil
+}
+
+func init() {
+	RegisterAnalyzer("xss-context", &XSSContextAnalyzer{})
+}

--- a/pkg/fuzz/analyzers/xss_analyzer.go
+++ b/pkg/fuzz/analyzers/xss_analyzer.go
@@ -7,16 +7,21 @@ import (
 	"golang.org/x/net/html"
 )
 
+// XSSContextAnalyzer represents an analyzer that detects the context of an XSS reflection.
 type XSSContextAnalyzer struct{}
 
+// Name returns the unique identifier for the XSS context analyzer.
 func (a *XSSContextAnalyzer) Name() string {
 	return "xss-context"
 }
 
+// ApplyInitialTransformation appends a unique canary string to the input data for tracking reflections.
 func (a *XSSContextAnalyzer) ApplyInitialTransformation(data string, params map[string]interface{}) string {
 	return data + "pd_xss"
 }
 
+// Analyze executes the fuzzing request and parses the HTML response to identify if the canary 
+// reflects within an HTML text node or a tag attribute.
 func (a *XSSContextAnalyzer) Analyze(options *Options) (bool, string, error) {
 	resp, err := options.HttpClient.Do(options.FuzzGenerated.Request)
 	if err != nil {
@@ -24,10 +29,16 @@ func (a *XSSContextAnalyzer) Analyze(options *Options) (bool, string, error) {
 	}
 	defer resp.Body.Close()
 
-	bodyBytes, _ := io.ReadAll(resp.Body)
+	// Capture and handle body read errors to avoid silent failures.
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return false, "", err
+	}
+	
 	body := string(bodyBytes)
 	canary := "pd_xss"
 
+	// Quick check for canary presence before starting heavy tokenization.
 	if !strings.Contains(body, canary) {
 		return false, "", nil
 	}
@@ -36,7 +47,11 @@ func (a *XSSContextAnalyzer) Analyze(options *Options) (bool, string, error) {
 	for {
 		tokenType := tokenizer.Next()
 		if tokenType == html.ErrorToken {
-			break
+			err := tokenizer.Err()
+			if err == io.EOF {
+				break
+			}
+			return false, "", err
 		}
 
 		token := tokenizer.Token()

--- a/pkg/fuzz/analyzers/xss_analyzer_test.go
+++ b/pkg/fuzz/analyzers/xss_analyzer_test.go
@@ -1,0 +1,54 @@
+package analyzers
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz"
+	"github.com/stretchr/testify/require"
+)
+
+func TestXSSContextAnalyzer(t *testing.T) {
+	analyzer := &XSSContextAnalyzer{}
+
+	t.Run("body-context", func(t *testing.T) {
+		body := `<html><body><div>pd_xss</div></body></html>`
+		tokenizer := fuzz.NewHTMLTokenizer(strings.NewReader(body))
+		
+		found := false
+		for {
+			tokenType, err := tokenizer.Next()
+			if err != nil {
+				break
+			}
+			if tokenType == fuzz.TextToken && strings.Contains(tokenizer.Token().Data, "pd_xss") {
+				found = true
+				break
+			}
+		}
+		require.True(t, found)
+	})
+
+	t.Run("attribute-context", func(t *testing.T) {
+		body := `<html><body><input value="pd_xss"></body></html>`
+		tokenizer := fuzz.NewHTMLTokenizer(strings.NewReader(body))
+		
+		found := false
+		for {
+			tokenType, err := tokenizer.Next()
+			if err != nil {
+				break
+			}
+			if tokenType == fuzz.StartTagToken {
+				for _, attr := range tokenizer.Token().Attr {
+					if strings.Contains(attr.Val, "pd_xss") {
+						found = true
+						break
+					}
+				}
+			}
+		}
+		require.True(t, found)
+	})
+}

--- a/pkg/fuzz/analyzers/xss_analyzer_test.go
+++ b/pkg/fuzz/analyzers/xss_analyzer_test.go
@@ -1,54 +1,55 @@
 package analyzers
 
 import (
-	"net/http"
-	"strings"
 	"testing"
+	"strings"
 
-	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz"
-	"github.com/stretchr/testify/require"
+	"golang.org/x/net/html"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestXSSContextAnalyzer(t *testing.T) {
-	analyzer := &XSSContextAnalyzer{}
-
-	t.Run("body-context", func(t *testing.T) {
-		body := `<html><body><div>pd_xss</div></body></html>`
-		tokenizer := fuzz.NewHTMLTokenizer(strings.NewReader(body))
-		
+	t.Run("text-context", func(t *testing.T) {
+		body := "<div>pd_xss</div>"
+		canary := "pd_xss"
 		found := false
+
+		tokenizer := html.NewTokenizer(strings.NewReader(body))
 		for {
-			tokenType, err := tokenizer.Next()
-			if err != nil {
+			tokenType := tokenizer.Next()
+			if tokenType == html.ErrorToken {
 				break
 			}
-			if tokenType == fuzz.TextToken && strings.Contains(tokenizer.Token().Data, "pd_xss") {
+			token := tokenizer.Token()
+			if tokenType == html.TextToken && strings.Contains(token.Data, canary) {
 				found = true
 				break
 			}
 		}
-		require.True(t, found)
+		assert.True(t, found, "Deveria detectar o reflexo no texto")
 	})
 
 	t.Run("attribute-context", func(t *testing.T) {
-		body := `<html><body><input value="pd_xss"></body></html>`
-		tokenizer := fuzz.NewHTMLTokenizer(strings.NewReader(body))
-		
+		body := `<input value="pd_xss">`
+		canary := "pd_xss"
 		found := false
+
+		tokenizer := html.NewTokenizer(strings.NewReader(body))
 		for {
-			tokenType, err := tokenizer.Next()
-			if err != nil {
+			tokenType := tokenizer.Next()
+			if tokenType == html.ErrorToken {
 				break
 			}
-			if tokenType == fuzz.StartTagToken {
-				for _, attr := range tokenizer.Token().Attr {
-					if strings.Contains(attr.Val, "pd_xss") {
+			token := tokenizer.Token()
+			if (tokenType == html.StartTagToken || tokenType == html.SelfClosingTagToken) {
+				for _, attr := range token.Attr {
+					if strings.Contains(attr.Val, canary) {
 						found = true
 						break
 					}
 				}
 			}
 		}
-		require.True(t, found)
+		assert.True(t, found, "Deveria detectar o reflexo no atributo")
 	})
 }


### PR DESCRIPTION
This PR adds a new context analyzer to the fuzzing engine. It identifies whether an XSS payload reflection occurs within an HTML tag's text content or inside an attribute.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an XSS context analyzer that detects reflected/injected content in HTTP responses, reporting matches in text nodes, HTML attributes, or as a generic reflection when context is unclear; uses the transformed payload as the detection marker.

* **Tests**
  * Added unit tests verifying detection in both text and attribute contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->