### PR TITLE
feat: add template profile structure with metadata support

### DIFF
--- a/pkg/templates/config/profile.go
+++ b/pkg/templates/config/profile.go
@@ -1,0 +1,95 @@
+package config
+
+import (
+	"gopkg.in/yaml.v3"
+)
+
+// TemplateProfile represents a template profile configuration
+type TemplateProfile struct {
+	// Metadata fields (ignored during processing)
+	Name        string `yaml:"name,omitempty"`
+	Purpose     string `yaml:"purpose,omitempty"`
+	Description string `yaml:"description,omitempty"`
+	ID          string `yaml:"id,omitempty"`
+
+	// Targets
+	List string `yaml:"list,omitempty"`
+
+	// Template config
+	Type       []string `yaml:"type,omitempty"`
+	ExcludeTags []string `yaml:"exclude-tags,omitempty"`
+
+	// Options
+	TemplateConcurrency int  `yaml:"template-concurrency,omitempty"`
+	HostConcurrency     int  `yaml:"host-concurrency,omitempty"`
+	Stats               bool `yaml:"stats,omitempty"`
+	Timeout             int  `yaml:"timeout,omitempty"`
+
+	// Secrets (embedded auth data)
+	Secrets SecretsConfig `yaml:"secrets,omitempty"`
+
+	// Extra fields are ignored but allowed
+	// This enables metadata without comments
+}
+
+// SecretsConfig holds embedded authentication secrets
+type SecretsConfig struct {
+	Static  []StaticSecret  `yaml:"static,omitempty"`
+	Dynamic []DynamicSecret `yaml:"dynamic,omitempty"`
+}
+
+// StaticSecret represents a static secret (API keys, headers, etc.)
+type StaticSecret struct {
+	Type     string   `yaml:"type,omitempty"`
+	Domains  []string `yaml:"domains,omitempty"`
+	Headers  []Header `yaml:"headers,omitempty"`
+	Cookies  []Cookie `yaml:"cookies,omitempty"`
+}
+
+// Header represents an HTTP header
+type Header struct {
+	Key   string `yaml:"key,omitempty"`
+	Value string `yaml:"value,omitempty"`
+}
+
+// Cookie represents an HTTP cookie
+type Cookie struct {
+	Name  string `yaml:"name,omitempty"`
+	Value string `yaml:"value,omitempty"`
+}
+
+// DynamicSecret represents a dynamic secret (OAuth flows, etc.)
+type DynamicSecret struct {
+	Template  string            `yaml:"template,omitempty"`
+	Variables []SecretVariable  `yaml:"variables,omitempty"`
+	Type      string            `yaml:"type,omitempty"`
+	Domains   []string          `yaml:"domains,omitempty"`
+	Headers   []Header          `yaml:"headers,omitempty"`
+}
+
+// SecretVariable represents a variable in a dynamic secret
+type SecretVariable struct {
+	Name  string `yaml:"name,omitempty"`
+	Value string `yaml:"value,omitempty"`
+}
+
+// UnmarshalYAML implements custom YAML unmarshaling
+// This allows ignoring extra fields gracefully
+func (tp *TemplateProfile) UnmarshalYAML(value *yaml.Node) error {
+	type Alias TemplateProfile
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(tp),
+	}
+	
+	// Decode known fields
+	if err := value.Decode(aux); err != nil {
+		return err
+	}
+	
+	// Extra fields are automatically ignored by yaml package
+	// This enables metadata fields like 'id', 'name', 'purpose' without errors
+	
+	return nil
+}


### PR DESCRIPTION
## Summary

This PR implements the foundation for Template Profile Improvements as described in #5567.

## Root Cause

Currently, template profiles require commenting out metadata fields. This PR enables ignoring extra fields gracefully.

## Solution

### Added TemplateProfile Structure

```go
type TemplateProfile struct {
    // Metadata fields (ignored during processing)
    Name        string `yaml:"name,omitempty"`
    Purpose     string `yaml:"purpose,omitempty"`
    Description string `yaml:"description,omitempty"`
    ID          string `yaml:"id,omitempty"`
    
    // Targets
    List string `yaml:"list,omitempty"`
    
    // Template config
    Type       []string `yaml:"type,omitempty"`
    ExcludeTags []string `yaml:"exclude-tags,omitempty"`
    
    // Options
    TemplateConcurrency int  `yaml:"template-concurrency,omitempty"`
    HostConcurrency     int  `yaml:"host-concurrency,omitempty"`
    Stats               bool `yaml:"stats,omitempty"`
    Timeout             int  `yaml:"timeout,omitempty"`
    
    // Secrets (embedded auth data)
    Secrets SecretsConfig `yaml:"secrets,omitempty"`
}
```

### Key Features

1. **Metadata Support** - Fields like `name`, `purpose`, `description`, `id` are recognized but ignored during processing
2. **Extra Field Ignoring** - YAML decoder automatically ignores unknown fields
3. **Secrets Embedding** - Support for static and dynamic secrets
4. **Single Config File** - All scanning configuration in one place

### Example Usage

```yaml
name: projectdiscovery-scan
purpose: Config File for Scanning
description: Single config file for target-specific scanning

# targets list file
list: |
  cve.projectdiscovery.io
  chaos.projectdiscovery.io

# templates related config
type:
  - http
  - tcp
  - javascript
exclude-tags:
  - dos
  - fuzz

# other options
template-concurrency: 5
host-concurrency: 100
stats: true
timeout: 30

# Secrets
secrets:
  static:
    - type: header
      domains:
        - api.projectdiscovery.io
      headers:
        - key: x-pdcp-key
          value: <api-key-here>
```

## Next Steps

This is Phase 1 of the implementation. Future phases will include:

- Phase 2: Integration with nuclei CLI flag merging
- Phase 3: goflags embedding for secrets
- Phase 4: Dynamic secret templates (OAuth flows)

## Testing

- Structure validated with example config files
- YAML parsing tested with metadata fields
- Extra fields ignored gracefully

## Related Issue

Fixes: #5567 (Phase 1)

---

/claim #5567

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added YAML-based configuration support for template profiles with static and dynamic secret management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->