### PR TITLE
fix for #7013

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -242,7 +242,9 @@ func New(options *types.Options) (*Runner, error) {
 		}()
 	}
 
-	if (len(options.Templates) == 0 || !options.NewTemplates || (options.TargetsFilePath == "" && !options.Stdin && len(options.Targets) == 0)) && options.UpdateTemplates {
+	noTemplatesSpecified := len(options.Templates) == 0 && !options.NewTemplates
+	noTargetsSpecified := options.TargetsFilePath == "" && !options.Stdin && len(options.Targets) == 0
+	if noTemplatesSpecified && noTargetsSpecified && options.UpdateTemplates {
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
## Proposed Changes
Fixes #7013

This PR fixes the logical condition in `internal/runner/runner.go` that determines when nuclei should exit after updating templates using the `-ut` flag.

The Problem:
The original condition used incorrect || (OR) logic:

This caused nuclei to exit prematurely after template update even when templates or targets were explicitly specified, preventing users from running scans with -ut alongside other options.

The Fix:
Changed the logic to use proper && (AND) conditions, ensuring nuclei only exits early when:

- No templates are specified AND -nt flag is not set
- No targets are specified (no -l, no stdin, no -u)
- -ut flag is set

This allows users to combine -ut with template/target options and have nuclei continue execution after updating templates.

### Proof
#### Before
Note that nuclei exits despite target being specified.
<img width="571" height="220" alt="image" src="https://github.com/user-attachments/assets/b5ebe459-2fd6-47b8-ae0d-5c04729dc08f" />

#### After
Note that nuclei continues to the scan after checking for template updates.
<img width="654" height="397" alt="image" src="https://github.com/user-attachments/assets/0d884a3b-a00d-4d4d-a5d8-e2e49716610f" />

## Checklist
- [x] I have read the CONTRIBUTING guide.
- [x] I ran tests (`make test`) which passed and also ran `make vet`
- [x] I have verified the changes work as intended

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

No user-facing changes in this release. Internal code improvements were made to enhance maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->