### PR TITLE
fix: add Snapshot method to prevent InFlight map race condition

### DIFF
--- a/pkg/core/executors.go
+++ b/pkg/core/executors.go
@@ -127,20 +127,22 @@ func (e *Engine) executeTemplateWithTargets(ctx context.Context, template *templ
 		default:
 		}
 
+		completed, skipUnder, doAbove, isInFlight := resumeFromInfo.Snapshot(index)
+
 		// Best effort to track the host progression
 		// skips indexes lower than the minimum in-flight at interruption time
 		var skip bool
-		if resumeFromInfo.Completed { // the template was completed
+		if completed { // the template was completed
 			e.options.Logger.Debug().Msgf("[%s] Skipping \"%s\": Resume - Template already completed", template.ID, scannedValue.Input)
 			skip = true
-		} else if index < resumeFromInfo.SkipUnder { // index lower than the sliding window (bulk-size)
+		} else if index < skipUnder { // index lower than the sliding window (bulk-size)
 			e.options.Logger.Debug().Msgf("[%s] Skipping \"%s\": Resume - Target already processed", template.ID, scannedValue.Input)
 			skip = true
-		} else if _, isInFlight := resumeFromInfo.InFlight[index]; isInFlight { // the target wasn't completed successfully
+		} else if isInFlight { // the target wasn't completed successfully
 			e.options.Logger.Debug().Msgf("[%s] Repeating \"%s\": Resume - Target wasn't completed", template.ID, scannedValue.Input)
 			// skip is already false, but leaving it here for clarity
 			skip = false
-		} else if index > resumeFromInfo.DoAbove { // index above the sliding window (bulk-size)
+		} else if index > doAbove { // index above the sliding window (bulk-size)
 			// skip is already false - but leaving it here for clarity
 			skip = false
 		}

--- a/pkg/core/executors.go
+++ b/pkg/core/executors.go
@@ -68,9 +68,7 @@ func (e *Engine) executeTemplateWithTargets(ctx context.Context, template *templ
 		currentInfo = &generalTypes.ResumeInfo{}
 		e.executerOpts.ResumeCfg.Current[template.ID] = currentInfo
 	}
-	if currentInfo.InFlight == nil {
-		currentInfo.InFlight = make(map[uint32]struct{})
-	}
+	currentInfo.InitInFlight()
 	resumeFromInfo, ok := e.executerOpts.ResumeCfg.ResumeFrom[template.ID]
 	if !ok {
 		resumeFromInfo = &generalTypes.ResumeInfo{}

--- a/pkg/core/executors.go
+++ b/pkg/core/executors.go
@@ -127,22 +127,20 @@ func (e *Engine) executeTemplateWithTargets(ctx context.Context, template *templ
 		default:
 		}
 
-		completed, skipUnder, doAbove, isInFlight := resumeFromInfo.Snapshot(index)
-
 		// Best effort to track the host progression
 		// skips indexes lower than the minimum in-flight at interruption time
 		var skip bool
-		if completed { // the template was completed
+		if resumeFromInfo.IsCompleted() { // the template was completed
 			e.options.Logger.Debug().Msgf("[%s] Skipping \"%s\": Resume - Template already completed", template.ID, scannedValue.Input)
 			skip = true
-		} else if index < skipUnder { // index lower than the sliding window (bulk-size)
+		} else if index < resumeFromInfo.GetSkipUnder() { // index lower than the sliding window (bulk-size)
 			e.options.Logger.Debug().Msgf("[%s] Skipping \"%s\": Resume - Target already processed", template.ID, scannedValue.Input)
 			skip = true
-		} else if isInFlight { // the target wasn't completed successfully
+		} else if resumeFromInfo.IsInFlight(index) { // the target wasn't completed successfully
 			e.options.Logger.Debug().Msgf("[%s] Repeating \"%s\": Resume - Target wasn't completed", template.ID, scannedValue.Input)
 			// skip is already false, but leaving it here for clarity
 			skip = false
-		} else if index > doAbove { // index above the sliding window (bulk-size)
+		} else if index > resumeFromInfo.GetDoAbove() { // index above the sliding window (bulk-size)
 			// skip is already false - but leaving it here for clarity
 			skip = false
 		}

--- a/pkg/types/resume.go
+++ b/pkg/types/resume.go
@@ -35,6 +35,17 @@ type ResumeInfo struct {
 	DoAbove   uint32              `json:"-"`
 }
 
+// Snapshot returns the current state of the ResumeInfo instance
+func (resumeInfo *ResumeInfo) Snapshot(index uint32) (bool, uint32, uint32, bool) {
+	resumeInfo.RLock()
+	defer resumeInfo.RUnlock()
+	completed := resumeInfo.Completed
+	skipUnder := resumeInfo.SkipUnder
+	doAbove := resumeInfo.DoAbove
+	_, isInFlight := resumeInfo.InFlight[index]
+	return completed, skipUnder, doAbove, isInFlight
+}
+
 // Clone the ResumeInfo structure
 func (resumeInfo *ResumeInfo) Clone() *ResumeInfo {
 	resumeInfo.Lock()

--- a/pkg/types/resume.go
+++ b/pkg/types/resume.go
@@ -36,14 +36,15 @@ type ResumeInfo struct {
 }
 
 // Snapshot returns the current state of the ResumeInfo instance
-func (resumeInfo *ResumeInfo) Snapshot(index uint32) (bool, uint32, uint32, bool) {
+func (resumeInfo *ResumeInfo) Snapshot(index uint32) (completed bool, skipUnder uint32, doAbove uint32, isInFlight bool) {
+ 	resumeInfo.RLock()
 	resumeInfo.RLock()
 	defer resumeInfo.RUnlock()
-	completed := resumeInfo.Completed
-	skipUnder := resumeInfo.SkipUnder
-	doAbove := resumeInfo.DoAbove
-	_, isInFlight := resumeInfo.InFlight[index]
-	return completed, skipUnder, doAbove, isInFlight
+	completed = resumeInfo.Completed
+	skipUnder = resumeInfo.SkipUnder
+	doAbove = resumeInfo.DoAbove
+	_, isInFlight = resumeInfo.InFlight[index]
+	return
 }
 
 // Clone the ResumeInfo structure

--- a/pkg/types/resume.go
+++ b/pkg/types/resume.go
@@ -35,16 +35,29 @@ type ResumeInfo struct {
 	DoAbove   uint32              `json:"-"`
 }
 
-// Snapshot returns the current state of the ResumeInfo instance
-func (resumeInfo *ResumeInfo) Snapshot(index uint32) (completed bool, skipUnder uint32, doAbove uint32, isInFlight bool) {
- 	resumeInfo.RLock()
+func (resumeInfo *ResumeInfo) IsCompleted() bool {
 	resumeInfo.RLock()
 	defer resumeInfo.RUnlock()
-	completed = resumeInfo.Completed
-	skipUnder = resumeInfo.SkipUnder
-	doAbove = resumeInfo.DoAbove
-	_, isInFlight = resumeInfo.InFlight[index]
-	return
+	return resumeInfo.Completed
+}
+
+func (resumeInfo *ResumeInfo) GetSkipUnder() uint32 {
+	resumeInfo.RLock()
+	defer resumeInfo.RUnlock()
+	return resumeInfo.SkipUnder
+}
+
+func (resumeInfo *ResumeInfo) GetDoAbove() uint32 {
+	resumeInfo.RLock()
+	defer resumeInfo.RUnlock()
+	return resumeInfo.DoAbove
+}
+
+func (resumeInfo *ResumeInfo) IsInFlight(index uint32) bool {
+	resumeInfo.RLock()
+	defer resumeInfo.RUnlock()
+	_, ok := resumeInfo.InFlight[index]
+	return ok
 }
 
 // Clone the ResumeInfo structure

--- a/pkg/types/resume.go
+++ b/pkg/types/resume.go
@@ -53,6 +53,14 @@ func (resumeInfo *ResumeInfo) GetDoAbove() uint32 {
 	return resumeInfo.DoAbove
 }
 
+func (resumeInfo *ResumeInfo) InitInFlight() {
+	resumeInfo.Lock()
+	defer resumeInfo.Unlock()
+	if resumeInfo.InFlight == nil {
+		resumeInfo.InFlight = make(map[uint32]struct{})
+	}
+}
+
 func (resumeInfo *ResumeInfo) IsInFlight(index uint32) bool {
 	resumeInfo.RLock()
 	defer resumeInfo.RUnlock()


### PR DESCRIPTION
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->

There appears to be a race condition accessing the `InFlight` map within the `ResumeInfo` struct that can lead to a runtime panic. This change wraps access to the struct's map using  `RLock()/RUnlock()` calls to serialize read/write access across goroutines.

### Proof

<!-- How has this been tested? Please describe the tests that you ran to verify your changes. -->

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Encapsulated resume state behind accessor and initializer methods to simplify internal control flow.
  * Preserved existing behavior, logging, concurrency safety, and decision outcomes while improving code clarity and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->