### PR TITLE
fix(fuzz): prevent concurrent map writes in MultiPartForm.Decode

### DIFF
--- a/pkg/fuzz/component/body.go
+++ b/pkg/fuzz/component/body.go
@@ -77,18 +77,27 @@ func (b *Body) Parse(req *retryablehttp.Request) (bool, error) {
 
 // parseBody parses a body with a custom decoder
 func (b *Body) parseBody(decoderName string, req *retryablehttp.Request) (bool, error) {
-	decoder := dataformat.Get(decoderName)
+	var decoder dataformat.DataFormat
 	if decoderName == dataformat.MultiPartFormDataFormat {
-		// set content type to extract boundary
-		if err := decoder.(*dataformat.MultiPartForm).ParseBoundary(req.Header.Get("Content-Type")); err != nil {
+		// MultiPartForm is stateful (boundary, filesMetadata) so a fresh
+		// instance is required to avoid concurrent map writes when multiple
+		// goroutines fuzz in parallel.
+		mpf := dataformat.NewMultiPartForm()
+		if err := mpf.ParseBoundary(req.Header.Get("Content-Type")); err != nil {
 			return false, errors.Wrap(err, "could not parse boundary")
 		}
+		decoder = mpf
+	} else {
+		decoder = dataformat.Get(decoderName)
 	}
 	decoded, err := decoder.Decode(b.value.String())
 	if err != nil {
 		return false, errors.Wrap(err, "could not decode raw")
 	}
 	b.value.SetParsed(decoded, decoder.Name())
+	if decoderName == dataformat.MultiPartFormDataFormat {
+		b.value.encoder = decoder
+	}
 	return true, nil
 }
 

--- a/pkg/fuzz/component/value.go
+++ b/pkg/fuzz/component/value.go
@@ -19,6 +19,7 @@ type Value struct {
 	data       string
 	parsed     dataformat.KV
 	dataFormat string
+	encoder    dataformat.DataFormat
 }
 
 // NewValue returns a new value component
@@ -42,6 +43,7 @@ func (v *Value) Clone() *Value {
 		data:       v.data,
 		parsed:     v.parsed.Clone(),
 		dataFormat: v.dataFormat,
+		encoder:    v.encoder,
 	}
 }
 
@@ -138,9 +140,8 @@ func (v *Value) Delete(key string) bool {
 func (v *Value) Encode() (string, error) {
 	toEncodeStr := v.data
 	if v.parsed.OrderedMap != nil {
-		// flattening orderedmap not supported
 		if v.dataFormat != "" {
-			dataformatStr, err := dataformat.Encode(v.parsed, v.dataFormat)
+			dataformatStr, err := v.encode(v.parsed)
 			if err != nil {
 				return "", err
 			}
@@ -154,13 +155,20 @@ func (v *Value) Encode() (string, error) {
 		return "", err
 	}
 	if v.dataFormat != "" {
-		dataformatStr, err := dataformat.Encode(dataformat.KVMap(nested), v.dataFormat)
+		dataformatStr, err := v.encode(dataformat.KVMap(nested))
 		if err != nil {
 			return "", err
 		}
 		toEncodeStr = dataformatStr
 	}
 	return toEncodeStr, nil
+}
+
+func (v *Value) encode(data dataformat.KV) (string, error) {
+	if v.encoder != nil {
+		return v.encoder.Encode(data)
+	}
+	return dataformat.Encode(data, v.dataFormat)
 }
 
 // In go, []int, []string are not implictily converted to []interface{}

--- a/pkg/fuzz/dataformat/multipart_test.go
+++ b/pkg/fuzz/dataformat/multipart_test.go
@@ -384,10 +384,10 @@ func TestMultiPartFormDecode_ConcurrentWithSeparateInstances(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			mpf := NewMultiPartForm()
-			require.NoError(t, mpf.ParseBoundary("multipart/form-data; boundary="+boundary))
+			assert.NoError(t, mpf.ParseBoundary("multipart/form-data; boundary="+boundary))
 			kv, err := mpf.Decode(body)
-			require.NoError(t, err)
-			require.NotNil(t, kv)
+			assert.NoError(t, err)
+			assert.NotNil(t, kv)
 		}()
 	}
 	wg.Wait()

--- a/pkg/fuzz/dataformat/multipart_test.go
+++ b/pkg/fuzz/dataformat/multipart_test.go
@@ -1,6 +1,7 @@
 package dataformat
 
 import (
+	"sync"
 	"testing"
 
 	mapsutil "github.com/projectdiscovery/utils/maps"
@@ -367,4 +368,27 @@ func TestMultiPartForm_GetFileMetadataWithNilMap(t *testing.T) {
 	// GetFileMetadata should handle nil filesMetadata gracefully
 	_, exists := form.GetFileMetadata("anything")
 	assert.False(t, exists)
+}
+
+func TestMultiPartFormDecode_ConcurrentWithSeparateInstances(t *testing.T) {
+	boundary := "boundary123"
+	body := "--" + boundary + "\r\n" +
+		"Content-Disposition: form-data; name=\"file\"; filename=\"test.txt\"\r\n" +
+		"Content-Type: text/plain\r\n\r\n" +
+		"file content\r\n" +
+		"--" + boundary + "--\r\n"
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			mpf := NewMultiPartForm()
+			require.NoError(t, mpf.ParseBoundary("multipart/form-data; boundary="+boundary))
+			kv, err := mpf.Decode(body)
+			require.NoError(t, err)
+			require.NotNil(t, kv)
+		}()
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
### Is there an existing issue for this?

- [x] I have searched the existing issues.

### Linked Issue

Fixes #6947

### Description

`MultiPartForm` is the only stateful `DataFormat` implementation — it stores `boundary` (string) and `filesMetadata` (map) as instance fields. However, it is registered as a singleton in `dataformat.init()` and shared across all goroutines via `dataformat.Get()`.

When multiple fuzzing goroutines call `Body.parseBody("multipart/form-data", ...)` concurrently, they all mutate the same `MultiPartForm` instance, resulting in `fatal error: concurrent map writes` — an unrecoverable crash that kills the entire process.

**Call path:**

```
engine.ExecuteScanWithOpts (concurrent goroutines)
  → fuzz.Rule.Execute
    → Body.Parse
      → parseBody("multipart/form-data", req)
        → dataformat.Get("multipart/form-data")    // returns singleton
        → singleton.ParseBoundary(contentType)      // writes to m.boundary     ← data race
        → singleton.Decode(body)                    // writes to m.filesMetadata ← fatal: concurrent map writes
```

**Fix:** In `parseBody`, create a fresh `MultiPartForm` instance instead of reusing the singleton. The per-request instance is also preserved in `Value.encoder` so that `Encode()` round-trips correctly (using the same `boundary` and `filesMetadata` from `Decode`).

### Changes

| File | Change |
|------|--------|
| `pkg/fuzz/component/body.go` | Create new `MultiPartForm` per `parseBody` call instead of `dataformat.Get()` singleton; store it as `Value.encoder` for round-trip encoding |
| `pkg/fuzz/component/value.go` | Add `encoder` field to `Value`; add `encode()` helper that delegates to per-request encoder when available, falls back to `dataformat.Encode()` |
| `pkg/fuzz/dataformat/multipart_test.go` | Add `TestMultiPartFormDecode_ConcurrentWithSeparateInstances` — verifies separate instances are safe under `-race` |

### Reproduction

**Template** (`multipart-fuzz.yaml`) — simplified from `integration_tests/fuzz/fuzz-body-multipart-form-sqli.yaml`:

```yaml
id: multipart-fuzz

info:
  name: multipart form body fuzzing
  author: pdteam
  severity: info

http:
  - pre-condition:
      - type: dsl
        dsl:
          - method != "GET"
          - method != "HEAD"
          - contains(content_type, "multipart/form-data")
        condition: and

    payloads:
      injection:
        - "'"
        - "\""
        - ";"

    fuzzing:
      - part: body
        type: postfix
        mode: single
        fuzz:
          - '{{injection}}'

    stop-at-first-match: true
    matchers:
      - type: word
        words:
          - "ok"
```

**Proxify input** (`input.proxify.yaml`):

```yaml
timestamp: 2024-01-01T00:00:00+00:00
url: http://localhost:8080/upload
request:
  header:
    Content-Type: multipart/form-data; boundary=----WebKitFormBoundary7MA4YWxkTrZu0gW
    method: POST
    path: /upload
    host: localhost:8080
  raw: |+
    POST /upload HTTP/1.1
    Host: localhost:8080
    Content-Type: multipart/form-data; boundary=----WebKitFormBoundary7MA4YWxkTrZu0gW

    ------WebKitFormBoundary7MA4YWxkTrZu0gW
    Content-Disposition: form-data; name="file"; filename="test.txt"
    Content-Type: text/plain

    file content
    ------WebKitFormBoundary7MA4YWxkTrZu0gW
    Content-Disposition: form-data; name="description"

    test upload
    ------WebKitFormBoundary7MA4YWxkTrZu0gW--
response:
  header:
    Content-Type: text/plain
  raw: |+
    HTTP/1.1 200 OK
    Content-Type: text/plain

    ok
```

**SDK code** (`main.go`):

```go
package main

import (
	"context"
	"fmt"
	"net/http"
	"net/http/httptest"

	nuclei "github.com/projectdiscovery/nuclei/v3/lib"
	"github.com/projectdiscovery/nuclei/v3/pkg/output"
)

func main() {
	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
		w.WriteHeader(200)
		fmt.Fprint(w, "ok")
	}))
	defer ts.Close()

	ne, err := nuclei.NewNucleiEngineCtx(
		context.Background(),
		nuclei.WithTemplatesOrWorkflows(nuclei.TemplateSources{
			Templates: []string{"multipart-fuzz.yaml"},
		}),
		nuclei.DisableUpdateCheck(),
	)
	if err != nil {
		panic(err)
	}
	defer ne.Close()

	// Update url/host in input.proxify.yaml to ts.URL before running
	if err := ne.LoadTargetsWithHttpData("input.proxify.yaml", "yaml"); err != nil {
		panic(err)
	}

	if err := ne.ExecuteCallbackWithCtx(context.Background(), func(event *output.ResultEvent) {
		fmt.Printf("Result: %s\n", event.TemplateID)
	}); err != nil {
		panic(err)
	}
}
```

**Run:**

```bash
go run -race main.go
# or: CGO_ENABLED=1 go build -race -o nuclei-race ./cmd/nuclei
#     ./nuclei-race -t multipart-fuzz.yaml -l targets.txt -im yaml -duc
```

**Race detector output (before fix):**

```
==================
WARNING: DATA RACE
Write at 0x00c00000e108 by goroutine 17:
  ...MultiPartForm).ParseBoundary()
      pkg/fuzz/dataformat/multipart.go:146

Previous write at 0x00c00000e108 by goroutine 8:
  ...MultiPartForm).ParseBoundary()
      pkg/fuzz/dataformat/multipart.go:146
==================
--- FAIL: TestMultiPartFormDecode_SharedInstance_Race (0.00s)
    testing.go:1617: race detected during execution of test
FAIL
```

**After fix (separate instances, no race):**

```
$ go test -race -count=1 -run TestMultiPartFormDecode_ConcurrentWithSeparateInstances ./pkg/fuzz/dataformat/
ok  	github.com/projectdiscovery/nuclei/v3/pkg/fuzz/dataformat	1.270s
```

### Test plan

- [x] `go test -race ./pkg/fuzz/dataformat/` — passes including new concurrent test
- [x] `go test -race ./pkg/fuzz/...` — no regressions
- [x] Shared-instance race test confirms the bug is real (race detected by `-race`)
- [x] Separate-instance test confirms the fix pattern is safe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multipart form handling reliability during concurrent operations.

* **Tests**
  * Added concurrent execution testing for multipart form decoding scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->