### PR TITLE
feat(fuzz): add xss_context analyzer with context classification

### DIFF
--- a/SYNTAX-REFERENCE.md
+++ b/SYNTAX-REFERENCE.md
@@ -2066,6 +2066,7 @@ Valid values:
 
 
   - <code>time_delay</code>
+  - <code>xss_context</code>
 </div>
 
 <hr />
@@ -4572,7 +4573,6 @@ Appears in:
 
 
 - <code><a href="#template">Template</a>.variables</code>
-
 
 
 

--- a/pkg/fuzz/analyzers/analyzers.go
+++ b/pkg/fuzz/analyzers/analyzers.go
@@ -27,6 +27,7 @@ type AnalyzerTemplate struct {
 	//   Name is the name of the analyzer to use
 	// values:
 	//   - time_delay
+	//   - xss_context
 	Name string `json:"name" yaml:"name"`
 	// description: |
 	//   Parameters is the parameters for the analyzer

--- a/pkg/fuzz/analyzers/xss/analyzer.go
+++ b/pkg/fuzz/analyzers/xss/analyzer.go
@@ -49,12 +49,13 @@ func (a *Analyzer) Analyze(options *analyzers.Options) (bool, string, error) {
 	if payload == "" {
 		return false, "", nil
 	}
+	originalValue := gr.OriginalValue
 
 	if err := gr.Component.SetValue(gr.Key, payload); err != nil {
 		return false, "", err
 	}
 	defer func() {
-		_ = gr.Component.SetValue(gr.Key, gr.Value)
+		_ = gr.Component.SetValue(gr.Key, originalValue)
 	}()
 
 	rebuilt, err := gr.Component.Rebuild()

--- a/pkg/fuzz/analyzers/xss/analyzer.go
+++ b/pkg/fuzz/analyzers/xss/analyzer.go
@@ -1,0 +1,177 @@
+package xss
+
+import (
+	"io"
+	"strings"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz/analyzers"
+	"golang.org/x/net/html"
+	"golang.org/x/net/html/atom"
+)
+
+const (
+	analyzerName         = "xss_context"
+	maxResponseBodyBytes = 10 * 1024 * 1024 // 10 MiB
+	contextScript        = "script"
+	contextAttribute     = "attribute"
+	contextComment       = "comment"
+	contextHTML          = "html"
+	contextRawHTML       = "raw_html"
+)
+
+// Analyzer is an XSS reflection analyzer that classifies where payloads are reflected.
+type Analyzer struct{}
+
+var _ analyzers.Analyzer = &Analyzer{}
+
+func init() {
+	analyzers.RegisterAnalyzer(analyzerName, &Analyzer{})
+}
+
+// Name returns the analyzer identifier used in templates.
+func (a *Analyzer) Name() string {
+	return analyzerName
+}
+
+// ApplyInitialTransformation applies standard fuzz payload transformations to the payload.
+func (a *Analyzer) ApplyInitialTransformation(data string, _ map[string]interface{}) string {
+	return analyzers.ApplyPayloadTransformations(data)
+}
+
+// Analyze replays the generated request and inspects reflection context for the injected payload.
+func (a *Analyzer) Analyze(options *analyzers.Options) (bool, string, error) {
+	if options == nil || options.FuzzGenerated.Component == nil || options.HttpClient == nil {
+		return false, "", nil
+	}
+
+	gr := options.FuzzGenerated
+	payload := gr.Value
+	if payload == "" {
+		return false, "", nil
+	}
+
+	if err := gr.Component.SetValue(gr.Key, payload); err != nil {
+		return false, "", err
+	}
+	defer func() {
+		_ = gr.Component.SetValue(gr.Key, gr.Value)
+	}()
+
+	rebuilt, err := gr.Component.Rebuild()
+	if err != nil {
+		return false, "", err
+	}
+
+	resp, err := options.HttpClient.Do(rebuilt)
+	if err != nil {
+		return false, "", err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBodyBytes+1))
+	if err != nil {
+		return false, "", err
+	}
+	if len(body) > maxResponseBodyBytes {
+		body = body[:maxResponseBodyBytes]
+	}
+
+	matched, reason := classifyContexts(string(body), payload)
+	if !matched {
+		return false, "", nil
+	}
+	return true, reason, nil
+}
+
+func classifyContexts(body, payload string) (bool, string) {
+	if body == "" || payload == "" || !strings.Contains(body, payload) {
+		return false, ""
+	}
+
+	context := contextRawHTML
+	tokenizer := html.NewTokenizer(strings.NewReader(body))
+	inScript := false
+
+	for {
+		switch tokenizer.Next() {
+		case html.ErrorToken:
+			return true, buildReason(context)
+		case html.StartTagToken:
+			token := tokenizer.Token()
+			if token.DataAtom == atom.Script {
+				inScript = true
+			}
+			context = higherPriorityContext(context, contextFromTag(token, payload))
+		case html.SelfClosingTagToken:
+			token := tokenizer.Token()
+			context = higherPriorityContext(context, contextFromTag(token, payload))
+		case html.EndTagToken:
+			token := tokenizer.Token()
+			if token.DataAtom == atom.Script {
+				inScript = false
+			}
+		case html.CommentToken:
+			if strings.Contains(tokenizer.Token().Data, payload) {
+				context = higherPriorityContext(context, contextComment)
+			}
+		case html.TextToken:
+			text := tokenizer.Token().Data
+			if !strings.Contains(text, payload) {
+				continue
+			}
+			if inScript {
+				context = higherPriorityContext(context, contextScript)
+			} else {
+				context = higherPriorityContext(context, contextHTML)
+			}
+		}
+
+		if context == contextScript {
+			return true, buildReason(context)
+		}
+	}
+}
+
+func contextFromTag(token html.Token, payload string) string {
+	for _, attr := range token.Attr {
+		if strings.Contains(attr.Key, payload) || strings.Contains(attr.Val, payload) {
+			return contextAttribute
+		}
+	}
+	if strings.Contains(token.Data, payload) {
+		return contextRawHTML
+	}
+	return ""
+}
+
+func higherPriorityContext(current, candidate string) string {
+	if candidate == "" {
+		return current
+	}
+
+	if contextPriority(candidate) > contextPriority(current) {
+		return candidate
+	}
+	return current
+}
+
+func contextPriority(context string) int {
+	switch context {
+	case contextScript:
+		return 5
+	case contextAttribute:
+		return 4
+	case contextHTML:
+		return 3
+	case contextComment:
+		return 2
+	case contextRawHTML:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func buildReason(context string) string {
+	return "reflected payload detected in " + context + " context"
+}

--- a/pkg/fuzz/analyzers/xss/analyzer_test.go
+++ b/pkg/fuzz/analyzers/xss/analyzer_test.go
@@ -107,6 +107,7 @@ func TestAnalyzeUsesFinalValueAndRestoresComponent(t *testing.T) {
 			Component:       fakeComp,
 			Key:             "k",
 			Value:           "final-payload",
+			OriginalValue:   "seed",
 			OriginalPayload: "template-[RANDSTR]",
 		},
 		HttpClient: newTestClient(true, "k"),
@@ -123,8 +124,8 @@ func TestAnalyzeUsesFinalValueAndRestoresComponent(t *testing.T) {
 	if fakeComp.setCalls[0].value != "final-payload" {
 		t.Fatalf("expected first SetValue to use generated final value, got %q", fakeComp.setCalls[0].value)
 	}
-	if fakeComp.setCalls[1].value != "final-payload" {
-		t.Fatalf("expected restore to keep generated final value, got %q", fakeComp.setCalls[1].value)
+	if fakeComp.setCalls[1].value != "seed" {
+		t.Fatalf("expected restore to use original value, got %q", fakeComp.setCalls[1].value)
 	}
 	if fakeComp.rebuildCalls != 1 {
 		t.Fatalf("expected Rebuild to be called once, got %d", fakeComp.rebuildCalls)
@@ -140,6 +141,7 @@ func TestAnalyzeNoReflection(t *testing.T) {
 			Component:       fakeComp,
 			Key:             "k",
 			Value:           "probe",
+			OriginalValue:   "seed",
 			OriginalPayload: "template",
 		},
 		HttpClient: newTestClient(false, "k"),
@@ -152,6 +154,9 @@ func TestAnalyzeNoReflection(t *testing.T) {
 	}
 	if len(fakeComp.setCalls) != 2 {
 		t.Fatalf("expected 2 SetValue calls (set + restore), got %d", len(fakeComp.setCalls))
+	}
+	if fakeComp.setCalls[1].value != "seed" {
+		t.Fatalf("expected restore to use original value, got %q", fakeComp.setCalls[1].value)
 	}
 }
 

--- a/pkg/fuzz/analyzers/xss/analyzer_test.go
+++ b/pkg/fuzz/analyzers/xss/analyzer_test.go
@@ -1,0 +1,263 @@
+package xss
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz"
+	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz/analyzers"
+	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz/component"
+	"github.com/projectdiscovery/retryablehttp-go"
+)
+
+func TestClassifyContexts(t *testing.T) {
+	tests := []struct {
+		name        string
+		body        string
+		payload     string
+		wantMatch   bool
+		wantContext string
+	}{
+		{
+			name:        "script context",
+			body:        `<html><script>const x = "PAYLOAD";</script></html>`,
+			payload:     "PAYLOAD",
+			wantMatch:   true,
+			wantContext: contextScript,
+		},
+		{
+			name:        "attribute context",
+			body:        `<img src="x" onerror="PAYLOAD">`,
+			payload:     "PAYLOAD",
+			wantMatch:   true,
+			wantContext: contextAttribute,
+		},
+		{
+			name:        "comment context",
+			body:        `<!-- PAYLOAD -->`,
+			payload:     "PAYLOAD",
+			wantMatch:   true,
+			wantContext: contextComment,
+		},
+		{
+			name:        "html context",
+			body:        `<div>hello PAYLOAD world</div>`,
+			payload:     "PAYLOAD",
+			wantMatch:   true,
+			wantContext: contextHTML,
+		},
+		{
+			name:        "raw html fallback for malformed markup",
+			body:        `<div attr=PAYLOAD`,
+			payload:     "PAYLOAD",
+			wantMatch:   true,
+			wantContext: contextRawHTML,
+		},
+		{
+			name:      "not reflected",
+			body:      `<div>hello world</div>`,
+			payload:   "PAYLOAD",
+			wantMatch: false,
+		},
+		{
+			name:      "empty payload",
+			body:      `<div>PAYLOAD</div>`,
+			payload:   "",
+			wantMatch: false,
+		},
+		{
+			name:      "empty body",
+			body:      "",
+			payload:   "PAYLOAD",
+			wantMatch: false,
+		},
+		{
+			name:        "multiple contexts chooses highest severity",
+			body:        `<div>PAYLOAD</div><script>var s = "PAYLOAD"</script>`,
+			payload:     "PAYLOAD",
+			wantMatch:   true,
+			wantContext: contextScript,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			matched, reason := classifyContexts(tc.body, tc.payload)
+			if matched != tc.wantMatch {
+				t.Fatalf("matched=%v want=%v reason=%q", matched, tc.wantMatch, reason)
+			}
+			if tc.wantContext != "" {
+				if !strings.Contains(reason, tc.wantContext) {
+					t.Fatalf("reason=%q does not include context=%q", reason, tc.wantContext)
+				}
+			}
+		})
+	}
+}
+
+func TestAnalyzeUsesFinalValueAndRestoresComponent(t *testing.T) {
+	fakeComp := &fakeComponent{current: "seed"}
+	analyzer := &Analyzer{}
+
+	matched, reason, err := analyzer.Analyze(&analyzers.Options{
+		FuzzGenerated: fuzz.GeneratedRequest{
+			Component:       fakeComp,
+			Key:             "k",
+			Value:           "final-payload",
+			OriginalPayload: "template-[RANDSTR]",
+		},
+		HttpClient: newTestClient(true, "k"),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !matched {
+		t.Fatalf("expected reflection match, reason=%q", reason)
+	}
+	if len(fakeComp.setCalls) != 2 {
+		t.Fatalf("expected 2 SetValue calls (set + restore), got %d", len(fakeComp.setCalls))
+	}
+	if fakeComp.setCalls[0].value != "final-payload" {
+		t.Fatalf("expected first SetValue to use generated final value, got %q", fakeComp.setCalls[0].value)
+	}
+	if fakeComp.setCalls[1].value != "final-payload" {
+		t.Fatalf("expected restore to keep generated final value, got %q", fakeComp.setCalls[1].value)
+	}
+	if fakeComp.rebuildCalls != 1 {
+		t.Fatalf("expected Rebuild to be called once, got %d", fakeComp.rebuildCalls)
+	}
+}
+
+func TestAnalyzeNoReflection(t *testing.T) {
+	fakeComp := &fakeComponent{current: "seed"}
+	analyzer := &Analyzer{}
+
+	matched, reason, err := analyzer.Analyze(&analyzers.Options{
+		FuzzGenerated: fuzz.GeneratedRequest{
+			Component:       fakeComp,
+			Key:             "k",
+			Value:           "probe",
+			OriginalPayload: "template",
+		},
+		HttpClient: newTestClient(false, "k"),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if matched || reason != "" {
+		t.Fatalf("expected no reflection, got matched=%v reason=%q", matched, reason)
+	}
+	if len(fakeComp.setCalls) != 2 {
+		t.Fatalf("expected 2 SetValue calls (set + restore), got %d", len(fakeComp.setCalls))
+	}
+}
+
+func TestAnalyzeEmptyPayloadEarlyExit(t *testing.T) {
+	fakeComp := &fakeComponent{current: "seed"}
+	analyzer := &Analyzer{}
+
+	matched, reason, err := analyzer.Analyze(&analyzers.Options{
+		FuzzGenerated: fuzz.GeneratedRequest{
+			Component:       fakeComp,
+			Key:             "k",
+			Value:           "",
+			OriginalPayload: "template",
+		},
+		HttpClient: newTestClient(true, "k"),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if matched || reason != "" {
+		t.Fatalf("expected no match for empty payload, got matched=%v reason=%q", matched, reason)
+	}
+	if len(fakeComp.setCalls) != 0 {
+		t.Fatalf("expected no SetValue calls for empty payload, got %d", len(fakeComp.setCalls))
+	}
+	if fakeComp.rebuildCalls != 0 {
+		t.Fatalf("expected no Rebuild calls for empty payload, got %d", fakeComp.rebuildCalls)
+	}
+}
+
+func TestAnalyzeApplyInitialTransformation(t *testing.T) {
+	analyzer := &Analyzer{}
+	transformed := analyzer.ApplyInitialTransformation("x-[RANDNUM]-[RANDSTR]", nil)
+	if !strings.HasPrefix(transformed, "x-") {
+		t.Fatalf("unexpected transformed payload prefix: %q", transformed)
+	}
+	if strings.Contains(transformed, "[RANDNUM]") || strings.Contains(transformed, "[RANDSTR]") {
+		t.Fatalf("expected placeholder replacement, got %q", transformed)
+	}
+}
+
+type roundTripFn func(req *http.Request) (*http.Response, error)
+
+func (f roundTripFn) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func newTestClient(reflectPayload bool, reflectKey string) *retryablehttp.Client {
+	client := retryablehttp.NewClient(retryablehttp.DefaultOptionsSingle)
+	client.HTTPClient.Transport = roundTripFn(func(req *http.Request) (*http.Response, error) {
+		body := "<html><body>no reflection</body></html>"
+		if reflectPayload {
+			payload := req.URL.Query().Get(reflectKey)
+			body = "<html><body>" + payload + "</body></html>"
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Request:    req,
+		}, nil
+	})
+	return client
+}
+
+type setCall struct {
+	key   string
+	value string
+}
+
+type fakeComponent struct {
+	key          string
+	current      string
+	setCalls     []setCall
+	rebuildCalls int
+}
+
+func (f *fakeComponent) Name() string { return "fake" }
+
+func (f *fakeComponent) Parse(_ *retryablehttp.Request) (bool, error) { return true, nil }
+
+func (f *fakeComponent) Iterate(cb func(key string, value interface{}) error) error {
+	if cb == nil {
+		return nil
+	}
+	return cb(f.key, f.current)
+}
+
+func (f *fakeComponent) SetValue(key string, value string) error {
+	f.key = key
+	f.current = value
+	f.setCalls = append(f.setCalls, setCall{key: key, value: value})
+	return nil
+}
+
+func (f *fakeComponent) Delete(_ string) error { return nil }
+
+func (f *fakeComponent) Rebuild() (*retryablehttp.Request, error) {
+	f.rebuildCalls++
+	query := url.Values{}
+	query.Set(f.key, f.current)
+	return retryablehttp.NewRequest(http.MethodGet, "https://example.test/?"+query.Encode(), nil)
+}
+
+func (f *fakeComponent) Clone() component.Component {
+	copied := *f
+	copied.setCalls = append([]setCall(nil), f.setCalls...)
+	return &copied
+}

--- a/pkg/protocols/http/http.go
+++ b/pkg/protocols/http/http.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/projectdiscovery/fastdialer/fastdialer"
 	_ "github.com/projectdiscovery/nuclei/v3/pkg/fuzz/analyzers/time"
+	_ "github.com/projectdiscovery/nuclei/v3/pkg/fuzz/analyzers/xss"
 
 	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz"
 	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz/analyzers"


### PR DESCRIPTION
/claim #5838

## Proposed changes

- add a new `xss_context` analyzer under `pkg/fuzz/analyzers/xss`
- classify reflected payload contexts using the HTML tokenizer into:
  - `script`
  - `attribute`
  - `comment`
  - `html`
  - `raw_html`
- use the final generated value (`FuzzGenerated.Value`) when replaying analyzer requests
- restore component state after analyzer request execution
- cap response-body reads to 10 MiB using `io.LimitReader`
- register analyzer in the HTTP protocol package
- update analyzer valid values in schema comments and syntax reference

### Proof

```bash
go test ./pkg/fuzz/analyzers/xss -count=1
go test ./pkg/fuzz/... -count=1
go test ./pkg/protocols/http -count=1
```

```text
ok   github.com/projectdiscovery/nuclei/v3/pkg/fuzz/analyzers/xss    0.741s
ok   github.com/projectdiscovery/nuclei/v3/pkg/fuzz                  0.863s
?    github.com/projectdiscovery/nuclei/v3/pkg/fuzz/analyzers        [no test files]
ok   github.com/projectdiscovery/nuclei/v3/pkg/fuzz/analyzers/time   3.378s
ok   github.com/projectdiscovery/nuclei/v3/pkg/fuzz/analyzers/xss    1.857s
ok   github.com/projectdiscovery/nuclei/v3/pkg/fuzz/component        1.079s
ok   github.com/projectdiscovery/nuclei/v3/pkg/fuzz/dataformat       1.271s
?    github.com/projectdiscovery/nuclei/v3/pkg/fuzz/frequency        [no test files]
ok   github.com/projectdiscovery/nuclei/v3/pkg/fuzz/stats            0.241s
ok   github.com/projectdiscovery/nuclei/v3/pkg/protocols/http        9.267s
```

## Checklist

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added XSS Context Analyzer to detect and classify where injected payloads are reflected (script, attribute, comment, HTML) and report highest-severity context.

* **Documentation**
  * Updated docs to include new analyzer option (xss_context) in valid values and removed a trailing formatting artifact.

* **Tests**
  * Added comprehensive tests validating context classification, analyzer behavior, payload handling, and component rebuild/restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->