### PR TITLE
fix: replace panic with graceful recovery when dialers are not found

### DIFF
--- a/pkg/catalog/loader/loader.go
+++ b/pkg/catalog/loader/loader.go
@@ -717,7 +717,16 @@ func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) []*templ
 
 	dialers := protocolstate.GetDialersWithId(typesOpts.ExecutionId)
 	if dialers == nil {
-		panic("dialers with executionId " + typesOpts.ExecutionId + " not found")
+		gologger.Warning().Msgf("dialers with executionId %s not found, attempting late initialization", typesOpts.ExecutionId)
+		if err := protocolstate.Init(typesOpts); err != nil {
+			gologger.Error().Msgf("could not initialize dialers for executionId %s: %v", typesOpts.ExecutionId, err)
+			return nil
+		}
+		dialers = protocolstate.GetDialersWithId(typesOpts.ExecutionId)
+		if dialers == nil {
+			gologger.Error().Msgf("dialers still not available after init for executionId %s, skipping template loading", typesOpts.ExecutionId)
+			return nil
+		}
 	}
 
 	for _, templatePath := range includedTemplates {

--- a/pkg/catalog/loader/loader.go
+++ b/pkg/catalog/loader/loader.go
@@ -717,14 +717,14 @@ func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) []*templ
 
 	dialers := protocolstate.GetDialersWithId(typesOpts.ExecutionId)
 	if dialers == nil {
-		gologger.Warning().Msgf("dialers with executionId %s not found, attempting late initialization", typesOpts.ExecutionId)
+		store.logger.Warning().Msgf("dialers with executionId %s not found, attempting late initialization", typesOpts.ExecutionId)
 		if err := protocolstate.Init(typesOpts); err != nil {
-			gologger.Error().Msgf("could not initialize dialers for executionId %s: %v", typesOpts.ExecutionId, err)
+			store.logger.Error().Msgf("could not initialize dialers for executionId %s: %v", typesOpts.ExecutionId, err)
 			return nil
 		}
 		dialers = protocolstate.GetDialersWithId(typesOpts.ExecutionId)
 		if dialers == nil {
-			gologger.Error().Msgf("dialers still not available after init for executionId %s, skipping template loading", typesOpts.ExecutionId)
+			store.logger.Error().Msgf("dialers still not available after init for executionId %s, skipping template loading", typesOpts.ExecutionId)
 			return nil
 		}
 	}

--- a/pkg/catalog/loader/loader_test.go
+++ b/pkg/catalog/loader/loader_test.go
@@ -4,8 +4,11 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/config"
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/disk"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols"
+	"github.com/projectdiscovery/nuclei/v3/pkg/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -44,6 +47,33 @@ func TestLoadTemplates(t *testing.T) {
 		require.Nil(t, err, "could not load templates")
 		require.Equal(t, []string{templatesDirectory}, store.finalTemplates, "could not get correct templates")
 	})
+}
+
+// TestLoadTemplatesWithTagsNilDialers verifies that LoadTemplatesWithTags
+// does not panic when dialers are not initialized for the given execution ID.
+// Before the fix, calling LoadTemplatesWithTags without prior dialer
+// initialization would panic with "dialers with executionId ... not found".
+// The fix attempts late initialization and falls back to a graceful nil return.
+func TestLoadTemplatesWithTagsNilDialers(t *testing.T) {
+
+	catalog := disk.NewCatalog("")
+	opts := &types.Options{
+		ExecutionId: "nonexistent-test-id",
+	}
+	store, err := New(&Config{
+		Templates: []string{"cves/CVE-2021-21315.yaml"},
+		Catalog:   catalog,
+		Logger:    gologger.DefaultLogger,
+		ExecutorOptions: &protocols.ExecutorOptions{
+			Options: opts,
+		},
+	})
+	require.Nil(t, err, "could not create store")
+
+	// Before the fix, this would panic. Now it should return nil gracefully.
+	require.NotPanics(t, func() {
+		store.LoadTemplatesWithTags([]string{}, nil)
+	}, "LoadTemplatesWithTags should not panic when dialers are not found")
 }
 
 func TestRemoteTemplates(t *testing.T) {


### PR DESCRIPTION
## Summary

Replace `panic` in `LoadTemplatesWithTags` (loader.go:720) when `GetDialersWithId()` returns `nil`. Instead of crashing the process, attempt late initialization via `protocolstate.Init()` and fall back to a graceful `return nil` with error logging if that fails.

## Changes

- **pkg/catalog/loader/loader.go**: Replace `panic("dialers with executionId ... not found")` with:
  1. Warning log + attempt `protocolstate.Init()` to recover
  2. If init succeeds, continue loading templates normally
  3. If init fails, log error and return nil (empty template list)
- **pkg/catalog/loader/loader_test.go**: Add `TestLoadTemplatesWithTagsNilDialers` to verify no panic occurs when dialers are uninitialized

## Why

A `panic` in a public API is too harsh — callers have no way to handle it. The downstream code already handles empty/nil template lists gracefully, so returning nil is safe. The late init attempt means that in race condition scenarios, the scan can self-recover instead of crashing.

Fixes #6674

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented crashes when required runtime resources are missing; the system now attempts lazy initialization, logs warnings/errors, and gracefully skips template loading if resources remain unavailable.
* **Tests**
  * Added a regression test to ensure template loading no longer panics when those runtime resources are not initialized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->