### PR TITLE
feat(fuzz): add xss context analyzer and fix #7086 edge cases

### DIFF
--- a/pkg/fuzz/analyzers/analyzers.go
+++ b/pkg/fuzz/analyzers/analyzers.go
@@ -4,6 +4,7 @@ import (
 	"math/rand"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz"
@@ -27,6 +28,7 @@ type AnalyzerTemplate struct {
 	//   Name is the name of the analyzer to use
 	// values:
 	//   - time_delay
+	//   - xss_context
 	Name string `json:"name" yaml:"name"`
 	// description: |
 	//   Parameters is the parameters for the analyzer
@@ -61,10 +63,18 @@ type Options struct {
 	HttpClient         *retryablehttp.Client
 	ResponseTimeDelay  time.Duration
 	AnalyzerParameters map[string]interface{}
+
+	// ResponseBody is the body of the HTTP response
+	ResponseBody string
+	// ResponseHeaders is the headers of the HTTP response
+	ResponseHeaders map[string][]string
+	// ResponseStatusCode is the status code of the HTTP response
+	ResponseStatusCode int
 }
 
 var (
-	random = rand.New(rand.NewSource(time.Now().UnixNano()))
+	random   = rand.New(rand.NewSource(time.Now().UnixNano()))
+	randomMu sync.Mutex
 )
 
 // ApplyPayloadTransformations applies the payload transformations to the payload
@@ -73,7 +83,7 @@ var (
 //   - [RANDSTR] => random string of 4 characters
 func ApplyPayloadTransformations(value string) string {
 	randomInt := GetRandomInteger()
-	randomStr := randStringBytesMask(4)
+	randomStr := RandStringBytesMask(4)
 
 	value = strings.ReplaceAll(value, "[RANDNUM]", strconv.Itoa(randomInt))
 	value = strings.ReplaceAll(value, "[RANDSTR]", randomStr)
@@ -82,7 +92,10 @@ func ApplyPayloadTransformations(value string) string {
 
 const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
-func randStringBytesMask(n int) string {
+// RandStringBytesMask generates a random string of n characters
+func RandStringBytesMask(n int) string {
+	randomMu.Lock()
+	defer randomMu.Unlock()
 	b := make([]byte, n)
 	for i := range b {
 		b[i] = letterBytes[random.Intn(len(letterBytes))]
@@ -92,5 +105,7 @@ func randStringBytesMask(n int) string {
 
 // GetRandomInteger returns a random integer between 1000 and 9999
 func GetRandomInteger() int {
+	randomMu.Lock()
+	defer randomMu.Unlock()
 	return random.Intn(9000) + 1000
 }

--- a/pkg/fuzz/analyzers/xss/analyzer.go
+++ b/pkg/fuzz/analyzers/xss/analyzer.go
@@ -1,0 +1,307 @@
+package xss
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/projectdiscovery/gologger"
+	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz/analyzers"
+)
+
+// Analyzer is an XSS context analyzer for the fuzzer.
+// It detects the reflection context of injected payloads and
+// verifies XSS by replaying context-appropriate payloads.
+type Analyzer struct{}
+
+var _ analyzers.Analyzer = &Analyzer{}
+
+func init() {
+	analyzers.RegisterAnalyzer("xss_context", &Analyzer{})
+}
+
+// Name returns the name of the analyzer
+func (a *Analyzer) Name() string {
+	return "xss_context"
+}
+
+// ApplyInitialTransformation replaces placeholder tokens in the payload.
+//
+// It supports:
+//   - [XSS_CANARY] => unique canary string with XSS-critical characters for reflection/context detection
+//
+// It also applies the standard [RANDNUM] and [RANDSTR] transformations.
+func (a *Analyzer) ApplyInitialTransformation(data string, params map[string]interface{}) string {
+	if strings.Contains(data, "[XSS_CANARY]") {
+		canary := generateCanary()
+		if params != nil {
+			params["xss_canary"] = canary
+		}
+		// The canary includes special chars for character survival detection
+		canaryWithChars := canary + canaryChars
+		data = strings.ReplaceAll(data, "[XSS_CANARY]", canaryWithChars)
+	}
+	data = analyzers.ApplyPayloadTransformations(data)
+	return data
+}
+
+// generateCanary creates a unique canary string
+func generateCanary() string {
+	return "nuclei" + analyzers.RandStringBytesMask(8)
+}
+
+// Analyze detects XSS vulnerabilities by:
+// 1. Checking for canary reflection in the initial response
+// 2. Detecting the HTML context of the reflection
+// 3. Replaying context-appropriate payloads to verify exploitability
+func (a *Analyzer) Analyze(options *analyzers.Options) (bool, string, error) {
+	// Determine the canary from parameters
+	canary := ""
+	if v, ok := options.AnalyzerParameters["xss_canary"]; ok {
+		canary, _ = v.(string)
+	}
+	if canary == "" {
+		return false, "", nil
+	}
+
+	body := options.ResponseBody
+	if body == "" {
+		return false, "", nil
+	}
+
+	// Check Content-Type - only analyze HTML responses
+	if !isHTMLResponse(options.ResponseHeaders) {
+		return false, "", nil
+	}
+
+	// Check if canary is reflected at all
+	if !strings.Contains(body, canary) {
+		return false, "", nil
+	}
+
+	// Detect character survival
+	chars := detectCharacterSurvival(body, canary)
+
+	// Detect reflection contexts using the HTML tokenizer
+	reflections := DetectReflections(body, canary)
+	if len(reflections) == 0 {
+		return false, "", nil
+	}
+
+	best := BestReflection(reflections)
+	if best == nil || best.Context == ContextNone {
+		return false, "", nil
+	}
+
+	// Select payloads appropriate for the detected context
+	payloads := selectPayloads(best, chars)
+	if len(payloads) == 0 {
+		return false, "", fmt.Errorf("no suitable payloads for context %s", best.Context)
+	}
+
+	// Replay with context-appropriate payloads
+	for _, payload := range payloads {
+		matched, details, err := a.replayAndVerify(options, payload, best)
+		if err != nil {
+			gologger.Verbose().Msgf("[%s] replay error: %v", a.Name(), err)
+			continue
+		}
+		if matched {
+			return true, details, nil
+		}
+	}
+
+	return false, "", nil
+}
+
+// replayAndVerify sends a request with the given payload and checks
+// if the payload appears unencoded in the response.
+func (a *Analyzer) replayAndVerify(options *analyzers.Options, payload string, reflection *ReflectionInfo) (bool, string, error) {
+	gr := options.FuzzGenerated
+
+	if gr.Component == nil {
+		return false, "", errors.New("fuzz component is nil")
+	}
+
+	origPayload := gr.OriginalPayload
+
+	// Set the payload into the component
+	if err := gr.Component.SetValue(gr.Key, payload); err != nil {
+		return false, "", errors.Wrap(err, "could not set value in component")
+	}
+
+	rebuilt, err := gr.Component.Rebuild()
+	if err != nil {
+		return false, "", errors.Wrap(err, "could not rebuild request")
+	}
+
+	// Restore original value after rebuild so subsequent replays start from clean state
+	defer func() {
+		_ = gr.Component.SetValue(gr.Key, gr.OriginalValue)
+	}()
+
+	gologger.Verbose().Msgf("[%s] Replaying with payload for %s context: %s", a.Name(), reflection.Context, rebuilt.String())
+
+	resp, err := options.HttpClient.Do(rebuilt)
+	if err != nil {
+		return false, "", errors.Wrap(err, "could not send replay request")
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return false, "", errors.Wrap(err, "could not read replay response body")
+	}
+
+	respBodyStr := string(respBody)
+
+	// Check if the payload is reflected unencoded
+	if strings.Contains(respBodyStr, payload) {
+		details := fmt.Sprintf(
+			"[xss_context] XSS confirmed in %s context (tag: %s, param: %s). Payload reflected unencoded: %s (original: %s)",
+			reflection.Context,
+			reflection.TagName,
+			gr.Key,
+			payload,
+			origPayload,
+		)
+
+		if hasCSP(options.ResponseHeaders) {
+			details += " [note: CSP header present, may limit exploitability]"
+		}
+
+		return true, details, nil
+	}
+
+	return false, "", nil
+}
+
+// isHTMLResponse checks if the Content-Type indicates an HTML response
+func isHTMLResponse(headers map[string][]string) bool {
+	if headers == nil {
+		return true // assume HTML if no headers available
+	}
+	ct := getHeader(headers, "Content-Type")
+	if ct == "" {
+		return true // assume HTML if no Content-Type
+	}
+	ctLower := strings.ToLower(ct)
+	return strings.Contains(ctLower, "text/html") || strings.Contains(ctLower, "application/xhtml")
+}
+
+// hasCSP checks if Content-Security-Policy header is present
+func hasCSP(headers map[string][]string) bool {
+	if headers == nil {
+		return false
+	}
+	return getHeader(headers, "Content-Security-Policy") != ""
+}
+
+// getHeader gets the first value for a header (case-insensitive)
+func getHeader(headers map[string][]string, name string) string {
+	// http.Header is already canonical, use direct lookup first
+	if vals, ok := headers[http.CanonicalHeaderKey(name)]; ok && len(vals) > 0 {
+		return vals[0]
+	}
+	// Fallback: case-insensitive search
+	nameLower := strings.ToLower(name)
+	for k, vals := range headers {
+		if strings.ToLower(k) == nameLower && len(vals) > 0 {
+			return vals[0]
+		}
+	}
+	return ""
+}
+
+// detectCharacterSurvival checks which XSS-critical characters survived server-side encoding
+func detectCharacterSurvival(body string, canary string) CharacterSet {
+	return CharacterSet{
+		LessThan:     strings.Contains(body, canary+"<"),
+		GreaterThan:  strings.Contains(body, canary+"<>") || strings.Contains(body, canary+">"),
+		DoubleQuote:  strings.Contains(body, canary+`<>"`),
+		SingleQuote:  strings.Contains(body, canary+`<>"'`),
+		ForwardSlash: strings.Contains(body, canary+canaryChars), // full canary+chars survived
+	}
+}
+
+// selectPayloads returns context-appropriate XSS payloads filtered by character availability
+func selectPayloads(reflection *ReflectionInfo, chars CharacterSet) []string {
+	var candidates []string
+
+	switch reflection.Context {
+	case ContextHTMLText:
+		if chars.LessThan && chars.GreaterThan {
+			candidates = []string{
+				`<img src=x onerror=alert(1)>`,
+				`<svg onload=alert(1)>`,
+				`<details open ontoggle=alert(1)>`,
+			}
+		}
+
+	case ContextAttribute:
+		if reflection.QuoteChar == '"' && chars.DoubleQuote {
+			candidates = []string{
+				`" onfocus=alert(1) autofocus="`,
+				`" onmouseover=alert(1) "`,
+				`"><img src=x onerror=alert(1)>`,
+			}
+		} else if reflection.QuoteChar == '\'' && chars.SingleQuote {
+			candidates = []string{
+				`' onfocus=alert(1) autofocus='`,
+				`' onmouseover=alert(1) '`,
+				`'><img src=x onerror=alert(1)>`,
+			}
+		}
+		// If angle brackets available, try tag breakout even without matching quotes
+		if len(candidates) == 0 && chars.LessThan && chars.GreaterThan {
+			candidates = []string{
+				`"><img src=x onerror=alert(1)>`,
+				`'><img src=x onerror=alert(1)>`,
+			}
+		}
+
+	case ContextAttributeUnquoted:
+		candidates = []string{
+			` onfocus=alert(1) autofocus`,
+			` onmouseover=alert(1)`,
+		}
+		if chars.LessThan && chars.GreaterThan {
+			candidates = append(candidates, `><img src=x onerror=alert(1)>`)
+		}
+
+	case ContextScript:
+		candidates = []string{
+			`</script><img src=x onerror=alert(1)>`,
+			`;alert(1)//`,
+			`\nalert(1)//`,
+		}
+
+	case ContextScriptString:
+		if chars.SingleQuote {
+			candidates = append(candidates, `';alert(1)//`)
+		}
+		if chars.DoubleQuote {
+			candidates = append(candidates, `";alert(1)//`)
+		}
+		if chars.LessThan && chars.GreaterThan {
+			candidates = append(candidates, `</script><img src=x onerror=alert(1)>`)
+		}
+		if len(candidates) == 0 {
+			candidates = []string{`</script><img src=x onerror=alert(1)>`}
+		}
+
+	case ContextStyle:
+		candidates = []string{
+			`</style><img src=x onerror=alert(1)>`,
+		}
+
+	case ContextHTMLComment:
+		candidates = []string{
+			`--><img src=x onerror=alert(1)>`,
+		}
+	}
+
+	return candidates
+}

--- a/pkg/fuzz/analyzers/xss/context.go
+++ b/pkg/fuzz/analyzers/xss/context.go
@@ -259,8 +259,15 @@ func detectAttrQuoting(rawToken, attrName string) (byte, bool) {
 		return '"', false // default to double-quoted
 	}
 	afterEq := idx + len(attrAssign)
+	for afterEq < len(rawToken) {
+		ch := rawToken[afterEq]
+		if ch != ' ' && ch != '\t' && ch != '\n' && ch != '\r' {
+			break
+		}
+		afterEq++
+	}
 	if afterEq >= len(rawToken) {
-		return '"', false
+		return 0, true
 	}
 	switch rawToken[afterEq] {
 	case '"':

--- a/pkg/fuzz/analyzers/xss/context.go
+++ b/pkg/fuzz/analyzers/xss/context.go
@@ -9,12 +9,12 @@ import (
 // DetectReflections parses the HTML body and returns all reflection contexts
 // where the marker is found.
 func DetectReflections(body string, marker string) []ReflectionInfo {
-	if !strings.Contains(body, marker) {
+	markerLower := strings.ToLower(marker)
+	if !strings.Contains(strings.ToLower(body), markerLower) {
 		return nil
 	}
 
 	var reflections []ReflectionInfo
-	markerLower := strings.ToLower(marker)
 
 	tokenizer := html.NewTokenizer(strings.NewReader(body))
 
@@ -44,6 +44,7 @@ func DetectReflections(body string, marker string) []ReflectionInfo {
 
 			switch tagNameLower {
 			case "script":
+				// Empty type means executable JS for script tags.
 				inScript = true
 			case "style":
 				inStyle = true
@@ -52,6 +53,8 @@ func DetectReflections(body string, marker string) []ReflectionInfo {
 					inRCDATA = true
 				}
 			}
+
+			scriptType := ""
 
 			// Check if marker is reflected in the tag name itself
 			if strings.Contains(strings.ToLower(tagName), markerLower) {
@@ -67,6 +70,9 @@ func DetectReflections(body string, marker string) []ReflectionInfo {
 					key, val, moreAttr := tokenizer.TagAttr()
 					attrName := strings.ToLower(string(key))
 					attrVal := string(val)
+					if tagNameLower == "script" && attrName == "type" {
+						scriptType = attrVal
+					}
 
 					// Check if marker is in the attribute value
 					if strings.Contains(strings.ToLower(attrVal), markerLower) {
@@ -76,6 +82,14 @@ func DetectReflections(body string, marker string) []ReflectionInfo {
 						quote, unquoted := detectAttrQuoting(rawToken, attrName)
 						if unquoted {
 							ctx = ContextAttributeUnquoted
+						}
+
+						if isJavaScriptURLAttribute(attrName) && isJavascriptURI(attrVal) {
+							ctx = ContextScript
+						}
+
+						if isHTMLInjectionAttr(attrName) {
+							ctx = ContextHTMLText
 						}
 
 						if isEventHandler(attrName) {
@@ -103,6 +117,10 @@ func DetectReflections(body string, marker string) []ReflectionInfo {
 						break
 					}
 				}
+			}
+
+			if tagNameLower == "script" {
+				inScript = isExecutableScriptType(scriptType)
 			}
 
 		case html.EndTagToken:

--- a/pkg/fuzz/analyzers/xss/context.go
+++ b/pkg/fuzz/analyzers/xss/context.go
@@ -1,0 +1,270 @@
+package xss
+
+import (
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+// DetectReflections parses the HTML body and returns all reflection contexts
+// where the marker is found.
+func DetectReflections(body string, marker string) []ReflectionInfo {
+	if !strings.Contains(body, marker) {
+		return nil
+	}
+
+	var reflections []ReflectionInfo
+	markerLower := strings.ToLower(marker)
+
+	tokenizer := html.NewTokenizer(strings.NewReader(body))
+
+	var tagStack []string
+	inScript := false
+	inStyle := false
+	inRCDATA := false
+
+	for {
+		tt := tokenizer.Next()
+		if tt == html.ErrorToken {
+			break
+		}
+
+		switch tt {
+		case html.StartTagToken, html.SelfClosingTagToken:
+			// Capture raw token text before consuming attributes
+			rawToken := string(tokenizer.Raw())
+
+			tn, hasAttr := tokenizer.TagName()
+			tagName := string(tn)
+			tagNameLower := strings.ToLower(tagName)
+
+			if tt == html.StartTagToken {
+				tagStack = append(tagStack, tagNameLower)
+			}
+
+			switch tagNameLower {
+			case "script":
+				inScript = true
+			case "style":
+				inStyle = true
+			default:
+				if _, ok := rcdataElements[tagNameLower]; ok {
+					inRCDATA = true
+				}
+			}
+
+			// Check if marker is reflected in the tag name itself
+			if strings.Contains(strings.ToLower(tagName), markerLower) {
+				reflections = append(reflections, ReflectionInfo{
+					Context: ContextHTMLText,
+					TagName: tagNameLower,
+				})
+			}
+
+			// Check attributes
+			if hasAttr {
+				for {
+					key, val, moreAttr := tokenizer.TagAttr()
+					attrName := strings.ToLower(string(key))
+					attrVal := string(val)
+
+					// Check if marker is in the attribute value
+					if strings.Contains(strings.ToLower(attrVal), markerLower) {
+						ctx := ContextAttribute
+
+						// Detect quoting style by looking at raw token text
+						quote, unquoted := detectAttrQuoting(rawToken, attrName)
+						if unquoted {
+							ctx = ContextAttributeUnquoted
+						}
+
+						if isEventHandler(attrName) {
+							// Event handler attributes contain JavaScript
+							ctx = ContextScript
+						}
+
+						reflections = append(reflections, ReflectionInfo{
+							Context:   ctx,
+							AttrName:  attrName,
+							QuoteChar: quote,
+							TagName:   tagNameLower,
+						})
+					}
+
+					// Check if marker is in the attribute name
+					if strings.Contains(attrName, markerLower) {
+						reflections = append(reflections, ReflectionInfo{
+							Context: ContextHTMLText,
+							TagName: tagNameLower,
+						})
+					}
+
+					if !moreAttr {
+						break
+					}
+				}
+			}
+
+		case html.EndTagToken:
+			tn, _ := tokenizer.TagName()
+			tagNameLower := strings.ToLower(string(tn))
+
+			switch tagNameLower {
+			case "script":
+				inScript = false
+			case "style":
+				inStyle = false
+			default:
+				if _, ok := rcdataElements[tagNameLower]; ok {
+					inRCDATA = false
+				}
+			}
+
+			// Pop tag stack
+			for i := len(tagStack) - 1; i >= 0; i-- {
+				if tagStack[i] == tagNameLower {
+					tagStack = tagStack[:i]
+					break
+				}
+			}
+
+		case html.TextToken:
+			text := string(tokenizer.Text())
+			if !strings.Contains(strings.ToLower(text), markerLower) {
+				continue
+			}
+
+			if inScript {
+				ctx := detectScriptStringContext(text, marker)
+				parentTag := "script"
+				if len(tagStack) > 0 {
+					parentTag = tagStack[len(tagStack)-1]
+				}
+				reflections = append(reflections, ReflectionInfo{
+					Context: ctx,
+					TagName: parentTag,
+				})
+			} else if inStyle {
+				reflections = append(reflections, ReflectionInfo{
+					Context: ContextStyle,
+					TagName: "style",
+				})
+			} else if inRCDATA {
+				tag := ""
+				if len(tagStack) > 0 {
+					tag = tagStack[len(tagStack)-1]
+				}
+				reflections = append(reflections, ReflectionInfo{
+					Context: ContextHTMLText,
+					TagName: tag,
+				})
+			} else {
+				tag := ""
+				if len(tagStack) > 0 {
+					tag = tagStack[len(tagStack)-1]
+				}
+				reflections = append(reflections, ReflectionInfo{
+					Context: ContextHTMLText,
+					TagName: tag,
+				})
+			}
+
+		case html.CommentToken:
+			text := string(tokenizer.Text())
+			if strings.Contains(strings.ToLower(text), markerLower) {
+				reflections = append(reflections, ReflectionInfo{
+					Context: ContextHTMLComment,
+				})
+			}
+		}
+	}
+
+	return reflections
+}
+
+// detectScriptStringContext determines if the marker is inside a JS string literal
+// or in bare script code.
+func detectScriptStringContext(scriptContent, marker string) Context {
+	markerLower := strings.ToLower(marker)
+	contentLower := strings.ToLower(scriptContent)
+
+	idx := strings.Index(contentLower, markerLower)
+	if idx < 0 {
+		return ContextScript
+	}
+
+	// Walk through the script content tracking quote state
+	inSingleQuote := false
+	inDoubleQuote := false
+	inBacktick := false
+	escaped := false
+
+	for i := 0; i < idx; i++ {
+		ch := scriptContent[i]
+		if escaped {
+			escaped = false
+			continue
+		}
+		if ch == '\\' {
+			escaped = true
+			continue
+		}
+		switch ch {
+		case '\'':
+			if !inDoubleQuote && !inBacktick {
+				inSingleQuote = !inSingleQuote
+			}
+		case '"':
+			if !inSingleQuote && !inBacktick {
+				inDoubleQuote = !inDoubleQuote
+			}
+		case '`':
+			if !inSingleQuote && !inDoubleQuote {
+				inBacktick = !inBacktick
+			}
+		}
+	}
+
+	if inSingleQuote || inDoubleQuote || inBacktick {
+		return ContextScriptString
+	}
+	return ContextScript
+}
+
+// detectAttrQuoting detects the quoting style of an attribute from raw HTML.
+// Returns the quote character and whether the attribute is unquoted.
+func detectAttrQuoting(rawToken, attrName string) (byte, bool) {
+	attrAssign := attrName + "="
+	rawLower := strings.ToLower(rawToken)
+	idx := strings.Index(rawLower, attrAssign)
+	if idx < 0 {
+		return '"', false // default to double-quoted
+	}
+	afterEq := idx + len(attrAssign)
+	if afterEq >= len(rawToken) {
+		return '"', false
+	}
+	switch rawToken[afterEq] {
+	case '"':
+		return '"', false
+	case '\'':
+		return '\'', false
+	default:
+		return 0, true
+	}
+}
+
+// BestReflection returns the highest-priority reflection from the list
+func BestReflection(reflections []ReflectionInfo) *ReflectionInfo {
+	if len(reflections) == 0 {
+		return nil
+	}
+
+	best := &reflections[0]
+	for i := 1; i < len(reflections); i++ {
+		if reflections[i].Context.priority() > best.Context.priority() {
+			best = &reflections[i]
+		}
+	}
+	return best
+}

--- a/pkg/fuzz/analyzers/xss/context_test.go
+++ b/pkg/fuzz/analyzers/xss/context_test.go
@@ -55,6 +55,24 @@ func TestDetectReflections_AttributeSingleQuoted(t *testing.T) {
 	}
 }
 
+func TestDetectReflections_AttributeQuoted_WithSpaceAfterEquals(t *testing.T) {
+	body := `<html><body><input value= "nucleiXSScanary"></body></html>`
+	reflections := DetectReflections(body, testMarker)
+	if len(reflections) == 0 {
+		t.Fatal("expected at least one reflection in spaced quoted attribute")
+	}
+	found := false
+	for _, r := range reflections {
+		if r.Context == ContextAttribute && r.AttrName == "value" && r.QuoteChar == '"' {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected quoted ContextAttribute for spaced assignment, got %v", reflections)
+	}
+}
+
 func TestDetectReflections_ScriptBlock(t *testing.T) {
 	body := `<html><body><script>var x = nucleiXSScanary;</script></body></html>`
 	reflections := DetectReflections(body, testMarker)

--- a/pkg/fuzz/analyzers/xss/context_test.go
+++ b/pkg/fuzz/analyzers/xss/context_test.go
@@ -1,0 +1,496 @@
+package xss
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+const testMarker = "nucleiXSScanary"
+
+func TestDetectReflections_HTMLText(t *testing.T) {
+	body := `<html><body><p>Hello nucleiXSScanary world</p></body></html>`
+	reflections := DetectReflections(body, testMarker)
+	if len(reflections) == 0 {
+		t.Fatal("expected at least one reflection in HTML text")
+	}
+	if reflections[0].Context != ContextHTMLText {
+		t.Fatalf("expected ContextHTMLText, got %s", reflections[0].Context)
+	}
+}
+
+func TestDetectReflections_AttributeDoubleQuoted(t *testing.T) {
+	body := `<html><body><input value="nucleiXSScanary"></body></html>`
+	reflections := DetectReflections(body, testMarker)
+	if len(reflections) == 0 {
+		t.Fatal("expected at least one reflection in attribute")
+	}
+	found := false
+	for _, r := range reflections {
+		if r.Context == ContextAttribute && r.AttrName == "value" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected ContextAttribute for value attr, got %v", reflections)
+	}
+}
+
+func TestDetectReflections_AttributeSingleQuoted(t *testing.T) {
+	body := `<html><body><input value='nucleiXSScanary'></body></html>`
+	reflections := DetectReflections(body, testMarker)
+	if len(reflections) == 0 {
+		t.Fatal("expected at least one reflection in single-quoted attribute")
+	}
+	found := false
+	for _, r := range reflections {
+		if r.Context == ContextAttribute && r.QuoteChar == '\'' {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected single-quoted ContextAttribute, got %v", reflections)
+	}
+}
+
+func TestDetectReflections_ScriptBlock(t *testing.T) {
+	body := `<html><body><script>var x = nucleiXSScanary;</script></body></html>`
+	reflections := DetectReflections(body, testMarker)
+	if len(reflections) == 0 {
+		t.Fatal("expected at least one reflection in script")
+	}
+	if reflections[0].Context != ContextScript {
+		t.Fatalf("expected ContextScript, got %s", reflections[0].Context)
+	}
+}
+
+func TestDetectReflections_ScriptStringDouble(t *testing.T) {
+	body := `<html><body><script>var x = "nucleiXSScanary";</script></body></html>`
+	reflections := DetectReflections(body, testMarker)
+	if len(reflections) == 0 {
+		t.Fatal("expected at least one reflection in script string")
+	}
+	if reflections[0].Context != ContextScriptString {
+		t.Fatalf("expected ContextScriptString, got %s", reflections[0].Context)
+	}
+}
+
+func TestDetectReflections_ScriptStringSingle(t *testing.T) {
+	body := `<html><body><script>var x = 'nucleiXSScanary';</script></body></html>`
+	reflections := DetectReflections(body, testMarker)
+	if len(reflections) == 0 {
+		t.Fatal("expected at least one reflection in script string")
+	}
+	if reflections[0].Context != ContextScriptString {
+		t.Fatalf("expected ContextScriptString, got %s", reflections[0].Context)
+	}
+}
+
+func TestDetectReflections_ScriptStringBacktick(t *testing.T) {
+	body := "<html><body><script>var x = `nucleiXSScanary`;</script></body></html>"
+	reflections := DetectReflections(body, testMarker)
+	if len(reflections) == 0 {
+		t.Fatal("expected at least one reflection in template literal")
+	}
+	if reflections[0].Context != ContextScriptString {
+		t.Fatalf("expected ContextScriptString, got %s", reflections[0].Context)
+	}
+}
+
+func TestDetectReflections_HTMLComment(t *testing.T) {
+	body := `<html><body><!-- nucleiXSScanary --></body></html>`
+	reflections := DetectReflections(body, testMarker)
+	if len(reflections) == 0 {
+		t.Fatal("expected at least one reflection in HTML comment")
+	}
+	if reflections[0].Context != ContextHTMLComment {
+		t.Fatalf("expected ContextHTMLComment, got %s", reflections[0].Context)
+	}
+}
+
+func TestDetectReflections_StyleBlock(t *testing.T) {
+	body := `<html><head><style>.x { background: url(nucleiXSScanary); }</style></head></html>`
+	reflections := DetectReflections(body, testMarker)
+	if len(reflections) == 0 {
+		t.Fatal("expected at least one reflection in style")
+	}
+	if reflections[0].Context != ContextStyle {
+		t.Fatalf("expected ContextStyle, got %s", reflections[0].Context)
+	}
+}
+
+func TestDetectReflections_EventHandler(t *testing.T) {
+	body := `<html><body><div onmouseover="nucleiXSScanary">test</div></body></html>`
+	reflections := DetectReflections(body, testMarker)
+	if len(reflections) == 0 {
+		t.Fatal("expected at least one reflection in event handler")
+	}
+	found := false
+	for _, r := range reflections {
+		if r.Context == ContextScript && r.AttrName == "onmouseover" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected ContextScript for event handler, got %v", reflections)
+	}
+}
+
+func TestDetectReflections_NoReflection(t *testing.T) {
+	body := `<html><body><p>Hello world</p></body></html>`
+	reflections := DetectReflections(body, testMarker)
+	if len(reflections) != 0 {
+		t.Fatalf("expected no reflections, got %d", len(reflections))
+	}
+}
+
+func TestDetectReflections_MultipleContexts(t *testing.T) {
+	body := `<html><body>
+		<p>nucleiXSScanary</p>
+		<input value="nucleiXSScanary">
+		<script>var x = "nucleiXSScanary";</script>
+	</body></html>`
+	reflections := DetectReflections(body, testMarker)
+	if len(reflections) < 3 {
+		t.Fatalf("expected at least 3 reflections, got %d", len(reflections))
+	}
+
+	contexts := make(map[Context]bool)
+	for _, r := range reflections {
+		contexts[r.Context] = true
+	}
+	if !contexts[ContextHTMLText] {
+		t.Error("expected ContextHTMLText in multiple reflections")
+	}
+	if !contexts[ContextAttribute] {
+		t.Error("expected ContextAttribute in multiple reflections")
+	}
+	if !contexts[ContextScriptString] {
+		t.Error("expected ContextScriptString in multiple reflections")
+	}
+}
+
+func TestDetectReflections_Textarea(t *testing.T) {
+	body := `<html><body><textarea>nucleiXSScanary</textarea></body></html>`
+	reflections := DetectReflections(body, testMarker)
+	if len(reflections) == 0 {
+		t.Fatal("expected reflection in textarea (RCDATA element)")
+	}
+	if reflections[0].Context != ContextHTMLText {
+		t.Fatalf("expected ContextHTMLText for RCDATA element, got %s", reflections[0].Context)
+	}
+}
+
+func TestDetectReflections_Title(t *testing.T) {
+	body := `<html><head><title>nucleiXSScanary</title></head></html>`
+	reflections := DetectReflections(body, testMarker)
+	if len(reflections) == 0 {
+		t.Fatal("expected reflection in title element")
+	}
+}
+
+func TestDetectReflections_CaseInsensitive(t *testing.T) {
+	body := `<html><body><p>NUCLEIxssCANARY</p></body></html>`
+	reflections := DetectReflections(body, "nucleixsscanary")
+	if len(reflections) == 0 {
+		t.Fatal("expected case-insensitive reflection detection")
+	}
+}
+
+func TestDetectReflections_TagNameReflection(t *testing.T) {
+	body := `<html><body><nucleiXSScanary>test</nucleiXSScanary></body></html>`
+	reflections := DetectReflections(body, testMarker)
+	if len(reflections) == 0 {
+		t.Fatal("expected reflection in tag name")
+	}
+}
+
+func TestBestReflection_Priority(t *testing.T) {
+	reflections := []ReflectionInfo{
+		{Context: ContextHTMLComment},
+		{Context: ContextHTMLText},
+		{Context: ContextAttribute},
+		{Context: ContextScript},
+	}
+	best := BestReflection(reflections)
+	if best == nil || best.Context != ContextScript {
+		t.Fatal("expected ContextScript as highest priority")
+	}
+}
+
+func TestBestReflection_Empty(t *testing.T) {
+	best := BestReflection(nil)
+	if best != nil {
+		t.Fatal("expected nil for empty reflections")
+	}
+}
+
+func TestDetectScriptStringContext_NotInString(t *testing.T) {
+	content := `var x = nucleiXSScanary;`
+	ctx := detectScriptStringContext(content, testMarker)
+	if ctx != ContextScript {
+		t.Fatalf("expected ContextScript, got %s", ctx)
+	}
+}
+
+func TestDetectScriptStringContext_InDoubleQuote(t *testing.T) {
+	content := `var x = "nucleiXSScanary";`
+	ctx := detectScriptStringContext(content, testMarker)
+	if ctx != ContextScriptString {
+		t.Fatalf("expected ContextScriptString, got %s", ctx)
+	}
+}
+
+func TestDetectScriptStringContext_InSingleQuote(t *testing.T) {
+	content := `var x = 'nucleiXSScanary';`
+	ctx := detectScriptStringContext(content, testMarker)
+	if ctx != ContextScriptString {
+		t.Fatalf("expected ContextScriptString, got %s", ctx)
+	}
+}
+
+func TestDetectScriptStringContext_EscapedQuote(t *testing.T) {
+	content := `var x = "test\"nucleiXSScanary";`
+	ctx := detectScriptStringContext(content, testMarker)
+	if ctx != ContextScriptString {
+		t.Fatalf("expected ContextScriptString for escaped quote, got %s", ctx)
+	}
+}
+
+func TestDetectScriptStringContext_AfterClosedString(t *testing.T) {
+	content := `var x = "test"; var y = nucleiXSScanary;`
+	ctx := detectScriptStringContext(content, testMarker)
+	if ctx != ContextScript {
+		t.Fatalf("expected ContextScript after closed string, got %s", ctx)
+	}
+}
+
+func TestIsEventHandler(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected bool
+	}{
+		{"onclick", true},
+		{"onload", true},
+		{"onerror", true},
+		{"onmouseover", true},
+		{"ONCLICK", true},
+		{"OnClick", true},
+		{"class", false},
+		{"href", false},
+		{"style", false},
+		{"data-onclick", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isEventHandler(tt.name); got != tt.expected {
+				t.Errorf("isEventHandler(%q) = %v, want %v", tt.name, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestContextString(t *testing.T) {
+	tests := []struct {
+		ctx      Context
+		expected string
+	}{
+		{ContextNone, "none"},
+		{ContextHTMLComment, "html_comment"},
+		{ContextHTMLText, "html_text"},
+		{ContextAttribute, "attribute"},
+		{ContextAttributeUnquoted, "attribute_unquoted"},
+		{ContextScript, "script"},
+		{ContextScriptString, "script_string"},
+		{ContextStyle, "style"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			if got := tt.ctx.String(); got != tt.expected {
+				t.Errorf("Context.String() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSelectPayloads(t *testing.T) {
+	tests := []struct {
+		name       string
+		reflection ReflectionInfo
+		chars      CharacterSet
+		wantEmpty  bool
+	}{
+		{
+			name:       "HTML text with angle brackets",
+			reflection: ReflectionInfo{Context: ContextHTMLText},
+			chars:      CharacterSet{LessThan: true, GreaterThan: true},
+			wantEmpty:  false,
+		},
+		{
+			name:       "HTML text without angle brackets",
+			reflection: ReflectionInfo{Context: ContextHTMLText},
+			chars:      CharacterSet{},
+			wantEmpty:  true,
+		},
+		{
+			name:       "Double-quoted attribute with quotes",
+			reflection: ReflectionInfo{Context: ContextAttribute, QuoteChar: '"'},
+			chars:      CharacterSet{DoubleQuote: true},
+			wantEmpty:  false,
+		},
+		{
+			name:       "Script context",
+			reflection: ReflectionInfo{Context: ContextScript},
+			chars:      CharacterSet{},
+			wantEmpty:  false,
+		},
+		{
+			name:       "Script string with single quote",
+			reflection: ReflectionInfo{Context: ContextScriptString},
+			chars:      CharacterSet{SingleQuote: true},
+			wantEmpty:  false,
+		},
+		{
+			name:       "Comment context",
+			reflection: ReflectionInfo{Context: ContextHTMLComment},
+			chars:      CharacterSet{},
+			wantEmpty:  false,
+		},
+		{
+			name:       "Style context",
+			reflection: ReflectionInfo{Context: ContextStyle},
+			chars:      CharacterSet{},
+			wantEmpty:  false,
+		},
+		{
+			name:       "Unquoted attribute",
+			reflection: ReflectionInfo{Context: ContextAttributeUnquoted},
+			chars:      CharacterSet{},
+			wantEmpty:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			payloads := selectPayloads(&tt.reflection, tt.chars)
+			if tt.wantEmpty && len(payloads) > 0 {
+				t.Errorf("expected no payloads, got %d", len(payloads))
+			}
+			if !tt.wantEmpty && len(payloads) == 0 {
+				t.Error("expected payloads but got none")
+			}
+		})
+	}
+}
+
+func TestDetectCharacterSurvival(t *testing.T) {
+	canary := "testcanary"
+	body := canary + `<>"'/`
+	chars := detectCharacterSurvival(body, canary)
+	if !chars.LessThan {
+		t.Error("expected LessThan to survive")
+	}
+	if !chars.GreaterThan {
+		t.Error("expected GreaterThan to survive")
+	}
+	if !chars.DoubleQuote {
+		t.Error("expected DoubleQuote to survive")
+	}
+	if !chars.SingleQuote {
+		t.Error("expected SingleQuote to survive")
+	}
+	if !chars.ForwardSlash {
+		t.Error("expected ForwardSlash to survive")
+	}
+}
+
+func TestDetectCharacterSurvival_Encoded(t *testing.T) {
+	canary := "testcanary"
+	body := canary + `&lt;&gt;&quot;&#39;/`
+	chars := detectCharacterSurvival(body, canary)
+	if chars.LessThan {
+		t.Error("expected LessThan to be encoded")
+	}
+	if chars.GreaterThan {
+		t.Error("expected GreaterThan to be encoded")
+	}
+}
+
+func TestIsHTMLResponse(t *testing.T) {
+	tests := []struct {
+		name     string
+		headers  map[string][]string
+		expected bool
+	}{
+		{"nil headers", nil, true},
+		{"empty headers", map[string][]string{}, true},
+		{"text/html", map[string][]string{"Content-Type": {"text/html; charset=utf-8"}}, true},
+		{"application/xhtml", map[string][]string{"Content-Type": {"application/xhtml+xml"}}, true},
+		{"application/json", map[string][]string{"Content-Type": {"application/json"}}, false},
+		{"text/plain", map[string][]string{"Content-Type": {"text/plain"}}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isHTMLResponse(tt.headers); got != tt.expected {
+				t.Errorf("isHTMLResponse() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestHasCSP(t *testing.T) {
+	tests := []struct {
+		name     string
+		headers  map[string][]string
+		expected bool
+	}{
+		{"no CSP", map[string][]string{}, false},
+		{"has CSP", map[string][]string{"Content-Security-Policy": {"default-src 'self'"}}, true},
+		{"nil headers", nil, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasCSP(tt.headers); got != tt.expected {
+				t.Errorf("hasCSP() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func BenchmarkDetectReflections(b *testing.B) {
+	var sb strings.Builder
+	sb.WriteString("<html><body>")
+	for i := 0; i < 100; i++ {
+		sb.WriteString(fmt.Sprintf("<div class='item-%d'>Content %d</div>", i, i))
+	}
+	sb.WriteString("<p>nucleiXSScanary</p>")
+	sb.WriteString("</body></html>")
+	body := sb.String()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		DetectReflections(body, testMarker)
+	}
+}
+
+func BenchmarkDetectReflections_LargeBody(b *testing.B) {
+	var sb strings.Builder
+	sb.WriteString("<html><body>")
+	for i := 0; i < 1000; i++ {
+		sb.WriteString(fmt.Sprintf(`<div id="item-%d"><a href="/page/%d">Link %d</a><span class="data">Data %d</span></div>`, i, i, i, i))
+	}
+	sb.WriteString(`<input value="nucleiXSScanary">`)
+	sb.WriteString("</body></html>")
+	body := sb.String()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		DetectReflections(body, testMarker)
+	}
+}

--- a/pkg/fuzz/analyzers/xss/context_test.go
+++ b/pkg/fuzz/analyzers/xss/context_test.go
@@ -139,6 +139,72 @@ func TestDetectReflections_EventHandler(t *testing.T) {
 	}
 }
 
+func TestDetectReflections_JavascriptURI(t *testing.T) {
+	body := `<html><body><a href="javascript:alert(nucleiXSScanary)">click</a></body></html>`
+	reflections := DetectReflections(body, testMarker)
+	if len(reflections) == 0 {
+		t.Fatal("expected at least one reflection in javascript: URI")
+	}
+
+	found := false
+	for _, r := range reflections {
+		if r.AttrName == "href" {
+			if r.Context != ContextScript {
+				t.Fatalf("expected ContextScript for javascript: URI, got %s", r.Context)
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected reflection for href attribute, got %v", reflections)
+	}
+}
+
+func TestDetectReflections_ScriptTypeApplicationJSON(t *testing.T) {
+	body := `<html><body><script type="application/json">{"x":"nucleiXSScanary"}</script></body></html>`
+	reflections := DetectReflections(body, testMarker)
+	if len(reflections) == 0 {
+		t.Fatal("expected at least one reflection in non-executable script block")
+	}
+	for _, r := range reflections {
+		if r.Context == ContextScript || r.Context == ContextScriptString {
+			t.Fatalf("expected non-script context for application/json script, got %s", r.Context)
+		}
+	}
+}
+
+func TestDetectReflections_ScriptTypeModule(t *testing.T) {
+	body := `<html><body><script type="module">const x = "nucleiXSScanary";</script></body></html>`
+	reflections := DetectReflections(body, testMarker)
+	if len(reflections) == 0 {
+		t.Fatal("expected at least one reflection in module script block")
+	}
+	if reflections[0].Context != ContextScriptString {
+		t.Fatalf("expected ContextScriptString, got %s", reflections[0].Context)
+	}
+}
+
+func TestDetectReflections_Srcdoc(t *testing.T) {
+	body := `<html><body><iframe srcdoc="<img src=x onerror=alert(nucleiXSScanary)>"></iframe></body></html>`
+	reflections := DetectReflections(body, testMarker)
+	if len(reflections) == 0 {
+		t.Fatal("expected at least one reflection in srcdoc attribute")
+	}
+
+	found := false
+	for _, r := range reflections {
+		if r.AttrName == "srcdoc" {
+			if r.Context != ContextHTMLText {
+				t.Fatalf("expected ContextHTMLText for srcdoc, got %s", r.Context)
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected reflection for srcdoc attribute, got %v", reflections)
+	}
+}
+
 func TestDetectReflections_NoReflection(t *testing.T) {
 	body := `<html><body><p>Hello world</p></body></html>`
 	reflections := DetectReflections(body, testMarker)
@@ -291,6 +357,85 @@ func TestIsEventHandler(t *testing.T) {
 				t.Errorf("isEventHandler(%q) = %v, want %v", tt.name, got, tt.expected)
 			}
 		})
+	}
+}
+
+func TestIsExecutableScriptType(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected bool
+	}{
+		{"", true},
+		{"text/javascript", true},
+		{"application/javascript", true},
+		{"application/ecmascript", true},
+		{"module", true},
+		{"application/json", false},
+		{"application/ld+json", false},
+		{"text/plain", false},
+		{"application/json; charset=utf-8", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := isExecutableScriptType(tt.input); got != tt.expected {
+				t.Errorf("isExecutableScriptType(%q) = %v, want %v", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsJavaScriptURLAttribute(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected bool
+	}{
+		{"href", true},
+		{"src", true},
+		{"formaction", true},
+		{"xlink:href", true},
+		{"data-href", false},
+		{"class", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isJavaScriptURLAttribute(tt.name); got != tt.expected {
+				t.Errorf("isJavaScriptURLAttribute(%q) = %v, want %v", tt.name, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsJavascriptURI(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected bool
+	}{
+		{"javascript:alert(1)", true},
+		{" JAVASCRIPT:void(0)", true},
+		{"https://example.com", false},
+		{"data:text/html,<h1>x</h1>", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := isJavascriptURI(tt.input); got != tt.expected {
+				t.Errorf("isJavascriptURI(%q) = %v, want %v", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsHTMLInjectionAttr(t *testing.T) {
+	if !isHTMLInjectionAttr("srcdoc") {
+		t.Fatal("expected srcdoc to be treated as HTML injection attribute")
+	}
+	if !isHTMLInjectionAttr("SRCDOC") {
+		t.Fatal("expected case-insensitive srcdoc match")
+	}
+	if isHTMLInjectionAttr("href") {
+		t.Fatal("expected href not to be treated as HTML injection attribute")
 	}
 }
 

--- a/pkg/fuzz/analyzers/xss/types.go
+++ b/pkg/fuzz/analyzers/xss/types.go
@@ -1,0 +1,206 @@
+package xss
+
+import "strings"
+
+// Context represents the HTML context where a reflection occurs
+type Context int
+
+const (
+	// ContextNone means the marker was not found in the response
+	ContextNone Context = iota
+	// ContextHTMLComment means the marker is inside an HTML comment
+	ContextHTMLComment
+	// ContextHTMLText means the marker is inside HTML text content
+	ContextHTMLText
+	// ContextAttribute means the marker is inside a quoted HTML attribute
+	ContextAttribute
+	// ContextAttributeUnquoted means the marker is inside an unquoted HTML attribute
+	ContextAttributeUnquoted
+	// ContextScript means the marker is inside a script block
+	ContextScript
+	// ContextScriptString means the marker is inside a string literal within a script block
+	ContextScriptString
+	// ContextStyle means the marker is inside a style block
+	ContextStyle
+)
+
+// String returns the string representation of the context
+func (c Context) String() string {
+	switch c {
+	case ContextNone:
+		return "none"
+	case ContextHTMLComment:
+		return "html_comment"
+	case ContextHTMLText:
+		return "html_text"
+	case ContextAttribute:
+		return "attribute"
+	case ContextAttributeUnquoted:
+		return "attribute_unquoted"
+	case ContextScript:
+		return "script"
+	case ContextScriptString:
+		return "script_string"
+	case ContextStyle:
+		return "style"
+	default:
+		return "unknown"
+	}
+}
+
+// priority returns the priority of the context for choosing the best one.
+// Higher value = more interesting for exploitation.
+func (c Context) priority() int {
+	switch c {
+	case ContextScript, ContextScriptString:
+		return 5
+	case ContextAttributeUnquoted:
+		return 4
+	case ContextAttribute:
+		return 3
+	case ContextHTMLText:
+		return 2
+	case ContextStyle:
+		return 1
+	case ContextHTMLComment:
+		return 0
+	default:
+		return -1
+	}
+}
+
+// ReflectionInfo holds information about a detected reflection
+type ReflectionInfo struct {
+	Context   Context
+	AttrName  string // attribute name if in attribute context
+	QuoteChar byte   // quote character if in attribute context (' or ")
+	TagName   string // parent tag name
+}
+
+// CharacterSet tracks which XSS-critical characters survived encoding
+type CharacterSet struct {
+	LessThan    bool // <
+	GreaterThan bool // >
+	DoubleQuote bool // "
+	SingleQuote bool // '
+	ForwardSlash bool // /
+}
+
+// canaryChars are the characters appended to the canary to check survival
+const canaryChars = `<>"'/`
+
+// eventHandlers is a set of known HTML event handler attribute names
+var eventHandlers = map[string]struct{}{
+	"onabort":             {},
+	"onafterprint":        {},
+	"onanimationend":      {},
+	"onanimationiteration": {},
+	"onanimationstart":    {},
+	"onauxclick":          {},
+	"onbeforecopy":        {},
+	"onbeforecut":         {},
+	"onbeforeinput":       {},
+	"onbeforepaste":       {},
+	"onbeforeprint":       {},
+	"onbeforeunload":      {},
+	"onblur":              {},
+	"oncanplay":           {},
+	"oncanplaythrough":    {},
+	"onchange":            {},
+	"onclick":             {},
+	"onclose":             {},
+	"oncontextmenu":       {},
+	"oncopy":              {},
+	"oncuechange":         {},
+	"oncut":               {},
+	"ondblclick":          {},
+	"ondrag":              {},
+	"ondragend":           {},
+	"ondragenter":         {},
+	"ondragleave":         {},
+	"ondragover":          {},
+	"ondragstart":         {},
+	"ondrop":              {},
+	"ondurationchange":    {},
+	"onemptied":           {},
+	"onended":             {},
+	"onerror":             {},
+	"onfocus":             {},
+	"onfocusin":           {},
+	"onfocusout":          {},
+	"onfullscreenchange":  {},
+	"ongotpointercapture": {},
+	"onhashchange":        {},
+	"oninput":             {},
+	"oninvalid":           {},
+	"onkeydown":           {},
+	"onkeypress":          {},
+	"onkeyup":             {},
+	"onload":              {},
+	"onloadeddata":        {},
+	"onloadedmetadata":    {},
+	"onloadstart":         {},
+	"onmessage":           {},
+	"onmousedown":         {},
+	"onmouseenter":        {},
+	"onmouseleave":        {},
+	"onmousemove":         {},
+	"onmouseout":          {},
+	"onmouseover":         {},
+	"onmouseup":           {},
+	"onmousewheel":        {},
+	"onoffline":           {},
+	"ononline":            {},
+	"onpagehide":          {},
+	"onpageshow":          {},
+	"onpaste":             {},
+	"onpause":             {},
+	"onplay":              {},
+	"onplaying":           {},
+	"onpointerdown":       {},
+	"onpointerenter":      {},
+	"onpointerleave":      {},
+	"onpointermove":       {},
+	"onpointerout":        {},
+	"onpointerover":       {},
+	"onpointerup":         {},
+	"onpopstate":          {},
+	"onprogress":          {},
+	"onratechange":        {},
+	"onreset":             {},
+	"onresize":            {},
+	"onscroll":            {},
+	"onsearch":            {},
+	"onseeked":            {},
+	"onseeking":           {},
+	"onselect":            {},
+	"onstalled":           {},
+	"onstorage":           {},
+	"onsubmit":            {},
+	"onsuspend":           {},
+	"ontimeupdate":        {},
+	"ontoggle":            {},
+	"ontouchcancel":       {},
+	"ontouchend":          {},
+	"ontouchmove":         {},
+	"ontouchstart":        {},
+	"ontransitionend":     {},
+	"onunload":            {},
+	"onvolumechange":      {},
+	"onwaiting":           {},
+	"onwheel":             {},
+}
+
+// isEventHandler returns true if the attribute name is a known event handler
+func isEventHandler(name string) bool {
+	_, ok := eventHandlers[strings.ToLower(name)]
+	return ok
+}
+
+// rcdataElements are HTML elements whose content is treated as RCDATA (no tag parsing)
+var rcdataElements = map[string]struct{}{
+	"textarea": {},
+	"title":    {},
+	"xmp":      {},
+	"noscript": {},
+}

--- a/pkg/fuzz/analyzers/xss/types.go
+++ b/pkg/fuzz/analyzers/xss/types.go
@@ -79,10 +79,10 @@ type ReflectionInfo struct {
 
 // CharacterSet tracks which XSS-critical characters survived encoding
 type CharacterSet struct {
-	LessThan    bool // <
-	GreaterThan bool // >
-	DoubleQuote bool // "
-	SingleQuote bool // '
+	LessThan     bool // <
+	GreaterThan  bool // >
+	DoubleQuote  bool // "
+	SingleQuote  bool // '
 	ForwardSlash bool // /
 }
 
@@ -91,104 +91,104 @@ const canaryChars = `<>"'/`
 
 // eventHandlers is a set of known HTML event handler attribute names
 var eventHandlers = map[string]struct{}{
-	"onabort":             {},
-	"onafterprint":        {},
-	"onanimationend":      {},
+	"onabort":              {},
+	"onafterprint":         {},
+	"onanimationend":       {},
 	"onanimationiteration": {},
-	"onanimationstart":    {},
-	"onauxclick":          {},
-	"onbeforecopy":        {},
-	"onbeforecut":         {},
-	"onbeforeinput":       {},
-	"onbeforepaste":       {},
-	"onbeforeprint":       {},
-	"onbeforeunload":      {},
-	"onblur":              {},
-	"oncanplay":           {},
-	"oncanplaythrough":    {},
-	"onchange":            {},
-	"onclick":             {},
-	"onclose":             {},
-	"oncontextmenu":       {},
-	"oncopy":              {},
-	"oncuechange":         {},
-	"oncut":               {},
-	"ondblclick":          {},
-	"ondrag":              {},
-	"ondragend":           {},
-	"ondragenter":         {},
-	"ondragleave":         {},
-	"ondragover":          {},
-	"ondragstart":         {},
-	"ondrop":              {},
-	"ondurationchange":    {},
-	"onemptied":           {},
-	"onended":             {},
-	"onerror":             {},
-	"onfocus":             {},
-	"onfocusin":           {},
-	"onfocusout":          {},
-	"onfullscreenchange":  {},
-	"ongotpointercapture": {},
-	"onhashchange":        {},
-	"oninput":             {},
-	"oninvalid":           {},
-	"onkeydown":           {},
-	"onkeypress":          {},
-	"onkeyup":             {},
-	"onload":              {},
-	"onloadeddata":        {},
-	"onloadedmetadata":    {},
-	"onloadstart":         {},
-	"onmessage":           {},
-	"onmousedown":         {},
-	"onmouseenter":        {},
-	"onmouseleave":        {},
-	"onmousemove":         {},
-	"onmouseout":          {},
-	"onmouseover":         {},
-	"onmouseup":           {},
-	"onmousewheel":        {},
-	"onoffline":           {},
-	"ononline":            {},
-	"onpagehide":          {},
-	"onpageshow":          {},
-	"onpaste":             {},
-	"onpause":             {},
-	"onplay":              {},
-	"onplaying":           {},
-	"onpointerdown":       {},
-	"onpointerenter":      {},
-	"onpointerleave":      {},
-	"onpointermove":       {},
-	"onpointerout":        {},
-	"onpointerover":       {},
-	"onpointerup":         {},
-	"onpopstate":          {},
-	"onprogress":          {},
-	"onratechange":        {},
-	"onreset":             {},
-	"onresize":            {},
-	"onscroll":            {},
-	"onsearch":            {},
-	"onseeked":            {},
-	"onseeking":           {},
-	"onselect":            {},
-	"onstalled":           {},
-	"onstorage":           {},
-	"onsubmit":            {},
-	"onsuspend":           {},
-	"ontimeupdate":        {},
-	"ontoggle":            {},
-	"ontouchcancel":       {},
-	"ontouchend":          {},
-	"ontouchmove":         {},
-	"ontouchstart":        {},
-	"ontransitionend":     {},
-	"onunload":            {},
-	"onvolumechange":      {},
-	"onwaiting":           {},
-	"onwheel":             {},
+	"onanimationstart":     {},
+	"onauxclick":           {},
+	"onbeforecopy":         {},
+	"onbeforecut":          {},
+	"onbeforeinput":        {},
+	"onbeforepaste":        {},
+	"onbeforeprint":        {},
+	"onbeforeunload":       {},
+	"onblur":               {},
+	"oncanplay":            {},
+	"oncanplaythrough":     {},
+	"onchange":             {},
+	"onclick":              {},
+	"onclose":              {},
+	"oncontextmenu":        {},
+	"oncopy":               {},
+	"oncuechange":          {},
+	"oncut":                {},
+	"ondblclick":           {},
+	"ondrag":               {},
+	"ondragend":            {},
+	"ondragenter":          {},
+	"ondragleave":          {},
+	"ondragover":           {},
+	"ondragstart":          {},
+	"ondrop":               {},
+	"ondurationchange":     {},
+	"onemptied":            {},
+	"onended":              {},
+	"onerror":              {},
+	"onfocus":              {},
+	"onfocusin":            {},
+	"onfocusout":           {},
+	"onfullscreenchange":   {},
+	"ongotpointercapture":  {},
+	"onhashchange":         {},
+	"oninput":              {},
+	"oninvalid":            {},
+	"onkeydown":            {},
+	"onkeypress":           {},
+	"onkeyup":              {},
+	"onload":               {},
+	"onloadeddata":         {},
+	"onloadedmetadata":     {},
+	"onloadstart":          {},
+	"onmessage":            {},
+	"onmousedown":          {},
+	"onmouseenter":         {},
+	"onmouseleave":         {},
+	"onmousemove":          {},
+	"onmouseout":           {},
+	"onmouseover":          {},
+	"onmouseup":            {},
+	"onmousewheel":         {},
+	"onoffline":            {},
+	"ononline":             {},
+	"onpagehide":           {},
+	"onpageshow":           {},
+	"onpaste":              {},
+	"onpause":              {},
+	"onplay":               {},
+	"onplaying":            {},
+	"onpointerdown":        {},
+	"onpointerenter":       {},
+	"onpointerleave":       {},
+	"onpointermove":        {},
+	"onpointerout":         {},
+	"onpointerover":        {},
+	"onpointerup":          {},
+	"onpopstate":           {},
+	"onprogress":           {},
+	"onratechange":         {},
+	"onreset":              {},
+	"onresize":             {},
+	"onscroll":             {},
+	"onsearch":             {},
+	"onseeked":             {},
+	"onseeking":            {},
+	"onselect":             {},
+	"onstalled":            {},
+	"onstorage":            {},
+	"onsubmit":             {},
+	"onsuspend":            {},
+	"ontimeupdate":         {},
+	"ontoggle":             {},
+	"ontouchcancel":        {},
+	"ontouchend":           {},
+	"ontouchmove":          {},
+	"ontouchstart":         {},
+	"ontransitionend":      {},
+	"onunload":             {},
+	"onvolumechange":       {},
+	"onwaiting":            {},
+	"onwheel":              {},
 }
 
 // isEventHandler returns true if the attribute name is a known event handler
@@ -203,4 +203,53 @@ var rcdataElements = map[string]struct{}{
 	"title":    {},
 	"xmp":      {},
 	"noscript": {},
+}
+
+// isExecutableScriptType returns true if script type resolves to executable JavaScript.
+// Empty type defaults to classic JavaScript behavior in browsers.
+func isExecutableScriptType(scriptType string) bool {
+	normalized := strings.TrimSpace(strings.ToLower(scriptType))
+	if normalized == "" {
+		return true
+	}
+	if idx := strings.IndexByte(normalized, ';'); idx >= 0 {
+		normalized = strings.TrimSpace(normalized[:idx])
+	}
+	if normalized == "module" {
+		return true
+	}
+	return strings.Contains(normalized, "javascript") ||
+		strings.Contains(normalized, "ecmascript") ||
+		strings.Contains(normalized, "jscript") ||
+		strings.Contains(normalized, "livescript")
+}
+
+var htmlInjectionAttrs = map[string]struct{}{
+	"srcdoc": {},
+}
+
+func isHTMLInjectionAttr(name string) bool {
+	_, ok := htmlInjectionAttrs[strings.ToLower(name)]
+	return ok
+}
+
+var javaScriptURLAttrs = map[string]struct{}{
+	"action":     {},
+	"cite":       {},
+	"data":       {},
+	"formaction": {},
+	"href":       {},
+	"poster":     {},
+	"src":        {},
+	"xlink:href": {},
+}
+
+func isJavaScriptURLAttribute(name string) bool {
+	_, ok := javaScriptURLAttrs[strings.ToLower(name)]
+	return ok
+}
+
+func isJavascriptURI(value string) bool {
+	normalized := strings.TrimSpace(strings.ToLower(value))
+	return strings.HasPrefix(normalized, "javascript:")
 }

--- a/pkg/protocols/http/http.go
+++ b/pkg/protocols/http/http.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/projectdiscovery/fastdialer/fastdialer"
 	_ "github.com/projectdiscovery/nuclei/v3/pkg/fuzz/analyzers/time"
+	_ "github.com/projectdiscovery/nuclei/v3/pkg/fuzz/analyzers/xss"
 
 	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz"
 	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz/analyzers"

--- a/pkg/protocols/http/request.go
+++ b/pkg/protocols/http/request.go
@@ -1009,11 +1009,20 @@ func (request *Request) executeRequest(input *contextargs.Context, generatedRequ
 
 		if request.Analyzer != nil {
 			analyzer := analyzers.GetAnalyzer(request.Analyzer.Name)
+			var respHeaders map[string][]string
+			var respStatusCode int
+			if respChain.Response() != nil {
+				respHeaders = respChain.Response().Header
+				respStatusCode = respChain.Response().StatusCode
+			}
 			analysisMatched, analysisDetails, err := analyzer.Analyze(&analyzers.Options{
 				FuzzGenerated:      generatedRequest.fuzzGeneratedRequest,
 				HttpClient:         request.httpClient,
 				ResponseTimeDelay:  duration,
 				AnalyzerParameters: request.Analyzer.Parameters,
+				ResponseBody:       bodyStr,
+				ResponseHeaders:    respHeaders,
+				ResponseStatusCode: respStatusCode,
 			})
 			if err != nil {
 				gologger.Warning().Msgf("Could not analyze response: %v\n", err)

--- a/pkg/protocols/http/request_fuzz.go
+++ b/pkg/protocols/http/request_fuzz.go
@@ -150,6 +150,9 @@ func (request *Request) executeAllFuzzingRules(input *contextargs.Context, value
 		if request.Analyzer != nil {
 			analyzer := analyzers.GetAnalyzer(request.Analyzer.Name)
 			input.ApplyPayloadInitialTransformation = analyzer.ApplyInitialTransformation
+			if request.Analyzer.Parameters == nil {
+				request.Analyzer.Parameters = make(map[string]interface{})
+			}
 			input.AnalyzerParams = request.Analyzer.Parameters
 		}
 		err := rule.Execute(input)


### PR DESCRIPTION
/claim #7086

## Proposed Changes
- Added the `xss_context` analyzer implementation for the fuzzing engine and wired it into HTTP fuzz execution so analyzer replay can use response body/headers context.
- Added XSS context detection + payload selection modules under `pkg/fuzz/analyzers/xss`.
- Fixed the four edge cases from #7086:
  - classify `javascript:` URI reflections in URL-bearing attributes as `ContextScript`
  - treat non-executable script MIME types (for example `application/json`) as non-script context
  - make initial reflection detection case-insensitive
  - classify `srcdoc` as HTML-injection context (`ContextHTMLText`)
- Added/extended regression tests for the above behavior in `pkg/fuzz/analyzers/xss/context_test.go`.

## Proof
```bash
go test ./pkg/fuzz/analyzers/xss -count=1
ok   github.com/projectdiscovery/nuclei/v3/pkg/fuzz/analyzers/xss 0.730s

go test ./pkg/protocols/http -run TestDoesNotExist -count=1
ok   github.com/projectdiscovery/nuclei/v3/pkg/protocols/http 0.775s [no tests to run]
```

## Checklist
- [x] PR created against `dev`
- [x] Tests added/updated for the fix
- [x] Relevant test commands executed locally
- [ ] Additional docs needed (not required for this bugfix)

If this PR is merged and bounty payout requires a wallet address, use:
`0xF57503F99fA20b912200ed90D26d945093136ef5`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an XSS context analyzer for detecting reflected XSS with context-aware payload selection.
  * Captures HTTP response body, headers, and status code for richer analysis.
  * Made random-generation utilities safe for concurrent use.

* **Bug Fixes**
  * Prevented nil map issue when initializing analyzer parameters during fuzzing.

* **Tests**
  * Added comprehensive unit and performance tests for XSS reflection detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->