### PR TITLE
feat: add honeypot detection to suppress results from deceptive hosts

### DIFF
--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -325,6 +325,8 @@ on extensive configurability, massive extensibility and ease of use.`)
 		flagSet.BoolVarP(&options.Timestamp, "timestamp", "ts", false, "enables printing timestamp in cli output"),
 		flagSet.StringVarP(&options.ReportingDB, "report-db", "rdb", "", "nuclei reporting database (always use this to persist report data)"),
 		flagSet.BoolVarP(&options.MatcherStatus, "matcher-status", "ms", false, "display match failure status"),
+		flagSet.BoolVarP(&options.HoneypotDetection, "honeypot-detection", "hd", false, "enable honeypot detection to suppress results from honeypot hosts"),
+		flagSet.IntVarP(&options.HoneypotThreshold, "honeypot-threshold", "hdt", 10, "minimum number of unique template matches before a host is flagged as honeypot"),
 		flagSet.StringVarP(&options.MarkdownExportDirectory, "markdown-export", "me", "", "directory to export results in markdown format"),
 		flagSet.StringVarP(&options.SarifExport, "sarif-export", "se", "", "file to export results in SARIF format"),
 		flagSet.StringVarP(&options.JSONExport, "json-export", "je", "", "file to export results in JSON format"),

--- a/pkg/output/honeypot.go
+++ b/pkg/output/honeypot.go
@@ -1,0 +1,80 @@
+package output
+
+import (
+	"net"
+	"net/url"
+	"sync"
+
+	"github.com/projectdiscovery/gologger"
+)
+
+const defaultHoneypotThreshold = 10
+
+// HoneypotTracker tracks unique template matches per host to detect honeypots.
+// Hosts that match more than the configured threshold of unique templates are
+// flagged as honeypots and their results are suppressed.
+type HoneypotTracker struct {
+	mu        sync.Mutex
+	hosts     map[string]map[string]struct{} // host -> set of template IDs
+	flagged   map[string]struct{}            // hosts already flagged
+	threshold int
+}
+
+// NewHoneypotTracker creates a new tracker with the given threshold.
+// If threshold <= 0, defaultHoneypotThreshold is used.
+func NewHoneypotTracker(threshold int) *HoneypotTracker {
+	if threshold <= 0 {
+		threshold = defaultHoneypotThreshold
+	}
+	return &HoneypotTracker{
+		hosts:     make(map[string]map[string]struct{}),
+		flagged:   make(map[string]struct{}),
+		threshold: threshold,
+	}
+}
+
+// Check records a template match for the given host and returns true if the
+// result should be suppressed (host is a honeypot).
+func (h *HoneypotTracker) Check(host, templateID string) bool {
+	normalized := normalizeHost(host)
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if _, ok := h.flagged[normalized]; ok {
+		return true
+	}
+
+	templates, ok := h.hosts[normalized]
+	if !ok {
+		templates = make(map[string]struct{})
+		h.hosts[normalized] = templates
+	}
+
+	templates[templateID] = struct{}{}
+
+	if len(templates) >= h.threshold {
+		h.flagged[normalized] = struct{}{}
+		delete(h.hosts, normalized) // free memory, no longer need per-template tracking
+		gologger.Warning().Msgf("Honeypot detected: %s (%d unique template matches, suppressing further results)", host, len(templates))
+		return true
+	}
+
+	return false
+}
+
+// normalizeHost extracts a consistent host identifier from various input formats.
+func normalizeHost(raw string) string {
+	if parsed, err := url.Parse(raw); err == nil && parsed.Host != "" {
+		host := parsed.Hostname() // strips brackets from IPv6, strips port
+		if host != "" {
+			return host
+		}
+	}
+	// Fallback: try as host:port
+	host, _, err := net.SplitHostPort(raw)
+	if err == nil && host != "" {
+		return host
+	}
+	return raw
+}

--- a/pkg/output/honeypot.go
+++ b/pkg/output/honeypot.go
@@ -3,12 +3,16 @@ package output
 import (
 	"net"
 	"net/url"
+	"strings"
 	"sync"
 
 	"github.com/projectdiscovery/gologger"
 )
 
-const defaultHoneypotThreshold = 10
+const (
+	defaultHoneypotThreshold = 10
+	maxTrackedHosts          = 100000 // cap to prevent unbounded memory growth
+)
 
 // HoneypotTracker tracks unique template matches per host to detect honeypots.
 // Hosts that match at least the configured threshold of unique templates are
@@ -47,6 +51,10 @@ func (h *HoneypotTracker) Check(host, templateID string) bool {
 
 	templates, ok := h.hosts[normalized]
 	if !ok {
+		// Cap tracked hosts to prevent unbounded memory growth
+		if len(h.hosts) >= maxTrackedHosts {
+			return false
+		}
 		templates = make(map[string]struct{})
 		h.hosts[normalized] = templates
 	}
@@ -64,17 +72,18 @@ func (h *HoneypotTracker) Check(host, templateID string) bool {
 }
 
 // normalizeHost extracts a consistent host identifier from various input formats.
+// Hostnames are lowercased since DNS is case-insensitive.
 func normalizeHost(raw string) string {
 	if parsed, err := url.Parse(raw); err == nil && parsed.Host != "" {
 		host := parsed.Hostname() // strips brackets from IPv6, strips port
 		if host != "" {
-			return host
+			return strings.ToLower(host)
 		}
 	}
 	// Fallback: try as host:port
 	host, _, err := net.SplitHostPort(raw)
 	if err == nil && host != "" {
-		return host
+		return strings.ToLower(host)
 	}
-	return raw
+	return strings.ToLower(raw)
 }

--- a/pkg/output/honeypot.go
+++ b/pkg/output/honeypot.go
@@ -11,7 +11,7 @@ import (
 const defaultHoneypotThreshold = 10
 
 // HoneypotTracker tracks unique template matches per host to detect honeypots.
-// Hosts that match more than the configured threshold of unique templates are
+// Hosts that match at least the configured threshold of unique templates are
 // flagged as honeypots and their results are suppressed.
 type HoneypotTracker struct {
 	mu        sync.Mutex

--- a/pkg/output/honeypot_test.go
+++ b/pkg/output/honeypot_test.go
@@ -61,6 +61,15 @@ func TestHoneypotTracker_HostNormalization(t *testing.T) {
 	}
 }
 
+func TestHoneypotTracker_CaseInsensitive(t *testing.T) {
+	tracker := NewHoneypotTracker(2)
+
+	tracker.Check("http://EXAMPLE.COM", "t1")
+	if !tracker.Check("http://example.com", "t2") {
+		t.Fatal("expected case-insensitive host matching")
+	}
+}
+
 func TestHoneypotTracker_Concurrent(t *testing.T) {
 	tracker := NewHoneypotTracker(100)
 
@@ -92,6 +101,8 @@ func TestNormalizeHost(t *testing.T) {
 		{"http://[::1]:8080/test", "::1"},
 		{"192.168.1.1:80", "192.168.1.1"},
 		{"example.com", "example.com"},
+		{"http://EXAMPLE.COM", "example.com"},
+		{"https://Example.Com:443/Path", "example.com"},
 	}
 
 	for _, tt := range tests {

--- a/pkg/output/honeypot_test.go
+++ b/pkg/output/honeypot_test.go
@@ -1,0 +1,103 @@
+package output
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+func TestHoneypotTracker_Basic(t *testing.T) {
+	tracker := NewHoneypotTracker(3)
+
+	// First two unique templates should not be suppressed
+	if tracker.Check("http://example.com", "template-1") {
+		t.Fatal("expected not suppressed for first match")
+	}
+	if tracker.Check("http://example.com", "template-2") {
+		t.Fatal("expected not suppressed for second match")
+	}
+
+	// Duplicate template should not increment count
+	if tracker.Check("http://example.com", "template-1") {
+		t.Fatal("expected not suppressed for duplicate template")
+	}
+
+	// Third unique template should trigger honeypot detection
+	if !tracker.Check("http://example.com", "template-3") {
+		t.Fatal("expected suppressed at threshold")
+	}
+
+	// Subsequent checks should remain suppressed
+	if !tracker.Check("http://example.com", "template-4") {
+		t.Fatal("expected suppressed after flagged")
+	}
+}
+
+func TestHoneypotTracker_DifferentHosts(t *testing.T) {
+	tracker := NewHoneypotTracker(3)
+
+	tracker.Check("http://host-a.com", "t1")
+	tracker.Check("http://host-a.com", "t2")
+	tracker.Check("http://host-b.com", "t1")
+
+	// host-a reaches threshold
+	if !tracker.Check("http://host-a.com", "t3") {
+		t.Fatal("expected host-a suppressed")
+	}
+
+	// host-b only has 1 unique match, should not be affected
+	if tracker.Check("http://host-b.com", "t2") {
+		t.Fatal("expected host-b not suppressed yet")
+	}
+}
+
+func TestHoneypotTracker_HostNormalization(t *testing.T) {
+	tracker := NewHoneypotTracker(2)
+
+	// Different formats of the same host should be normalized
+	tracker.Check("http://example.com:8080/path", "t1")
+	if !tracker.Check("https://example.com:443/other", "t2") {
+		t.Fatal("expected same host after normalization")
+	}
+}
+
+func TestHoneypotTracker_Concurrent(t *testing.T) {
+	tracker := NewHoneypotTracker(100)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < 10; j++ {
+				tracker.Check("http://target.com", fmt.Sprintf("template-%d-%d", id, j))
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	// After 50*10=500 unique templates (well over threshold of 100), host should be flagged
+	if !tracker.Check("http://target.com", "final") {
+		t.Fatal("expected host flagged after concurrent writes")
+	}
+}
+
+func TestNormalizeHost(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"http://example.com", "example.com"},
+		{"https://example.com:8443/path", "example.com"},
+		{"http://[::1]:8080/test", "::1"},
+		{"192.168.1.1:80", "192.168.1.1"},
+		{"example.com", "example.com"},
+	}
+
+	for _, tt := range tests {
+		got := normalizeHost(tt.input)
+		if got != tt.expected {
+			t.Errorf("normalizeHost(%q) = %q, want %q", tt.input, got, tt.expected)
+		}
+	}
+}

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -304,8 +304,9 @@ func (w *StandardWriter) Write(event *ResultEvent) error {
 		return nil
 	}
 
-	// Honeypot detection: suppress results from hosts with too many unique matches
-	if w.honeypotTracker != nil && event.Error == "" {
+	// Honeypot detection: suppress results from hosts with too many unique matches.
+	// Only count actual matches, not failure events from -matcher-status.
+	if w.honeypotTracker != nil && event.Error == "" && event.MatcherStatus {
 		if w.honeypotTracker.Check(event.Host, event.TemplateID) {
 			return nil
 		}

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -77,6 +77,7 @@ type StandardWriter struct {
 	DisableStdout         bool
 	AddNewLinesOutputFile bool // by default this is only done for stdout
 	KeysToRedact          []string
+	honeypotTracker       *HoneypotTracker
 
 	// JSONLogRequestHook is a hook that can be used to log request/response
 	// when using custom server code with output
@@ -282,6 +283,10 @@ func NewStandardWriter(options *types.Options) (*StandardWriter, error) {
 		KeysToRedact:     options.Redact,
 	}
 
+	if options.HoneypotDetection {
+		writer.honeypotTracker = NewHoneypotTracker(options.HoneypotThreshold)
+	}
+
 	if v := os.Getenv("DISABLE_STDOUT"); v == "true" || v == "1" {
 		writer.DisableStdout = true
 	}
@@ -297,6 +302,13 @@ func (w *StandardWriter) ResultCount() int {
 func (w *StandardWriter) Write(event *ResultEvent) error {
 	if event.Error != "" && !w.matcherStatus {
 		return nil
+	}
+
+	// Honeypot detection: suppress results from hosts with too many unique matches
+	if w.honeypotTracker != nil && event.Error == "" {
+		if w.honeypotTracker.Check(event.Host, event.TemplateID) {
+			return nil
+		}
 	}
 
 	// Enrich the result event with extra metadata on the template-path and url.

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -597,6 +597,8 @@ func (options *Options) Copy() *Options {
 		NoInteractsh:                   options.NoInteractsh,
 		EnvironmentVariables:           options.EnvironmentVariables,
 		MatcherStatus:                  options.MatcherStatus,
+		HoneypotDetection:             options.HoneypotDetection,
+		HoneypotThreshold:             options.HoneypotThreshold,
 		ClientCertFile:                 options.ClientCertFile,
 		ClientKeyFile:                  options.ClientKeyFile,
 		ClientCAFile:                   options.ClientCAFile,

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -274,6 +274,11 @@ type Options struct {
 	EnvironmentVariables bool
 	// MatcherStatus displays optional status for the failed matches as well
 	MatcherStatus bool
+	// HoneypotDetection enables honeypot detection to suppress results from hosts
+	// that trigger an unusually high number of unique template matches
+	HoneypotDetection bool
+	// HoneypotThreshold is the number of unique template matches before a host is flagged
+	HoneypotThreshold int
 	// ClientCertFile client certificate file (PEM-encoded) used for authenticating against scanned hosts
 	ClientCertFile string
 	// ClientKeyFile client key file (PEM-encoded) used for authenticating against scanned hosts


### PR DESCRIPTION
## Proposed Changes

Fixes #6403 — adds honeypot detection to reduce noise from hosts that match everything.

### How it works

New `--honeypot-detection` (`-hd`) flag enables per-host tracking of unique template matches. When a host exceeds the threshold (default 10, configurable via `--honeypot-threshold`), it is flagged as a honeypot and all further results are suppressed.

```bash
nuclei -l targets.txt -hd
nuclei -l targets.txt -hd -hdt 15  # custom threshold
```

When a honeypot is detected, a warning is logged:
```
[WRN] Honeypot detected: 192.168.1.100 (10 unique template matches, suppressing further results)
```

### Design

- **Thread-safe**: `sync.Mutex` protects concurrent access during multi-threaded scans
- **Unique match tracking**: Only distinct `TemplateID`s count — a noisy single template won't trigger false positives
- **Host normalization**: Uses `net/url.Parse` + `net.SplitHostPort` to handle URLs, IPv6 brackets, ports consistently
- **Memory efficient**: Once flagged, per-template map is freed (only the flagged set is retained)
- **Early check**: Runs before any JSON/text formatting in `Write()` to avoid unnecessary work
- **Opt-in**: Disabled by default, no impact on existing behavior

### Changes

| File | Change |
|------|--------|
| `pkg/output/honeypot.go` | `HoneypotTracker` with `Check()` and `normalizeHost()` |
| `pkg/output/honeypot_test.go` | Tests: basic, multi-host, normalization, concurrency |
| `pkg/output/output.go` | Hook tracker into `StandardWriter.Write()` |
| `pkg/types/types.go` | Add `HoneypotDetection` and `HoneypotThreshold` options |
| `cmd/nuclei/main.go` | Register `-hd` and `-hdt` CLI flags |

### Test output

```
=== RUN   TestHoneypotTracker_Basic
--- PASS: TestHoneypotTracker_Basic (0.00s)
=== RUN   TestHoneypotTracker_DifferentHosts
--- PASS: TestHoneypotTracker_DifferentHosts (0.00s)
=== RUN   TestHoneypotTracker_HostNormalization
--- PASS: TestHoneypotTracker_HostNormalization (0.00s)
=== RUN   TestHoneypotTracker_Concurrent
--- PASS: TestHoneypotTracker_Concurrent (0.00s)
=== RUN   TestNormalizeHost
--- PASS: TestNormalizeHost (0.00s)
PASS
```

## Checklist

- [x] PR created against the `dev` branch
- [x] `go vet` passes
- [x] All tests pass
- [x] Minimal diff: 5 files, +202 lines
- [x] No impact on existing behavior (opt-in flag)

/claim #6403

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional honeypot detection with CLI flags to enable it and set the threshold of unique template matches before a host is flagged and suppressed from further output.
* **Behavior**
  * Per-host detection with host normalization for consistent matching, suppression of further output for flagged hosts, memory controls to limit tracking, and warning logs when hosts are flagged.
* **Tests**
  * Unit tests covering threshold behavior, per-host isolation, normalization, case-insensitivity, and concurrent usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->