### PR TITLE
refactor(types)!: make resume state as cache data

### DIFF
--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -751,12 +751,13 @@ func resetCallback() {
 Using '-reset' will delete all nuclei configurations files and all nuclei-templates
 
 Following files will be deleted:
-1. All Config + Resumes files at %v
-2. All nuclei-templates at %v
+1. All config files at %v
+2. All cache files (including resume state) at %v
+3. All nuclei-templates at %v
 
 Note: Make sure you have backup of your custom nuclei-templates before proceeding
 
-`, config.DefaultConfig.GetConfigDir(), config.DefaultConfig.TemplatesDirectory)
+`, config.DefaultConfig.GetConfigDir(), config.DefaultConfig.GetCacheDir(), config.DefaultConfig.TemplatesDirectory)
 	options.Logger.Print().Msg(warning)
 	reader := bufio.NewReader(os.Stdin)
 	for {
@@ -777,6 +778,10 @@ Note: Make sure you have backup of your custom nuclei-templates before proceedin
 	err := os.RemoveAll(config.DefaultConfig.GetConfigDir())
 	if err != nil {
 		options.Logger.Fatal().Msgf("could not delete config dir: %s", err)
+	}
+	err = os.RemoveAll(config.DefaultConfig.GetCacheDir())
+	if err != nil {
+		options.Logger.Fatal().Msgf("could not delete cache dir: %s", err)
 	}
 	err = os.RemoveAll(config.DefaultConfig.TemplatesDirectory)
 	if err != nil {

--- a/pkg/types/resume.go
+++ b/pkg/types/resume.go
@@ -14,8 +14,8 @@ import (
 const DefaultResumeFileName = "resume-%s.cfg"
 
 func DefaultResumeFilePath() string {
-	configDir := config.DefaultConfig.GetCacheDir()
-	resumeFile := filepath.Join(configDir, fmt.Sprintf(DefaultResumeFileName, xid.New().String()))
+	cacheDir := config.DefaultConfig.GetCacheDir()
+	resumeFile := filepath.Join(cacheDir, fmt.Sprintf(DefaultResumeFileName, xid.New().String()))
 	return resumeFile
 }
 


### PR DESCRIPTION
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->

Resume files are runtime artifacts and SHOULD NOT
be presented as persistent config.

Update reset messaging to separate config vs cache
and explicitly include resume state under cache
cleanup. Also delete the cache dir during `-reset`
to keep behavior aligned with the new semantics.

Close #6792

### Proof

<!-- How has this been tested? Please describe the tests that you ran to verify your changes. -->

N/A

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reset now reliably removes configuration, cache (including resume state), and templates to ensure complete cleanup.
  * Updated warning and success messages to accurately reflect the three areas that will be deleted and the deletion order.
  * Improved handling of cache-deletion failures so reset reports and halts on errors during cache removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->