### PR TITLE
fix(fuzz): include numeric path segments in fuzzing logic (#6398)

### DIFF
--- a/cmd/integration-test/fuzz.go
+++ b/cmd/integration-test/fuzz.go
@@ -158,6 +158,7 @@ func (h *fuzzTypeOverride) Execute(filePath string) error {
 	return nil
 }
 
+// fuzzPathNumericSegment validates fuzzing behavior for numeric path segments.
 type fuzzPathNumericSegment struct{}
 
 // Execute verifies that numeric path segments are fuzzed and not skipped.

--- a/cmd/integration-test/fuzz.go
+++ b/cmd/integration-test/fuzz.go
@@ -158,7 +158,7 @@ func (h *fuzzTypeOverride) Execute(filePath string) error {
 	return nil
 }
 
-// fuzzPathNumericSegment validates fuzzing behavior for numeric path segments.
+// fuzzPathNumericSegment verifies that numeric path segments are fuzzed and not skipped.
 type fuzzPathNumericSegment struct{}
 
 // Execute verifies that numeric path segments are fuzzed and not skipped.

--- a/cmd/integration-test/fuzz.go
+++ b/cmd/integration-test/fuzz.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 
 	"github.com/julienschmidt/httprouter"
 	"github.com/projectdiscovery/nuclei/v3/pkg/output"
@@ -27,6 +28,7 @@ var fuzzingTestCases = []TestCaseInfo{
 	{Path: "fuzz/fuzz-query-num-replace.yaml", TestCase: &genericFuzzTestCase{expectedResults: 2}},
 	{Path: "fuzz/fuzz-host-header-injection.yaml", TestCase: &genericFuzzTestCase{expectedResults: 1}},
 	{Path: "fuzz/fuzz-path-sqli.yaml", TestCase: &genericFuzzTestCase{expectedResults: 1}},
+	{Path: "fuzz/fuzz-path-numeric-segment.yaml", TestCase: &fuzzPathNumericSegment{}},
 	{Path: "fuzz/fuzz-cookie-error-sqli.yaml", TestCase: &genericFuzzTestCase{expectedResults: 1}},
 	{Path: "fuzz/fuzz-body-json-sqli.yaml", TestCase: &genericFuzzTestCase{expectedResults: 1}},
 	{Path: "fuzz/fuzz-body-multipart-form-sqli.yaml", TestCase: &genericFuzzTestCase{expectedResults: 1}},
@@ -154,6 +156,31 @@ func (h *fuzzTypeOverride) Execute(filePath string) error {
 		return fmt.Errorf("expected id to be fuzz-word, got %s", values.Get("id"))
 	}
 	return nil
+}
+
+type fuzzPathNumericSegment struct{}
+
+// Execute verifies that numeric path segments are fuzzed and not skipped.
+func (h *fuzzPathNumericSegment) Execute(filePath string) error {
+	router := httprouter.New()
+	router.GET("/*path", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+		escapedPath := r.URL.EscapedPath()
+		if strings.Contains(escapedPath, "/456%20OR%20True/") || strings.Contains(r.URL.Path, "/456 OR True/") {
+			w.WriteHeader(http.StatusTeapot)
+			_, _ = fmt.Fprint(w, "numeric-segment-fuzzed")
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, "ok")
+	})
+	ts := httptest.NewTLSServer(router)
+	defer ts.Close()
+
+	got, err := testutils.RunNucleiTemplateAndGetResults(filePath, ts.URL+"/api/v1/456/data", debug, "-fuzz")
+	if err != nil {
+		return err
+	}
+	return expectResultsCount(got, 1)
 }
 
 // HeadlessFuzzingQuery tests fuzzing is working not in headless mode

--- a/integration_tests/fuzz/fuzz-path-numeric-segment.yaml
+++ b/integration_tests/fuzz/fuzz-path-numeric-segment.yaml
@@ -1,0 +1,28 @@
+id: fuzz-path-numeric-segment
+
+info:
+  name: Fuzz Numeric Path Segment
+  author: pdteam
+  severity: info
+  description: Ensure numeric URL path segments are not skipped during path fuzzing.
+
+http:
+  - payloads:
+      suffix:
+        - "%20OR%20True"
+
+    fuzzing:
+      - part: path
+        type: postfix
+        mode: single
+        fuzz:
+          - "{{suffix}}"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 418
+      - type: word
+        words:
+          - "numeric-segment-fuzzed"

--- a/pkg/fuzz/component/path_test.go
+++ b/pkg/fuzz/component/path_test.go
@@ -127,3 +127,33 @@ func TestPathComponent_SQLInjection(t *testing.T) {
 	// Let's also test what the actual URL looks like
 	t.Logf("Full URL: %s", newReq.String())
 }
+
+// TestPathComponent_NumericSegmentsAllFuzzed is a regression test for #6398.
+func TestPathComponent_NumericSegmentsAllFuzzed(t *testing.T) {
+	path := NewPath()
+	req, err := retryablehttp.NewRequest(http.MethodGet, "https://example.com/api/v1/456/data", nil)
+	require.NoError(t, err)
+
+	found, err := path.Parse(req)
+	require.NoError(t, err)
+	require.True(t, found)
+
+	seen := make(map[string]string)
+	err = path.Iterate(func(key string, value interface{}) error {
+		seen[key] = value.(string)
+		return nil
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, map[string]string{
+		"1": "api",
+		"2": "v1",
+		"3": "456",
+		"4": "data",
+	}, seen)
+
+	require.NoError(t, path.SetValue("3", "456 OR 1=1"))
+	rebuilt, err := path.Rebuild()
+	require.NoError(t, err)
+	require.Equal(t, "/api/v1/456 OR 1=1/data", rebuilt.Path)
+}

--- a/pkg/fuzz/parts.go
+++ b/pkg/fuzz/parts.go
@@ -2,7 +2,6 @@ package fuzz
 
 import (
 	"io"
-	"strconv"
 	"strings"
 
 	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz/component"
@@ -152,11 +151,10 @@ func (rule *Rule) executePartComponentOnKV(input *ExecuteRuleInput, payload Valu
 
 // execWithInput executes a rule with input via callback
 func (rule *Rule) execWithInput(input *ExecuteRuleInput, httpReq *retryablehttp.Request, interactURLs []string, component component.Component, parameter, parameterValue, originalPayload, originalValue, key, value string) error {
-	// If the parameter is a number, replace it with the parameter value
-	// or if the parameter is empty and the parameter value is not empty
-	// replace it with the parameter value
+	// Keep positional parameters (for example path segment keys "1", "2", "3")
+	// unchanged. Replacing them with values causes incorrect frequency tracking.
 	actualParameter := parameter
-	if _, err := strconv.Atoi(parameter); err == nil || (parameter == "" && parameterValue != "") {
+	if parameter == "" && parameterValue != "" {
 		actualParameter = parameterValue
 	}
 	// If the parameter is frequent, skip it if the option is enabled


### PR DESCRIPTION
## Proposed changes
This PR fixes a bug where the fuzzing engine incorrectly skipped numeric segments in a URL path (e.g., /api/v1/456/data). The issue was caused by a strconv.Atoi check in pkg/fuzz/parts.go that treated numeric positional parameters as values rather than keys, causing them to be excluded from frequency tracking and iteration.

### Proof
I have added both a unit test and a new integration test to verify the fix:

Unit Test: Added TestPathComponent_NumericSegmentsAllFuzzed in pkg/fuzz/component/path_test.go to ensure all segments, including numeric ones, are correctly parsed and fuzzed.

Integration Test: Created fuzz-path-numeric-segment.yaml and integrated it into the test suite via cmd/integration-test/fuzz.go.

## Checklist
- [x] Pull request is created against the dev branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
Fixes #6398
/claim #6398 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve numeric path segments during fuzzing so positional parameters are no longer incorrectly replaced, improving fuzz accuracy and frequency tracking.
* **Tests**
  * Added regression and integration tests validating numeric-segment fuzzing, including scenarios with TLS-backed servers and asserting expected results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->