### PR TITLE
fix(loader): avoid panic when dialers are missing

### DIFF
--- a/pkg/catalog/loader/loader.go
+++ b/pkg/catalog/loader/loader.go
@@ -717,7 +717,15 @@ func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) []*templ
 
 	dialers := protocolstate.GetDialersWithId(typesOpts.ExecutionId)
 	if dialers == nil {
-		panic("dialers with executionId " + typesOpts.ExecutionId + " not found")
+		if err := protocolstate.Init(typesOpts); err != nil {
+			store.logger.Warning().Msgf("could not initialize dialers for executionId %s: %s", typesOpts.ExecutionId, err)
+			return loadedTemplates.Slice
+		}
+		dialers = protocolstate.GetDialersWithId(typesOpts.ExecutionId)
+		if dialers == nil {
+			store.logger.Warning().Msgf("dialers with executionId %s not found", typesOpts.ExecutionId)
+			return loadedTemplates.Slice
+		}
 	}
 
 	for _, templatePath := range includedTemplates {


### PR DESCRIPTION
## Proposed Changes

This PR removes a panic path in template loading when dialers are not initialized for the current execution ID.

- In `pkg/catalog/loader/loader.go`, when `protocolstate.GetDialersWithId(typesOpts.ExecutionId)` returns `nil`, it now attempts a safe initialization via `protocolstate.Init(typesOpts)`.
- If initialization fails, the loader logs a warning and returns safely instead of panicking.
- If dialers are still unavailable after init, the loader logs a warning and returns safely.

This keeps behavior stable for normal scanning flows while preventing hard crashes in non-scanning/partial-init paths.

## Proof

### Before
- Loader could panic with:
  - `panic("dialers with executionId ... not found")`

### After
- Loader no longer panics on missing dialers.
- It attempts init, then degrades gracefully with warning logs if dialers are still unavailable.

### Local verification
- Previously validated in local environment:
  - `go test ./pkg/catalog/loader -count=1`

## Checklist

- [x] PR targets the correct base branch (`dev`)
- [x] Changes are scoped to the reported issue
- [x] Added proof of behavior change (before/after + test command)
- [ ] Full repository checks
- [ ] Additional tests/docs (not required for this minimal fix)

/claim #6674


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for missing initialization states with automatic fallback initialization.
  * Replaced abrupt failures with graceful degradation and warning logs, enhancing application stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->