### PR TITLE
fix(fuzz): use effective parameter for frequency tracking

### DIFF
--- a/pkg/fuzz/parts.go
+++ b/pkg/fuzz/parts.go
@@ -162,7 +162,7 @@ func (rule *Rule) execWithInput(input *ExecuteRuleInput, httpReq *retryablehttp.
 	// If the parameter is frequent, skip it if the option is enabled
 	if rule.options.FuzzParamsFrequency != nil {
 		if rule.options.FuzzParamsFrequency.IsParameterFrequent(
-			parameter,
+			actualParameter,
 			httpReq.String(),
 			rule.options.TemplateID,
 		) {


### PR DESCRIPTION
Fixes a bug in fuzz param frequency tracking where we computed an `actualParameter` (e.g. numeric path segment -> real segment value) but still fed the original `parameter` into the frequency tracker.

This could cause unrelated inputs to collide under numeric indices and suppress legitimate fuzzing.

Changes:
- Use `actualParameter` when calling `FuzzParamsFrequency.IsParameterFrequent`.

Proof:
- `go test ./...`

/claim #6398

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed parameter frequency check in fuzzing operations to evaluate the correct parameter value when determining skip conditions. This improvement enhances accuracy for skipping fuzzing requests during parameter substitution, particularly for numeric and empty-original parameter scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->