### PR TITLE
fix(http): isolate project cache keys by scheme & host

### DIFF
--- a/pkg/protocols/http/request.go
+++ b/pkg/protocols/http/request.go
@@ -691,9 +691,10 @@ func (request *Request) executeRequest(input *contextargs.Context, generatedRequ
 	}
 
 	var (
-		resp          *http.Response
-		fromCache     bool
-		dumpedRequest []byte
+		resp            *http.Response
+		fromCache       bool
+		dumpedRequest   []byte
+		projectCacheKey []byte
 	)
 
 	// Dump request for variables checks
@@ -730,6 +731,11 @@ func (request *Request) executeRequest(input *contextargs.Context, generatedRequ
 		dumpedRequest, dumpError = dump(generatedRequest, input.MetaInput.Input)
 		if dumpError != nil {
 			return dumpError
+		}
+		if generatedRequest.request != nil && generatedRequest.request.URL != nil {
+			projectCacheKey = getHTTPProjectCacheScope(dumpedRequest, generatedRequest.request.Scheme, generatedRequest.request.URL.Host)
+		} else {
+			projectCacheKey = dumpedRequest
 		}
 		dumpedRequestString := string(dumpedRequest)
 
@@ -812,7 +818,7 @@ func (request *Request) executeRequest(input *contextargs.Context, generatedRequ
 		if request.options.ProjectFile != nil {
 			// if unavailable fail silently
 			fromCache = true
-			resp, err = request.options.ProjectFile.Get(dumpedRequest)
+			resp, err = request.options.ProjectFile.Get(projectCacheKey)
 			if err != nil {
 				fromCache = false
 			}
@@ -962,7 +968,7 @@ func (request *Request) executeRequest(input *contextargs.Context, generatedRequ
 	onceFunc := sync.OnceFunc(func() {
 		// if nuclei-project is enabled store the response if not previously done
 		if request.options.ProjectFile != nil && !fromCache {
-			if err := request.options.ProjectFile.Set(dumpedRequest, resp, respChain.BodyBytes()); err != nil {
+			if err := request.options.ProjectFile.Set(projectCacheKey, resp, respChain.BodyBytes()); err != nil {
 				errx = errors.Wrap(err, "could not store in project file")
 			}
 		}

--- a/pkg/protocols/http/utils.go
+++ b/pkg/protocols/http/utils.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"bytes"
 	"io"
 	"strings"
 
@@ -25,4 +26,21 @@ func dump(req *generatedRequest, reqURL string) ([]byte, error) {
 		return nil, errkit.Wrapf(err, "could not dump request: %v", reqURL)
 	}
 	return bin, nil
+}
+
+func getHTTPProjectCacheScope(requestDump []byte, scheme, host string) []byte {
+	scheme = strings.ToLower(strings.TrimSpace(scheme))
+	host = strings.ToLower(strings.TrimSpace(host))
+	if scheme == "" || host == "" {
+		return requestDump
+	}
+
+	var scoped bytes.Buffer
+	scoped.Grow(len(scheme) + len(host) + len(requestDump) + 4)
+	_, _ = scoped.WriteString(scheme)
+	_, _ = scoped.WriteString("://")
+	_, _ = scoped.WriteString(host)
+	_, _ = scoped.WriteString("\n")
+	_, _ = scoped.Write(requestDump)
+	return scoped.Bytes()
 }

--- a/pkg/protocols/http/utils_test.go
+++ b/pkg/protocols/http/utils_test.go
@@ -1,0 +1,19 @@
+package http
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetHTTPProjectCacheScope_SeparatesSchemeAndPort(t *testing.T) {
+	requestDump := []byte("GET / HTTP/1.1\r\nHost: example.com\r\n\r\n")
+
+	httpScoped := getHTTPProjectCacheScope(requestDump, "http", "example.com:80")
+	httpsScoped := getHTTPProjectCacheScope(requestDump, "https", "example.com:443")
+
+	require.NotEqual(t, httpScoped, httpsScoped)
+	require.True(t, bytes.HasSuffix(httpScoped, requestDump))
+	require.True(t, bytes.HasSuffix(httpsScoped, requestDump))
+}


### PR DESCRIPTION
## Proposed changes

Prev. project keyed cache lookups from dumped HTTP
request bytes alone. For eq requests, this allowed
"http" and "https" targets to collide and reuse
cached responses across schemes.

Derive a scoped cache key by prefixing normalized
scheme://host before `projectfile.{Get,Set}`
keying input in the HTTP protocol path.

Close #6866

### Proof

Patch is in `http` package because only HTTP knows the missing context (`scheme` and effective `host:port`) at request-build time. `projectfile` is a generic byte-key store so if it guessed scope from raw bytes, it would duplicate protocol parsing logic and risk breaking non-HTTP callers. (HTTP adds the scope before `Get/Set`, and `projectfile` remains protocol-agnostic and reusable, maybe, for future use).

```console
$ go test -v -run ^TestGetHTTPProjectCacheScope_SeparatesSchemeAndPort$ ./pkg/protocols/http
=== RUN   TestGetHTTPProjectCacheScope_SeparatesSchemeAndPort
--- PASS: TestGetHTTPProjectCacheScope_SeparatesSchemeAndPort (0.00s)
PASS
ok  	github.com/projectdiscovery/nuclei/v3/pkg/protocols/http	0.235s
```

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Scoped HTTP request caching by including scheme and host in cache keys to prevent cross-request cache collisions and ensure consistent behavior across different URL schemes and hosts.

* **Tests**
  * Added unit test to verify cache scoping produces distinct keys for different schemes/hosts while preserving the original request data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->