### PR TITLE
feat(http): respect `annotations` in `unsafe` mode

### DIFF
--- a/pkg/protocols/http/build_request.go
+++ b/pkg/protocols/http/build_request.go
@@ -374,13 +374,48 @@ func (r *requestGenerator) generateRawRequest(ctx context.Context, rawRequest st
 
 	// Unsafe option uses rawhttp library
 	if r.request.Unsafe {
+		annotationURL := rawRequestData.FullURL
+		if annotationURL == "" && baseURL != nil {
+			cloned := baseURL.Clone()
+			cloned.Params.IncludeEquals = true
+			cloned.Path = ""
+			_ = cloned.MergePath(rawRequestData.Path, true)
+			annotationURL = cloned.String()
+			rawRequestData.FullURL = annotationURL
+		}
+
+		var annotationOverrides annotationOverrides
+		if annotationURL != "" {
+			annotationRequest, reqErr := retryablehttp.NewRequestWithContext(ctx, rawRequestData.Method, annotationURL, nil)
+			if reqErr == nil {
+				if hostHeader, ok := rawRequestData.Headers["Host"]; ok {
+					annotationRequest.Host = hostHeader
+				}
+
+				annotationOverrides, _ = r.request.parseAnnotations(rawRequest, annotationRequest)
+				if annotationOverrides.request != nil && annotationOverrides.request.URL != nil {
+					rawRequestData.FullURL = annotationOverrides.request.String()
+				}
+			}
+		}
+
 		if len(r.options.Options.CustomHeaders) > 0 {
 			_ = rawRequestData.TryFillCustomHeaders(r.options.Options.CustomHeaders)
 		}
+
 		if rawRequestData.Data != "" && !stringsutil.EqualFoldAny(rawRequestData.Method, http.MethodHead, http.MethodGet) && rawRequestData.Headers["Transfer-Encoding"] != "chunked" {
 			rawRequestData.Headers["Content-Length"] = strconv.Itoa(len(rawRequestData.Data))
 		}
+
 		unsafeReq := &generatedRequest{rawRequest: rawRequestData, meta: generatorValues, original: r.request, interactshURLs: r.interactshURLs}
+		if annotationOverrides.cancelFunc != nil {
+			unsafeReq.customCancelFunction = annotationOverrides.cancelFunc
+		}
+
+		if len(annotationOverrides.interactshURLs) > 0 {
+			unsafeReq.interactshURLs = append(unsafeReq.interactshURLs, annotationOverrides.interactshURLs...)
+		}
+
 		return unsafeReq, nil
 	}
 	urlx, err := urlutil.ParseAbsoluteURL(rawRequestData.FullURL, true)

--- a/pkg/protocols/http/build_request_test.go
+++ b/pkg/protocols/http/build_request_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/generators"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/interactsh"
 	"github.com/projectdiscovery/nuclei/v3/pkg/testutils"
+	urlutil "github.com/projectdiscovery/utils/url"
 )
 
 func TestMakeRequestFromModal(t *testing.T) {
@@ -161,6 +162,39 @@ Accept-Encoding: gzip`},
 	require.Nil(t, err, "could not make http request")
 	authorization = req.request.Header.Get("Authorization")
 	require.Equal(t, "Basic YWRtaW46Z3Vlc3Q=", authorization, "could not get correct authorization headers from raw")
+}
+
+func TestMakeUnsafeRequestFromRawWithHostAnnotation(t *testing.T) {
+	options := testutils.DefaultOptions
+
+	testutils.Init(options)
+	templateID := "testing-http-unsafe-annotations"
+	request := &Request{
+		ID:     templateID,
+		Name:   "testing",
+		Unsafe: true,
+		Raw: []string{`@Host: honey.scanme.sh
+GET /foo HTTP/1.1
+Host: {{Hostname}}`},
+	}
+	executerOpts := testutils.NewMockExecuterOptions(options, &testutils.TemplateInfo{
+		ID:   templateID,
+		Info: model.Info{SeverityHolder: severity.Holder{Severity: severity.Low}, Name: "test"},
+	})
+	err := request.Compile(executerOpts)
+	require.Nil(t, err, "could not compile unsafe raw request")
+
+	generator := request.newGenerator(false)
+	inputData, payloads, _ := generator.nextValue()
+	req, err := generator.Make(context.Background(), contextargs.NewWithInput(context.Background(), "http://scanme.sh"), inputData, payloads, map[string]interface{}{})
+	require.Nil(t, err, "could not make unsafe http request")
+	require.NotNil(t, req.rawRequest, "raw request should be present")
+	require.NotContains(t, string(req.rawRequest.UnsafeRawBytes), "@Host:", "unsafe raw request bytes should not contain annotation lines")
+
+	parsedURL, parseErr := urlutil.ParseAbsoluteURL(req.rawRequest.FullURL, true)
+	require.Nil(t, parseErr, "could not parse generated unsafe request URL")
+	require.Equal(t, "honey.scanme.sh", parsedURL.Host, "host should be overridden by @Host annotation in unsafe mode")
+	require.Equal(t, "http", parsedURL.Scheme, "scheme should inherit from input when annotation host has no scheme")
 }
 
 func TestMakeRequestFromModelUniqueInteractsh(t *testing.T) {

--- a/pkg/protocols/http/raw/raw.go
+++ b/pkg/protocols/http/raw/raw.go
@@ -178,7 +178,7 @@ func readRawRequest(request string, unsafe bool) (*Request, error) {
 
 	// store body if it is unsafe request
 	if unsafe {
-		rawRequest.UnsafeRawBytes = []byte(request)
+		rawRequest.UnsafeRawBytes = stripLeadingAnnotations(request)
 	}
 
 	// parse raw request
@@ -263,6 +263,36 @@ read_line:
 	}
 	return rawRequest, nil
 
+}
+
+func stripLeadingAnnotations(request string) []byte {
+	reader := bufio.NewReader(strings.NewReader(request))
+	buffer := bufferPool.Get().(*bytes.Buffer)
+	buffer.Reset()
+	defer func() {
+		buffer.Reset()
+		bufferPool.Put(buffer)
+	}()
+
+	requestLineFound := false
+	for {
+		line, err := reader.ReadString('\n')
+		if len(line) > 0 {
+			if requestLineFound || !stringsutil.HasPrefixAny(line, "@") {
+				requestLineFound = true
+				_, _ = buffer.WriteString(line)
+			}
+		}
+
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return []byte(request)
+		}
+	}
+
+	return append([]byte(nil), buffer.Bytes()...)
 }
 
 // TryFillCustomHeaders after the Host header

--- a/pkg/protocols/http/raw/raw_test.go
+++ b/pkg/protocols/http/raw/raw_test.go
@@ -99,6 +99,16 @@ Connection: close`, parseURL(t, "https://test.com/test/"), true, false)
 	require.Contains(t, string(request.UnsafeRawBytes), "GET /test.js?a=b", "Could not parse unsafe method request path correctly")
 }
 
+func TestParseUnsafeRequestStripsLeadingAnnotations(t *testing.T) {
+	request, err := Parse(`@Host: honey.scanme.sh
+GET /foo HTTP/1.1
+Host: {{Hostname}}
+Connection: close`, parseURL(t, "http://scanme.sh"), true, false)
+	require.Nil(t, err, "could not parse unsafe request with annotation")
+	require.Contains(t, string(request.UnsafeRawBytes), "GET /foo HTTP/1.1", "unsafe request line should be preserved")
+	require.NotContains(t, string(request.UnsafeRawBytes), "@Host:", "annotation lines must not be present in unsafe raw bytes")
+}
+
 func TestTryFillCustomHeaders(t *testing.T) {
 	testValue := "GET /manager/html HTTP/1.1\r\nHost: Test\r\n"
 	expected := "GET /test/manager/html HTTP/1.1\r\nHost: Test\r\ntest: test\r\n"
@@ -179,7 +189,7 @@ Connection: close`, parseURL(t, "http://target.com/api"), true, true)
 	require.Nil(t, err, "could not parse unsafe request with full URL root path")
 	// With disable-path-automerge=true and root path, it becomes empty per existing logic
 	require.Equal(t, "", request.Path, "Root path with disable-path-automerge should be empty")
-	
+
 	// Test with disable-path-automerge=false
 	request, err = Parse(`GET http://example.com/ HTTP/1.1
 Host: {{Hostname}}

--- a/pkg/protocols/http/request.go
+++ b/pkg/protocols/http/request.go
@@ -787,6 +787,9 @@ func (request *Request) executeRequest(input *contextargs.Context, generatedRequ
 		options.ForceReadAllBody = request.ForceReadAllBody
 		options.SNI = request.options.Options.SNI
 		inputUrl := input.MetaInput.Input
+		if generatedRequest.rawRequest.FullURL != "" {
+			inputUrl = generatedRequest.rawRequest.FullURL
+		}
 		if url, err := urlutil.ParseURL(inputUrl, false); err == nil {
 			url.Path = ""
 			url.Params = urlutil.NewOrderedParams() // donot include query params


### PR DESCRIPTION
## Proposed changes

Apply request annotations during `unsafe` raw
request generation so @Host/@timeout/etc affect
the effective target and execution context.

Strip leading annotation directives from `unsafe`
wire bytes before sending, since `rawhttp`
transmits raw payload verbatim and annotation
lines can produce malformed HTTP requests.

Close #6747

### Proof

```console
$ go test -v -run "^Test(MakeUnsafeRequestFromRawWithHostAnnotation|ParseUnsafeRequestStripsLeadingAnnotations|UnsafeWithFullURLAndQueryParams|RequestParseAnnotations(Timeout|SNI)|UnsafeWith(FullURLAndPath|HTTPSFullURL)|UnsafeWithFullURL)$" ./pkg/protocols/http ./pkg/protocols/http/raw
=== RUN   TestMakeUnsafeRequestFromRawWithHostAnnotation
--- PASS: TestMakeUnsafeRequestFromRawWithHostAnnotation (0.04s)
=== RUN   TestRequestParseAnnotationsSNI
=== RUN   TestRequestParseAnnotationsSNI/compliant-SNI-value
=== RUN   TestRequestParseAnnotationsSNI/non-compliant-SNI-value
--- PASS: TestRequestParseAnnotationsSNI (0.00s)
    --- PASS: TestRequestParseAnnotationsSNI/compliant-SNI-value (0.00s)
    --- PASS: TestRequestParseAnnotationsSNI/non-compliant-SNI-value (0.00s)
=== RUN   TestRequestParseAnnotationsTimeout
=== RUN   TestRequestParseAnnotationsTimeout/positive
=== RUN   TestRequestParseAnnotationsTimeout/large-timeout
=== RUN   TestRequestParseAnnotationsTimeout/below-cap-timeout
=== RUN   TestRequestParseAnnotationsTimeout/negative
--- PASS: TestRequestParseAnnotationsTimeout (0.00s)
    --- PASS: TestRequestParseAnnotationsTimeout/positive (0.00s)
    --- PASS: TestRequestParseAnnotationsTimeout/large-timeout (0.00s)
    --- PASS: TestRequestParseAnnotationsTimeout/below-cap-timeout (0.00s)
    --- PASS: TestRequestParseAnnotationsTimeout/negative (0.00s)
PASS
ok  	github.com/projectdiscovery/nuclei/v3/pkg/protocols/http	0.207s
=== RUN   TestParseUnsafeRequestStripsLeadingAnnotations
--- PASS: TestParseUnsafeRequestStripsLeadingAnnotations (0.00s)
=== RUN   TestUnsafeWithFullURL
--- PASS: TestUnsafeWithFullURL (0.00s)
=== RUN   TestUnsafeWithFullURLAndPath
--- PASS: TestUnsafeWithFullURLAndPath (0.00s)
=== RUN   TestUnsafeWithFullURLAndQueryParams
--- PASS: TestUnsafeWithFullURLAndQueryParams (0.00s)
=== RUN   TestUnsafeWithHTTPSFullURL
--- PASS: TestUnsafeWithHTTPSFullURL (0.00s)
PASS
ok  	github.com/projectdiscovery/nuclei/v3/pkg/protocols/http/raw	0.140s
```

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Raw HTTP requests can pull per-request annotations (host overrides, cancellation hooks, and additional Interactsh URLs) and apply them at send time.
* **Bug Fixes**
  * Annotation lines are stripped from stored unsafe raw request payloads so sent requests do not contain annotation text.
* **Tests**
  * Added tests validating host annotation overrides, annotation stripping, and annotation-driven cancellation/Interactsh behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->