### PR TITLE
fix(authx): ensure secrets are fetched before template execution

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -681,8 +681,8 @@ func (r *Runner) RunEnumeration() error {
 	// display execution info like version , templates used etc
 	r.displayExecutionInfo(store)
 
-	// prefetch secrets if enabled
-	if executorOpts.AuthProvider != nil && r.options.PreFetchSecrets {
+	// prefetch secrets if auth provider is configured
+	if executorOpts.AuthProvider != nil {
 		r.Logger.Info().Msgf("Pre-fetching secrets from authprovider[s]")
 		if err := executorOpts.AuthProvider.PreFetchSecrets(); err != nil {
 			return errors.Wrap(err, "could not pre-fetch secrets")

--- a/lib/sdk_private.go
+++ b/lib/sdk_private.go
@@ -228,8 +228,8 @@ func (e *NucleiEngine) init(ctx context.Context) error {
 		e.executerOpts.AuthProvider = e.authprovider
 	}
 
-	// prefetch secrets
-	if e.executerOpts.AuthProvider != nil && e.opts.PreFetchSecrets {
+	// prefetch secrets if auth provider is configured
+	if e.executerOpts.AuthProvider != nil {
 		if err := e.executerOpts.AuthProvider.PreFetchSecrets(); err != nil {
 			return errors.Wrap(err, "could not prefetch secrets")
 		}

--- a/pkg/authprovider/authx/dynamic.go
+++ b/pkg/authprovider/authx/dynamic.go
@@ -202,6 +202,10 @@ func (d *Dynamic) GetStrategies() []AuthStrategy {
 // Uses sync.Once to ensure the fetch callback is called exactly once,
 // and all concurrent callers block until it completes.
 func (d *Dynamic) Fetch(isFatal bool) error {
+	if d.fetchOnce == nil {
+		return fmt.Errorf("dynamic secret not validated: call Validate() first")
+	}
+
 	d.fetchOnce.Do(func() {
 		d.error = d.fetchCallback(d)
 	})

--- a/pkg/authprovider/authx/dynamic.go
+++ b/pkg/authprovider/authx/dynamic.go
@@ -3,7 +3,7 @@ package authx
 import (
 	"fmt"
 	"strings"
-	"sync/atomic"
+	"sync"
 
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/replacer"
@@ -30,8 +30,7 @@ type Dynamic struct {
 	Input         string                 `json:"input" yaml:"input"` // (optional) target for the dynamic secret
 	Extracted     map[string]interface{} `json:"-" yaml:"-"`         // extracted values from the dynamic secret
 	fetchCallback LazyFetchSecret        `json:"-" yaml:"-"`
-	fetched       *atomic.Bool           `json:"-" yaml:"-"` // atomic flag to check if the secret has been fetched
-	fetching      *atomic.Bool           `json:"-" yaml:"-"` // atomic flag to prevent recursive fetch calls
+	fetchOnce     *sync.Once             `json:"-" yaml:"-"` // ensures fetch is called exactly once; all callers block until done
 	error         error                  `json:"-" yaml:"-"` // error if any
 }
 
@@ -70,8 +69,7 @@ func (d *Dynamic) UnmarshalJSON(data []byte) error {
 
 // Validate validates the dynamic secret
 func (d *Dynamic) Validate() error {
-	d.fetched = &atomic.Bool{}
-	d.fetching = &atomic.Bool{}
+	d.fetchOnce = &sync.Once{}
 	if d.TemplatePath == "" {
 		return errkit.New(" template-path is required for dynamic secret")
 	}
@@ -183,14 +181,8 @@ func (d *Dynamic) applyValuesToSecret(secret *Secret) error {
 
 // GetStrategy returns the auth strategies for the dynamic secret
 func (d *Dynamic) GetStrategies() []AuthStrategy {
-	if d.fetched.Load() {
-		if d.error != nil {
-			return nil
-		}
-	} else {
-		// Try to fetch if not already fetched
-		_ = d.Fetch(true)
-	}
+	// Fetch will block until the secret is fetched (sync.Once)
+	_ = d.Fetch(true)
 
 	if d.error != nil {
 		return nil
@@ -207,23 +199,12 @@ func (d *Dynamic) GetStrategies() []AuthStrategy {
 
 // Fetch fetches the dynamic secret
 // if isFatal is true, it will stop the execution if the secret could not be fetched
+// Uses sync.Once to ensure the fetch callback is called exactly once,
+// and all concurrent callers block until it completes.
 func (d *Dynamic) Fetch(isFatal bool) error {
-	if d.fetched.Load() {
-		return d.error
-	}
-
-	// Try to set fetching flag atomically
-	if !d.fetching.CompareAndSwap(false, true) {
-		// Already fetching, return current error
-		return d.error
-	}
-
-	// We're the only one fetching, call the callback
-	d.error = d.fetchCallback(d)
-
-	// Mark as fetched and clear fetching flag
-	d.fetched.Store(true)
-	d.fetching.Store(false)
+	d.fetchOnce.Do(func() {
+		d.error = d.fetchCallback(d)
+	})
 
 	if d.error != nil && isFatal {
 		gologger.Fatal().Msgf("Could not fetch dynamic secret: %s\n", d.error)

--- a/pkg/authprovider/authx/dynamic.go
+++ b/pkg/authprovider/authx/dynamic.go
@@ -203,7 +203,8 @@ func (d *Dynamic) GetStrategies() []AuthStrategy {
 // and all concurrent callers block until it completes.
 func (d *Dynamic) Fetch(isFatal bool) error {
 	if d.fetchOnce == nil {
-		return fmt.Errorf("dynamic secret not validated: call Validate() first")
+		d.error = fmt.Errorf("dynamic secret not validated: call Validate() first")
+		return d.error
 	}
 
 	d.fetchOnce.Do(func() {


### PR DESCRIPTION
## Proposed Changes

Fixes #6592 — authenticated scanning starts executing templates before the secret-file template finishes.

### Root Cause

Two independent issues:

**1. `PreFetchSecrets` gated behind a separate flag**

Running `nuclei -secret-file login.yaml` without `--prefetch-secrets` never awaited the login flow before templates started executing. Templates would fire immediately, sending unauthenticated requests.

**Fix:** Removed the `PreFetchSecrets` flag guard in both `runner.go` and `sdk_private.go`. Secrets are now always prefetched when an `AuthProvider` is configured.

**2. Race condition in `Dynamic.Fetch()`**

The old implementation used two `atomic.Bool` flags (`fetched` and `fetching`). When goroutine A was fetching, goroutine B would see `fetching=true` via `CompareAndSwap` and return immediately with `d.error` (which was still `nil`). B would then proceed to use the secret as if it was ready.

**Fix:** Replaced both `atomic.Bool` flags with a single `*sync.Once`. All concurrent callers now block inside `fetchOnce.Do()` until the fetch callback completes. This is both simpler and correct — the net change is -19 lines.

### Changes

| File | Change |
|------|--------|
| `internal/runner/runner.go` | Remove `PreFetchSecrets` flag guard |
| `lib/sdk_private.go` | Same for SDK mode |
| `pkg/authprovider/authx/dynamic.go` | Replace `atomic.Bool` with `sync.Once` |

## Checklist

- [x] PR created against the `dev` branch
- [x] `go vet` passes on changed packages
- [x] Minimal diff: 3 files, +14/-33 lines (net simplification)

/claim #6592

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Secret pre-fetching now runs automatically whenever an authentication provider is configured, removing the need for a manual option and improving reliability across flows.

* **Refactor**
  * Consolidated concurrent secret-fetch synchronization so fetch operations execute only once and callers properly wait for completion, reducing race conditions and redundant work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->