### PR TITLE
feat: add honeypot detection to flag hosts matching too many templates

### DIFF
--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -330,6 +330,8 @@ on extensive configurability, massive extensibility and ease of use.`)
 		flagSet.StringVarP(&options.JSONExport, "json-export", "je", "", "file to export results in JSON format"),
 		flagSet.StringVarP(&options.JSONLExport, "jsonl-export", "jle", "", "file to export results in JSONL(ine) format"),
 		flagSet.StringSliceVarP(&options.Redact, "redact", "rd", nil, "redact given list of keys from query parameter, request header and body", goflags.CommaSeparatedStringSliceOptions),
+		flagSet.IntVarP(&options.HoneypotThreshold, "honeypot-threshold", "hpt", 0, "minimum number of unique template matches before a host is flagged as honeypot (0 = disabled)"),
+		flagSet.BoolVarP(&options.HoneypotSuppress, "honeypot-suppress", "hpsu", false, "suppress results from hosts flagged as honeypots"),
 	)
 
 	flagSet.CreateGroup("configs", "Configurations",

--- a/pkg/honeypot/honeypot.go
+++ b/pkg/honeypot/honeypot.go
@@ -200,6 +200,11 @@ func NormalizeHost(raw string) string {
 		}
 	}
 
+	// Handle schemeless URL-like inputs (example.com/path, example.com:443/path)
+	if parsed, err := url.Parse("//" + raw); err == nil && parsed.Hostname() != "" {
+		return strings.ToLower(parsed.Hostname())
+	}
+
 	// Try host:port format
 	// Handle IPv6 with brackets: [::1]:8080
 	if strings.HasPrefix(raw, "[") {

--- a/pkg/honeypot/honeypot.go
+++ b/pkg/honeypot/honeypot.go
@@ -1,0 +1,221 @@
+package honeypot
+
+import (
+	"net/url"
+	"strings"
+	"sync"
+
+	"github.com/projectdiscovery/gologger"
+)
+
+// Detector tracks unique template matches per host and flags hosts
+// that exceed a configurable threshold as likely honeypots. Honeypots
+// on platforms like Shodan often return responses that match many
+// unrelated nuclei templates to confuse scanners.
+//
+// The detector is safe for concurrent use.
+type Detector struct {
+	mu        sync.Mutex
+	threshold int
+	suppress  bool
+
+	// hostMatches maps normalized host -> set of unique template IDs matched
+	hostMatches map[string]map[string]struct{}
+	// flagged tracks hosts that have crossed the threshold
+	flagged map[string]struct{}
+	// warned tracks hosts for which we already printed a warning
+	warned map[string]struct{}
+}
+
+// New creates a new honeypot Detector with the given threshold. If threshold
+// is 0 or negative, the detector is effectively disabled (IsEnabled returns false).
+// When suppress is true, results from flagged honeypot hosts will be suppressed.
+func New(threshold int, suppress bool) *Detector {
+	return &Detector{
+		threshold:   threshold,
+		suppress:    suppress,
+		hostMatches: make(map[string]map[string]struct{}),
+		flagged:     make(map[string]struct{}),
+		warned:      make(map[string]struct{}),
+	}
+}
+
+// IsEnabled returns true if the detector is active (threshold > 0).
+func (d *Detector) IsEnabled() bool {
+	return d.threshold > 0
+}
+
+// RecordMatch registers a template match for the given host. It returns
+// true if the host was just flagged as a honeypot (crossed threshold),
+// false otherwise. This method is thread-safe.
+func (d *Detector) RecordMatch(host, templateID string) bool {
+	if !d.IsEnabled() {
+		return false
+	}
+
+	normalized := NormalizeHost(host)
+	if normalized == "" {
+		return false
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	// If already flagged, no need to track further
+	if _, ok := d.flagged[normalized]; ok {
+		return false
+	}
+
+	templates, exists := d.hostMatches[normalized]
+	if !exists {
+		templates = make(map[string]struct{})
+		d.hostMatches[normalized] = templates
+	}
+	templates[templateID] = struct{}{}
+
+	if len(templates) >= d.threshold {
+		d.flagged[normalized] = struct{}{}
+		// Free the template set since we no longer need it after flagging
+		delete(d.hostMatches, normalized)
+		return true
+	}
+	return false
+}
+
+// IsFlagged returns true if the given host has been identified as a
+// likely honeypot. This method is thread-safe.
+func (d *Detector) IsFlagged(host string) bool {
+	if !d.IsEnabled() {
+		return false
+	}
+
+	normalized := NormalizeHost(host)
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	_, ok := d.flagged[normalized]
+	return ok
+}
+
+// ShouldSuppress returns true if results for this host should be suppressed.
+// A host is suppressed only if it has been flagged AND the suppress option is enabled.
+func (d *Detector) ShouldSuppress(host string) bool {
+	if !d.IsEnabled() || !d.suppress {
+		return false
+	}
+	return d.IsFlagged(host)
+}
+
+// WarnOnce prints a honeypot warning for the given host, but only the first
+// time it is called for that host. Returns true if a warning was emitted.
+func (d *Detector) WarnOnce(host string) bool {
+	if !d.IsEnabled() {
+		return false
+	}
+
+	normalized := NormalizeHost(host)
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if _, ok := d.warned[normalized]; ok {
+		return false
+	}
+	d.warned[normalized] = struct{}{}
+
+	action := "results may be unreliable"
+	if d.suppress {
+		action = "subsequent results will be suppressed"
+	}
+	gologger.Warning().Msgf(
+		"[honeypot] %s matched %d+ unique templates (likely honeypot, %s)",
+		host, d.threshold, action,
+	)
+	return true
+}
+
+// FlaggedHosts returns a list of all hosts that have been identified as
+// likely honeypots. This method is thread-safe.
+func (d *Detector) FlaggedHosts() []string {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	hosts := make([]string, 0, len(d.flagged))
+	for host := range d.flagged {
+		hosts = append(hosts, host)
+	}
+	return hosts
+}
+
+// MatchCount returns the number of unique template IDs that have matched
+// for the given host. For flagged hosts the exact count is not tracked
+// (returns the threshold). This method is thread-safe.
+func (d *Detector) MatchCount(host string) int {
+	if !d.IsEnabled() {
+		return 0
+	}
+
+	normalized := NormalizeHost(host)
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if _, ok := d.flagged[normalized]; ok {
+		return d.threshold
+	}
+	if templates, ok := d.hostMatches[normalized]; ok {
+		return len(templates)
+	}
+	return 0
+}
+
+// PrintSummary outputs a summary of detected honeypot hosts at the end
+// of the scan (if any were detected).
+func (d *Detector) PrintSummary() {
+	if !d.IsEnabled() {
+		return
+	}
+	hosts := d.FlaggedHosts()
+	if len(hosts) == 0 {
+		return
+	}
+	gologger.Info().Msgf("[honeypot] Detected %d likely honeypot host(s):", len(hosts))
+	for _, host := range hosts {
+		gologger.Info().Msgf("  - %s", host)
+	}
+}
+
+// NormalizeHost extracts a canonical host identifier from a URL, host:port,
+// or bare hostname/IP. It strips the scheme, port, path, and query string.
+// For IPv6 addresses, brackets are removed.
+func NormalizeHost(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+
+	// If it looks like a URL (has scheme), parse it
+	if strings.Contains(raw, "://") {
+		parsed, err := url.Parse(raw)
+		if err == nil && parsed.Hostname() != "" {
+			return strings.ToLower(parsed.Hostname())
+		}
+	}
+
+	// Try host:port format
+	// Handle IPv6 with brackets: [::1]:8080
+	if strings.HasPrefix(raw, "[") {
+		// IPv6 with brackets
+		if idx := strings.LastIndex(raw, "]"); idx != -1 {
+			return strings.ToLower(raw[1:idx])
+		}
+	}
+
+	// Regular host:port
+	if idx := strings.LastIndex(raw, ":"); idx != -1 {
+		// Make sure it's not just an IPv6 address without brackets
+		if strings.Count(raw, ":") == 1 {
+			return strings.ToLower(raw[:idx])
+		}
+	}
+
+	return strings.ToLower(raw)
+}

--- a/pkg/honeypot/honeypot_test.go
+++ b/pkg/honeypot/honeypot_test.go
@@ -16,6 +16,7 @@ func TestNormalizeHost(t *testing.T) {
 		expected string
 	}{
 		{"URL with scheme", "https://example.com/path?q=1", "example.com"},
+		{"Host with path (no scheme)", "example.com/path?q=1", "example.com"},
 		{"URL with port", "http://example.com:8080/admin", "example.com"},
 		{"Host:port", "example.com:443", "example.com"},
 		{"Bare host", "example.com", "example.com"},

--- a/pkg/honeypot/honeypot_test.go
+++ b/pkg/honeypot/honeypot_test.go
@@ -1,0 +1,185 @@
+package honeypot
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeHost(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"URL with scheme", "https://example.com/path?q=1", "example.com"},
+		{"URL with port", "http://example.com:8080/admin", "example.com"},
+		{"Host:port", "example.com:443", "example.com"},
+		{"Bare host", "example.com", "example.com"},
+		{"IPv4", "192.168.1.1", "192.168.1.1"},
+		{"IPv4 with port", "192.168.1.1:8080", "192.168.1.1"},
+		{"IPv6 with brackets and port", "[::1]:8080", "::1"},
+		{"IPv6 URL", "http://[2001:db8::1]:443/path", "2001:db8::1"},
+		{"Empty string", "", ""},
+		{"Whitespace", "  ", ""},
+		{"Mixed case", "HTTP://Example.COM:8080", "example.com"},
+		{"Trailing slash", "https://example.com/", "example.com"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := NormalizeHost(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestDetectorDisabled(t *testing.T) {
+	d := New(0, false)
+	assert.False(t, d.IsEnabled(), "detector should be disabled with threshold 0")
+	assert.False(t, d.RecordMatch("example.com", "cve-2021-1234"))
+	assert.False(t, d.IsFlagged("example.com"))
+	assert.False(t, d.ShouldSuppress("example.com"))
+	assert.Equal(t, 0, d.MatchCount("example.com"))
+	assert.Empty(t, d.FlaggedHosts())
+}
+
+func TestDetectorNegativeThreshold(t *testing.T) {
+	d := New(-1, false)
+	assert.False(t, d.IsEnabled())
+}
+
+func TestDetectorThresholdFlagging(t *testing.T) {
+	d := New(3, false)
+	require.True(t, d.IsEnabled())
+
+	// Add 2 unique templates - should NOT be flagged yet
+	assert.False(t, d.RecordMatch("example.com", "cve-2021-0001"))
+	assert.False(t, d.RecordMatch("example.com", "cve-2021-0002"))
+	assert.False(t, d.IsFlagged("example.com"))
+	assert.Equal(t, 2, d.MatchCount("example.com"))
+
+	// Add same template again - dedup, should NOT increase count
+	assert.False(t, d.RecordMatch("example.com", "cve-2021-0002"))
+	assert.Equal(t, 2, d.MatchCount("example.com"))
+	assert.False(t, d.IsFlagged("example.com"))
+
+	// Add 3rd unique template - should NOW be flagged
+	assert.True(t, d.RecordMatch("example.com", "cve-2021-0003"))
+	assert.True(t, d.IsFlagged("example.com"))
+
+	// Subsequent record should return false (already flagged)
+	assert.False(t, d.RecordMatch("example.com", "cve-2021-0004"))
+}
+
+func TestDetectorSuppression(t *testing.T) {
+	// suppress=false: should not suppress even if flagged
+	d := New(2, false)
+	d.RecordMatch("target.com", "tmpl-1")
+	d.RecordMatch("target.com", "tmpl-2")
+	assert.True(t, d.IsFlagged("target.com"))
+	assert.False(t, d.ShouldSuppress("target.com"))
+
+	// suppress=true: should suppress flagged hosts
+	d2 := New(2, true)
+	d2.RecordMatch("target.com", "tmpl-1")
+	d2.RecordMatch("target.com", "tmpl-2")
+	assert.True(t, d2.IsFlagged("target.com"))
+	assert.True(t, d2.ShouldSuppress("target.com"))
+
+	// Non-flagged host should not be suppressed
+	assert.False(t, d2.ShouldSuppress("clean.com"))
+}
+
+func TestDetectorHostNormalizationConsistency(t *testing.T) {
+	d := New(2, false)
+
+	// These should all map to the same host
+	d.RecordMatch("https://example.com/path1", "tmpl-1")
+	d.RecordMatch("http://example.com:8080/path2", "tmpl-2")
+
+	// Should be flagged via any form of the host
+	assert.True(t, d.IsFlagged("example.com"))
+	assert.True(t, d.IsFlagged("https://example.com"))
+	assert.True(t, d.IsFlagged("example.com:443"))
+}
+
+func TestDetectorMultipleHosts(t *testing.T) {
+	d := New(2, false)
+
+	// host1 gets 2 templates
+	d.RecordMatch("host1.com", "tmpl-1")
+	d.RecordMatch("host1.com", "tmpl-2")
+	// host2 gets only 1 template
+	d.RecordMatch("host2.com", "tmpl-1")
+
+	assert.True(t, d.IsFlagged("host1.com"))
+	assert.False(t, d.IsFlagged("host2.com"))
+
+	flagged := d.FlaggedHosts()
+	assert.Len(t, flagged, 1)
+	assert.Contains(t, flagged, "host1.com")
+}
+
+func TestDetectorWarnOnce(t *testing.T) {
+	d := New(2, false)
+	d.RecordMatch("target.com", "tmpl-1")
+	d.RecordMatch("target.com", "tmpl-2")
+
+	// First warn should emit
+	assert.True(t, d.WarnOnce("target.com"))
+	// Second warn should be suppressed
+	assert.False(t, d.WarnOnce("target.com"))
+}
+
+func TestDetectorConcurrency(t *testing.T) {
+	d := New(50, false)
+	var wg sync.WaitGroup
+
+	// Launch many goroutines recording matches concurrently
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			host := "concurrent-host.com"
+			tmplID := fmt.Sprintf("tmpl-%d", id)
+			d.RecordMatch(host, tmplID)
+		}(i)
+	}
+	wg.Wait()
+
+	// With 100 unique templates and threshold 50, host should be flagged
+	assert.True(t, d.IsFlagged("concurrent-host.com"))
+}
+
+func TestDetectorMemoryCleanup(t *testing.T) {
+	d := New(2, false)
+
+	d.RecordMatch("example.com", "tmpl-1")
+	d.RecordMatch("example.com", "tmpl-2")
+
+	// After flagging, the internal hostMatches entry should be cleaned up
+	d.mu.Lock()
+	_, hasEntry := d.hostMatches["example.com"]
+	d.mu.Unlock()
+	assert.False(t, hasEntry, "hostMatches should be cleaned up after flagging")
+}
+
+func TestDetectorEmptyHost(t *testing.T) {
+	d := New(2, false)
+	assert.False(t, d.RecordMatch("", "tmpl-1"))
+	assert.False(t, d.IsFlagged(""))
+}
+
+func TestDetectorMatchCountFlagged(t *testing.T) {
+	d := New(3, false)
+	d.RecordMatch("example.com", "a")
+	d.RecordMatch("example.com", "b")
+	d.RecordMatch("example.com", "c")
+
+	// Once flagged, MatchCount returns the threshold
+	assert.Equal(t, 3, d.MatchCount("example.com"))
+}

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -313,6 +313,9 @@ func (w *StandardWriter) Write(event *ResultEvent) error {
 	if w.HoneypotDetector != nil && w.HoneypotDetector.IsEnabled() && event.MatcherStatus {
 		host := event.Host
 		if host == "" {
+			host = event.URL
+		}
+		if host == "" {
 			host = event.Matched
 		}
 		justFlagged := w.HoneypotDetector.RecordMatch(host, event.TemplateID)

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -23,6 +23,7 @@ import (
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/interactsh/pkg/server"
 	"github.com/projectdiscovery/nuclei/v3/internal/colorizer"
+	"github.com/projectdiscovery/nuclei/v3/pkg/honeypot"
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/config"
 	"github.com/projectdiscovery/nuclei/v3/pkg/model"
 	"github.com/projectdiscovery/nuclei/v3/pkg/model/types/severity"
@@ -81,6 +82,9 @@ type StandardWriter struct {
 	// JSONLogRequestHook is a hook that can be used to log request/response
 	// when using custom server code with output
 	JSONLogRequestHook func(*JSONLogRequest)
+
+	// HoneypotDetector tracks template matches per host and flags likely honeypots
+	HoneypotDetector *honeypot.Detector
 
 	resultCount atomic.Int32
 }
@@ -264,6 +268,11 @@ func NewStandardWriter(options *types.Options) (*StandardWriter, error) {
 		}
 	}
 
+	var honeypotDetector *honeypot.Detector
+	if options.HoneypotThreshold > 0 {
+		honeypotDetector = honeypot.New(options.HoneypotThreshold, options.HoneypotSuppress)
+	}
+
 	writer := &StandardWriter{
 		json:             options.JSONL,
 		jsonReqResp:      !options.OmitRawRequests,
@@ -280,6 +289,7 @@ func NewStandardWriter(options *types.Options) (*StandardWriter, error) {
 		storeResponseDir: options.StoreResponseDir,
 		omitTemplate:     options.OmitTemplate,
 		KeysToRedact:     options.Redact,
+		HoneypotDetector: honeypotDetector,
 	}
 
 	if v := os.Getenv("DISABLE_STDOUT"); v == "true" || v == "1" {
@@ -297,6 +307,21 @@ func (w *StandardWriter) ResultCount() int {
 func (w *StandardWriter) Write(event *ResultEvent) error {
 	if event.Error != "" && !w.matcherStatus {
 		return nil
+	}
+
+	// Honeypot detection: track template matches per host
+	if w.HoneypotDetector != nil && w.HoneypotDetector.IsEnabled() && event.MatcherStatus {
+		host := event.Host
+		if host == "" {
+			host = event.Matched
+		}
+		justFlagged := w.HoneypotDetector.RecordMatch(host, event.TemplateID)
+		if justFlagged {
+			w.HoneypotDetector.WarnOnce(host)
+		}
+		if w.HoneypotDetector.ShouldSuppress(host) {
+			return nil
+		}
 	}
 
 	// Enrich the result event with extra metadata on the template-path and url.
@@ -453,6 +478,9 @@ func (w *StandardWriter) Colorizer() aurora.Aurora {
 
 // Close closes the output writing interface
 func (w *StandardWriter) Close() {
+	if w.HoneypotDetector != nil {
+		w.HoneypotDetector.PrintSummary()
+	}
 	if w.outputFile != nil {
 		_ = w.outputFile.Close()
 	}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -406,6 +406,11 @@ type Options struct {
 	EnableGlobalMatchersTemplates bool
 	// EnableFileTemplates enables file templates
 	EnableFileTemplates bool
+	// HoneypotThreshold is the number of unique template matches per host
+	// before that host is flagged as a likely honeypot. 0 disables detection.
+	HoneypotThreshold int
+	// HoneypotSuppress suppresses output for hosts flagged as honeypots
+	HoneypotSuppress bool
 	// Disables cloud upload
 	EnableCloudUpload bool
 	// ScanID is the scan ID to use for cloud upload
@@ -658,6 +663,8 @@ func (options *Options) Copy() *Options {
 		EnableSelfContainedTemplates:   options.EnableSelfContainedTemplates,
 		EnableGlobalMatchersTemplates:  options.EnableGlobalMatchersTemplates,
 		EnableFileTemplates:            options.EnableFileTemplates,
+		HoneypotThreshold:              options.HoneypotThreshold,
+		HoneypotSuppress:               options.HoneypotSuppress,
 		EnableCloudUpload:              options.EnableCloudUpload,
 		ScanID:                         options.ScanID,
 		ScanName:                       options.ScanName,


### PR DESCRIPTION
## Summary

Addresses #6403 — hosts on Shodan (and similar platforms) sometimes act as honeypots, returning responses that match many unrelated nuclei templates and producing noisy false positives. This PR adds **per-host tracking of unique template matches** with configurable threshold-based flagging.

/claim #6403

## Changes

### New package: `pkg/honeypot`
- **`Detector`** struct — thread-safe, tracks unique template IDs per normalized host
- **`NormalizeHost()`** — canonical host extraction from URLs, `host:port`, bare hostnames, IPv4/IPv6
- **`RecordMatch(host, templateID)`** — registers a match; returns `true` when threshold is crossed
- **`IsFlagged(host)`** / **`ShouldSuppress(host)`** — query flagged status
- **`WarnOnce(host)`** — emits a single warning log per flagged host
- **`PrintSummary()`** — end-of-scan summary of all flagged hosts
- **Memory cleanup** — template tracking map is freed after a host is flagged (no unbounded growth)
- **Comprehensive test suite** — 12 tests covering normalization (12 sub-cases), threshold logic, deduplication, suppression modes, concurrent access, memory cleanup, edge cases

### Integration: `pkg/output`
- `StandardWriter` gains a `HoneypotDetector` field
- `NewStandardWriter()` initializes the detector when threshold > 0
- `Write()` records every successful match and optionally suppresses output for flagged hosts
- `Close()` prints the honeypot summary

### CLI flags: `cmd/nuclei/main.go` + `pkg/types`
| Flag | Short | Default | Description |
|---|---|---|---|
| `--honeypot-threshold` | `-hpt` | `0` (disabled) | Unique template match count before flagging |
| `--honeypot-suppress` | `-hpsu` | `false` | Suppress results from flagged hosts |

## Usage

```bash
# Warn-only mode (default): flag honeypots but still show all results
nuclei -l targets.txt -t templates/ -honeypot-threshold 50

# Suppression mode: flag AND drop results from honeypot hosts
nuclei -l targets.txt -t templates/ -honeypot-threshold 50 -honeypot-suppress
```

## Test Results

```
=== RUN   TestNormalizeHost (12 sub-cases)            --- PASS
=== RUN   TestDetectorDisabled                        --- PASS
=== RUN   TestDetectorNegativeThreshold               --- PASS
=== RUN   TestDetectorThresholdFlagging               --- PASS
=== RUN   TestDetectorSuppression                     --- PASS
=== RUN   TestDetectorHostNormalizationConsistency    --- PASS
=== RUN   TestDetectorMultipleHosts                   --- PASS
=== RUN   TestDetectorWarnOnce                        --- PASS
=== RUN   TestDetectorConcurrency                     --- PASS
=== RUN   TestDetectorMemoryCleanup                   --- PASS
=== RUN   TestDetectorEmptyHost                       --- PASS
=== RUN   TestDetectorMatchCountFlagged               --- PASS
PASS — 0.589s
```

## Design Decisions

1. **Zero overhead when disabled** — threshold=0 (default) means `IsEnabled()` returns false and all methods short-circuit immediately
2. **Deduplication** — same template matching the same host multiple times doesn't inflate the count
3. **Memory-efficient** — after a host crosses the threshold, its template-ID set is deleted; only the flagged set is retained
4. **Warn-only by default** — users see a warning but no results are dropped unless `-honeypot-suppress` is explicitly set
5. **Thread-safe** — all Detector methods use a mutex, tested with 100 concurrent goroutines
6. **Host normalization** — handles URLs with schemes, `host:port`, IPv4, IPv6 with brackets, mixed case

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added honeypot detection with configurable threshold and suppression via CLI flags.
  * Integrated detection into output flow to warn once per host, optionally suppressing results, and print a summary on shutdown.

* **Tests**
  * Added comprehensive tests covering host normalization, thresholding, suppression, concurrency, and lifecycle behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->