### PR TITLE
fix(loader): avoid panic when dialers are missing

### DIFF
--- a/pkg/catalog/loader/loader.go
+++ b/pkg/catalog/loader/loader.go
@@ -725,7 +725,8 @@ func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) []*templ
 
 	wgLoadTemplates, errWg := syncutil.New(syncutil.WithSize(concurrency))
 	if errWg != nil {
-		panic("could not create wait group")
+		store.logger.Error().Msgf("could not create wait group: %s", errWg)
+		return []*templates.Template{}
 	}
 
 	for _, templatePath := range includedTemplates {

--- a/pkg/catalog/loader/loader.go
+++ b/pkg/catalog/loader/loader.go
@@ -42,6 +42,8 @@ const (
 
 var (
 	TrustedTemplateDomains = []string{"cloud.projectdiscovery.io"}
+	ErrDialersNotFound     = errors.New("dialers not found")
+	ErrNoMatchingTemplates = errors.New("no matching templates found")
 )
 
 // Config contains the configuration options for the loader
@@ -638,7 +640,13 @@ func isParsingError(store *Store, message string, template string, err error) bo
 
 // LoadTemplates takes a list of templates and returns paths for them
 func (store *Store) LoadTemplates(templatesList []string) []*templates.Template {
-	return store.LoadTemplatesWithTags(templatesList, nil)
+	loadedTemplates, err := store.LoadTemplatesWithTags(templatesList, nil)
+	if err != nil {
+		store.logger.Error().Msgf("could not load templates: %s", err)
+		return []*templates.Template{}
+	}
+
+	return loadedTemplates
 }
 
 // LoadWorkflows takes a list of workflows and returns paths for them
@@ -668,7 +676,7 @@ func (store *Store) LoadWorkflows(workflowsList []string) []*templates.Template 
 
 // LoadTemplatesWithTags takes a list of templates and extra tags
 // returning templates that match.
-func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) []*templates.Template {
+func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) ([]*templates.Template, error) {
 	defer store.saveMetadataIndexOnce()
 
 	indexFilter := store.indexFilter
@@ -710,23 +718,21 @@ func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) []*templ
 		typesOpts.ExecutionId = xid.New().String()
 	}
 
-	dialers := protocolstate.GetDialersWithId(typesOpts.ExecutionId)
-	if dialers == nil {
+	if protocolstate.GetDialersWithId(typesOpts.ExecutionId) == nil {
 		if err := protocolstate.Init(typesOpts); err != nil {
 			store.logger.Error().Msgf("dialers init failed for executionId %s: %s", typesOpts.ExecutionId, err)
-			return []*templates.Template{}
+			return nil, errors.Wrapf(err, "dialers init failed for executionId %s", typesOpts.ExecutionId)
 		}
-		dialers = protocolstate.GetDialersWithId(typesOpts.ExecutionId)
-		if dialers == nil {
+		if protocolstate.GetDialersWithId(typesOpts.ExecutionId) == nil {
 			store.logger.Error().Msgf("dialers with executionId %s not found", typesOpts.ExecutionId)
-			return []*templates.Template{}
+			return nil, errors.Wrapf(ErrDialersNotFound, "dialers with executionId %s not found", typesOpts.ExecutionId)
 		}
 	}
 
 	wgLoadTemplates, errWg := syncutil.New(syncutil.WithSize(concurrency))
 	if errWg != nil {
 		store.logger.Error().Msgf("could not create wait group: %s", errWg)
-		return []*templates.Template{}
+		return nil, errors.Wrap(errWg, "could not create wait group")
 	}
 
 	for _, templatePath := range includedTemplates {
@@ -861,7 +867,11 @@ func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) []*templ
 		return loadedTemplates.Slice[i].Path < loadedTemplates.Slice[j].Path
 	})
 
-	return loadedTemplates.Slice
+	if len(loadedTemplates.Slice) == 0 {
+		return nil, errors.Wrapf(ErrNoMatchingTemplates, "for tags %v", tags)
+	}
+
+	return loadedTemplates.Slice, nil
 }
 
 // IsHTTPBasedProtocolUsed returns true if http/headless protocol is being used for

--- a/pkg/catalog/loader/loader.go
+++ b/pkg/catalog/loader/loader.go
@@ -712,8 +712,15 @@ func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) []*templ
 
 	dialers := protocolstate.GetDialersWithId(typesOpts.ExecutionId)
 	if dialers == nil {
-		store.logger.Error().Msgf("dialers with executionId %s not found", typesOpts.ExecutionId)
-		return nil
+		if err := protocolstate.Init(typesOpts); err != nil {
+			store.logger.Error().Msgf("dialers init failed for executionId %s: %s", typesOpts.ExecutionId, err)
+			return []*templates.Template{}
+		}
+		dialers = protocolstate.GetDialersWithId(typesOpts.ExecutionId)
+		if dialers == nil {
+			store.logger.Error().Msgf("dialers with executionId %s not found", typesOpts.ExecutionId)
+			return []*templates.Template{}
+		}
 	}
 
 	wgLoadTemplates, errWg := syncutil.New(syncutil.WithSize(concurrency))

--- a/pkg/catalog/loader/loader.go
+++ b/pkg/catalog/loader/loader.go
@@ -717,7 +717,8 @@ func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) []*templ
 
 	dialers := protocolstate.GetDialersWithId(typesOpts.ExecutionId)
 	if dialers == nil {
-		panic("dialers with executionId " + typesOpts.ExecutionId + " not found")
+		store.logger.Error().Msgf("dialers with executionId %s not found", typesOpts.ExecutionId)
+		return nil
 	}
 
 	for _, templatePath := range includedTemplates {

--- a/pkg/catalog/loader/loader.go
+++ b/pkg/catalog/loader/loader.go
@@ -706,11 +706,6 @@ func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) []*templ
 		concurrency = types.DefaultTemplateLoadingConcurrency
 	}
 
-	wgLoadTemplates, errWg := syncutil.New(syncutil.WithSize(concurrency))
-	if errWg != nil {
-		panic("could not create wait group")
-	}
-
 	if typesOpts.ExecutionId == "" {
 		typesOpts.ExecutionId = xid.New().String()
 	}
@@ -719,6 +714,11 @@ func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) []*templ
 	if dialers == nil {
 		store.logger.Error().Msgf("dialers with executionId %s not found", typesOpts.ExecutionId)
 		return nil
+	}
+
+	wgLoadTemplates, errWg := syncutil.New(syncutil.WithSize(concurrency))
+	if errWg != nil {
+		panic("could not create wait group")
 	}
 
 	for _, templatePath := range includedTemplates {

--- a/pkg/protocols/common/automaticscan/util.go
+++ b/pkg/protocols/common/automaticscan/util.go
@@ -37,7 +37,10 @@ func getTemplateDirs(opts Options) ([]string, error) {
 
 // LoadTemplatesWithTags loads and returns templates with given tags
 func LoadTemplatesWithTags(opts Options, templateDirs []string, tags []string, logInfo bool) ([]*templates.Template, error) {
-	finalTemplates := opts.Store.LoadTemplatesWithTags(templateDirs, tags)
+	finalTemplates, err := opts.Store.LoadTemplatesWithTags(templateDirs, tags)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not load templates with tags")
+	}
 	if len(finalTemplates) == 0 {
 		return nil, errors.New("could not find any templates with tech tag")
 	}


### PR DESCRIPTION
Fixes #6674.

When dialers are missing for the current executionId, the loader currently panics and crashes the process.

This changes the behavior to:
- log an error with executionId
- attempt protocolstate.Init(typesOpts) once to initialize dialers
- if still missing: return empty slice (no panic)
- handle wait group init error gracefully

Local check:
- go test ./pkg/catalog/loader

/claim #6674


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented crashes when required runtime connections are missing; operations now log the issue and return errors instead of terminating.
  * Avoids starting concurrent work if necessary connection resources are absent, improving startup robustness and reducing wasted processing.
  * Loading templates now fails gracefully when no templates match or initialization problems occur, providing clearer error feedback to callers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
