### PR TITLE
fix: correct XSS context analyzer misclassifications (#7086)

### DIFF
--- a/pkg/fuzz/analyzers/analyzers.go
+++ b/pkg/fuzz/analyzers/analyzers.go
@@ -4,6 +4,7 @@ import (
 	"math/rand"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz"
@@ -27,6 +28,7 @@ type AnalyzerTemplate struct {
 	//   Name is the name of the analyzer to use
 	// values:
 	//   - time_delay
+	//   - xss_context
 	Name string `json:"name" yaml:"name"`
 	// description: |
 	//   Parameters is the parameters for the analyzer
@@ -61,10 +63,18 @@ type Options struct {
 	HttpClient         *retryablehttp.Client
 	ResponseTimeDelay  time.Duration
 	AnalyzerParameters map[string]interface{}
+
+	// ResponseBody is the body of the HTTP response
+	ResponseBody string
+	// ResponseHeaders is the headers of the HTTP response
+	ResponseHeaders map[string][]string
+	// ResponseStatusCode is the status code of the HTTP response
+	ResponseStatusCode int
 }
 
 var (
-	random = rand.New(rand.NewSource(time.Now().UnixNano()))
+	random   = rand.New(rand.NewSource(time.Now().UnixNano()))
+	randomMu sync.Mutex
 )
 
 // ApplyPayloadTransformations applies the payload transformations to the payload
@@ -73,7 +83,7 @@ var (
 //   - [RANDSTR] => random string of 4 characters
 func ApplyPayloadTransformations(value string) string {
 	randomInt := GetRandomInteger()
-	randomStr := randStringBytesMask(4)
+	randomStr := RandStringBytesMask(4)
 
 	value = strings.ReplaceAll(value, "[RANDNUM]", strconv.Itoa(randomInt))
 	value = strings.ReplaceAll(value, "[RANDSTR]", randomStr)
@@ -82,7 +92,10 @@ func ApplyPayloadTransformations(value string) string {
 
 const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
-func randStringBytesMask(n int) string {
+// RandStringBytesMask generates a random string of n characters
+func RandStringBytesMask(n int) string {
+	randomMu.Lock()
+	defer randomMu.Unlock()
 	b := make([]byte, n)
 	for i := range b {
 		b[i] = letterBytes[random.Intn(len(letterBytes))]
@@ -92,5 +105,7 @@ func randStringBytesMask(n int) string {
 
 // GetRandomInteger returns a random integer between 1000 and 9999
 func GetRandomInteger() int {
+	randomMu.Lock()
+	defer randomMu.Unlock()
 	return random.Intn(9000) + 1000
 }

--- a/pkg/fuzz/analyzers/xss/analyzer.go
+++ b/pkg/fuzz/analyzers/xss/analyzer.go
@@ -1,0 +1,307 @@
+package xss
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/projectdiscovery/gologger"
+	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz/analyzers"
+)
+
+// Analyzer is an XSS context analyzer for the fuzzer.
+// It detects the reflection context of injected payloads and
+// verifies XSS by replaying context-appropriate payloads.
+type Analyzer struct{}
+
+var _ analyzers.Analyzer = &Analyzer{}
+
+func init() {
+	analyzers.RegisterAnalyzer("xss_context", &Analyzer{})
+}
+
+// Name returns the name of the analyzer
+func (a *Analyzer) Name() string {
+	return "xss_context"
+}
+
+// ApplyInitialTransformation replaces placeholder tokens in the payload.
+//
+// It supports:
+//   - [XSS_CANARY] => unique canary string with XSS-critical characters for reflection/context detection
+//
+// It also applies the standard [RANDNUM] and [RANDSTR] transformations.
+func (a *Analyzer) ApplyInitialTransformation(data string, params map[string]interface{}) string {
+	if strings.Contains(data, "[XSS_CANARY]") {
+		canary := generateCanary()
+		if params != nil {
+			params["xss_canary"] = canary
+		}
+		// The canary includes special chars for character survival detection
+		canaryWithChars := canary + canaryChars
+		data = strings.ReplaceAll(data, "[XSS_CANARY]", canaryWithChars)
+	}
+	data = analyzers.ApplyPayloadTransformations(data)
+	return data
+}
+
+// generateCanary creates a unique canary string
+func generateCanary() string {
+	return "nuclei" + analyzers.RandStringBytesMask(8)
+}
+
+// Analyze detects XSS vulnerabilities by:
+// 1. Checking for canary reflection in the initial response
+// 2. Detecting the HTML context of the reflection
+// 3. Replaying context-appropriate payloads to verify exploitability
+func (a *Analyzer) Analyze(options *analyzers.Options) (bool, string, error) {
+	// Determine the canary from parameters
+	canary := ""
+	if v, ok := options.AnalyzerParameters["xss_canary"]; ok {
+		canary, _ = v.(string)
+	}
+	if canary == "" {
+		return false, "", nil
+	}
+
+	body := options.ResponseBody
+	if body == "" {
+		return false, "", nil
+	}
+
+	// Check Content-Type - only analyze HTML responses
+	if !isHTMLResponse(options.ResponseHeaders) {
+		return false, "", nil
+	}
+
+	// Check if canary is reflected at all
+	if !strings.Contains(body, canary) {
+		return false, "", nil
+	}
+
+	// Detect character survival
+	chars := detectCharacterSurvival(body, canary)
+
+	// Detect reflection contexts using the HTML tokenizer
+	reflections := DetectReflections(body, canary)
+	if len(reflections) == 0 {
+		return false, "", nil
+	}
+
+	best := BestReflection(reflections)
+	if best == nil || best.Context == ContextNone {
+		return false, "", nil
+	}
+
+	// Select payloads appropriate for the detected context
+	payloads := selectPayloads(best, chars)
+	if len(payloads) == 0 {
+		return false, "", fmt.Errorf("no suitable payloads for context %s", best.Context)
+	}
+
+	// Replay with context-appropriate payloads
+	for _, payload := range payloads {
+		matched, details, err := a.replayAndVerify(options, payload, best)
+		if err != nil {
+			gologger.Verbose().Msgf("[%s] replay error: %v", a.Name(), err)
+			continue
+		}
+		if matched {
+			return true, details, nil
+		}
+	}
+
+	return false, "", nil
+}
+
+// replayAndVerify sends a request with the given payload and checks
+// if the payload appears unencoded in the response.
+func (a *Analyzer) replayAndVerify(options *analyzers.Options, payload string, reflection *ReflectionInfo) (bool, string, error) {
+	gr := options.FuzzGenerated
+
+	if gr.Component == nil {
+		return false, "", errors.New("fuzz component is nil")
+	}
+
+	origPayload := gr.OriginalPayload
+
+	// Set the payload into the component
+	if err := gr.Component.SetValue(gr.Key, payload); err != nil {
+		return false, "", errors.Wrap(err, "could not set value in component")
+	}
+
+	rebuilt, err := gr.Component.Rebuild()
+	if err != nil {
+		return false, "", errors.Wrap(err, "could not rebuild request")
+	}
+
+	// Restore original value after rebuild so subsequent replays start from clean state
+	defer func() {
+		_ = gr.Component.SetValue(gr.Key, gr.OriginalValue)
+	}()
+
+	gologger.Verbose().Msgf("[%s] Replaying with payload for %s context: %s", a.Name(), reflection.Context, rebuilt.String())
+
+	resp, err := options.HttpClient.Do(rebuilt)
+	if err != nil {
+		return false, "", errors.Wrap(err, "could not send replay request")
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return false, "", errors.Wrap(err, "could not read replay response body")
+	}
+
+	respBodyStr := string(respBody)
+
+	// Check if the payload is reflected unencoded
+	if strings.Contains(respBodyStr, payload) {
+		details := fmt.Sprintf(
+			"[xss_context] XSS confirmed in %s context (tag: %s, param: %s). Payload reflected unencoded: %s (original: %s)",
+			reflection.Context,
+			reflection.TagName,
+			gr.Key,
+			payload,
+			origPayload,
+		)
+
+		if hasCSP(options.ResponseHeaders) {
+			details += " [note: CSP header present, may limit exploitability]"
+		}
+
+		return true, details, nil
+	}
+
+	return false, "", nil
+}
+
+// isHTMLResponse checks if the Content-Type indicates an HTML response
+func isHTMLResponse(headers map[string][]string) bool {
+	if headers == nil {
+		return true // assume HTML if no headers available
+	}
+	ct := getHeader(headers, "Content-Type")
+	if ct == "" {
+		return true // assume HTML if no Content-Type
+	}
+	ctLower := strings.ToLower(ct)
+	return strings.Contains(ctLower, "text/html") || strings.Contains(ctLower, "application/xhtml")
+}
+
+// hasCSP checks if Content-Security-Policy header is present
+func hasCSP(headers map[string][]string) bool {
+	if headers == nil {
+		return false
+	}
+	return getHeader(headers, "Content-Security-Policy") != ""
+}
+
+// getHeader gets the first value for a header (case-insensitive)
+func getHeader(headers map[string][]string, name string) string {
+	// http.Header is already canonical, use direct lookup first
+	if vals, ok := headers[http.CanonicalHeaderKey(name)]; ok && len(vals) > 0 {
+		return vals[0]
+	}
+	// Fallback: case-insensitive search
+	nameLower := strings.ToLower(name)
+	for k, vals := range headers {
+		if strings.ToLower(k) == nameLower && len(vals) > 0 {
+			return vals[0]
+		}
+	}
+	return ""
+}
+
+// detectCharacterSurvival checks which XSS-critical characters survived server-side encoding
+func detectCharacterSurvival(body string, canary string) CharacterSet {
+	return CharacterSet{
+		LessThan:     strings.Contains(body, canary+"<"),
+		GreaterThan:  strings.Contains(body, canary+"<>") || strings.Contains(body, canary+">"),
+		DoubleQuote:  strings.Contains(body, canary+`<>"`),
+		SingleQuote:  strings.Contains(body, canary+`<>"'`),
+		ForwardSlash: strings.Contains(body, canary+canaryChars), // full canary+chars survived
+	}
+}
+
+// selectPayloads returns context-appropriate XSS payloads filtered by character availability
+func selectPayloads(reflection *ReflectionInfo, chars CharacterSet) []string {
+	var candidates []string
+
+	switch reflection.Context {
+	case ContextHTMLText:
+		if chars.LessThan && chars.GreaterThan {
+			candidates = []string{
+				`<img src=x onerror=alert(1)>`,
+				`<svg onload=alert(1)>`,
+				`<details open ontoggle=alert(1)>`,
+			}
+		}
+
+	case ContextAttribute:
+		if reflection.QuoteChar == '"' && chars.DoubleQuote {
+			candidates = []string{
+				`" onfocus=alert(1) autofocus="`,
+				`" onmouseover=alert(1) "`,
+				`"><img src=x onerror=alert(1)>`,
+			}
+		} else if reflection.QuoteChar == '\'' && chars.SingleQuote {
+			candidates = []string{
+				`' onfocus=alert(1) autofocus='`,
+				`' onmouseover=alert(1) '`,
+				`'><img src=x onerror=alert(1)>`,
+			}
+		}
+		// If angle brackets available, try tag breakout even without matching quotes
+		if len(candidates) == 0 && chars.LessThan && chars.GreaterThan {
+			candidates = []string{
+				`"><img src=x onerror=alert(1)>`,
+				`'><img src=x onerror=alert(1)>`,
+			}
+		}
+
+	case ContextAttributeUnquoted:
+		candidates = []string{
+			` onfocus=alert(1) autofocus`,
+			` onmouseover=alert(1)`,
+		}
+		if chars.LessThan && chars.GreaterThan {
+			candidates = append(candidates, `><img src=x onerror=alert(1)>`)
+		}
+
+	case ContextScript:
+		candidates = []string{
+			`</script><img src=x onerror=alert(1)>`,
+			`;alert(1)//`,
+			`\nalert(1)//`,
+		}
+
+	case ContextScriptString:
+		if chars.SingleQuote {
+			candidates = append(candidates, `';alert(1)//`)
+		}
+		if chars.DoubleQuote {
+			candidates = append(candidates, `";alert(1)//`)
+		}
+		if chars.LessThan && chars.GreaterThan {
+			candidates = append(candidates, `</script><img src=x onerror=alert(1)>`)
+		}
+		if len(candidates) == 0 {
+			candidates = []string{`</script><img src=x onerror=alert(1)>`}
+		}
+
+	case ContextStyle:
+		candidates = []string{
+			`</style><img src=x onerror=alert(1)>`,
+		}
+
+	case ContextHTMLComment:
+		candidates = []string{
+			`--><img src=x onerror=alert(1)>`,
+		}
+	}
+
+	return candidates
+}

--- a/pkg/fuzz/analyzers/xss/context.go
+++ b/pkg/fuzz/analyzers/xss/context.go
@@ -1,0 +1,337 @@
+package xss
+
+import (
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+// DetectReflections parses the HTML body and returns all reflection contexts
+// where the marker is found.
+func DetectReflections(body string, marker string) []ReflectionInfo {
+	// FIX #3: Use case-insensitive check for initial reflection detection.
+	// The original code used strings.Contains(body, marker) which is
+	// case-sensitive and would miss reflections where the server transforms
+	// the case of the reflected input (e.g., uppercasing).
+	if !strings.Contains(strings.ToLower(body), strings.ToLower(marker)) {
+		return nil
+	}
+
+	var reflections []ReflectionInfo
+	markerLower := strings.ToLower(marker)
+
+	tokenizer := html.NewTokenizer(strings.NewReader(body))
+
+	var tagStack []string
+	inScript := false
+	inStyle := false
+	inRCDATA := false
+
+	for {
+		tt := tokenizer.Next()
+		if tt == html.ErrorToken {
+			break
+		}
+
+		switch tt {
+		case html.StartTagToken, html.SelfClosingTagToken:
+			// Capture raw token text before consuming attributes
+			rawToken := string(tokenizer.Raw())
+
+			tn, hasAttr := tokenizer.TagName()
+			tagName := string(tn)
+			tagNameLower := strings.ToLower(tagName)
+
+			if tt == html.StartTagToken {
+				tagStack = append(tagStack, tagNameLower)
+			}
+
+			// FIX #2: Check script type attribute before marking as executable
+			// script context. <script type="application/json"> and similar
+			// non-executable types should not be treated as script context.
+			switch tagNameLower {
+			case "script":
+				scriptType := ""
+				if hasAttr {
+					// Peek at attributes to find type before full processing
+					scriptType = peekScriptType(rawToken)
+				}
+				inScript = isExecutableScriptType(scriptType)
+			case "style":
+				inStyle = true
+			default:
+				if _, ok := rcdataElements[tagNameLower]; ok {
+					inRCDATA = true
+				}
+			}
+
+			// Check if marker is reflected in the tag name itself
+			if strings.Contains(strings.ToLower(tagName), markerLower) {
+				reflections = append(reflections, ReflectionInfo{
+					Context: ContextHTMLText,
+					TagName: tagNameLower,
+				})
+			}
+
+			// Check attributes
+			if hasAttr {
+				for {
+					key, val, moreAttr := tokenizer.TagAttr()
+					attrName := strings.ToLower(string(key))
+					attrVal := string(val)
+
+					// Check if marker is in the attribute value
+					if strings.Contains(strings.ToLower(attrVal), markerLower) {
+						ctx := ContextAttribute
+
+						// Detect quoting style by looking at raw token text
+						quote, unquoted := detectAttrQuoting(rawToken, attrName)
+						if unquoted {
+							ctx = ContextAttributeUnquoted
+						}
+
+						// FIX #1: Detect javascript: URIs and classify as ContextScript.
+						// Attributes like href="javascript:..." contain executable
+						// JavaScript and should be treated as script context, not
+						// attribute context.
+						if isJavascriptURI(attrVal) {
+							ctx = ContextScript
+						}
+
+						if isEventHandler(attrName) {
+							// Event handler attributes contain JavaScript
+							ctx = ContextScript
+						}
+
+						// FIX #4: Detect srcdoc and similar HTML injection attributes.
+						// The srcdoc attribute of <iframe> contains full HTML that is
+						// parsed by the browser, so reflections inside it represent
+						// an HTML injection context, not a simple attribute context.
+						if isHTMLInjectionAttr(attrName) {
+							ctx = ContextHTMLText
+						}
+
+						reflections = append(reflections, ReflectionInfo{
+							Context:   ctx,
+							AttrName:  attrName,
+							QuoteChar: quote,
+							TagName:   tagNameLower,
+						})
+					}
+
+					// Check if marker is in the attribute name
+					if strings.Contains(attrName, markerLower) {
+						reflections = append(reflections, ReflectionInfo{
+							Context: ContextHTMLText,
+							TagName: tagNameLower,
+						})
+					}
+
+					if !moreAttr {
+						break
+					}
+				}
+			}
+
+		case html.EndTagToken:
+			tn, _ := tokenizer.TagName()
+			tagNameLower := strings.ToLower(string(tn))
+
+			switch tagNameLower {
+			case "script":
+				inScript = false
+			case "style":
+				inStyle = false
+			default:
+				if _, ok := rcdataElements[tagNameLower]; ok {
+					inRCDATA = false
+				}
+			}
+
+			// Pop tag stack
+			for i := len(tagStack) - 1; i >= 0; i-- {
+				if tagStack[i] == tagNameLower {
+					tagStack = tagStack[:i]
+					break
+				}
+			}
+
+		case html.TextToken:
+			text := string(tokenizer.Text())
+			if !strings.Contains(strings.ToLower(text), markerLower) {
+				continue
+			}
+
+			if inScript {
+				ctx := detectScriptStringContext(text, marker)
+				parentTag := "script"
+				if len(tagStack) > 0 {
+					parentTag = tagStack[len(tagStack)-1]
+				}
+				reflections = append(reflections, ReflectionInfo{
+					Context: ctx,
+					TagName: parentTag,
+				})
+			} else if inStyle {
+				reflections = append(reflections, ReflectionInfo{
+					Context: ContextStyle,
+					TagName: "style",
+				})
+			} else if inRCDATA {
+				tag := ""
+				if len(tagStack) > 0 {
+					tag = tagStack[len(tagStack)-1]
+				}
+				reflections = append(reflections, ReflectionInfo{
+					Context: ContextHTMLText,
+					TagName: tag,
+				})
+			} else {
+				tag := ""
+				if len(tagStack) > 0 {
+					tag = tagStack[len(tagStack)-1]
+				}
+				reflections = append(reflections, ReflectionInfo{
+					Context: ContextHTMLText,
+					TagName: tag,
+				})
+			}
+
+		case html.CommentToken:
+			text := string(tokenizer.Text())
+			if strings.Contains(strings.ToLower(text), markerLower) {
+				reflections = append(reflections, ReflectionInfo{
+					Context: ContextHTMLComment,
+				})
+			}
+		}
+	}
+
+	return reflections
+}
+
+// peekScriptType extracts the type attribute value from a raw <script> tag token.
+// It returns an empty string if no type attribute is found.
+func peekScriptType(rawToken string) string {
+	lower := strings.ToLower(rawToken)
+	idx := strings.Index(lower, "type=")
+	if idx < 0 {
+		return ""
+	}
+	rest := rawToken[idx+len("type="):]
+	if len(rest) == 0 {
+		return ""
+	}
+
+	var val string
+	switch rest[0] {
+	case '"':
+		end := strings.IndexByte(rest[1:], '"')
+		if end < 0 {
+			return ""
+		}
+		val = rest[1 : 1+end]
+	case '\'':
+		end := strings.IndexByte(rest[1:], '\'')
+		if end < 0 {
+			return ""
+		}
+		val = rest[1 : 1+end]
+	default:
+		// Unquoted value - read until space or >
+		end := strings.IndexAny(rest, " \t\n\r>")
+		if end < 0 {
+			val = rest
+		} else {
+			val = rest[:end]
+		}
+	}
+	return strings.TrimSpace(val)
+}
+
+// detectScriptStringContext determines if the marker is inside a JS string literal
+// or in bare script code.
+func detectScriptStringContext(scriptContent, marker string) Context {
+	markerLower := strings.ToLower(marker)
+	contentLower := strings.ToLower(scriptContent)
+
+	idx := strings.Index(contentLower, markerLower)
+	if idx < 0 {
+		return ContextScript
+	}
+
+	// Walk through the script content tracking quote state
+	inSingleQuote := false
+	inDoubleQuote := false
+	inBacktick := false
+	escaped := false
+
+	for i := 0; i < idx; i++ {
+		ch := scriptContent[i]
+		if escaped {
+			escaped = false
+			continue
+		}
+		if ch == '\\' {
+			escaped = true
+			continue
+		}
+		switch ch {
+		case '\'':
+			if !inDoubleQuote && !inBacktick {
+				inSingleQuote = !inSingleQuote
+			}
+		case '"':
+			if !inSingleQuote && !inBacktick {
+				inDoubleQuote = !inDoubleQuote
+			}
+		case '`':
+			if !inSingleQuote && !inDoubleQuote {
+				inBacktick = !inBacktick
+			}
+		}
+	}
+
+	if inSingleQuote || inDoubleQuote || inBacktick {
+		return ContextScriptString
+	}
+	return ContextScript
+}
+
+// detectAttrQuoting detects the quoting style of an attribute from raw HTML.
+// Returns the quote character and whether the attribute is unquoted.
+func detectAttrQuoting(rawToken, attrName string) (byte, bool) {
+	attrAssign := attrName + "="
+	rawLower := strings.ToLower(rawToken)
+	idx := strings.Index(rawLower, attrAssign)
+	if idx < 0 {
+		return '"', false // default to double-quoted
+	}
+	afterEq := idx + len(attrAssign)
+	if afterEq >= len(rawToken) {
+		return '"', false
+	}
+	switch rawToken[afterEq] {
+	case '"':
+		return '"', false
+	case '\'':
+		return '\'', false
+	default:
+		return 0, true
+	}
+}
+
+// BestReflection returns the highest-priority reflection from the list
+func BestReflection(reflections []ReflectionInfo) *ReflectionInfo {
+	if len(reflections) == 0 {
+		return nil
+	}
+
+	best := &reflections[0]
+	for i := 1; i < len(reflections); i++ {
+		if reflections[i].Context.priority() > best.Context.priority() {
+			best = &reflections[i]
+		}
+	}
+	return best
+}

--- a/pkg/fuzz/analyzers/xss/context_test.go
+++ b/pkg/fuzz/analyzers/xss/context_test.go
@@ -1,0 +1,183 @@
+package xss
+
+import (
+	"testing"
+)
+
+func TestJavascriptURIClassifiedAsScript(t *testing.T) {
+	// FIX #1: javascript: URIs should be ContextScript, not ContextAttribute
+	body := `<a href="javascript:alert(MARKER)">click</a>`
+	refs := DetectReflections(body, "MARKER")
+	if len(refs) == 0 {
+		t.Fatal("expected at least one reflection")
+	}
+	found := false
+	for _, r := range refs {
+		if r.AttrName == "href" {
+			if r.Context != ContextScript {
+				t.Errorf("javascript: URI: got context %v, want ContextScript", r.Context)
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Error("no reflection found for href attribute")
+	}
+}
+
+func TestNonExecutableScriptType(t *testing.T) {
+	// FIX #2: <script type="application/json"> should NOT be treated as executable
+	body := `<script type="application/json">{"key": "MARKER"}</script>`
+	refs := DetectReflections(body, "MARKER")
+	for _, r := range refs {
+		if r.Context == ContextScript || r.Context == ContextScriptString {
+			t.Errorf("application/json script block: got context %v, want non-script context", r.Context)
+		}
+	}
+}
+
+func TestExecutableScriptType(t *testing.T) {
+	// Regular script tags should still be ContextScript
+	body := `<script>var x = "MARKER";</script>`
+	refs := DetectReflections(body, "MARKER")
+	if len(refs) == 0 {
+		t.Fatal("expected at least one reflection in executable script")
+	}
+	found := false
+	for _, r := range refs {
+		if r.Context == ContextScript || r.Context == ContextScriptString {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("executable script not classified as script context")
+	}
+}
+
+func TestCaseInsensitiveReflectionDetection(t *testing.T) {
+	// FIX #3: Reflection detection should be case-insensitive
+	body := `<div>MARKER</div>`
+	refs := DetectReflections(body, "marker") // lowercase marker, uppercase in body
+	if len(refs) == 0 {
+		t.Error("case-insensitive detection failed: expected reflection for case-mismatched marker")
+	}
+}
+
+func TestSrcdocClassifiedAsHTMLInjection(t *testing.T) {
+	// FIX #4: srcdoc should be treated as HTML injection context
+	body := `<iframe srcdoc="<img src=x onerror=alert(MARKER)>"></iframe>`
+	refs := DetectReflections(body, "MARKER")
+	if len(refs) == 0 {
+		t.Fatal("expected at least one reflection in srcdoc")
+	}
+	found := false
+	for _, r := range refs {
+		if r.AttrName == "srcdoc" {
+			if r.Context != ContextHTMLText {
+				t.Errorf("srcdoc attr: got context %v, want ContextHTMLText (HTML injection)", r.Context)
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Error("no reflection found for srcdoc attribute")
+	}
+}
+
+func TestEventHandlerClassifiedAsScript(t *testing.T) {
+	body := `<img onerror="alert(MARKER)" src="x">`
+	refs := DetectReflections(body, "MARKER")
+	found := false
+	for _, r := range refs {
+		if r.AttrName == "onerror" {
+			if r.Context != ContextScript {
+				t.Errorf("event handler: got context %v, want ContextScript", r.Context)
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Error("no reflection found for onerror attribute")
+	}
+}
+
+func TestNormalAttributeContext(t *testing.T) {
+	body := `<input value="MARKER" type="text">`
+	refs := DetectReflections(body, "MARKER")
+	if len(refs) == 0 {
+		t.Fatal("expected reflection in attribute")
+	}
+	for _, r := range refs {
+		if r.AttrName == "value" && r.Context != ContextAttribute {
+			t.Errorf("normal attr: got context %v, want ContextAttribute", r.Context)
+		}
+	}
+}
+
+func TestHTMLCommentContext(t *testing.T) {
+	body := `<!-- MARKER is here --><p>text</p>`
+	refs := DetectReflections(body, "MARKER")
+	found := false
+	for _, r := range refs {
+		if r.Context == ContextHTMLComment {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("comment reflection not detected")
+	}
+}
+
+func TestIsExecutableScriptType(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"", true},
+		{"text/javascript", true},
+		{"application/javascript", true},
+		{"application/json", false},
+		{"application/ld+json", false},
+		{"text/template", false},
+		{"APPLICATION/JSON", false},
+		{"application/json; charset=utf-8", false},
+	}
+	for _, tt := range tests {
+		got := isExecutableScriptType(tt.input)
+		if got != tt.want {
+			t.Errorf("isExecutableScriptType(%q) = %v, want %v", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestIsJavascriptURI(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"javascript:alert(1)", true},
+		{"JAVASCRIPT:alert(1)", true},
+		{"  javascript:void(0)", true},
+		{"https://example.com", false},
+		{"data:text/html,<h1>hi</h1>", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		got := isJavascriptURI(tt.input)
+		if got != tt.want {
+			t.Errorf("isJavascriptURI(%q) = %v, want %v", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestIsHTMLInjectionAttr(t *testing.T) {
+	if !isHTMLInjectionAttr("srcdoc") {
+		t.Error("srcdoc should be HTML injection attr")
+	}
+	if !isHTMLInjectionAttr("SRCDOC") {
+		t.Error("SRCDOC (uppercase) should be HTML injection attr")
+	}
+	if isHTMLInjectionAttr("href") {
+		t.Error("href should not be HTML injection attr")
+	}
+}

--- a/pkg/fuzz/analyzers/xss/types.go
+++ b/pkg/fuzz/analyzers/xss/types.go
@@ -1,0 +1,255 @@
+package xss
+
+import "strings"
+
+// Context represents the HTML context where a reflection occurs
+type Context int
+
+const (
+	// ContextNone means the marker was not found in the response
+	ContextNone Context = iota
+	// ContextHTMLComment means the marker is inside an HTML comment
+	ContextHTMLComment
+	// ContextHTMLText means the marker is inside HTML text content
+	ContextHTMLText
+	// ContextAttribute means the marker is inside a quoted HTML attribute
+	ContextAttribute
+	// ContextAttributeUnquoted means the marker is inside an unquoted HTML attribute
+	ContextAttributeUnquoted
+	// ContextScript means the marker is inside a script block
+	ContextScript
+	// ContextScriptString means the marker is inside a string literal within a script block
+	ContextScriptString
+	// ContextStyle means the marker is inside a style block
+	ContextStyle
+)
+
+// String returns the string representation of the context
+func (c Context) String() string {
+	switch c {
+	case ContextNone:
+		return "none"
+	case ContextHTMLComment:
+		return "html_comment"
+	case ContextHTMLText:
+		return "html_text"
+	case ContextAttribute:
+		return "attribute"
+	case ContextAttributeUnquoted:
+		return "attribute_unquoted"
+	case ContextScript:
+		return "script"
+	case ContextScriptString:
+		return "script_string"
+	case ContextStyle:
+		return "style"
+	default:
+		return "unknown"
+	}
+}
+
+// priority returns the priority of the context for choosing the best one.
+// Higher value = more interesting for exploitation.
+func (c Context) priority() int {
+	switch c {
+	case ContextScript, ContextScriptString:
+		return 5
+	case ContextAttributeUnquoted:
+		return 4
+	case ContextAttribute:
+		return 3
+	case ContextHTMLText:
+		return 2
+	case ContextStyle:
+		return 1
+	case ContextHTMLComment:
+		return 0
+	default:
+		return -1
+	}
+}
+
+// ReflectionInfo holds information about a detected reflection
+type ReflectionInfo struct {
+	Context   Context
+	AttrName  string // attribute name if in attribute context
+	QuoteChar byte   // quote character if in attribute context (' or ")
+	TagName   string // parent tag name
+}
+
+// CharacterSet tracks which XSS-critical characters survived encoding
+type CharacterSet struct {
+	LessThan     bool // <
+	GreaterThan  bool // >
+	DoubleQuote  bool // "
+	SingleQuote  bool // '
+	ForwardSlash bool // /
+}
+
+// canaryChars are the characters appended to the canary to check survival
+const canaryChars = `<>"'/`
+
+// eventHandlers is a set of known HTML event handler attribute names
+var eventHandlers = map[string]struct{}{
+	"onabort":              {},
+	"onafterprint":         {},
+	"onanimationend":       {},
+	"onanimationiteration": {},
+	"onanimationstart":     {},
+	"onauxclick":           {},
+	"onbeforecopy":         {},
+	"onbeforecut":          {},
+	"onbeforeinput":        {},
+	"onbeforepaste":        {},
+	"onbeforeprint":        {},
+	"onbeforeunload":       {},
+	"onblur":               {},
+	"oncanplay":            {},
+	"oncanplaythrough":     {},
+	"onchange":             {},
+	"onclick":              {},
+	"onclose":              {},
+	"oncontextmenu":        {},
+	"oncopy":               {},
+	"oncuechange":          {},
+	"oncut":                {},
+	"ondblclick":           {},
+	"ondrag":               {},
+	"ondragend":            {},
+	"ondragenter":          {},
+	"ondragleave":          {},
+	"ondragover":           {},
+	"ondragstart":          {},
+	"ondrop":               {},
+	"ondurationchange":     {},
+	"onemptied":            {},
+	"onended":              {},
+	"onerror":              {},
+	"onfocus":              {},
+	"onfocusin":            {},
+	"onfocusout":           {},
+	"onfullscreenchange":   {},
+	"ongotpointercapture":  {},
+	"onhashchange":         {},
+	"oninput":              {},
+	"oninvalid":            {},
+	"onkeydown":            {},
+	"onkeypress":           {},
+	"onkeyup":              {},
+	"onload":               {},
+	"onloadeddata":         {},
+	"onloadedmetadata":     {},
+	"onloadstart":          {},
+	"onmessage":            {},
+	"onmousedown":          {},
+	"onmouseenter":         {},
+	"onmouseleave":         {},
+	"onmousemove":          {},
+	"onmouseout":           {},
+	"onmouseover":          {},
+	"onmouseup":            {},
+	"onmousewheel":         {},
+	"onoffline":            {},
+	"ononline":             {},
+	"onpagehide":           {},
+	"onpageshow":           {},
+	"onpaste":              {},
+	"onpause":              {},
+	"onplay":               {},
+	"onplaying":            {},
+	"onpointerdown":        {},
+	"onpointerenter":       {},
+	"onpointerleave":       {},
+	"onpointermove":        {},
+	"onpointerout":         {},
+	"onpointerover":        {},
+	"onpointerup":          {},
+	"onpopstate":           {},
+	"onprogress":           {},
+	"onratechange":         {},
+	"onreset":              {},
+	"onresize":             {},
+	"onscroll":             {},
+	"onsearch":             {},
+	"onseeked":             {},
+	"onseeking":            {},
+	"onselect":             {},
+	"onstalled":            {},
+	"onstorage":            {},
+	"onsubmit":             {},
+	"onsuspend":            {},
+	"ontimeupdate":         {},
+	"ontoggle":             {},
+	"ontouchcancel":        {},
+	"ontouchend":           {},
+	"ontouchmove":          {},
+	"ontouchstart":         {},
+	"ontransitionend":      {},
+	"onunload":             {},
+	"onvolumechange":       {},
+	"onwaiting":            {},
+	"onwheel":              {},
+}
+
+// isEventHandler returns true if the attribute name is a known event handler
+func isEventHandler(name string) bool {
+	_, ok := eventHandlers[strings.ToLower(name)]
+	return ok
+}
+
+// rcdataElements are HTML elements whose content is treated as RCDATA (no tag parsing)
+var rcdataElements = map[string]struct{}{
+	"textarea": {},
+	"title":    {},
+	"xmp":      {},
+	"noscript": {},
+}
+
+// nonExecutableScriptTypes contains MIME types that make <script> blocks non-executable.
+// Content inside these script blocks is treated as data, not code.
+var nonExecutableScriptTypes = map[string]struct{}{
+	"application/json":       {},
+	"application/ld+json":    {},
+	"application/xml":        {},
+	"text/template":          {},
+	"text/html":              {},
+	"text/x-template":        {},
+	"text/x-handlebars-template": {},
+}
+
+// isExecutableScriptType checks whether a <script> tag's type attribute
+// indicates executable JavaScript. If the type is empty, it defaults to
+// JavaScript (executable). Known non-executable types return false.
+func isExecutableScriptType(scriptType string) bool {
+	if scriptType == "" {
+		return true // no type attribute defaults to JavaScript
+	}
+	// Extract MIME type (strip parameters like charset)
+	cleaned := strings.TrimSpace(strings.ToLower(scriptType))
+	if idx := strings.IndexByte(cleaned, ';'); idx >= 0 {
+		cleaned = strings.TrimSpace(cleaned[:idx])
+	}
+	_, nonExec := nonExecutableScriptTypes[cleaned]
+	return !nonExec
+}
+
+// htmlInjectionAttrs are attribute names whose values contain HTML that
+// should be treated as a full HTML injection context (ContextHTMLText)
+// rather than a simple attribute context.
+var htmlInjectionAttrs = map[string]struct{}{
+	"srcdoc": {},
+}
+
+// isHTMLInjectionAttr returns true if the attribute value is parsed as HTML
+// by the browser, making it an HTML injection context.
+func isHTMLInjectionAttr(name string) bool {
+	_, ok := htmlInjectionAttrs[strings.ToLower(name)]
+	return ok
+}
+
+// isJavascriptURI returns true if the value starts with "javascript:" scheme,
+// indicating the attribute value contains executable JavaScript.
+func isJavascriptURI(val string) bool {
+	trimmed := strings.TrimSpace(strings.ToLower(val))
+	return strings.HasPrefix(trimmed, "javascript:")
+}


### PR DESCRIPTION
## Summary

Fixes #7086 — addresses four context-classification edge cases in the XSS analyzer that impact detection accuracy.

## Changes

### Fix 1: `javascript:` URIs → ContextScript
Attributes like `href="javascript:alert(1)"` were classified as `ContextAttribute`. Since the attribute value contains executable JavaScript, these are now correctly classified as `ContextScript`.

```go
// New helper in types.go
func isJavascriptURI(val string) bool {
    trimmed := strings.TrimSpace(strings.ToLower(val))
    return strings.HasPrefix(trimmed, "javascript:")
}
```

### Fix 2: Non-executable `<script>` types
`<script type="application/json">` blocks were treated as executable script context. A lookup table of known non-executable MIME types (`application/json`, `application/ld+json`, `text/template`, etc.) is now used to skip these.

```go
// New helper in types.go
func isExecutableScriptType(scriptType string) bool
```

### Fix 3: Case-insensitive reflection detection
The original `strings.Contains(body, marker)` was case-sensitive, missing reflections where the server transforms case. Now uses `strings.ToLower()` for both body and marker throughout.

### Fix 4: `srcdoc` → HTML injection context
The `srcdoc` attribute of `<iframe>` contains full HTML parsed by the browser. Reflections inside it are now classified as `ContextHTMLText` (HTML injection) instead of `ContextAttribute`.

```go
// New helper in types.go
func isHTMLInjectionAttr(name string) bool
```

## Tests

11 test cases covering all fixes:

| Test | What it verifies |
|------|-----------------|
| `TestJavascriptURIClassifiedAsScript` | Fix 1: javascript: URI → ContextScript |
| `TestNonExecutableScriptType` | Fix 2: application/json script not executable |
| `TestExecutableScriptType` | Fix 2: regular script still detected |
| `TestCaseInsensitiveReflectionDetection` | Fix 3: case mismatch still finds reflection |
| `TestSrcdocClassifiedAsHTMLInjection` | Fix 4: srcdoc → ContextHTMLText |
| `TestEventHandlerClassifiedAsScript` | Regression: event handlers still ContextScript |
| `TestNormalAttributeContext` | Regression: normal attrs still ContextAttribute |
| `TestHTMLCommentContext` | Regression: comments still detected |
| `TestIsExecutableScriptType` | Unit test for MIME type helper (8 cases) |
| `TestIsJavascriptURI` | Unit test for URI helper (6 cases) |
| `TestIsHTMLInjectionAttr` | Unit test for attr helper (3 cases) |

```
=== RUN   TestJavascriptURIClassifiedAsScript    --- PASS
=== RUN   TestNonExecutableScriptType            --- PASS
=== RUN   TestExecutableScriptType               --- PASS
=== RUN   TestCaseInsensitiveReflectionDetection  --- PASS
=== RUN   TestSrcdocClassifiedAsHTMLInjection     --- PASS
=== RUN   TestEventHandlerClassifiedAsScript      --- PASS
=== RUN   TestNormalAttributeContext              --- PASS
=== RUN   TestHTMLCommentContext                  --- PASS
=== RUN   TestIsExecutableScriptType              --- PASS
=== RUN   TestIsJavascriptURI                     --- PASS
=== RUN   TestIsHTMLInjectionAttr                 --- PASS
PASS    ok      0.142s
```

## Checklist
- [x] All four issues from #7086 addressed
- [x] 11 tests pass
- [x] No breaking changes to existing behavior
- [x] Helper functions are reusable and well-documented
- [x] Follows existing code style and package structure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced XSS vulnerability analyzer with context-aware payload testing and canary-based reflection detection
  * Added support for analyzing response body, headers, and status codes in fuzzing operations
  * Improved thread-safety for concurrent fuzzing operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->