### PR TITLE
fix(http): host var scope across multi-request URLs

### DIFF
--- a/cmd/integration-test/http.go
+++ b/cmd/integration-test/http.go
@@ -86,6 +86,7 @@ var httpTestcases = []TestCaseInfo{
 	{Path: "protocols/http/disable-path-automerge.yaml", TestCase: &httpDisablePathAutomerge{}},
 	{Path: "protocols/http/http-preprocessor.yaml", TestCase: &httpPreprocessor{}},
 	{Path: "protocols/http/multi-request.yaml", TestCase: &httpMultiRequest{}},
+	{Path: "protocols/http/multi-request-host-variable-scope.yaml", TestCase: &httpMultiRequestHostVariableScope{}},
 	{Path: "protocols/http/http-matcher-extractor-dy-extractor.yaml", TestCase: &httpMatcherExtractorDynamicExtractor{}},
 	{Path: "protocols/http/multi-http-var-sharing.yaml", TestCase: &httpMultiVarSharing{}},
 	{Path: "protocols/http/raw-path-single-slash.yaml", TestCase: &httpRawPathSingleSlash{}},
@@ -1700,6 +1701,18 @@ func (h *httpMultiRequest) Execute(filePath string) error {
 	defer ts.Close()
 
 	results, err := testutils.RunNucleiTemplateAndGetResults(filePath, ts.URL, debug)
+	if err != nil {
+		return err
+	}
+
+	return expectResultsCount(results, 1)
+}
+
+type httpMultiRequestHostVariableScope struct{}
+
+// Execute executes a test case and returns an error if occurred
+func (h *httpMultiRequestHostVariableScope) Execute(filePath string) error {
+	results, err := testutils.RunNucleiTemplateAndGetResults(filePath, "http://scanme.sh/?foo=bar", debug)
 	if err != nil {
 		return err
 	}

--- a/integration_tests/protocols/http/multi-request-host-variable-scope.yaml
+++ b/integration_tests/protocols/http/multi-request-host-variable-scope.yaml
@@ -1,0 +1,20 @@
+id: http-multi-request-host-variable-scope
+
+info:
+  name: HTTP multi request host variable scope
+  author: pdteam
+  severity: info
+  description: Ensures request-scoped host variables are derived from each request URL.
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+  - method: GET
+    path:
+      - "http://honey.scanme.sh"
+    matchers:
+      - type: dsl
+        dsl:
+          - http_2_host == "http://honey.scanme.sh"

--- a/pkg/protocols/http/build_request.go
+++ b/pkg/protocols/http/build_request.go
@@ -250,9 +250,13 @@ func (r *requestGenerator) Make(ctx context.Context, input *contextargs.Context,
 		return nil, errkit.Newf("failed to parse url %v while creating http request", reqData)
 	}
 	// while merging parameters first preference is given to target params
-	finalparams := parsed.Params
-	finalparams.Merge(reqURL.Params.Encode())
-	reqURL.Params = finalparams
+	// only merge target params when the evaluated request host matches input host
+	// absolute cross-domain URLs should not inherit query params from the original input
+	if reqURL.Host == parsed.Host {
+		finalparams := parsed.Params
+		finalparams.Merge(reqURL.Params.Encode())
+		reqURL.Params = finalparams
+	}
 	return r.generateHttpRequest(ctx, reqURL, finalVars, payloads)
 }
 

--- a/pkg/protocols/http/request.go
+++ b/pkg/protocols/http/request.go
@@ -900,7 +900,7 @@ func (request *Request) executeRequest(input *contextargs.Context, generatedRequ
 		// In case of interactsh markers and request times out, still send
 		// a callback event so in case we receive an interaction, correlation is possible.
 		// Also, to log failed use-cases.
-		outputEvent := request.responseToDSLMap(&http.Response{}, input.MetaInput.Input, formedURL, convUtil.String(dumpedRequest), "", "", "", 0, generatedRequest.meta)
+		outputEvent := request.responseToDSLMap(&http.Response{}, formedURL, formedURL, convUtil.String(dumpedRequest), "", "", "", 0, generatedRequest.meta)
 		if i := strings.LastIndex(hostname, ":"); i != -1 {
 			hostname = hostname[:i]
 		}
@@ -1024,7 +1024,7 @@ func (request *Request) executeRequest(input *contextargs.Context, generatedRequ
 			}
 		}
 
-		outputEvent := request.responseToDSLMap(respChain.Response(), input.MetaInput.Input, matchedURL, convUtil.String(dumpedRequest), fullResponseStr, bodyStr, headersStr, duration, generatedRequest.meta)
+		outputEvent := request.responseToDSLMap(respChain.Response(), matchedURL, matchedURL, convUtil.String(dumpedRequest), fullResponseStr, bodyStr, headersStr, duration, generatedRequest.meta)
 		// add response fields to template context and merge templatectx variables to output event
 		request.options.AddTemplateVars(input.MetaInput, request.Type(), request.ID, outputEvent)
 		if request.options.HasTemplateCtx(input.MetaInput) {


### PR DESCRIPTION
## Proposed changes

In multi-request HTTP templates, request-scoped
host variables could inherit state from the
original input target, and absolute URL requests
could inherit queryparams from input URL.

Fixes #7062

### Proof

before:

```console
$ ./bin/nuclei-3.7.0 -silent -t integration_tests/protocols/http/multi-request-host-variable-scope.yaml -u "http://scanme.sh/?foo=bar"
# no results
```

after (this patch):

```console
$ ./bin/nuclei -silent -t integration_tests/protocols/http/multi-request-host-variable-scope.yaml -u "http://scanme.sh/?foo=bar"
[http-multi-request-host-variable-scope] [http] [info] http://honey.scanme.sh
```

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented cross-domain query-parameter leakage — parameters now merge only when request hosts match.
  * Ensured response processing uses the actual formed request URL so reported/mapped URLs match the real request.

* **Tests**
  * Added an integration test covering host variable scope in multi-request HTTP scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->