### PR TITLE
fix(utils): normalize unbracketed IPv6 literals for probing

### DIFF
--- a/pkg/utils/http_probe.go
+++ b/pkg/utils/http_probe.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/netip"
 	"strconv"
+	"strings"
 
 	"github.com/projectdiscovery/httpx/common/httpx"
 	"github.com/projectdiscovery/nuclei/v3/pkg/input/types"
@@ -48,9 +50,10 @@ func determineSchemeOrder(input string) []string {
 // http schemes are selected with heuristics
 // If none succeeds, probing is abandoned for such URLs.
 func ProbeURL(input string, httpxclient *httpx.HTTPX) string {
-	schemes := determineSchemeOrder(input)
+	normalizedInput := normalizeProbeInput(input)
+	schemes := determineSchemeOrder(normalizedInput)
 	for _, scheme := range schemes {
-		formedURL := fmt.Sprintf("%s://%s", scheme, input)
+		formedURL := fmt.Sprintf("%s://%s", scheme, normalizedInput)
 		req, err := httpxclient.NewRequest(http.MethodHead, formedURL)
 		if err != nil {
 			continue
@@ -65,6 +68,18 @@ func ProbeURL(input string, httpxclient *httpx.HTTPX) string {
 		return formedURL
 	}
 	return ""
+}
+
+// normalizeProbeInput rewrites unbracketed IPv6 literals to bracketed host form.
+func normalizeProbeInput(input string) string {
+	if strings.Contains(input, "://") || strings.HasPrefix(input, "[") {
+		return input
+	}
+	addr, err := netip.ParseAddr(input)
+	if err != nil || !addr.Is6() {
+		return input
+	}
+	return fmt.Sprintf("[%s]", addr.String())
 }
 
 type inputLivenessChecker struct {

--- a/pkg/utils/http_probe_test.go
+++ b/pkg/utils/http_probe_test.go
@@ -57,3 +57,40 @@ func TestDetermineSchemeOrderWithHighPorts(t *testing.T) {
 		})
 	}
 }
+
+func TestDetermineSchemeOrderAmbiguousIPv6Literal(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected []string
+	}{
+		{"::1:8065", []string{"https", "http"}},
+		{"[::1]:8065", []string{"http", "https"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			actual := determineSchemeOrder(normalizeProbeInput(tc.input))
+			require.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
+func TestNormalizeProbeInput(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"::1:8065", "[::1:8065]"},
+		{"fe80::1", "[fe80::1]"},
+		{"[::1]:8065", "[::1]:8065"},
+		{"127.0.0.1:8080", "127.0.0.1:8080"},
+		{"example.com:443", "example.com:443"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			actual := normalizeProbeInput(tc.input)
+			require.Equal(t, tc.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
## Proposed changes

fix(utils): normalize unbracketed IPv6 literals for probing

Fix ambiguous interpretation of IPv6 addresses
like "::1:8065" by bracketing them before URL
formation to make sure they are treated as hosts
rather than "host:port" pairs.

Close #6960

### Proof

<!-- How has this been tested? Please describe the tests that you ran to verify your changes. -->

```console
$ go test -v -run "^(TestDetermineSchemeOrder|TestDetermineSchemeOrderWithHighPorts|TestDetermineSchemeOrderAmbiguousIPv6Literal|TestNormalizeProbeInput)$" ./pkg/utils
=== RUN   TestDetermineSchemeOrder
=== RUN   TestDetermineSchemeOrder/example.com
=== RUN   TestDetermineSchemeOrder/example.com:443
=== RUN   TestDetermineSchemeOrder/127.0.0.1
=== RUN   TestDetermineSchemeOrder/[fe80::1]:443
=== RUN   TestDetermineSchemeOrder/example.com:80
=== RUN   TestDetermineSchemeOrder/example.com:8080
=== RUN   TestDetermineSchemeOrder/127.0.0.1:80
=== RUN   TestDetermineSchemeOrder/127.0.0.1:8080
=== RUN   TestDetermineSchemeOrder/fe80::1
=== RUN   TestDetermineSchemeOrder/[fe80::1]:80
=== RUN   TestDetermineSchemeOrder/[fe80::1]:8080
--- PASS: TestDetermineSchemeOrder (0.00s)
    --- PASS: TestDetermineSchemeOrder/example.com (0.00s)
    --- PASS: TestDetermineSchemeOrder/example.com:443 (0.00s)
    --- PASS: TestDetermineSchemeOrder/127.0.0.1 (0.00s)
    --- PASS: TestDetermineSchemeOrder/[fe80::1]:443 (0.00s)
    --- PASS: TestDetermineSchemeOrder/example.com:80 (0.00s)
    --- PASS: TestDetermineSchemeOrder/example.com:8080 (0.00s)
    --- PASS: TestDetermineSchemeOrder/127.0.0.1:80 (0.00s)
    --- PASS: TestDetermineSchemeOrder/127.0.0.1:8080 (0.00s)
    --- PASS: TestDetermineSchemeOrder/fe80::1 (0.00s)
    --- PASS: TestDetermineSchemeOrder/[fe80::1]:80 (0.00s)
    --- PASS: TestDetermineSchemeOrder/[fe80::1]:8080 (0.00s)
=== RUN   TestDetermineSchemeOrderWithHighPorts
=== RUN   TestDetermineSchemeOrderWithHighPorts/example.com:2048
=== RUN   TestDetermineSchemeOrderWithHighPorts/example.com:8081
=== RUN   TestDetermineSchemeOrderWithHighPorts/[fe80::1]:2048
=== RUN   TestDetermineSchemeOrderWithHighPorts/[fe80::1]:12345
--- PASS: TestDetermineSchemeOrderWithHighPorts (0.00s)
    --- PASS: TestDetermineSchemeOrderWithHighPorts/example.com:2048 (0.00s)
    --- PASS: TestDetermineSchemeOrderWithHighPorts/example.com:8081 (0.00s)
    --- PASS: TestDetermineSchemeOrderWithHighPorts/[fe80::1]:2048 (0.00s)
    --- PASS: TestDetermineSchemeOrderWithHighPorts/[fe80::1]:12345 (0.00s)
=== RUN   TestDetermineSchemeOrderAmbiguousIPv6Literal
=== RUN   TestDetermineSchemeOrderAmbiguousIPv6Literal/::1:8065
=== RUN   TestDetermineSchemeOrderAmbiguousIPv6Literal/[::1]:8065
--- PASS: TestDetermineSchemeOrderAmbiguousIPv6Literal (0.00s)
    --- PASS: TestDetermineSchemeOrderAmbiguousIPv6Literal/::1:8065 (0.00s)
    --- PASS: TestDetermineSchemeOrderAmbiguousIPv6Literal/[::1]:8065 (0.00s)
=== RUN   TestNormalizeProbeInput
=== RUN   TestNormalizeProbeInput/::1:8065
=== RUN   TestNormalizeProbeInput/fe80::1
=== RUN   TestNormalizeProbeInput/[::1]:8065
=== RUN   TestNormalizeProbeInput/127.0.0.1:8080
=== RUN   TestNormalizeProbeInput/example.com:443
--- PASS: TestNormalizeProbeInput (0.00s)
    --- PASS: TestNormalizeProbeInput/::1:8065 (0.00s)
    --- PASS: TestNormalizeProbeInput/fe80::1 (0.00s)
    --- PASS: TestNormalizeProbeInput/[::1]:8065 (0.00s)
    --- PASS: TestNormalizeProbeInput/127.0.0.1:8080 (0.00s)
    --- PASS: TestNormalizeProbeInput/example.com:443 (0.00s)
PASS
ok  	github.com/projectdiscovery/nuclei/v3/pkg/utils	0.133s
```

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * IPv6 addresses provided without brackets are now normalized to bracketed form during HTTP probing, preventing malformed URLs and improving connection reliability.
* **Tests**
  * Added tests covering IPv6 normalization and scheme selection for ambiguous inputs to ensure consistent probing behavior across address formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->