### PR TITLE
feat(profiles): support metadata fields, inline secrets, and inline targets

### DIFF
--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -656,8 +656,15 @@ Additional documentation is available at: https://docs.nuclei.sh/getting-started
 		if !fileutil.FileExists(templateProfile) {
 			options.Logger.Fatal().Msgf("given template profile file '%s' does not exist", templateProfile)
 		}
-		if err := flagSet.MergeConfigFile(templateProfile); err != nil {
-			options.Logger.Fatal().Msgf("Could not read template profile: %s\n", err)
+		sanitizedProfile, err := processTemplateProfile(templateProfile)
+		if err != nil {
+			options.Logger.Fatal().Msgf("Could not process template profile: %s\n", err)
+		}
+		if sanitizedProfile != "" {
+			defer os.Remove(sanitizedProfile)
+			if err := flagSet.MergeConfigFile(sanitizedProfile); err != nil {
+				options.Logger.Fatal().Msgf("Could not read template profile: %s\n", err)
+			}
 		}
 	}
 
@@ -805,4 +812,124 @@ func findProfilePathById(profileId, templatesDir string) string {
 		options.Logger.Error().Msgf("%s\n", err)
 	}
 	return profilePath
+}
+
+// profileMetadataKeys are extra informational fields allowed in template profiles
+// that are not nuclei flags. These are stripped before passing to goflags merge.
+var profileMetadataKeys = map[string]bool{
+	"id":          true,
+	"name":        true,
+	"purpose":     true,
+	"description": true,
+}
+
+// processTemplateProfile reads a template profile YAML, extracts inline secrets
+// and inline targets, stores them in options, and writes a sanitized copy of the
+// profile (with metadata and special keys removed) for goflags to merge.
+// Returns the path to the sanitized temp file, or empty string if nothing to merge.
+func processTemplateProfile(profilePath string) (string, error) {
+	data, err := os.ReadFile(profilePath)
+	if err != nil {
+		return "", fmt.Errorf("could not read template profile: %w", err)
+	}
+
+	var profileData map[string]interface{}
+	if err := yaml.Unmarshal(data, &profileData); err != nil {
+		return "", fmt.Errorf("could not parse template profile: %w", err)
+	}
+
+	// Extract and handle inline secrets
+	if secretsRaw, ok := profileData["secrets"]; ok && secretsRaw != nil {
+		options.InlineSecrets = secretsRaw
+		delete(profileData, "secrets")
+	}
+
+	// Extract and handle inline target list
+	if listRaw, ok := profileData["list"]; ok && listRaw != nil {
+		if err := materializeInlineTargets(listRaw); err != nil {
+			return "", fmt.Errorf("could not process inline targets: %w", err)
+		}
+		delete(profileData, "list")
+	}
+
+	// Remove metadata keys that are not nuclei flags
+	for key := range profileMetadataKeys {
+		delete(profileData, key)
+	}
+
+	// If nothing left after stripping, no need to create a temp file
+	if len(profileData) == 0 {
+		return "", nil
+	}
+
+	// Write sanitized profile to temp file for goflags merge
+	sanitizedData, err := yaml.Marshal(profileData)
+	if err != nil {
+		return "", fmt.Errorf("could not marshal sanitized profile: %w", err)
+	}
+
+	tmpFile, err := os.CreateTemp("", "nuclei-profile-*.yaml")
+	if err != nil {
+		return "", fmt.Errorf("could not create temp profile file: %w", err)
+	}
+	if _, err := tmpFile.Write(sanitizedData); err != nil {
+		tmpFile.Close()
+		os.Remove(tmpFile.Name())
+		return "", fmt.Errorf("could not write temp profile file: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		os.Remove(tmpFile.Name())
+		return "", fmt.Errorf("could not close temp profile file: %w", err)
+	}
+	return tmpFile.Name(), nil
+}
+
+// materializeInlineTargets takes inline target list data from a template profile
+// and writes it to a temporary file, setting options.TargetsFilePath if not already
+// set via CLI flags. Supports both multiline string and string array formats.
+func materializeInlineTargets(listRaw interface{}) error {
+	var targets string
+
+	switch v := listRaw.(type) {
+	case string:
+		targets = strings.TrimSpace(v)
+	case []interface{}:
+		var lines []string
+		for _, item := range v {
+			if s, ok := item.(string); ok {
+				lines = append(lines, strings.TrimSpace(s))
+			}
+		}
+		targets = strings.Join(lines, "\n")
+	default:
+		return fmt.Errorf("unsupported list value type: %T", listRaw)
+	}
+
+	if targets == "" {
+		return nil
+	}
+
+	// Only set inline targets if no explicit -l flag was given
+	if options.TargetsFilePath != "" {
+		return nil
+	}
+
+	tmpFile, err := os.CreateTemp("", "nuclei-targets-*.txt")
+	if err != nil {
+		return fmt.Errorf("could not create temp targets file: %w", err)
+	}
+	if !strings.HasSuffix(targets, "\n") {
+		targets += "\n"
+	}
+	if _, err := tmpFile.WriteString(targets); err != nil {
+		tmpFile.Close()
+		os.Remove(tmpFile.Name())
+		return fmt.Errorf("could not write temp targets file: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		os.Remove(tmpFile.Name())
+		return fmt.Errorf("could not close temp targets file: %w", err)
+	}
+	options.TargetsFilePath = tmpFile.Name()
+	return nil
 }

--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -47,10 +47,11 @@ import (
 )
 
 var (
-	cfgFile         string
-	templateProfile string
-	memProfile      string // optional profile file path
-	options         = &types.Options{}
+	cfgFile            string
+	templateProfile    string
+	memProfile         string // optional profile file path
+	options            = &types.Options{}
+	inlineTargetsFile  string // temp file for inline targets, cleaned up on exit
 )
 
 func main() {
@@ -221,6 +222,9 @@ func main() {
 				options.Logger.Error().Msgf("Couldn't create resume file: %s\n", err)
 			}
 		}
+		if inlineTargetsFile != "" {
+			_ = os.Remove(inlineTargetsFile)
+		}
 		os.Exit(1)
 	}()
 
@@ -232,6 +236,10 @@ func main() {
 		}
 	}
 	nucleiRunner.Close()
+	// clean up inline targets temp file if one was created
+	if inlineTargetsFile != "" {
+		_ = os.Remove(inlineTargetsFile)
+	}
 	// on successful execution remove the resume file in case it exists
 	if fileutil.FileExists(resumeFileName) {
 		_ = os.Remove(resumeFileName)
@@ -931,5 +939,6 @@ func materializeInlineTargets(listRaw interface{}) error {
 		return fmt.Errorf("could not close temp targets file: %w", err)
 	}
 	options.TargetsFilePath = tmpFile.Name()
+	inlineTargetsFile = tmpFile.Name()
 	return nil
 }

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -14,6 +14,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/internal/pdcp"
 	"github.com/projectdiscovery/nuclei/v3/internal/server"
 	"github.com/projectdiscovery/nuclei/v3/pkg/authprovider"
+	"github.com/projectdiscovery/nuclei/v3/pkg/authprovider/authx"
 	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz/frequency"
 	"github.com/projectdiscovery/nuclei/v3/pkg/input/provider"
 	"github.com/projectdiscovery/nuclei/v3/pkg/installer"
@@ -67,6 +68,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/utils/yaml"
 	"github.com/projectdiscovery/retryablehttp-go"
 	ptrutil "github.com/projectdiscovery/utils/ptr"
+	yamlv2 "gopkg.in/yaml.v2"
 )
 
 var (
@@ -576,24 +578,51 @@ func (r *Runner) RunEnumeration() error {
 		executorOpts.ExportReqURLPattern = true
 	}
 
-	if len(r.options.SecretsFile) > 0 && !r.options.Validate {
+	hasSecretsFile := len(r.options.SecretsFile) > 0
+	hasInlineSecrets := r.options.InlineSecrets != nil
+	if (hasSecretsFile || hasInlineSecrets) && !r.options.Validate {
 		// Clone options so GetAuthTmplStore can modify them without affecting the original
 		authOptions := r.options.Copy()
 		authTmplStore, err := GetAuthTmplStore(authOptions, r.catalog, executorOpts)
 		if err != nil {
 			return errors.Wrap(err, "failed to load dynamic auth templates")
 		}
-		authOpts := &authprovider.AuthProviderOptions{SecretsFiles: r.options.SecretsFile}
-		authOpts.LazyFetchSecret = GetLazyAuthFetchCallback(&AuthLazyFetchOptions{
+		lazyFetchCallback := GetLazyAuthFetchCallback(&AuthLazyFetchOptions{
 			TemplateStore: authTmplStore,
 			ExecOpts:      executorOpts,
 		})
-		// initialize auth provider
-		provider, err := authprovider.NewAuthProvider(authOpts)
-		if err != nil {
-			return errors.Wrap(err, "could not create auth provider")
+
+		var providers []authprovider.AuthProvider
+
+		// File-based secrets
+		if hasSecretsFile {
+			authOpts := &authprovider.AuthProviderOptions{SecretsFiles: r.options.SecretsFile}
+			authOpts.LazyFetchSecret = lazyFetchCallback
+			fileProvider, err := authprovider.NewAuthProvider(authOpts)
+			if err != nil {
+				return errors.Wrap(err, "could not create file auth provider")
+			}
+			providers = append(providers, fileProvider)
 		}
-		executorOpts.AuthProvider = provider
+
+		// Inline secrets from template profile
+		if hasInlineSecrets {
+			secretsBytes, err := yamlv2.Marshal(r.options.InlineSecrets)
+			if err != nil {
+				return errors.Wrap(err, "could not marshal inline secrets")
+			}
+			authData, err := authx.GetAuthDataFromYAML(secretsBytes)
+			if err != nil {
+				return errors.Wrap(err, "could not parse inline secrets")
+			}
+			inlineProvider, err := authprovider.NewAuthProviderFromData(authData, lazyFetchCallback)
+			if err != nil {
+				return errors.Wrap(err, "could not create inline auth provider")
+			}
+			providers = append(providers, inlineProvider)
+		}
+
+		executorOpts.AuthProvider = authprovider.NewMultiAuthProvider(providers...)
 	}
 
 	if r.options.ShouldUseHostError() {

--- a/pkg/authprovider/interface.go
+++ b/pkg/authprovider/interface.go
@@ -57,3 +57,33 @@ func NewAuthProvider(options *AuthProviderOptions) (AuthProvider, error) {
 	}
 	return NewMultiAuthProvider(providers...), nil
 }
+
+// NewAuthProviderFromData creates a new auth provider directly from already-parsed
+// authx data. This avoids writing secrets to temp files and is used for inline
+// secrets embedded in template profile YAML.
+func NewAuthProviderFromData(data *authx.Authx, callback authx.LazyFetchSecret) (AuthProvider, error) {
+	if data == nil {
+		return nil, ErrNoSecrets
+	}
+	if len(data.Secrets) == 0 && len(data.Dynamic) == 0 {
+		return nil, ErrNoSecrets
+	}
+	if len(data.Dynamic) > 0 && callback == nil {
+		return nil, fmt.Errorf("lazy fetch callback is required for dynamic secrets")
+	}
+	for _, secret := range data.Secrets {
+		if err := secret.Validate(); err != nil {
+			return nil, fmt.Errorf("invalid inline secret: %w", err)
+		}
+	}
+	for i, dynamic := range data.Dynamic {
+		if err := dynamic.Validate(); err != nil {
+			return nil, fmt.Errorf("invalid inline dynamic secret: %w", err)
+		}
+		dynamic.SetLazyFetchCallback(callback)
+		data.Dynamic[i] = dynamic
+	}
+	f := &FileAuthProvider{Path: "<inline>", store: data}
+	f.init()
+	return f, nil
+}

--- a/pkg/authprovider/interface_test.go
+++ b/pkg/authprovider/interface_test.go
@@ -1,0 +1,167 @@
+package authprovider
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/authprovider/authx"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewAuthProviderFromData(t *testing.T) {
+	t.Run("nil data returns error", func(t *testing.T) {
+		provider, err := NewAuthProviderFromData(nil, nil)
+		require.ErrorIs(t, err, ErrNoSecrets)
+		require.Nil(t, provider)
+	})
+
+	t.Run("empty secrets returns error", func(t *testing.T) {
+		data := &authx.Authx{}
+		provider, err := NewAuthProviderFromData(data, nil)
+		require.ErrorIs(t, err, ErrNoSecrets)
+		require.Nil(t, provider)
+	})
+
+	t.Run("static secrets create provider", func(t *testing.T) {
+		data := &authx.Authx{
+			Secrets: []authx.Secret{
+				{
+					Type:    "BearerToken",
+					Domains: []string{"example.com"},
+					Token:   "test-token-123",
+				},
+			},
+		}
+		provider, err := NewAuthProviderFromData(data, nil)
+		require.NoError(t, err)
+		require.NotNil(t, provider)
+
+		// Verify lookup by addr works
+		strategies := provider.LookupAddr("example.com")
+		require.NotEmpty(t, strategies, "should find strategy for example.com")
+
+		// Verify lookup by URL works
+		u, _ := url.Parse("https://example.com/api/v1")
+		strategies = provider.LookupURL(u)
+		require.NotEmpty(t, strategies, "should find strategy for URL")
+
+		// Verify no match for unrelated domain
+		strategies = provider.LookupAddr("other.com")
+		require.Empty(t, strategies, "should not find strategy for other.com")
+	})
+
+	t.Run("multiple static secrets", func(t *testing.T) {
+		data := &authx.Authx{
+			Secrets: []authx.Secret{
+				{
+					Type:    "BearerToken",
+					Domains: []string{"api.example.com"},
+					Token:   "bearer-token",
+				},
+				{
+					Type:     "BasicAuth",
+					Domains:  []string{"admin.example.com"},
+					Username: "admin",
+					Password: "password",
+				},
+			},
+		}
+		provider, err := NewAuthProviderFromData(data, nil)
+		require.NoError(t, err)
+		require.NotNil(t, provider)
+
+		// Both domains should resolve
+		strategies := provider.LookupAddr("api.example.com")
+		require.NotEmpty(t, strategies)
+
+		strategies = provider.LookupAddr("admin.example.com")
+		require.NotEmpty(t, strategies)
+	})
+
+	t.Run("invalid secret returns validation error", func(t *testing.T) {
+		data := &authx.Authx{
+			Secrets: []authx.Secret{
+				{
+					Type:    "InvalidType",
+					Domains: []string{"example.com"},
+				},
+			},
+		}
+		provider, err := NewAuthProviderFromData(data, nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid inline secret")
+		require.Nil(t, provider)
+	})
+
+	t.Run("dynamic secrets without callback returns error", func(t *testing.T) {
+		data := &authx.Authx{
+			Dynamic: []authx.Dynamic{
+				{
+					Secret: &authx.Secret{
+						Type:    "Cookie",
+						Domains: []string{"example.com"},
+					},
+					TemplatePath: "/path/to/template.yaml",
+				},
+			},
+		}
+		provider, err := NewAuthProviderFromData(data, nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "lazy fetch callback is required")
+		require.Nil(t, provider)
+	})
+
+	t.Run("template paths empty for static-only provider", func(t *testing.T) {
+		data := &authx.Authx{
+			Secrets: []authx.Secret{
+				{
+					Type:    "BearerToken",
+					Domains: []string{"example.com"},
+					Token:   "token",
+				},
+			},
+		}
+		provider, err := NewAuthProviderFromData(data, nil)
+		require.NoError(t, err)
+		paths := provider.GetTemplatePaths()
+		require.Empty(t, paths)
+	})
+
+	t.Run("provider path is inline marker", func(t *testing.T) {
+		data := &authx.Authx{
+			Secrets: []authx.Secret{
+				{
+					Type:    "BearerToken",
+					Domains: []string{"example.com"},
+					Token:   "token",
+				},
+			},
+		}
+		provider, err := NewAuthProviderFromData(data, nil)
+		require.NoError(t, err)
+		fp, ok := provider.(*FileAuthProvider)
+		require.True(t, ok)
+		require.Equal(t, "<inline>", fp.Path)
+	})
+
+	t.Run("regex domain matching", func(t *testing.T) {
+		data := &authx.Authx{
+			Secrets: []authx.Secret{
+				{
+					Type:         "BearerToken",
+					DomainsRegex: []string{".*\\.example\\.com"},
+					Token:        "regex-token",
+				},
+			},
+		}
+		provider, err := NewAuthProviderFromData(data, nil)
+		require.NoError(t, err)
+		require.NotNil(t, provider)
+
+		strategies := provider.LookupAddr("api.example.com")
+		require.NotEmpty(t, strategies, "regex should match api.example.com")
+
+		strategies = provider.LookupAddr("other.com")
+		require.Empty(t, strategies, "regex should not match other.com")
+	})
+}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -422,6 +422,10 @@ type Options struct {
 	SecretsFile goflags.StringSlice
 	// PreFetchSecrets pre-fetches the secrets from the auth provider
 	PreFetchSecrets bool
+	// InlineSecrets holds parsed secrets data from a template profile's
+	// embedded secrets section. Used instead of SecretsFile when secrets
+	// are defined inline in the profile YAML.
+	InlineSecrets interface{}
 	// FormatUseRequiredOnly only uses required fields when generating requests
 	FormatUseRequiredOnly bool
 	// SkipFormatValidation is used to skip format validation
@@ -666,6 +670,7 @@ func (options *Options) Copy() *Options {
 		JsConcurrency:                  options.JsConcurrency,
 		SecretsFile:                    options.SecretsFile,
 		PreFetchSecrets:                options.PreFetchSecrets,
+		InlineSecrets:                  options.InlineSecrets,
 		FormatUseRequiredOnly:          options.FormatUseRequiredOnly,
 		SkipFormatValidation:           options.SkipFormatValidation,
 		PayloadConcurrency:             options.PayloadConcurrency,


### PR DESCRIPTION
/claim #5567

## Summary

Implements the template profile improvements requested in #5567:

1. **Metadata field support**: Template profiles now accept informational fields (`id`, `name`, `purpose`, `description`) without errors. These are stripped before merging with goflags, so users can annotate profiles with context.

2. **Inline secrets**: Secrets can be embedded directly in the profile YAML under a `secrets` key instead of requiring a separate secrets file. The runner creates an auth provider from the inline data via `NewAuthProviderFromData()` — no temp file workaround needed.

3. **Inline target lists**: Targets can be specified under a `list` key (multiline string or YAML array), materialized to a temp file and wired to the target input path. CLI `-l` flag takes precedence.

### Example profile with all features

```yaml
id: my-scan-profile
name: Production API Scan
description: Weekly scan of production API endpoints
purpose: security-audit

# Nuclei flags (merged normally by goflags)
templates:
  - cves/
  - exposures/
severity: critical,high
rate-limit: 100

# Inline secrets (passed to auth provider)
secrets:
  static:
    - type: BearerToken
      domains:
        - api.example.com
      token: my-api-key

# Inline targets
list: |
  api.example.com
  staging.example.com
```

## Changes

| File | Change |
|---|---|
| `cmd/nuclei/main.go` | Added `processTemplateProfile()` to sanitize profile YAML — extracts secrets, targets, and metadata before writing a clean copy for goflags. Added `materializeInlineTargets()` for temp file creation. |
| `pkg/types/types.go` | Added `InlineSecrets interface{}` field to `Options` struct + `Copy()` method. |
| `pkg/authprovider/interface.go` | Added `NewAuthProviderFromData()` to create an auth provider directly from parsed `*authx.Authx` data without going through a file. |
| `pkg/authprovider/interface_test.go` | 9 test cases covering nil/empty data, static secrets, multiple secrets, invalid secrets, dynamic secrets without callback, regex domain matching, and inline marker path. |
| `internal/runner/runner.go` | Extended auth provider initialization to handle both file-based and inline secrets, combining them via `NewMultiAuthProvider`. |

## Design decisions

- **Profile sanitization via temp file**: The profile is parsed, special keys are extracted, and a sanitized copy is written for goflags to merge. This keeps the existing goflags merge path intact and avoids forking or patching goflags.
- **`NewAuthProviderFromData()`**: Direct construction from `*authx.Authx` avoids the temp-file approach that was rejected in PR #6804 review. Validates all secrets and wires lazy fetch callbacks for dynamic secrets.
- **`interface{}` for InlineSecrets**: Avoids import cycles between `pkg/types` and `pkg/authprovider/authx`. The raw YAML map is marshaled back to bytes in the runner and parsed via `authx.GetAuthDataFromYAML()`.

## Test plan

- [x] `go build ./cmd/nuclei/` passes
- [x] `go vet ./cmd/nuclei/ ./internal/runner/ ./pkg/authprovider/ ./pkg/types/` passes
- [x] All 9 `TestNewAuthProviderFromData` subtests pass
- [x] Existing `TestSecretsUnmarshal` and `TestDynamicUnmarshalJSON` still pass
- [ ] Manual test: profile with only metadata fields (no flags) loads without error
- [ ] Manual test: profile with inline secrets authenticates requests correctly
- [ ] Manual test: profile with inline target list scans specified targets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Template profiles can include inline secrets and inline targets; these are processed automatically.
  * Authentication now supports multiple providers (file-based and inline) for flexible credential use.

* **Bug Fixes**
  * Inline-target temporary files are cleaned up on exit and handled properly across resume/crash paths.
  * Template profiles are preprocessed to remove non-app metadata before merging.

* **Tests**
  * Added tests covering inline-auth provider creation and lookup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->