### PR TITLE
ci: add GITHUB_TOKEN to workflows for auth'd template updates

### DIFF
--- a/.github/workflows/flamegraph.yaml
+++ b/.github/workflows/flamegraph.yaml
@@ -7,6 +7,7 @@ jobs:
   flamegraph:
     name: "Flamegraph"
     env:
+      GITHUB_TOKEN: "${{ github.token }}"
       PROFILE_MEM: "/tmp/nuclei-profile"
       TARGET_URL: "http://honey.scanme.sh/-/?foo=bar"
     runs-on: ubuntu-latest

--- a/.github/workflows/generate-pgo.yaml
+++ b/.github/workflows/generate-pgo.yaml
@@ -11,6 +11,7 @@ jobs:
     permissions:
       contents: write
     env:
+      GITHUB_TOKEN: "${{ github.token }}"
       PGO_FILE: "cmd/nuclei/default.pgo"
       TARGET: "https://honey.scanme.sh"
       TARGET_COUNT: "100"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,6 +30,8 @@ jobs:
   tests:
     name: "Tests"
     needs: ["lint"]
+    env:
+      GITHUB_TOKEN: "${{ github.token }}"
     strategy:
       fail-fast: false
       matrix:
@@ -53,7 +55,6 @@ jobs:
       - run: make build
       - run: make test
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           PDCP_API_KEY: "${{ secrets.PDCP_API_KEY }}"
       - run: go run -race . -l ../functional-test/targets.txt -id tech-detect,tls-version
         if: ${{ matrix.os != 'windows-latest' }} # known issue: https://github.com/golang/go/issues/46099
@@ -63,6 +64,8 @@ jobs:
     name: "Run example SDK"
     needs: ["tests"]
     runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: "${{ github.token }}"
     steps:
       - uses: actions/checkout@v6
       - uses: projectdiscovery/actions/setup/go@v1
@@ -82,6 +85,8 @@ jobs:
   integration:
     name: "Integration tests"
     needs: ["tests"]
+    env:
+      GITHUB_TOKEN: "${{ github.token }}"
     strategy:
       fail-fast: false
       matrix:
@@ -95,7 +100,6 @@ jobs:
       - uses: projectdiscovery/actions/cache/go-rod-browser@v1
       - run: bash run.sh "${{ matrix.os }}"
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           PDCP_API_KEY: "${{ secrets.PDCP_API_KEY }}"
         timeout-minutes: 50
         working-directory: integration_tests/
@@ -103,6 +107,8 @@ jobs:
   functional:
     name: "Functional tests"
     needs: ["tests"]
+    env:
+      GITHUB_TOKEN: "${{ github.token }}"
     strategy:
       fail-fast: false
       matrix:
@@ -115,14 +121,14 @@ jobs:
       - uses: projectdiscovery/actions/setup/python@v1
       - uses: projectdiscovery/actions/cache/go-rod-browser@v1
       - run: bash run.sh
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         working-directory: cmd/functional-test/
 
   validate:
     name: "Template validate"
     needs: ["tests"]
     runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: "${{ github.token }}"
     steps:
       - uses: actions/checkout@v6
       - uses: projectdiscovery/actions/setup/go@v1


### PR DESCRIPTION
## Proposed changes

ci: add GITHUB_TOKEN to workflows for auth'd template updates

* Updated `.github/workflows/tests.yaml`:
  * Added `GITHUB_TOKEN` to `validate` job to
    support `make template-validate`.
* Updated `.github/workflows/flamegraph.yaml`:
  * Added `GITHUB_TOKEN` to `flamegraph` job for
    `nuclei -update-templates`.
* Updated `.github/workflows/generate-pgo.yaml`:
  * Added `GITHUB_TOKEN` to `pgo` job for
    `nuclei -update-templates`.

This make sure auth'd GitHub API calls during
template updates, avoiding rate limit issues.
Closes #7118

### Proof

N/A

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)