### PR TITLE
fix(headless): avoid cross-test chrome teardown races

### DIFF
--- a/pkg/protocols/headless/engine/engine.go
+++ b/pkg/protocols/headless/engine/engine.go
@@ -15,7 +15,6 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/types"
 	fileutil "github.com/projectdiscovery/utils/file"
 	osutils "github.com/projectdiscovery/utils/os"
-	processutil "github.com/projectdiscovery/utils/process"
 )
 
 // Browser is a browser structure for nuclei headless module
@@ -23,7 +22,6 @@ type Browser struct {
 	customAgent    string
 	defaultHeaders map[string]string
 	tempDir        string
-	previousPIDs   map[int32]struct{} // track already running PIDs
 	engine         *rod.Browser
 	options        *types.Options
 	launcher       *launcher.Launcher
@@ -36,14 +34,11 @@ type Browser struct {
 // New creates a new nuclei headless browser module
 func New(options *types.Options) (*Browser, error) {
 	var launcherURL, dataStore string
-	var previousPIDs map[int32]struct{}
 	var err error
 
 	chromeLauncher := launcher.New()
 
 	if options.CDPEndpoint == "" {
-		previousPIDs = processutil.FindProcesses(processutil.IsChromeProcess)
-
 		dataStore, err = os.MkdirTemp("", "nuclei-*")
 		if err != nil {
 			return nil, errors.Wrap(err, "could not create temporary directory")
@@ -135,7 +130,6 @@ func New(options *types.Options) (*Browser, error) {
 		httpClientOnce: &sync.Once{},
 		launcher:       chromeLauncher,
 	}
-	engine.previousPIDs = previousPIDs
 	return engine, nil
 }
 
@@ -199,5 +193,4 @@ func (b *Browser) Close() {
 	_ = b.engine.Close()
 	b.launcher.Kill()
 	_ = os.RemoveAll(b.tempDir)
-	processutil.CloseProcesses(processutil.IsChromeProcess, b.previousPIDs)
 }

--- a/pkg/protocols/headless/engine/page_actions_test.go
+++ b/pkg/protocols/headless/engine/page_actions_test.go
@@ -41,7 +41,10 @@ func TestActionNavigate(t *testing.T) {
 
 	testHeadlessSimpleResponse(t, response, actions, 60*time.Second, func(page *Page, err error, out ActionData) {
 		require.Nilf(t, err, "could not run page actions")
-		require.Equal(t, "Nuclei Test Page", page.Page().MustInfo().Title, "could not navigate correctly")
+		require.NotNil(t, page, "page should not be nil")
+		info, infoErr := page.Page().Info()
+		require.NoError(t, infoErr, "could not fetch page info")
+		require.Equal(t, "Nuclei Test Page", info.Title, "could not navigate correctly")
 	})
 }
 


### PR DESCRIPTION
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->

Drop global Chrome process sweeping from browser
shutdown.

The `previousPIDs` snapshot + delta kill logic is
unsafe on shared/parallel runners: a test can
classify another test's Chrome as "new" and kill
it during `(*Browser).Close()`, triggering
intermittent Rod panics (use of closed network
connection).

### Proof

<!-- How has this been tested? Please describe the tests that you ran to verify your changes. -->

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)