### PR TITLE
fix(fuzz): use actual parameter for frequency dedupe

### DIFF
--- a/pkg/fuzz/parts.go
+++ b/pkg/fuzz/parts.go
@@ -162,7 +162,7 @@ func (rule *Rule) execWithInput(input *ExecuteRuleInput, httpReq *retryablehttp.
 	// If the parameter is frequent, skip it if the option is enabled
 	if rule.options.FuzzParamsFrequency != nil {
 		if rule.options.FuzzParamsFrequency.IsParameterFrequent(
-			parameter,
+			actualParameter,
 			httpReq.String(),
 			rule.options.TemplateID,
 		) {

--- a/pkg/fuzz/parts_frequency_test.go
+++ b/pkg/fuzz/parts_frequency_test.go
@@ -1,0 +1,77 @@
+package fuzz
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz/frequency"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols"
+	retryablehttp "github.com/projectdiscovery/retryablehttp-go"
+	"github.com/stretchr/testify/require"
+)
+
+// TestExecWithInputDoesNotUseNumericParameterIndexForFrequency verifies frequency
+// checks do not key on numeric path segment indexes.
+func TestExecWithInputDoesNotUseNumericParameterIndexForFrequency(t *testing.T) {
+	tracker := frequency.New(64, 1)
+	defer tracker.Close()
+
+	const target = "https://example.com/users/55"
+	const templateID = "tmpl-frequency-check"
+
+	req, err := retryablehttp.NewRequest(http.MethodGet, target, nil)
+	require.NoError(t, err)
+
+	tracker.MarkParameter("2", req.String(), templateID)
+
+	called := false
+	rule := &Rule{
+		options: &protocols.ExecutorOptions{
+			TemplateID:          templateID,
+			FuzzParamsFrequency: tracker,
+		},
+	}
+	input := &ExecuteRuleInput{
+		Callback: func(GeneratedRequest) bool {
+			called = true
+			return true
+		},
+	}
+
+	err = rule.execWithInput(input, req, nil, nil, "2", "55", "", "", "", "")
+	require.NoError(t, err)
+	require.True(t, called, "numeric path index should not be used as frequency key")
+}
+
+// TestExecWithInputSkipsWhenActualParameterIsFrequent verifies requests are
+// skipped when the normalized parameter value is marked frequent.
+func TestExecWithInputSkipsWhenActualParameterIsFrequent(t *testing.T) {
+	tracker := frequency.New(64, 1)
+	defer tracker.Close()
+
+	const target = "https://example.com/users/55"
+	const templateID = "tmpl-frequency-check"
+
+	req, err := retryablehttp.NewRequest(http.MethodGet, target, nil)
+	require.NoError(t, err)
+
+	tracker.MarkParameter("55", req.String(), templateID)
+
+	called := false
+	rule := &Rule{
+		options: &protocols.ExecutorOptions{
+			TemplateID:          templateID,
+			FuzzParamsFrequency: tracker,
+		},
+	}
+	input := &ExecuteRuleInput{
+		Callback: func(GeneratedRequest) bool {
+			called = true
+			return true
+		},
+	}
+
+	err = rule.execWithInput(input, req, nil, nil, "2", "55", "", "", "", "")
+	require.NoError(t, err)
+	require.False(t, called, "frequent actual parameter should be skipped")
+}


### PR DESCRIPTION
## Summary
- use `actualParameter` for fuzz frequency checks in `pkg/fuzz/parts.go` to avoid numeric path-index collisions
- add focused regression tests in `pkg/fuzz/parts_frequency_test.go` for numeric-index vs actual-parameter frequency behavior
- keep changes minimal and scoped to issue #6398

## Validation
- `go test ./pkg/fuzz -run 'TestExecWithInput.*Frequency' -count=1`
- `go test ./pkg/fuzz/... ./pkg/protocols/http/... -count=1`

/claim #6398


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Frequency checking now uses actual parameter values (not parameter indexes) when deciding if an input is frequent, preventing valid inputs from being incorrectly skipped during execution.

* **Tests**
  * Added tests that validate frequency-based execution control, ensuring inputs are included or skipped correctly based on their actual values and the frequency tracker behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->