### PR TITLE
fix(authx): race condition in Dynamic.Fetch with -secret-file

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -681,8 +681,8 @@ func (r *Runner) RunEnumeration() error {
 	// display execution info like version , templates used etc
 	r.displayExecutionInfo(store)
 
-	// prefetch secrets if enabled
-	if executorOpts.AuthProvider != nil && r.options.PreFetchSecrets {
+	// prefetch secrets when auth provider is configured
+	if executorOpts.AuthProvider != nil {
 		r.Logger.Info().Msgf("Pre-fetching secrets from authprovider[s]")
 		if err := executorOpts.AuthProvider.PreFetchSecrets(); err != nil {
 			return errors.Wrap(err, "could not pre-fetch secrets")

--- a/lib/sdk_private.go
+++ b/lib/sdk_private.go
@@ -229,7 +229,7 @@ func (e *NucleiEngine) init(ctx context.Context) error {
 	}
 
 	// prefetch secrets
-	if e.executerOpts.AuthProvider != nil && e.opts.PreFetchSecrets {
+	if e.executerOpts.AuthProvider != nil {
 		if err := e.executerOpts.AuthProvider.PreFetchSecrets(); err != nil {
 			return errors.Wrap(err, "could not prefetch secrets")
 		}

--- a/pkg/authprovider/authx/dynamic.go
+++ b/pkg/authprovider/authx/dynamic.go
@@ -12,6 +12,7 @@ import (
 	sliceutil "github.com/projectdiscovery/utils/slice"
 )
 
+// LazyFetchSecret is a callback that fetches credentials into the given Dynamic.
 type LazyFetchSecret func(d *Dynamic) error
 
 var (
@@ -44,6 +45,7 @@ type Dynamic struct {
 	fetchState *fetchState `json:"-" yaml:"-"`
 }
 
+// GetDomainAndDomainRegex returns the deduplicated domain and domain-regex lists for this secret.
 func (d *Dynamic) GetDomainAndDomainRegex() ([]string, []string) {
 	var domains []string
 	var domainRegex []string
@@ -60,6 +62,7 @@ func (d *Dynamic) GetDomainAndDomainRegex() ([]string, []string) {
 	return uniqueDomains, uniqueDomainRegex
 }
 
+// UnmarshalJSON implements json.Unmarshaler for Dynamic.
 func (d *Dynamic) UnmarshalJSON(data []byte) error {
 	if d == nil {
 		return errkit.New("cannot unmarshal into nil Dynamic struct")
@@ -77,9 +80,11 @@ func (d *Dynamic) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// Validate validates the dynamic secret
+// Validate validates the dynamic secret and initializes fetch state. Safe to call once.
 func (d *Dynamic) Validate() error {
-	d.fetchState = &fetchState{}
+	if d.fetchState == nil {
+		d.fetchState = &fetchState{}
+	}
 	if d.TemplatePath == "" {
 		return errkit.New(" template-path is required for dynamic secret")
 	}
@@ -102,7 +107,7 @@ func (d *Dynamic) Validate() error {
 	return nil
 }
 
-// SetLazyFetchCallback sets the lazy fetch callback for the dynamic secret
+// SetLazyFetchCallback sets the callback used by Fetch to retrieve credentials.
 func (d *Dynamic) SetLazyFetchCallback(callback LazyFetchSecret) {
 	d.fetchCallback = func(d *Dynamic) error {
 		err := callback(d)
@@ -189,7 +194,7 @@ func (d *Dynamic) applyValuesToSecret(secret *Secret) error {
 	return nil
 }
 
-// GetStrategy returns the auth strategies for the dynamic secret
+// GetStrategies returns the auth strategies for the dynamic secret.
 func (d *Dynamic) GetStrategies() []AuthStrategy {
 	if err := d.Fetch(true); err != nil {
 		return nil
@@ -205,12 +210,11 @@ func (d *Dynamic) GetStrategies() []AuthStrategy {
 	return strategies
 }
 
-// Fetch fetches the dynamic secret
-// if isFatal is true, it will stop the execution if the secret could not be fetched
+// Fetch fetches the dynamic secret. If isFatal is true, errors are logged at error level.
 func (d *Dynamic) Fetch(isFatal bool) error {
 	if d.fetchState == nil {
 		if isFatal {
-			gologger.Fatal().Msgf("Could not fetch dynamic secret: %s\n", ErrNotValidated)
+			gologger.Error().Msgf("Could not fetch dynamic secret: %s\n", ErrNotValidated)
 		}
 		return ErrNotValidated
 	}
@@ -224,16 +228,16 @@ func (d *Dynamic) Fetch(isFatal bool) error {
 	})
 
 	if d.fetchState.err != nil && isFatal {
-		gologger.Fatal().Msgf("Could not fetch dynamic secret: %s\n", d.fetchState.err)
+		gologger.Error().Msgf("Could not fetch dynamic secret: %s\n", d.fetchState.err)
 	}
 	return d.fetchState.err
 }
 
-// Error returns the error if any
+// Error returns the fetch error, or ErrNotValidated if Validate has not been called.
 func (d *Dynamic) Error() error {
 	if d.fetchState == nil {
-		return nil
+		return ErrNotValidated
 	}
-	d.fetchState.once.Do(func() {})  // ensure happens-before for err read
+	d.fetchState.once.Do(func() {}) // ensure happens-before for err read
 	return d.fetchState.err
 }

--- a/pkg/authprovider/authx/dynamic.go
+++ b/pkg/authprovider/authx/dynamic.go
@@ -3,7 +3,7 @@ package authx
 import (
 	"fmt"
 	"strings"
-	"sync/atomic"
+	"sync"
 
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/replacer"
@@ -18,6 +18,15 @@ var (
 	_ json.Unmarshaler = &Dynamic{}
 )
 
+// ErrNotValidated is returned when Fetch is called before Validate.
+var ErrNotValidated = errkit.New("dynamic secret not validated: call Validate() before Fetch()")
+
+// fetchState bundles sync.Once and error so they are shared across value copies of Dynamic.
+type fetchState struct {
+	once sync.Once
+	err  error
+}
+
 // Dynamic is a struct for dynamic secret or credential
 // these are high level secrets that take action to generate the actual secret
 // ex: username and password are dynamic secrets, the actual secret is the token obtained
@@ -30,9 +39,9 @@ type Dynamic struct {
 	Input         string                 `json:"input" yaml:"input"` // (optional) target for the dynamic secret
 	Extracted     map[string]interface{} `json:"-" yaml:"-"`         // extracted values from the dynamic secret
 	fetchCallback LazyFetchSecret        `json:"-" yaml:"-"`
-	fetched       *atomic.Bool           `json:"-" yaml:"-"` // atomic flag to check if the secret has been fetched
-	fetching      *atomic.Bool           `json:"-" yaml:"-"` // atomic flag to prevent recursive fetch calls
-	error         error                  `json:"-" yaml:"-"` // error if any
+	// fetchState is a pointer so all value copies of Dynamic share the same fetch state.
+	// Initialized by Validate() before Fetch() is called.
+	fetchState *fetchState `json:"-" yaml:"-"`
 }
 
 func (d *Dynamic) GetDomainAndDomainRegex() ([]string, []string) {
@@ -70,8 +79,7 @@ func (d *Dynamic) UnmarshalJSON(data []byte) error {
 
 // Validate validates the dynamic secret
 func (d *Dynamic) Validate() error {
-	d.fetched = &atomic.Bool{}
-	d.fetching = &atomic.Bool{}
+	d.fetchState = &fetchState{}
 	if d.TemplatePath == "" {
 		return errkit.New(" template-path is required for dynamic secret")
 	}
@@ -183,18 +191,10 @@ func (d *Dynamic) applyValuesToSecret(secret *Secret) error {
 
 // GetStrategy returns the auth strategies for the dynamic secret
 func (d *Dynamic) GetStrategies() []AuthStrategy {
-	if d.fetched.Load() {
-		if d.error != nil {
-			return nil
-		}
-	} else {
-		// Try to fetch if not already fetched
-		_ = d.Fetch(true)
-	}
-
-	if d.error != nil {
+	if err := d.Fetch(true); err != nil {
 		return nil
 	}
+
 	var strategies []AuthStrategy
 	if d.Secret != nil {
 		strategies = append(strategies, d.GetStrategy())
@@ -208,30 +208,32 @@ func (d *Dynamic) GetStrategies() []AuthStrategy {
 // Fetch fetches the dynamic secret
 // if isFatal is true, it will stop the execution if the secret could not be fetched
 func (d *Dynamic) Fetch(isFatal bool) error {
-	if d.fetched.Load() {
-		return d.error
+	if d.fetchState == nil {
+		if isFatal {
+			gologger.Fatal().Msgf("Could not fetch dynamic secret: %s\n", ErrNotValidated)
+		}
+		return ErrNotValidated
 	}
 
-	// Try to set fetching flag atomically
-	if !d.fetching.CompareAndSwap(false, true) {
-		// Already fetching, return current error
-		return d.error
+	d.fetchState.once.Do(func() {
+		if d.fetchCallback == nil {
+			d.fetchState.err = errkit.New("dynamic secret fetch callback not set: call SetLazyFetchCallback() before Fetch()")
+			return
+		}
+		d.fetchState.err = d.fetchCallback(d)
+	})
+
+	if d.fetchState.err != nil && isFatal {
+		gologger.Fatal().Msgf("Could not fetch dynamic secret: %s\n", d.fetchState.err)
 	}
-
-	// We're the only one fetching, call the callback
-	d.error = d.fetchCallback(d)
-
-	// Mark as fetched and clear fetching flag
-	d.fetched.Store(true)
-	d.fetching.Store(false)
-
-	if d.error != nil && isFatal {
-		gologger.Fatal().Msgf("Could not fetch dynamic secret: %s\n", d.error)
-	}
-	return d.error
+	return d.fetchState.err
 }
 
 // Error returns the error if any
 func (d *Dynamic) Error() error {
-	return d.error
+	if d.fetchState == nil {
+		return nil
+	}
+	d.fetchState.once.Do(func() {})  // ensure happens-before for err read
+	return d.fetchState.err
 }

--- a/pkg/authprovider/authx/dynamic.go
+++ b/pkg/authprovider/authx/dynamic.go
@@ -23,8 +23,10 @@ var (
 var ErrNotValidated = errkit.New("dynamic secret not validated: call Validate() before Fetch()")
 
 // fetchState bundles sync.Once and error so they are shared across value copies of Dynamic.
+// mu protects err for concurrent reads after once.Do completes.
 type fetchState struct {
 	once sync.Once
+	mu   sync.RWMutex
 	err  error
 }
 
@@ -220,17 +222,24 @@ func (d *Dynamic) Fetch(isFatal bool) error {
 	}
 
 	d.fetchState.once.Do(func() {
+		var err error
 		if d.fetchCallback == nil {
-			d.fetchState.err = errkit.New("dynamic secret fetch callback not set: call SetLazyFetchCallback() before Fetch()")
-			return
+			err = errkit.New("dynamic secret fetch callback not set: call SetLazyFetchCallback() before Fetch()")
+		} else {
+			err = d.fetchCallback(d)
 		}
-		d.fetchState.err = d.fetchCallback(d)
+		d.fetchState.mu.Lock()
+		d.fetchState.err = err
+		d.fetchState.mu.Unlock()
 	})
 
-	if d.fetchState.err != nil && isFatal {
-		gologger.Error().Msgf("Could not fetch dynamic secret: %s\n", d.fetchState.err)
+	d.fetchState.mu.RLock()
+	err := d.fetchState.err
+	d.fetchState.mu.RUnlock()
+	if err != nil && isFatal {
+		gologger.Error().Msgf("Could not fetch dynamic secret: %s\n", err)
 	}
-	return d.fetchState.err
+	return err
 }
 
 // Error returns the fetch error, or ErrNotValidated if Validate has not been called.
@@ -238,6 +247,7 @@ func (d *Dynamic) Error() error {
 	if d.fetchState == nil {
 		return ErrNotValidated
 	}
-	d.fetchState.once.Do(func() {}) // ensure happens-before for err read
+	d.fetchState.mu.RLock()
+	defer d.fetchState.mu.RUnlock()
 	return d.fetchState.err
 }

--- a/pkg/authprovider/authx/dynamic_test.go
+++ b/pkg/authprovider/authx/dynamic_test.go
@@ -5,6 +5,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/projectdiscovery/utils/errkit"
 	"github.com/stretchr/testify/require"
 )
 
@@ -188,10 +189,47 @@ func TestDynamicFetchConcurrent(t *testing.T) {
 		}
 	})
 
+	t.Run("all-waiters-get-same-non-nil-error", func(t *testing.T) {
+		ready := make(chan struct{})
+		sentinel := errkit.New("fetch failed")
+
+		d := &Dynamic{
+			TemplatePath: "test.yaml",
+			Variables:    []KV{{Key: "k", Value: "v"}},
+		}
+		require.NoError(t, d.Validate())
+		d.fetchCallback = func(_ *Dynamic) error {
+			<-ready
+			return sentinel
+		}
+
+		errs := make([]error, 20)
+		var wg sync.WaitGroup
+		wg.Add(len(errs))
+		for i := range errs {
+			i := i
+			go func() {
+				defer wg.Done()
+				errs[i] = d.Fetch(false)
+			}()
+		}
+		close(ready)
+		wg.Wait()
+
+		for _, err := range errs {
+			require.ErrorIs(t, err, sentinel)
+		}
+	})
+
 	t.Run("unvalidated-returns-ErrNotValidated", func(t *testing.T) {
 		d := &Dynamic{}
 		err := d.Fetch(false)
 		require.ErrorIs(t, err, ErrNotValidated)
+	})
+
+	t.Run("error-returns-ErrNotValidated-before-validate", func(t *testing.T) {
+		d := &Dynamic{}
+		require.ErrorIs(t, d.Error(), ErrNotValidated)
 	})
 
 	t.Run("shared-state-across-value-copies", func(t *testing.T) {

--- a/pkg/authprovider/authx/dynamic_test.go
+++ b/pkg/authprovider/authx/dynamic_test.go
@@ -131,6 +131,7 @@ func TestDynamicFetchConcurrent(t *testing.T) {
 	t.Run("fetch-callback-runs-once", func(t *testing.T) {
 		var callCount atomic.Int32
 		ready := make(chan struct{})
+		entered := make(chan struct{})
 
 		d := &Dynamic{
 			TemplatePath: "test.yaml",
@@ -138,6 +139,7 @@ func TestDynamicFetchConcurrent(t *testing.T) {
 		}
 		require.NoError(t, d.Validate())
 		d.fetchCallback = func(_ *Dynamic) error {
+			close(entered) // signal: winner goroutine is inside the callback
 			<-ready
 			callCount.Add(1)
 			return nil
@@ -152,6 +154,7 @@ func TestDynamicFetchConcurrent(t *testing.T) {
 				_ = d.Fetch(false)
 			}()
 		}
+		<-entered  // wait until the winning goroutine is blocked inside fetchCallback
 		close(ready)
 		wg.Wait()
 
@@ -160,6 +163,7 @@ func TestDynamicFetchConcurrent(t *testing.T) {
 
 	t.Run("all-waiters-get-same-error", func(t *testing.T) {
 		ready := make(chan struct{})
+		entered := make(chan struct{})
 
 		d := &Dynamic{
 			TemplatePath: "test.yaml",
@@ -167,6 +171,7 @@ func TestDynamicFetchConcurrent(t *testing.T) {
 		}
 		require.NoError(t, d.Validate())
 		d.fetchCallback = func(_ *Dynamic) error {
+			close(entered)
 			<-ready
 			return nil
 		}
@@ -181,6 +186,7 @@ func TestDynamicFetchConcurrent(t *testing.T) {
 				errs[i] = d.Fetch(false)
 			}()
 		}
+		<-entered
 		close(ready)
 		wg.Wait()
 
@@ -191,6 +197,7 @@ func TestDynamicFetchConcurrent(t *testing.T) {
 
 	t.Run("all-waiters-get-same-non-nil-error", func(t *testing.T) {
 		ready := make(chan struct{})
+		entered := make(chan struct{})
 		sentinel := errkit.New("fetch failed")
 
 		d := &Dynamic{
@@ -199,6 +206,7 @@ func TestDynamicFetchConcurrent(t *testing.T) {
 		}
 		require.NoError(t, d.Validate())
 		d.fetchCallback = func(_ *Dynamic) error {
+			close(entered)
 			<-ready
 			return sentinel
 		}
@@ -213,6 +221,7 @@ func TestDynamicFetchConcurrent(t *testing.T) {
 				errs[i] = d.Fetch(false)
 			}()
 		}
+		<-entered
 		close(ready)
 		wg.Wait()
 

--- a/pkg/authprovider/authx/dynamic_test.go
+++ b/pkg/authprovider/authx/dynamic_test.go
@@ -1,6 +1,8 @@
 package authx
 
 import (
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -121,5 +123,98 @@ func TestDynamicUnmarshalJSON(t *testing.T) {
 		var d Dynamic
 		err := d.UnmarshalJSON(data)
 		require.NoError(t, err)
+	})
+}
+
+func TestDynamicFetchConcurrent(t *testing.T) {
+	t.Run("fetch-callback-runs-once", func(t *testing.T) {
+		var callCount atomic.Int32
+		ready := make(chan struct{})
+
+		d := &Dynamic{
+			TemplatePath: "test.yaml",
+			Variables:    []KV{{Key: "k", Value: "v"}},
+		}
+		require.NoError(t, d.Validate())
+		d.fetchCallback = func(_ *Dynamic) error {
+			<-ready
+			callCount.Add(1)
+			return nil
+		}
+
+		var wg sync.WaitGroup
+		const n = 20
+		wg.Add(n)
+		for i := 0; i < n; i++ {
+			go func() {
+				defer wg.Done()
+				_ = d.Fetch(false)
+			}()
+		}
+		close(ready)
+		wg.Wait()
+
+		require.Equal(t, int32(1), callCount.Load())
+	})
+
+	t.Run("all-waiters-get-same-error", func(t *testing.T) {
+		ready := make(chan struct{})
+
+		d := &Dynamic{
+			TemplatePath: "test.yaml",
+			Variables:    []KV{{Key: "k", Value: "v"}},
+		}
+		require.NoError(t, d.Validate())
+		d.fetchCallback = func(_ *Dynamic) error {
+			<-ready
+			return nil
+		}
+
+		errs := make([]error, 20)
+		var wg sync.WaitGroup
+		wg.Add(len(errs))
+		for i := range errs {
+			i := i
+			go func() {
+				defer wg.Done()
+				errs[i] = d.Fetch(false)
+			}()
+		}
+		close(ready)
+		wg.Wait()
+
+		for _, err := range errs {
+			require.NoError(t, err)
+		}
+	})
+
+	t.Run("unvalidated-returns-ErrNotValidated", func(t *testing.T) {
+		d := &Dynamic{}
+		err := d.Fetch(false)
+		require.ErrorIs(t, err, ErrNotValidated)
+	})
+
+	t.Run("shared-state-across-value-copies", func(t *testing.T) {
+		var callCount atomic.Int32
+
+		d := &Dynamic{
+			TemplatePath: "test.yaml",
+			Variables:    []KV{{Key: "k", Value: "v"}},
+		}
+		require.NoError(t, d.Validate())
+		d.fetchCallback = func(_ *Dynamic) error {
+			callCount.Add(1)
+			return nil
+		}
+
+		// simulate what file.go does: embed Dynamic by value into DynamicAuthStrategy
+		s1 := &DynamicAuthStrategy{Dynamic: *d}
+		s2 := &DynamicAuthStrategy{Dynamic: *d}
+
+		require.NoError(t, s1.Dynamic.Fetch(false))
+		require.NoError(t, s2.Dynamic.Fetch(false))
+
+		// fetchCallback must have run exactly once across both copies
+		require.Equal(t, int32(1), callCount.Load())
 	})
 }

--- a/pkg/authprovider/authx/dynamic_test.go
+++ b/pkg/authprovider/authx/dynamic_test.go
@@ -130,6 +130,7 @@ func TestDynamicUnmarshalJSON(t *testing.T) {
 func TestDynamicFetchConcurrent(t *testing.T) {
 	t.Run("fetch-callback-runs-once", func(t *testing.T) {
 		var callCount atomic.Int32
+		var completed atomic.Int32
 		ready := make(chan struct{})
 		entered := make(chan struct{})
 
@@ -152,13 +153,17 @@ func TestDynamicFetchConcurrent(t *testing.T) {
 			go func() {
 				defer wg.Done()
 				_ = d.Fetch(false)
+				completed.Add(1)
 			}()
 		}
-		<-entered  // wait until the winning goroutine is blocked inside fetchCallback
+		<-entered // wait until the winning goroutine is blocked inside fetchCallback
+		// All non-winning goroutines are blocked on once.Do; none should have completed yet.
+		require.Equal(t, int32(0), completed.Load(), "no goroutine should complete while callback blocks")
 		close(ready)
 		wg.Wait()
 
 		require.Equal(t, int32(1), callCount.Load())
+		require.Equal(t, int32(n), completed.Load())
 	})
 
 	t.Run("all-waiters-get-same-error", func(t *testing.T) {


### PR DESCRIPTION
Fixes #6592
/claim #6592

When using `-secret-file`, templates can fire unauthenticated due to two issues:

1. `runner.go` and `sdk_private.go` gate `PreFetchSecrets()` behind a flag that defaults to false, so secrets aren't fetched before scanning starts
2. `Dynamic.Fetch()` uses `atomic.Bool` CAS which lets concurrent callers return immediately with a nil error while the first caller is still fetching — they proceed without auth

This replaces the two `atomic.Bool` fields with a `*fetchState` struct containing `sync.Once` + `error`. All concurrent callers now block inside `once.Do` until the fetch callback completes. The pointer ensures the state is shared when `Dynamic` is copied by value into `DynamicAuthStrategy`.

Also fixes `GetStrategies()` to check `Fetch()` return value directly instead of inspecting `fetchState` fields, which could bypass the error guard when `fetchState` is nil.

Changes:
- `dynamic.go`: replace atomic CAS with `sync.Once` via shared `*fetchState`
- `runner.go`, `sdk_private.go`: always prefetch when AuthProvider is set
- `dynamic_test.go`: add concurrent fetch tests (callback-runs-once, waiters-block, value-copy sharing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Secrets are now always prefetched when an AuthProvider is present, improving authentication consistency and error handling.

* **New Features**
  * Added a public error sentinel for unvalidated auth strategies.
  * Added public methods to expose domain information and JSON unmarshaling for dynamic auth strategies.

* **Tests**
  * Added concurrency tests to ensure single-call fetch semantics and consistent behavior across concurrent access and copies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->