### PR TITLE
docs: update outdated documentation links in all translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,11 +376,11 @@ Run nuclei with a JSON output:
 Run nuclei with sorted Markdown outputs (with environment variables):
 	$ MARKDOWN_EXPORT_SORT_MODE=template nuclei -target example.com -markdown-export nuclei_report/
 
-Additional documentation is available at: https://docs.nuclei.sh/getting-started/running
+Additional documentation is available at: https://docs.projectdiscovery.io/getting-started/running
 
 ```
 
-Additional documentation is available at: [**`docs.nuclei.sh/getting-started/running`**](https://docs.nuclei.sh/getting-started/running?utm_source=github&utm_medium=web&utm_campaign=nuclei_readme)
+Additional documentation is available at: [**`docs.projectdiscovery.io/getting-started/running`**](https://docs.projectdiscovery.io/getting-started/running?utm_source=github&utm_medium=web&utm_campaign=nuclei_readme)
 
 </details>
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -320,7 +320,7 @@ UNCOVER引擎:
 
 ```
 
-更多信息请参考文档: https://docs.nuclei.sh/getting-started/running
+更多信息请参考文档: https://docs.projectdiscovery.io/getting-started/running
 
 
 ### 运行Nuclei

--- a/README_ES.md
+++ b/README_ES.md
@@ -328,7 +328,7 @@ Ejecutar nuclei con una salida JSON:
 Ejecutar nuclei con salidas Markdown ordenadas (con variables de entorno):
    $ MARKDOWN_EXPORT_SORT_MODE=template nuclei -target example.com -markdown-export nuclei_report/
 
-Documentación adicional disponible en: https://docs.nuclei.sh/getting-started/running
+Documentación adicional disponible en: https://docs.projectdiscovery.io/getting-started/running
 ```
 
 ### Ejecutando Nuclei

--- a/README_ID.md
+++ b/README_ID.md
@@ -291,7 +291,7 @@ Run nuclei with a JSON output:
 Run nuclei with sorted Markdown outputs (with environment variables):
 	$ MARKDOWN_EXPORT_SORT_MODE=template nuclei -target example.com -markdown-export nuclei_report/
 
-Additional documentation is available at: https://docs.nuclei.sh/getting-started/running
+Additional documentation is available at: https://docs.projectdiscovery.io/getting-started/running
 ```
 
 ### Menjalankan Nuclei

--- a/README_KR.md
+++ b/README_KR.md
@@ -289,7 +289,7 @@ JSON 출력으로 nuclei 실행:
 정렬된 Markdown 출력으로 nuclei 실행 (환경 변수 사용):
 	$ MARKDOWN_EXPORT_SORT_MODE=template nuclei -target example.com -markdown-export nuclei_report/
 
-추가 문서는 여기에서 확인할 수 있습니다: https://docs.nuclei.sh/getting-started/running
+추가 문서는 여기에서 확인할 수 있습니다: https://docs.projectdiscovery.io/getting-started/running
 ```
 
 ### Nuclei 실행

--- a/README_PT-BR.md
+++ b/README_PT-BR.md
@@ -328,7 +328,7 @@ Executar nuclei com saída JSON:
 Executar nuclei com saídas Markdown organizadas (com variáveis de ambiente):
    $ MARKDOWN_EXPORT_SORT_MODE=template nuclei -target example.com -markdown-export nuclei_report/
 
-Documentação adicional disponível em: https://docs.nuclei.sh/getting-started/running
+Documentação adicional disponível em: https://docs.projectdiscovery.io/getting-started/running
 ```
 
 ### Executando Nuclei

--- a/README_TR.md
+++ b/README_TR.md
@@ -173,7 +173,7 @@ TEMPLATES:
 ... (Diğer bayraklar orijinalindeki gibi, tam çeviri için çok uzun olabilir, ancak bağlam için yeterli)
 ```
 
-Ek dokümantasyon şu adreste mevcuttur: [**`docs.nuclei.sh/getting-started/running`**](https://docs.nuclei.sh/getting-started/running?utm_source=github&utm_medium=web&utm_campaign=nuclei_readme)
+Ek dokümantasyon şu adreste mevcuttur: [**`docs.projectdiscovery.io/getting-started/running`**](https://docs.projectdiscovery.io/getting-started/running?utm_source=github&utm_medium=web&utm_campaign=nuclei_readme)
 
 </details>
 


### PR DESCRIPTION
## Description
This PR updates outdated documentation links in README.md and its translations (CN, ES, ID, KR, PT-BR, TR).
It replaces the deprecated `docs.nuclei.sh` domain with the current `docs.projectdiscovery.io`.

## Changes
- Updated `README.md`
- Updated `README_CN.md`
- Updated `README_ES.md`
- Updated `README_ID.md`
- Updated `README_KR.md`
- Updated `README_PT-BR.md`
- Updated `README_TR.md`

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated documentation links across README files in multiple languages (English, Chinese, Spanish, Indonesian, Korean, Portuguese-Brazilian, and Turkish) to reference the new documentation location for getting-started guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->