### PR TITLE
feat(fuzz): Add XSS Context Analyzer (Closes #5838)

### DIFF
--- a/pkg/fuzz/analyzers/xss/analyzer.go
+++ b/pkg/fuzz/analyzers/xss/analyzer.go
@@ -36,6 +36,14 @@ func (a *Analyzer) Analyze(options *analyzers.Options) (bool, string, error) {
 		return false, "", nil
 	}
 
+	// Set the fuzz value on the component before rebuilding
+	if err := options.FuzzGenerated.Component.SetValue(
+		options.FuzzGenerated.Key,
+		options.FuzzGenerated.Value,
+	); err != nil {
+		return false, "", errors.Wrap(err, "could not set component value")
+	}
+
 	req, err := options.FuzzGenerated.Component.Rebuild()
 	if err != nil {
 		return false, "", errors.Wrap(err, "could not rebuild request")

--- a/pkg/fuzz/analyzers/xss/analyzer.go
+++ b/pkg/fuzz/analyzers/xss/analyzer.go
@@ -1,0 +1,110 @@
+package xss
+
+import (
+	"bytes"
+	"io"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz/analyzers"
+	"golang.org/x/net/html"
+)
+
+// Analyzer checks for XSS reflection and its context in the HTTP response
+type Analyzer struct{}
+
+// Ensure the Analyzer interface is fully implemented at compile time
+var _ analyzers.Analyzer = &Analyzer{}
+
+func init() {
+	analyzers.RegisterAnalyzer("xss_context", &Analyzer{})
+}
+
+// Name is the name of the analyzer
+func (a *Analyzer) Name() string {
+	return "xss_context"
+}
+
+// ApplyInitialTransformation fulfills the Analyzer interface requirement
+func (a *Analyzer) ApplyInitialTransformation(data string, params map[string]interface{}) string {
+	return data
+}
+
+// Analyze sends the request and checks for payload reflection context securely
+func (a *Analyzer) Analyze(options *analyzers.Options) (bool, string, error) {
+	if options == nil || options.FuzzGenerated.Component == nil {
+		return false, "", nil
+	}
+
+	req, err := options.FuzzGenerated.Component.Rebuild()
+	if err != nil {
+		return false, "", errors.Wrap(err, "could not rebuild request")
+	}
+
+	resp, err := options.HttpClient.Do(req)
+	if err != nil {
+		return false, "", errors.Wrap(err, "could not send request")
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return false, "", errors.Wrap(err, "could not read response body")
+	}
+	bodyStr := string(bodyBytes)
+
+	payload := options.FuzzGenerated.Value
+
+	if payload == "" || !strings.Contains(bodyStr, payload) {
+		return false, "", nil
+	}
+
+	context := determineContext(bodyBytes, payload)
+
+	return true, "Reflected Context: " + context, nil
+}
+
+// determineContext parses HTML nodes to pinpoint the exact location of the payload reflection
+func determineContext(body []byte, payload string) string {
+	tokenizer := html.NewTokenizer(bytes.NewReader(body))
+
+	for {
+		tt := tokenizer.Next()
+		if tt == html.ErrorToken {
+			break
+		}
+
+		token := tokenizer.Token()
+
+		switch tt {
+		case html.TextToken:
+			if strings.Contains(token.Data, payload) {
+				return "HTML Text"
+			}
+		case html.StartTagToken, html.SelfClosingTagToken:
+			for _, attr := range token.Attr {
+				if strings.Contains(attr.Key, payload) {
+					return "Attribute Name (" + token.Data + ")"
+				}
+				if strings.Contains(attr.Val, payload) {
+					return "Attribute Value (" + token.Data + "[" + attr.Key + "])"
+				}
+			}
+
+			if token.Data == "script" {
+				ttNext := tokenizer.Next()
+				if ttNext == html.TextToken {
+					if strings.Contains(tokenizer.Token().Data, payload) {
+						return "Script Block"
+					}
+				}
+			}
+		case html.CommentToken:
+			if strings.Contains(token.Data, payload) {
+				return "HTML Comment"
+			}
+		}
+	}
+
+	return "Unknown Context"
+}

--- a/pkg/fuzz/analyzers/xss/analyzer_test.go
+++ b/pkg/fuzz/analyzers/xss/analyzer_test.go
@@ -1,0 +1,55 @@
+package xss
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetermineContext(t *testing.T) {
+	payload := "pwned_payload"
+
+	tests := []struct {
+		name     string
+		htmlBody string
+		expected string
+	}{
+		{
+			name:     "HTML Text Context",
+			htmlBody: "<html><body>Hello pwned_payload world</body></html>",
+			expected: "HTML Text",
+		},
+		{
+			name:     "Script Block Context",
+			htmlBody: "<html><script>var a = 'pwned_payload';</script></html>",
+			expected: "Script Block",
+		},
+		{
+			name:     "Attribute Value Context",
+			htmlBody: "<input type='text' value='pwned_payload'>",
+			expected: "Attribute Value (input[value])",
+		},
+		{
+			name:     "Attribute Name Context",
+			htmlBody: "<svg pwned_payload='1'>",
+			expected: "Attribute Name (svg)",
+		},
+		{
+			name:     "HTML Comment Context",
+			htmlBody: "<!-- pwned_payload -->", // ← fix: payload add kiya
+			expected: "HTML Comment",
+		},
+		{
+			name:     "No Reflection",
+			htmlBody: "<html><body>Safe body</body></html>",
+			expected: "Unknown Context",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := determineContext([]byte(tt.htmlBody), payload)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/fuzz/analyzers/xss/analyzer_test.go
+++ b/pkg/fuzz/analyzers/xss/analyzer_test.go
@@ -1,6 +1,7 @@
 package xss
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -16,27 +17,27 @@ func TestDetermineContext(t *testing.T) {
 	}{
 		{
 			name:     "HTML Text Context",
-			htmlBody: "<html><body>Hello pwned_payload world</body></html>",
+			htmlBody: fmt.Sprintf("<html><body>Hello %s world</body></html>", payload),
 			expected: "HTML Text",
 		},
 		{
 			name:     "Script Block Context",
-			htmlBody: "<html><script>var a = 'pwned_payload';</script></html>",
+			htmlBody: fmt.Sprintf("<html><script>var a = '%s';</script></html>", payload),
 			expected: "Script Block",
 		},
 		{
 			name:     "Attribute Value Context",
-			htmlBody: "<input type='text' value='pwned_payload'>",
+			htmlBody: fmt.Sprintf("<input type='text' value='%s'>", payload),
 			expected: "Attribute Value (input[value])",
 		},
 		{
 			name:     "Attribute Name Context",
-			htmlBody: "<svg pwned_payload='1'>",
+			htmlBody: fmt.Sprintf("<svg %s='1'>", payload),
 			expected: "Attribute Name (svg)",
 		},
 		{
 			name:     "HTML Comment Context",
-			htmlBody: "<!-- pwned_payload -->", // ← fix: payload add kiya
+			htmlBody: fmt.Sprintf("<!-- %s -->", payload),
 			expected: "HTML Comment",
 		},
 		{


### PR DESCRIPTION
/claim #5838

### Proposed Changes
I have added an intelligent XSS Context Analyzer in `pkg/fuzz/analyzers/xss`. 
It uses `golang.org/x/net/html` for proper HTML tokenization, allowing it to accurately detect reflection in:
- HTML Text
- Script Blocks
- Attribute Values & Names
- HTML Comments

### Proof
Verified with 6 local unit tests. All tests passed.
Output:
--- PASS: TestDetermineContext (0.00s)
    --- PASS: TestDetermineContext/HTML_Text_Context (0.00s)
    --- PASS: TestDetermineContext/Script_Block_Context (0.00s)
    --- PASS: TestDetermineContext/Attribute_Value_Context (0.00s)
    --- PASS: TestDetermineContext/Attribute_Name_Context (0.00s)
    --- PASS: TestDetermineContext/HTML_Comment_Context (0.00s)

### Checklist
- [x] PR created against the correct branch (dev)
- [x] Tests added to prove the feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an XSS context analyzer that detects payload reflection in HTTP responses and reports the precise reflection context (HTML text, attribute name, attribute value, script block, HTML comment, or unknown).

* **Tests**
  * Added tests validating context detection across varied HTML constructs to ensure accurate classification of reflected payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->