### PR TITLE
fix: replace panic with error logging in loader.go for missing dialers

### DIFF
--- a/pkg/catalog/loader/loader.go
+++ b/pkg/catalog/loader/loader.go
@@ -708,7 +708,8 @@ func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) []*templ
 
 	wgLoadTemplates, errWg := syncutil.New(syncutil.WithSize(concurrency))
 	if errWg != nil {
-		panic("could not create wait group")
+	   store.logger.Error().Msgf("could not create wait group: %s", errWg)
+           return nil
 	}
 
 	if typesOpts.ExecutionId == "" {
@@ -717,8 +718,9 @@ func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) []*templ
 
 	dialers := protocolstate.GetDialersWithId(typesOpts.ExecutionId)
 	if dialers == nil {
-		panic("dialers with executionId " + typesOpts.ExecutionId + " not found")
-	}
+           store.logger.Error().Msgf("dialers with executionId %s not found", typesOpts.ExecutionId)
+           return nil
+}
 
 	for _, templatePath := range includedTemplates {
 		wgLoadTemplates.Add()


### PR DESCRIPTION
## Proposed Changes
Replaced two panics in `pkg/catalog/loader/loader.go` with graceful error handling:

1. `GetDialersWithId()` returning nil now logs an error and returns nil instead of panicking
2. `syncutil.New()` failure now logs an error and returns nil instead of panicking

## Before
```go
if dialers == nil {
    panic("dialers with executionId " + typesOpts.ExecutionId + " not found")
}
```

## After
```go
if dialers == nil {
    store.logger.Error().Msgf("dialers with executionId %s not found", typesOpts.ExecutionId)
    return nil
}
```

## Proof
- `go build ./pkg/catalog/loader/...` passes with no errors

/claim #5838

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error handling to gracefully log and recover from initialization errors instead of crashing the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->