### PR TITLE
feat(reporting): add PDF exporter for scan results

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -323,6 +323,7 @@ require (
 	github.com/openrdap/rdap v0.9.1 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.8 // indirect
 	github.com/perimeterx/marshmallow v1.1.5 // indirect
+	github.com/phpdave11/gofpdf v1.4.3 // indirect
 	github.com/pierrec/lz4/v4 v4.1.23 // indirect
 	github.com/pjbgf/sha1cd v0.3.2 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect

--- a/go.sum
+++ b/go.sum
@@ -216,6 +216,7 @@ github.com/bodgit/sevenzip v1.6.1 h1:kikg2pUMYC9ljU7W9SaqHXhym5HyKm8/M/jd31fYan4
 github.com/bodgit/sevenzip v1.6.1/go.mod h1:GVoYQbEVbOGT8n2pfqCIMRUaRjQ8F9oSqoBEqZh5fQ8=
 github.com/bodgit/windows v1.0.1 h1:tF7K6KOluPYygXa3Z2594zxlkbKPAOvqr97etrGNIz4=
 github.com/bodgit/windows v1.0.1/go.mod h1:a6JLwrB4KrTR5hBpp8FI9/9W9jJfeQ2h4XDXU74ZCdM=
+github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/brianvoe/gofakeit/v7 v7.2.1 h1:AGojgaaCdgq4Adzrd2uWdbGNDyX6MWNhHdQBraNfOHI=
 github.com/brianvoe/gofakeit/v7 v7.2.1/go.mod h1:QXuPeBw164PJCzCUZVmgpgHJ3Llj49jSLVkKPMtxtxA=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
@@ -637,6 +638,7 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
+github.com/jung-kurt/gofpdf v1.0.0/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/k14s/difflib v0.0.0-20201117154628-0c031775bf57 h1:CwBRArr+BWBopnUJhDjJw86rPL/jGbEjfHWKzTasSqE=
 github.com/k14s/difflib v0.0.0-20201117154628-0c031775bf57/go.mod h1:B0xN2MiNBGWOWi9CcfAo9LBI8IU4J1utlbOIJCsmKr4=
 github.com/k14s/starlark-go v0.0.0-20200720175618-3a5c849cc368 h1:4bcRTTSx+LKSxMWibIwzHnDNmaN1x52oEpvnjCy+8vk=
@@ -812,6 +814,9 @@ github.com/pelletier/go-toml/v2 v2.0.8 h1:0ctb6s9mE31h0/lhu+J6OPmVeDxJn+kYnJc2jZ
 github.com/pelletier/go-toml/v2 v2.0.8/go.mod h1:vuYfssBdrU2XDZ9bYydBu6t+6a6PYNcZljzZR9VXg+4=
 github.com/perimeterx/marshmallow v1.1.5 h1:a2LALqQ1BlHM8PZblsDdidgv1mWi1DgC2UmX50IvK2s=
 github.com/perimeterx/marshmallow v1.1.5/go.mod h1:dsXbUu8CRzfYP5a87xpp0xq9S3u0Vchtcl8we9tYaXw=
+github.com/phpdave11/gofpdf v1.4.3 h1:M/zHvS8FO3zh9tUd2RCOPEjyuVcs281FCyF22Qlz/IA=
+github.com/phpdave11/gofpdf v1.4.3/go.mod h1:MAwzoUIgD3J55u0rxIG2eu37c+XWhBtXSpPAhnQXf/o=
+github.com/phpdave11/gofpdi v1.0.15/go.mod h1:vBmVV0Do6hSBHC8uKUQ71JGW+ZGQq74llk/7bXwjDoI=
 github.com/pierrec/lz4/v4 v4.1.23 h1:oJE7T90aYBGtFNrI8+KbETnPymobAhzRrR8Mu8n1yfU=
 github.com/pierrec/lz4/v4 v4.1.23/go.mod h1:EoQMVJgeeEOMsCqCzqFm2O0cJvljX2nGZjcRIPL34O4=
 github.com/pjbgf/sha1cd v0.3.2 h1:a9wb0bp1oC2TGwStyn0Umc/IGKQnEgF0vVaZ8QF8eo4=
@@ -938,6 +943,7 @@ github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0t
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/rs/xid v1.6.0 h1:fV591PaemRlL6JfRxGDEPl69wICngIQ3shQtzfy2gxU=
 github.com/rs/xid v1.6.0/go.mod h1:7XoLgs4eV+QndskICGsho+ADou8ySMSjJKDIan90Nz0=
+github.com/ruudk/golang-pdf417 v0.0.0-20181029194003-1af4ab5afa58/go.mod h1:6lfFZQK844Gfx8o5WFuvpxWRwnSoipWe/p622j1v06w=
 github.com/rwcarlsen/goexif v0.0.0-20190401172101-9e8deecbddbd/go.mod h1:hPqNNc0+uJM6H+SuU8sEs5K5IQeKccPqeSjfgcKGgPk=
 github.com/saintfish/chardet v0.0.0-20230101081208-5e3ef4b5456d h1:hrujxIzL1woJ7AwssoOcM/tq5JjjG2yYOc8odClEiXA=
 github.com/saintfish/chardet v0.0.0-20230101081208-5e3ef4b5456d/go.mod h1:uugorj2VCxiV1x+LzaIdVa9b4S4qGAcH6cbhh4qVxOU=
@@ -1239,6 +1245,7 @@ golang.org/x/exp v0.0.0-20250911091902-df9299821621 h1:2id6c1/gto0kaHYyrixvknJ8t
 golang.org/x/exp v0.0.0-20250911091902-df9299821621/go.mod h1:TwQYMMnGpvZyc+JpB/UAuTNIsVJifOlSkrZkhcvpVUk=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
+golang.org/x/image v0.0.0-20190910094157-69e4b8554b2a/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190301231843-5614ed5bae6f/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/pkg/reporting/exporters/pdf/pdf.go
+++ b/pkg/reporting/exporters/pdf/pdf.go
@@ -51,6 +51,9 @@ func New(options *Options) (*Exporter, error) {
 	if options.File == "" {
 		options.File = defaultFileName
 	}
+	if filepath.IsAbs(options.File) {
+		return nil, fmt.Errorf("invalid PDF report path: absolute path is not allowed")
+	}
 	if hasParentPathSegment(options.File) {
 		return nil, fmt.Errorf("invalid PDF report path: parent directory traversal is not allowed")
 	}

--- a/pkg/reporting/exporters/pdf/pdf.go
+++ b/pkg/reporting/exporters/pdf/pdf.go
@@ -51,6 +51,10 @@ func New(options *Options) (*Exporter, error) {
 	if options.File == "" {
 		options.File = defaultFileName
 	}
+	if hasParentPathSegment(options.File) {
+		return nil, fmt.Errorf("invalid PDF report path: parent directory traversal is not allowed")
+	}
+	options.File = filepath.Clean(options.File)
 	if dir := filepath.Dir(options.File); dir != "" && dir != "." {
 		if err := os.MkdirAll(dir, 0755); err != nil {
 			return nil, fmt.Errorf("could not create directory for PDF report: %w", err)
@@ -93,7 +97,6 @@ func (e *Exporter) generatePDF(results []*output.ResultEvent) error {
 	pdf := gofpdf.New("P", "mm", "A4", "")
 	pdf.SetMargins(15, 15, 15)
 	pdf.SetAutoPageBreak(true, 15)
-	pdf.SetCompression(false)
 
 	pdf.SetFooterFunc(func() {
 		pdf.SetY(-13)
@@ -112,6 +115,15 @@ func (e *Exporter) generatePDF(results []*output.ResultEvent) error {
 		return fmt.Errorf("failed to write PDF report: %w", err)
 	}
 	return nil
+}
+
+func hasParentPathSegment(path string) bool {
+	for _, segment := range strings.Split(filepath.ToSlash(path), "/") {
+		if segment == ".." {
+			return true
+		}
+	}
+	return false
 }
 
 func (e *Exporter) writeHeader(pdf *gofpdf.Fpdf, total int) {

--- a/pkg/reporting/exporters/pdf/pdf.go
+++ b/pkg/reporting/exporters/pdf/pdf.go
@@ -1,0 +1,332 @@
+package pdf
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/phpdave11/gofpdf"
+	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/config"
+	"github.com/projectdiscovery/nuclei/v3/pkg/output"
+)
+
+const (
+	defaultFileName         = "nuclei-report.pdf"
+	maxRawBlockRunes        = 2048
+	rawBlockTruncatedSuffix = "\n... Truncated ..."
+)
+
+var severityColors = map[string][3]int{
+	"critical": {139, 0, 0},
+	"high":     {255, 69, 0},
+	"medium":   {255, 140, 0},
+	"low":      {128, 128, 0},
+	"info":     {0, 0, 139},
+	"unknown":  {128, 128, 128},
+}
+
+// Options contains the configuration options for PDF exporter client.
+type Options struct {
+	// File is the file to export found PDF result to.
+	File string `yaml:"file"`
+	// OmitRaw removes raw request/response blocks from the exported report.
+	OmitRaw bool `yaml:"omit-raw"`
+}
+
+// Exporter is an exporter for nuclei PDF output format.
+type Exporter struct {
+	options *Options
+	mu      sync.Mutex
+	results []*output.ResultEvent
+}
+
+// New creates a new PDF exporter integration client based on options.
+func New(options *Options) (*Exporter, error) {
+	if options == nil {
+		options = &Options{}
+	}
+	if options.File == "" {
+		options.File = defaultFileName
+	}
+	if dir := filepath.Dir(options.File); dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return nil, fmt.Errorf("could not create directory for PDF report: %w", err)
+		}
+	}
+	return &Exporter{
+		options: options,
+		results: make([]*output.ResultEvent, 0),
+	}, nil
+}
+
+// Export exports a passed result event to the PDF exporter.
+func (e *Exporter) Export(event *output.ResultEvent) error {
+	if event == nil {
+		return nil
+	}
+
+	eventCopy := *event
+	e.mu.Lock()
+	e.results = append(e.results, &eventCopy)
+	e.mu.Unlock()
+
+	return nil
+}
+
+// Close writes the PDF file and closes the exporter after operation.
+func (e *Exporter) Close() error {
+	e.mu.Lock()
+	if len(e.results) == 0 {
+		e.mu.Unlock()
+		return nil
+	}
+	results := append([]*output.ResultEvent(nil), e.results...)
+	e.mu.Unlock()
+
+	return e.generatePDF(results)
+}
+
+func (e *Exporter) generatePDF(results []*output.ResultEvent) error {
+	pdf := gofpdf.New("P", "mm", "A4", "")
+	pdf.SetMargins(15, 15, 15)
+	pdf.SetAutoPageBreak(true, 15)
+	pdf.SetCompression(false)
+
+	pdf.SetFooterFunc(func() {
+		pdf.SetY(-13)
+		pdf.SetFont("Helvetica", "I", 8)
+		pdf.SetTextColor(128, 128, 128)
+		pdf.CellFormat(0, 8, fmt.Sprintf("Page %d | Nuclei %s", pdf.PageNo(), config.Version), "", 0, "C", false, 0, "")
+	})
+
+	pdf.AddPage()
+	e.writeHeader(pdf, len(results))
+	e.writeSeveritySummary(pdf, results)
+	e.writeFindingsTable(pdf, results)
+	e.writeDetailedFindings(pdf, results)
+
+	if err := pdf.OutputFileAndClose(e.options.File); err != nil {
+		return fmt.Errorf("failed to write PDF report: %w", err)
+	}
+	return nil
+}
+
+func (e *Exporter) writeHeader(pdf *gofpdf.Fpdf, total int) {
+	pdf.SetFont("Helvetica", "B", 18)
+	pdf.SetTextColor(0, 0, 0)
+	pdf.CellFormat(0, 10, "Nuclei Scan Report", "", 1, "C", false, 0, "")
+
+	pdf.SetFont("Helvetica", "", 10)
+	pdf.SetTextColor(90, 90, 90)
+	pdf.CellFormat(0, 6, fmt.Sprintf("Generated: %s", time.Now().UTC().Format("2006-01-02 15:04:05 UTC")), "", 1, "C", false, 0, "")
+	pdf.CellFormat(0, 6, fmt.Sprintf("Version: %s", config.Version), "", 1, "C", false, 0, "")
+	pdf.CellFormat(0, 6, fmt.Sprintf("Total Findings: %d", total), "", 1, "C", false, 0, "")
+	pdf.Ln(5)
+}
+
+func (e *Exporter) writeSeveritySummary(pdf *gofpdf.Fpdf, results []*output.ResultEvent) {
+	counts := map[string]int{
+		"critical": 0,
+		"high":     0,
+		"medium":   0,
+		"low":      0,
+		"info":     0,
+		"unknown":  0,
+	}
+
+	for _, result := range results {
+		if result == nil {
+			continue
+		}
+		severity := strings.ToLower(result.Info.SeverityHolder.Severity.String())
+		if _, ok := counts[severity]; ok {
+			counts[severity]++
+			continue
+		}
+		counts["unknown"]++
+	}
+
+	pdf.SetFont("Helvetica", "B", 13)
+	pdf.SetTextColor(0, 0, 0)
+	pdf.CellFormat(0, 8, "Severity Summary", "", 1, "L", false, 0, "")
+	pdf.Ln(1)
+
+	pdf.SetFont("Helvetica", "", 10)
+	orderedSeverities := []string{"critical", "high", "medium", "low", "info", "unknown"}
+	for _, sev := range orderedSeverities {
+		count := counts[sev]
+		if count == 0 {
+			continue
+		}
+		color := severityColor(sev)
+		pdf.SetTextColor(color[0], color[1], color[2])
+		pdf.CellFormat(0, 6, fmt.Sprintf("%s: %d", strings.ToUpper(sev), count), "", 1, "L", false, 0, "")
+	}
+	pdf.SetTextColor(0, 0, 0)
+	pdf.Ln(2)
+}
+
+func (e *Exporter) writeFindingsTable(pdf *gofpdf.Fpdf, results []*output.ResultEvent) {
+	pdf.SetFont("Helvetica", "B", 13)
+	pdf.SetTextColor(0, 0, 0)
+	pdf.CellFormat(0, 8, "Findings Overview", "", 1, "L", false, 0, "")
+	pdf.Ln(1)
+
+	pdf.SetFont("Helvetica", "B", 9)
+	pdf.SetFillColor(235, 235, 235)
+	colWidths := []float64{22, 45, 40, 45, 28}
+	headers := []string{"Severity", "Template", "Host", "Matched", "Timestamp"}
+	for i, header := range headers {
+		pdf.CellFormat(colWidths[i], 7, header, "1", 0, "C", true, 0, "")
+	}
+	pdf.Ln(-1)
+
+	pdf.SetFont("Helvetica", "", 8)
+	for _, result := range results {
+		if result == nil {
+			continue
+		}
+
+		severity := strings.ToLower(result.Info.SeverityHolder.Severity.String())
+		color := severityColor(severity)
+		pdf.SetTextColor(color[0], color[1], color[2])
+		pdf.CellFormat(colWidths[0], 6, strings.ToUpper(severity), "1", 0, "C", false, 0, "")
+
+		pdf.SetTextColor(0, 0, 0)
+		pdf.CellFormat(colWidths[1], 6, truncateRunes(result.TemplateID, 28), "1", 0, "L", false, 0, "")
+		pdf.CellFormat(colWidths[2], 6, truncateRunes(result.Host, 25), "1", 0, "L", false, 0, "")
+		pdf.CellFormat(colWidths[3], 6, truncateRunes(result.Matched, 28), "1", 0, "L", false, 0, "")
+		pdf.CellFormat(colWidths[4], 6, formatTimestamp(result.Timestamp), "1", 0, "C", false, 0, "")
+		pdf.Ln(-1)
+	}
+	pdf.Ln(2)
+}
+
+func (e *Exporter) writeDetailedFindings(pdf *gofpdf.Fpdf, results []*output.ResultEvent) {
+	for idx, result := range results {
+		if result == nil {
+			continue
+		}
+
+		pdf.AddPage()
+		severity := strings.ToLower(result.Info.SeverityHolder.Severity.String())
+		color := severityColor(severity)
+
+		pdf.SetFont("Helvetica", "B", 13)
+		pdf.SetTextColor(color[0], color[1], color[2])
+		pdf.CellFormat(0, 8, fmt.Sprintf("#%d [%s] %s", idx+1, strings.ToUpper(severity), truncateRunes(result.Info.Name, 80)), "", 1, "L", false, 0, "")
+
+		pdf.SetTextColor(0, 0, 0)
+		pdf.SetFont("Helvetica", "", 10)
+		writeField(pdf, "Template", result.TemplateID)
+		writeField(pdf, "Host", result.Host)
+		writeField(pdf, "Matched", result.Matched)
+		writeField(pdf, "Protocol", strings.ToUpper(result.Type))
+		writeField(pdf, "Timestamp", formatFullTimestamp(result.Timestamp))
+
+		if result.Info.Description != "" {
+			pdf.Ln(1)
+			pdf.SetFont("Helvetica", "B", 10)
+			pdf.CellFormat(0, 6, "Description:", "", 1, "L", false, 0, "")
+			pdf.SetFont("Helvetica", "", 9)
+			pdf.MultiCell(0, 5, result.Info.Description, "", "L", false)
+		}
+
+		if result.Info.Reference != nil && !result.Info.Reference.IsEmpty() {
+			pdf.Ln(1)
+			pdf.SetFont("Helvetica", "B", 10)
+			pdf.CellFormat(0, 6, "References:", "", 1, "L", false, 0, "")
+			pdf.SetFont("Helvetica", "", 9)
+			for _, ref := range result.Info.Reference.ToSlice() {
+				pdf.CellFormat(0, 5, "- "+truncateRunes(ref, 110), "", 1, "L", false, 0, "")
+			}
+		}
+
+		if len(result.ExtractedResults) > 0 {
+			pdf.Ln(1)
+			pdf.SetFont("Helvetica", "B", 10)
+			pdf.CellFormat(0, 6, "Extracted Results:", "", 1, "L", false, 0, "")
+			pdf.SetFont("Helvetica", "", 9)
+			for _, value := range result.ExtractedResults {
+				pdf.CellFormat(0, 5, "- "+truncateRunes(value, 110), "", 1, "L", false, 0, "")
+			}
+		}
+
+		if e.options.OmitRaw {
+			continue
+		}
+		if result.Request != "" {
+			writeCodeBlock(pdf, "Request", result.Request)
+		}
+		if result.Response != "" {
+			writeCodeBlock(pdf, "Response", result.Response)
+		}
+	}
+}
+
+func writeField(pdf *gofpdf.Fpdf, label, value string) {
+	if value == "" {
+		return
+	}
+	pdf.SetFont("Helvetica", "B", 10)
+	pdf.CellFormat(28, 6, label+":", "", 0, "L", false, 0, "")
+	pdf.SetFont("Helvetica", "", 10)
+	pdf.CellFormat(0, 6, truncateRunes(value, 110), "", 1, "L", false, 0, "")
+}
+
+func writeCodeBlock(pdf *gofpdf.Fpdf, title, content string) {
+	pdf.Ln(1)
+	pdf.SetFont("Helvetica", "B", 10)
+	pdf.CellFormat(0, 6, title+":", "", 1, "L", false, 0, "")
+
+	pdf.SetFont("Courier", "", 7)
+	pdf.SetFillColor(245, 245, 245)
+	pdf.MultiCell(0, 4, truncateRawBlock(content), "1", "L", true)
+	pdf.SetFont("Helvetica", "", 10)
+}
+
+func truncateRawBlock(content string) string {
+	runes := []rune(content)
+	if len(runes) <= maxRawBlockRunes {
+		return content
+	}
+	return string(runes[:maxRawBlockRunes]) + rawBlockTruncatedSuffix
+}
+
+func truncateRunes(value string, maxLen int) string {
+	if maxLen <= 0 {
+		return ""
+	}
+	runes := []rune(value)
+	if len(runes) <= maxLen {
+		return value
+	}
+	if maxLen <= 3 {
+		return strings.Repeat(".", maxLen)
+	}
+	return string(runes[:maxLen-3]) + "..."
+}
+
+func severityColor(severity string) [3]int {
+	if color, ok := severityColors[severity]; ok {
+		return color
+	}
+	return severityColors["unknown"]
+}
+
+func formatTimestamp(value time.Time) string {
+	if value.IsZero() {
+		return "-"
+	}
+	return value.UTC().Format("15:04:05")
+}
+
+func formatFullTimestamp(value time.Time) string {
+	if value.IsZero() {
+		return "-"
+	}
+	return value.UTC().Format("2006-01-02 15:04:05 UTC")
+}

--- a/pkg/reporting/exporters/pdf/pdf.go
+++ b/pkg/reporting/exporters/pdf/pdf.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/phpdave11/gofpdf"
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/config"
+	"github.com/projectdiscovery/nuclei/v3/pkg/model"
 	"github.com/projectdiscovery/nuclei/v3/pkg/output"
 )
 
@@ -75,9 +76,9 @@ func (e *Exporter) Export(event *output.ResultEvent) error {
 		return nil
 	}
 
-	eventCopy := *event
+	eventCopy := cloneResultEvent(event)
 	e.mu.Lock()
-	e.results = append(e.results, &eventCopy)
+	e.results = append(e.results, eventCopy)
 	e.mu.Unlock()
 
 	return nil
@@ -344,4 +345,76 @@ func formatFullTimestamp(value time.Time) string {
 		return "-"
 	}
 	return value.UTC().Format("2006-01-02 15:04:05 UTC")
+}
+
+func cloneResultEvent(event *output.ResultEvent) *output.ResultEvent {
+	if event == nil {
+		return nil
+	}
+
+	eventCopy := *event
+	eventCopy.Info = cloneInfo(event.Info)
+	eventCopy.ExtractedResults = append([]string(nil), event.ExtractedResults...)
+	eventCopy.Lines = append([]int(nil), event.Lines...)
+	eventCopy.Metadata = cloneMetadataMap(event.Metadata)
+	eventCopy.IssueTrackers = cloneIssueTrackers(event.IssueTrackers)
+	eventCopy.FileToIndexPosition = cloneFileIndexMap(event.FileToIndexPosition)
+	if event.Interaction != nil {
+		interactionCopy := *event.Interaction
+		eventCopy.Interaction = &interactionCopy
+	}
+
+	return &eventCopy
+}
+
+func cloneInfo(info model.Info) model.Info {
+	infoCopy := info
+	infoCopy.Authors.Value = append([]string(nil), info.Authors.ToSlice()...)
+	infoCopy.Tags.Value = append([]string(nil), info.Tags.ToSlice()...)
+	if info.Reference != nil {
+		referenceCopy := *info.Reference
+		referenceCopy.Value = append([]string(nil), info.Reference.ToSlice()...)
+		infoCopy.Reference = &referenceCopy
+	}
+	infoCopy.Metadata = cloneMetadataMap(info.Metadata)
+	if info.Classification != nil {
+		classificationCopy := *info.Classification
+		classificationCopy.CVEID.Value = append([]string(nil), info.Classification.CVEID.ToSlice()...)
+		classificationCopy.CWEID.Value = append([]string(nil), info.Classification.CWEID.ToSlice()...)
+		infoCopy.Classification = &classificationCopy
+	}
+	return infoCopy
+}
+
+func cloneMetadataMap(values map[string]interface{}) map[string]interface{} {
+	if values == nil {
+		return nil
+	}
+	cloned := make(map[string]interface{}, len(values))
+	for key, value := range values {
+		cloned[key] = value
+	}
+	return cloned
+}
+
+func cloneIssueTrackers(values map[string]output.IssueTrackerMetadata) map[string]output.IssueTrackerMetadata {
+	if values == nil {
+		return nil
+	}
+	cloned := make(map[string]output.IssueTrackerMetadata, len(values))
+	for key, value := range values {
+		cloned[key] = value
+	}
+	return cloned
+}
+
+func cloneFileIndexMap(values map[string]int) map[string]int {
+	if values == nil {
+		return nil
+	}
+	cloned := make(map[string]int, len(values))
+	for key, value := range values {
+		cloned[key] = value
+	}
+	return cloned
 }

--- a/pkg/reporting/exporters/pdf/pdf_test.go
+++ b/pkg/reporting/exporters/pdf/pdf_test.go
@@ -43,6 +43,43 @@ func TestExportIgnoresNilEvent(t *testing.T) {
 	require.Empty(t, exporter.results)
 }
 
+func TestExportDeepCopiesMutableFields(t *testing.T) {
+	chdirTemp(t)
+	exporter, err := New(&Options{File: "report.pdf"})
+	require.NoError(t, err)
+
+	event := buildEvent("copy.example.com", severity.Critical)
+	event.ExtractedResults = []string{"alpha"}
+	event.Metadata = map[string]interface{}{"source": "initial"}
+	event.Lines = []int{7, 8}
+	event.IssueTrackers = map[string]output.IssueTrackerMetadata{
+		"jira": {IssueID: "ISSUE-1", IssueURL: "https://tracker.local/ISSUE-1"},
+	}
+	event.FileToIndexPosition = map[string]int{"req.txt": 3}
+
+	require.NoError(t, exporter.Export(event))
+	require.Len(t, exporter.results, 1)
+	stored := exporter.results[0]
+
+	event.ExtractedResults[0] = "mutated"
+	event.Metadata["source"] = "changed"
+	event.Lines[0] = 99
+	event.IssueTrackers["jira"] = output.IssueTrackerMetadata{IssueID: "ISSUE-2", IssueURL: "https://tracker.local/ISSUE-2"}
+	event.FileToIndexPosition["req.txt"] = 11
+	event.Info.Reference = stringslice.NewRawStringSlice("https://changed.local")
+	event.Info.Authors.Value = []string{"mutated-author"}
+	event.Info.Tags.Value = []string{"mutated-tag"}
+
+	require.Equal(t, []string{"alpha"}, stored.ExtractedResults)
+	require.Equal(t, "initial", stored.Metadata["source"])
+	require.Equal(t, []int{7, 8}, stored.Lines)
+	require.Equal(t, "ISSUE-1", stored.IssueTrackers["jira"].IssueID)
+	require.Equal(t, 3, stored.FileToIndexPosition["req.txt"])
+	require.Equal(t, []string{"https://docs.example.com/finding"}, stored.Info.Reference.ToSlice())
+	require.Empty(t, stored.Info.Authors.ToSlice())
+	require.Empty(t, stored.Info.Tags.ToSlice())
+}
+
 func TestCloseWithoutResultsDoesNotCreateFile(t *testing.T) {
 	chdirTemp(t)
 	outputFile := "empty.pdf"

--- a/pkg/reporting/exporters/pdf/pdf_test.go
+++ b/pkg/reporting/exporters/pdf/pdf_test.go
@@ -17,8 +17,8 @@ import (
 )
 
 func TestNewDefaultsAndCreatesOutputDirectory(t *testing.T) {
-	tmpDir := t.TempDir()
-	outputFile := filepath.Join(tmpDir, "reports", "scan-report.pdf")
+	chdirTemp(t)
+	outputFile := filepath.Join("reports", "scan-report.pdf")
 
 	exporter, err := New(&Options{File: outputFile})
 	require.NoError(t, err)
@@ -35,8 +35,8 @@ func TestNewDefaultsAndCreatesOutputDirectory(t *testing.T) {
 }
 
 func TestExportIgnoresNilEvent(t *testing.T) {
-	tmpDir := t.TempDir()
-	exporter, err := New(&Options{File: filepath.Join(tmpDir, "report.pdf")})
+	chdirTemp(t)
+	exporter, err := New(&Options{File: "report.pdf"})
 	require.NoError(t, err)
 
 	require.NoError(t, exporter.Export(nil))
@@ -44,8 +44,8 @@ func TestExportIgnoresNilEvent(t *testing.T) {
 }
 
 func TestCloseWithoutResultsDoesNotCreateFile(t *testing.T) {
-	tmpDir := t.TempDir()
-	outputFile := filepath.Join(tmpDir, "empty.pdf")
+	chdirTemp(t)
+	outputFile := "empty.pdf"
 
 	exporter, err := New(&Options{File: outputFile})
 	require.NoError(t, err)
@@ -59,8 +59,8 @@ func TestCloseWritesPDFAndRespectsOmitRaw(t *testing.T) {
 	reset := setDefaultCompression(t, false)
 	defer reset()
 
-	tmpDir := t.TempDir()
-	outputFile := filepath.Join(tmpDir, "findings.pdf")
+	chdirTemp(t)
+	outputFile := "findings.pdf"
 
 	exporter, err := New(&Options{File: outputFile, OmitRaw: true})
 	require.NoError(t, err)
@@ -87,8 +87,8 @@ func TestCloseTruncatesLargeRawBlocks(t *testing.T) {
 	reset := setDefaultCompression(t, false)
 	defer reset()
 
-	tmpDir := t.TempDir()
-	outputFile := filepath.Join(tmpDir, "large-raw.pdf")
+	chdirTemp(t)
+	outputFile := "large-raw.pdf"
 
 	exporter, err := New(&Options{File: outputFile, OmitRaw: false})
 	require.NoError(t, err)
@@ -109,8 +109,8 @@ func TestCloseTruncatesLargeRawBlocks(t *testing.T) {
 }
 
 func TestConcurrentExportAndClose(t *testing.T) {
-	tmpDir := t.TempDir()
-	outputFile := filepath.Join(tmpDir, "concurrent.pdf")
+	chdirTemp(t)
+	outputFile := "concurrent.pdf"
 
 	exporter, err := New(&Options{File: outputFile})
 	require.NoError(t, err)
@@ -147,6 +147,15 @@ func TestNewRejectsParentTraversalPath(t *testing.T) {
 	require.Contains(t, err.Error(), "parent directory traversal")
 }
 
+func TestNewRejectsAbsolutePath(t *testing.T) {
+	absolutePath := filepath.Join(string(os.PathSeparator), "tmp", "outside", "report.pdf")
+
+	_, err := New(&Options{File: absolutePath})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "absolute path")
+}
+
 func setDefaultCompression(t *testing.T, enabled bool) func() {
 	t.Helper()
 
@@ -155,6 +164,19 @@ func setDefaultCompression(t *testing.T, enabled bool) func() {
 	return func() {
 		gofpdf.SetDefaultCompression(true)
 	}
+}
+
+func chdirTemp(t *testing.T) {
+	t.Helper()
+
+	oldWD, err := os.Getwd()
+	require.NoError(t, err)
+
+	tmpDir := t.TempDir()
+	require.NoError(t, os.Chdir(tmpDir))
+	t.Cleanup(func() {
+		require.NoError(t, os.Chdir(oldWD))
+	})
 }
 
 func buildEvent(host string, sev severity.Severity) *output.ResultEvent {

--- a/pkg/reporting/exporters/pdf/pdf_test.go
+++ b/pkg/reporting/exporters/pdf/pdf_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/phpdave11/gofpdf"
 	"github.com/projectdiscovery/nuclei/v3/pkg/model"
 	"github.com/projectdiscovery/nuclei/v3/pkg/model/types/severity"
 	"github.com/projectdiscovery/nuclei/v3/pkg/model/types/stringslice"
@@ -55,6 +56,9 @@ func TestCloseWithoutResultsDoesNotCreateFile(t *testing.T) {
 }
 
 func TestCloseWritesPDFAndRespectsOmitRaw(t *testing.T) {
+	reset := setDefaultCompression(t, false)
+	defer reset()
+
 	tmpDir := t.TempDir()
 	outputFile := filepath.Join(tmpDir, "findings.pdf")
 
@@ -80,6 +84,9 @@ func TestCloseWritesPDFAndRespectsOmitRaw(t *testing.T) {
 }
 
 func TestCloseTruncatesLargeRawBlocks(t *testing.T) {
+	reset := setDefaultCompression(t, false)
+	defer reset()
+
 	tmpDir := t.TempDir()
 	outputFile := filepath.Join(tmpDir, "large-raw.pdf")
 
@@ -109,16 +116,21 @@ func TestConcurrentExportAndClose(t *testing.T) {
 	require.NoError(t, err)
 
 	var wg sync.WaitGroup
+	errCh := make(chan error, 30)
 	for i := 0; i < 30; i++ {
 		wg.Add(1)
 		go func(index int) {
 			defer wg.Done()
 			event := buildEvent("concurrent.example.com", severity.Low)
 			event.TemplateID = "tmpl-concurrent-" + time.Unix(int64(index), 0).UTC().Format("150405")
-			_ = exporter.Export(event)
+			errCh <- exporter.Export(event)
 		}(i)
 	}
 	wg.Wait()
+	close(errCh)
+	for exportErr := range errCh {
+		require.NoError(t, exportErr)
+	}
 
 	require.Len(t, exporter.results, 30)
 	require.NoError(t, exporter.Close())
@@ -126,6 +138,23 @@ func TestConcurrentExportAndClose(t *testing.T) {
 	info, err := os.Stat(outputFile)
 	require.NoError(t, err)
 	require.True(t, info.Size() > 0)
+}
+
+func TestNewRejectsParentTraversalPath(t *testing.T) {
+	_, err := New(&Options{File: "../outside/report.pdf"})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "parent directory traversal")
+}
+
+func setDefaultCompression(t *testing.T, enabled bool) func() {
+	t.Helper()
+
+	gofpdf.SetDefaultCompression(enabled)
+
+	return func() {
+		gofpdf.SetDefaultCompression(true)
+	}
 }
 
 func buildEvent(host string, sev severity.Severity) *output.ResultEvent {

--- a/pkg/reporting/exporters/pdf/pdf_test.go
+++ b/pkg/reporting/exporters/pdf/pdf_test.go
@@ -1,0 +1,149 @@
+package pdf
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/model"
+	"github.com/projectdiscovery/nuclei/v3/pkg/model/types/severity"
+	"github.com/projectdiscovery/nuclei/v3/pkg/model/types/stringslice"
+	"github.com/projectdiscovery/nuclei/v3/pkg/output"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewDefaultsAndCreatesOutputDirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+	outputFile := filepath.Join(tmpDir, "reports", "scan-report.pdf")
+
+	exporter, err := New(&Options{File: outputFile})
+	require.NoError(t, err)
+	require.NotNil(t, exporter)
+	require.Equal(t, outputFile, exporter.options.File)
+
+	info, err := os.Stat(filepath.Dir(outputFile))
+	require.NoError(t, err)
+	require.True(t, info.IsDir())
+
+	defaultExporter, err := New(nil)
+	require.NoError(t, err)
+	require.Equal(t, defaultFileName, defaultExporter.options.File)
+}
+
+func TestExportIgnoresNilEvent(t *testing.T) {
+	tmpDir := t.TempDir()
+	exporter, err := New(&Options{File: filepath.Join(tmpDir, "report.pdf")})
+	require.NoError(t, err)
+
+	require.NoError(t, exporter.Export(nil))
+	require.Empty(t, exporter.results)
+}
+
+func TestCloseWithoutResultsDoesNotCreateFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	outputFile := filepath.Join(tmpDir, "empty.pdf")
+
+	exporter, err := New(&Options{File: outputFile})
+	require.NoError(t, err)
+	require.NoError(t, exporter.Close())
+
+	_, statErr := os.Stat(outputFile)
+	require.ErrorIs(t, statErr, os.ErrNotExist)
+}
+
+func TestCloseWritesPDFAndRespectsOmitRaw(t *testing.T) {
+	tmpDir := t.TempDir()
+	outputFile := filepath.Join(tmpDir, "findings.pdf")
+
+	exporter, err := New(&Options{File: outputFile, OmitRaw: true})
+	require.NoError(t, err)
+
+	event := buildEvent("example.com", severity.High)
+	event.Request = "GET /secret HTTP/1.1"
+	event.Response = "secret-response-body"
+
+	require.NoError(t, exporter.Export(event))
+	require.NoError(t, exporter.Close())
+
+	pdfData, err := os.ReadFile(outputFile)
+	require.NoError(t, err)
+	require.NotEmpty(t, pdfData)
+
+	content := string(pdfData)
+	require.Contains(t, content, "Nuclei Scan Report")
+	require.Contains(t, content, "Severity Summary")
+	require.NotContains(t, content, "secret-response-body")
+	require.NotContains(t, content, "GET /secret HTTP/1.1")
+}
+
+func TestCloseTruncatesLargeRawBlocks(t *testing.T) {
+	tmpDir := t.TempDir()
+	outputFile := filepath.Join(tmpDir, "large-raw.pdf")
+
+	exporter, err := New(&Options{File: outputFile, OmitRaw: false})
+	require.NoError(t, err)
+
+	event := buildEvent("raw.example.com", severity.Medium)
+	event.Response = "START-" + strings.Repeat("A", maxRawBlockRunes+500) + "-END-MARKER"
+
+	require.NoError(t, exporter.Export(event))
+	require.NoError(t, exporter.Close())
+
+	pdfData, err := os.ReadFile(outputFile)
+	require.NoError(t, err)
+
+	content := string(pdfData)
+	require.Contains(t, content, "START-")
+	require.Contains(t, content, strings.TrimSpace(rawBlockTruncatedSuffix))
+	require.NotContains(t, content, "END-MARKER")
+}
+
+func TestConcurrentExportAndClose(t *testing.T) {
+	tmpDir := t.TempDir()
+	outputFile := filepath.Join(tmpDir, "concurrent.pdf")
+
+	exporter, err := New(&Options{File: outputFile})
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 30; i++ {
+		wg.Add(1)
+		go func(index int) {
+			defer wg.Done()
+			event := buildEvent("concurrent.example.com", severity.Low)
+			event.TemplateID = "tmpl-concurrent-" + time.Unix(int64(index), 0).UTC().Format("150405")
+			_ = exporter.Export(event)
+		}(i)
+	}
+	wg.Wait()
+
+	require.Len(t, exporter.results, 30)
+	require.NoError(t, exporter.Close())
+
+	info, err := os.Stat(outputFile)
+	require.NoError(t, err)
+	require.True(t, info.Size() > 0)
+}
+
+func buildEvent(host string, sev severity.Severity) *output.ResultEvent {
+	return &output.ResultEvent{
+		TemplateID: "test-template",
+		Template:   "http/test-template.yaml",
+		Type:       "http",
+		Host:       host,
+		Matched:    "https://" + host + "/login",
+		Path:       "/login",
+		Request:    "GET /login HTTP/1.1",
+		Response:   "HTTP/1.1 200 OK",
+		Timestamp:  time.Date(2026, time.February, 27, 23, 0, 0, 0, time.UTC),
+		Info: model.Info{
+			Name:           "Test finding",
+			Description:    "A reproducible test finding",
+			SeverityHolder: severity.Holder{Severity: sev},
+			Reference:      stringslice.NewRawStringSlice("https://docs.example.com/finding"),
+		},
+	}
+}

--- a/pkg/reporting/options.go
+++ b/pkg/reporting/options.go
@@ -7,6 +7,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/reporting/exporters/jsonl"
 	"github.com/projectdiscovery/nuclei/v3/pkg/reporting/exporters/markdown"
 	"github.com/projectdiscovery/nuclei/v3/pkg/reporting/exporters/mongo"
+	"github.com/projectdiscovery/nuclei/v3/pkg/reporting/exporters/pdf"
 	"github.com/projectdiscovery/nuclei/v3/pkg/reporting/exporters/sarif"
 	"github.com/projectdiscovery/nuclei/v3/pkg/reporting/exporters/splunk"
 	"github.com/projectdiscovery/nuclei/v3/pkg/reporting/trackers/filters"
@@ -50,6 +51,8 @@ type Options struct {
 	JSONLExporter *jsonl.Options `yaml:"jsonl"`
 	// MongoDBExporter containers the configuration options for the MongoDB Exporter Module
 	MongoDBExporter *mongo.Options `yaml:"mongodb"`
+	// PDFExporter contains configuration options for PDF Exporter Module
+	PDFExporter *pdf.Options `yaml:"pdf"`
 
 	HttpClient *retryablehttp.Client `yaml:"-"`
 	OmitRaw    bool                  `yaml:"-"`

--- a/pkg/reporting/reporting.go
+++ b/pkg/reporting/reporting.go
@@ -23,6 +23,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/reporting/dedupe"
 	"github.com/projectdiscovery/nuclei/v3/pkg/reporting/exporters/es"
 	"github.com/projectdiscovery/nuclei/v3/pkg/reporting/exporters/markdown"
+	"github.com/projectdiscovery/nuclei/v3/pkg/reporting/exporters/pdf"
 	"github.com/projectdiscovery/nuclei/v3/pkg/reporting/exporters/sarif"
 	"github.com/projectdiscovery/nuclei/v3/pkg/reporting/exporters/splunk"
 	"github.com/projectdiscovery/nuclei/v3/pkg/reporting/trackers/filters"
@@ -177,6 +178,13 @@ func New(options *Options, db string, doNotDedupe bool) (Client, error) {
 		}
 		client.exporters = append(client.exporters, exporter)
 	}
+	if options.PDFExporter != nil {
+		exporter, err := pdf.New(options.PDFExporter)
+		if err != nil {
+			return nil, errkit.Wrapf(err, "could not create export client: %v", ErrExportClientCreation)
+		}
+		client.exporters = append(client.exporters, exporter)
+	}
 
 	if doNotDedupe {
 		return client, nil
@@ -226,6 +234,7 @@ func CreateConfigIfNotExists() error {
 		JSONExporter:          &json_exporter.Options{},
 		JSONLExporter:         &jsonl.Options{},
 		MongoDBExporter:       &mongo.Options{},
+		PDFExporter:           &pdf.Options{},
 	}
 	reportingFile, err := os.Create(reportingConfig)
 	if err != nil {


### PR DESCRIPTION
## Proposed changes

- add a new `pdf` exporter under `pkg/reporting/exporters/pdf` that implements the existing reporting `Exporter` interface
- include report sections for summary + severity counts + findings overview + per-finding details
- include optional raw request/response blocks with bounded truncation and `omit-raw` support
- make exporter safe for concurrent `Export` calls by guarding shared state and snapshotting before render
- wire PDF exporter into reporting configuration (`yaml: pdf`) and exporter registration in `pkg/reporting/reporting.go`
- add focused unit tests for constructor behavior, nil event handling, omit-raw behavior, truncation, and concurrency

### Proof

Executed locally:

```bash
go test ./pkg/reporting/exporters/pdf
go test -race ./pkg/reporting/exporters/pdf
go test ./pkg/reporting/...
```

## Checklist

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

/claim #2063


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - PDF export for scan findings with configurable output path, header, severity summary, findings overview, and detailed per-finding sections.
  - Option to omit raw request/response blocks and safe truncation of large raw content.
  - Thread-safe result collection and safe handling of output directories.

* **Tests**
  - Comprehensive tests for PDF output, omission/truncation behavior, concurrency, and file handling.

* **Chores**
  - Added PDF generation dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->