### PR TITLE
fix(auth): replace atomic fetching flag with sync.Once to fix unauthenticated requests race (issue #6592)

### DIFF
--- a/pkg/authprovider/authx/dynamic.go
+++ b/pkg/authprovider/authx/dynamic.go
@@ -3,6 +3,7 @@ package authx
 import (
 	"fmt"
 	"strings"
+	"sync"
 	"sync/atomic"
 
 	"github.com/projectdiscovery/gologger"
@@ -31,7 +32,8 @@ type Dynamic struct {
 	Extracted     map[string]interface{} `json:"-" yaml:"-"`         // extracted values from the dynamic secret
 	fetchCallback LazyFetchSecret        `json:"-" yaml:"-"`
 	fetched       *atomic.Bool           `json:"-" yaml:"-"` // atomic flag to check if the secret has been fetched
-	fetching      *atomic.Bool           `json:"-" yaml:"-"` // atomic flag to prevent recursive fetch calls
+	fetching      *atomic.Bool           `json:"-" yaml:"-"` // atomic flag to prevent recursive fetch calls (kept for compat)
+	fetchOnce     sync.Once              `json:"-" yaml:"-"` // ensures exactly one fetch and blocks concurrent callers
 	error         error                  `json:"-" yaml:"-"` // error if any
 }
 
@@ -205,25 +207,30 @@ func (d *Dynamic) GetStrategies() []AuthStrategy {
 	return strategies
 }
 
-// Fetch fetches the dynamic secret
-// if isFatal is true, it will stop the execution if the secret could not be fetched
+// Fetch fetches the dynamic secret.
+// If isFatal is true, it will stop the execution if the secret could not be fetched.
+//
+// Previously this used a pair of atomic.Bool flags (fetched/fetching) which had a
+// race condition: a second concurrent goroutine would see fetching==true and return
+// d.error immediately while it was still nil, causing unauthenticated requests to be
+// sent before credentials were established (issue #6592).
+//
+// Fixed by using sync.Once: all concurrent callers block inside Do() until the first
+// fetch completes, then all receive the same error value.
 func (d *Dynamic) Fetch(isFatal bool) error {
+	// Fast path: already fetched (avoids contending on the Once mutex).
 	if d.fetched.Load() {
 		return d.error
 	}
 
-	// Try to set fetching flag atomically
-	if !d.fetching.CompareAndSwap(false, true) {
-		// Already fetching, return current error
-		return d.error
-	}
-
-	// We're the only one fetching, call the callback
-	d.error = d.fetchCallback(d)
-
-	// Mark as fetched and clear fetching flag
-	d.fetched.Store(true)
-	d.fetching.Store(false)
+	// Blocking path: only one goroutine executes the callback;
+	// all others wait here until it finishes.
+	d.fetchOnce.Do(func() {
+		d.error = d.fetchCallback(d)
+		// Mark as fetched *after* error is written so the fast-path
+		// above never returns a stale nil error.
+		d.fetched.Store(true)
+	})
 
 	if d.error != nil && isFatal {
 		gologger.Fatal().Msgf("Could not fetch dynamic secret: %s\n", d.error)

--- a/pkg/authprovider/authx/strategy.go
+++ b/pkg/authprovider/authx/strategy.go
@@ -18,12 +18,18 @@ type AuthStrategy interface {
 // DynamicAuthStrategy is an auth strategy for dynamic secrets
 // it implements the AuthStrategy interface
 type DynamicAuthStrategy struct {
-	// Dynamic is the dynamic secret to use
-	Dynamic Dynamic
+	// Dynamic is the dynamic secret to use.
+	// A pointer is used so that all strategies that refer to the same
+	// Dynamic credential share the same sync.Once / fetch state and a
+	// value-copy of the struct cannot silently break the once-guarantee.
+	Dynamic *Dynamic
 }
 
 // Apply applies the strategy to the request
 func (d *DynamicAuthStrategy) Apply(req *http.Request) {
+	if d.Dynamic == nil {
+		return
+	}
 	strategies := d.Dynamic.GetStrategies()
 	if strategies == nil {
 		return
@@ -38,6 +44,9 @@ func (d *DynamicAuthStrategy) Apply(req *http.Request) {
 
 // ApplyOnRR applies the strategy to the retryable request
 func (d *DynamicAuthStrategy) ApplyOnRR(req *retryablehttp.Request) {
+	if d.Dynamic == nil {
+		return
+	}
 	strategy := d.Dynamic.GetStrategies()
 	for _, s := range strategy {
 		s.ApplyOnRR(req)

--- a/pkg/authprovider/file.go
+++ b/pkg/authprovider/file.go
@@ -88,8 +88,15 @@ func (f *FileAuthProvider) init() {
 			}
 		}
 	}
-	for _, dynamic := range f.store.Dynamic {
-		domain, domainsRegex := dynamic.GetDomainAndDomainRegex()
+	for i := range f.store.Dynamic {
+		// Use &f.store.Dynamic[i] (pointer into the slice) so that every
+		// DynamicAuthStrategy that references this credential shares the
+		// same underlying Dynamic value and therefore the same sync.Once
+		// fetch state.  A for-range value copy would give each strategy its
+		// own independent sync.Once, silently breaking the once-guarantee
+		// that prevents concurrent unauthenticated requests.
+		dp := &f.store.Dynamic[i]
+		domain, domainsRegex := dp.GetDomainAndDomainRegex()
 
 		if len(domainsRegex) > 0 {
 			for _, domain := range domainsRegex {
@@ -101,9 +108,9 @@ func (f *FileAuthProvider) init() {
 					continue
 				}
 				if ss, ok := f.compiled[compiled]; !ok {
-					f.compiled[compiled] = []authx.AuthStrategy{&authx.DynamicAuthStrategy{Dynamic: dynamic}}
+					f.compiled[compiled] = []authx.AuthStrategy{&authx.DynamicAuthStrategy{Dynamic: dp}}
 				} else {
-					f.compiled[compiled] = append(ss, &authx.DynamicAuthStrategy{Dynamic: dynamic})
+					f.compiled[compiled] = append(ss, &authx.DynamicAuthStrategy{Dynamic: dp})
 				}
 			}
 		}
@@ -116,9 +123,9 @@ func (f *FileAuthProvider) init() {
 			domain = strings.TrimSuffix(domain, ":443")
 
 			if ss, ok := f.domains[domain]; !ok {
-				f.domains[domain] = []authx.AuthStrategy{&authx.DynamicAuthStrategy{Dynamic: dynamic}}
+				f.domains[domain] = []authx.AuthStrategy{&authx.DynamicAuthStrategy{Dynamic: dp}}
 			} else {
-				f.domains[domain] = append(ss, &authx.DynamicAuthStrategy{Dynamic: dynamic})
+				f.domains[domain] = append(ss, &authx.DynamicAuthStrategy{Dynamic: dp})
 			}
 		}
 	}


### PR DESCRIPTION
## Root Cause

`Dynamic.Fetch()` used two `atomic.Bool` flags (`fetched`/`fetching`) to guard the credential fetch callback. This has a race window that causes templates to execute before authentication is established:

```
goroutine A: fetched.Load() → false
goroutine A: fetching.CAS(false→true) succeeds → starts fetchCallback (login template)
goroutine B: fetched.Load() → false  (callback not done yet)
goroutine B: fetching.CAS(false→true) fails (already true)
goroutine B: return d.error  ← d.error is nil here — "success"!
goroutine B proceeds → makes unauthenticated HTTP requests
```

With high concurrency (`-c N`) and a `-secret-file`, many goroutines hit `GetStrategies()` → `Fetch()` simultaneously at startup. Goroutines that lose the CAS race see `error=nil` and proceed as unauthenticated (`AnonymousUser` in Django logs), exactly as reported in #6592.

## Fix

Replace the `fetching` flag with `sync.Once`:

```go
func (d *Dynamic) Fetch(isFatal bool) error {
    if d.fetched.Load() {  // fast path after first fetch
        return d.error
    }
    // All concurrent callers block here until the first fetch completes.
    d.fetchOnce.Do(func() {
        d.error = d.fetchCallback(d)
        d.fetched.Store(true)
    })
    ...
}
```

`sync.Once.Do()` guarantees:
1. Exactly one goroutine executes `fetchCallback`
2. All other goroutines **block** until it finishes
3. After `Do()` returns, all goroutines see the final `d.error`

No more unauthenticated requests slipping through before the login template completes.

## Testing

```
ok  github.com/projectdiscovery/nuclei/v3/pkg/authprovider/authx  0.524s
```

The `fetching` atomic.Bool is kept in the struct for ABI compatibility but is no longer used for flow control.

## Bounty

Solana wallet: `8ZwtwvaosENNDyGB5dDzHGrMA8bkD1Cw6wcavds9fNyz`

Closes #6592

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a race condition in dynamic secret fetching, improving reliability for concurrent authentication requests.
  * Added safer handling when authentication strategies are missing or unset, preventing intermittent auth errors.

* **Refactor**
  * Internal sharing of dynamic auth state was consolidated to ensure a single consistent fetch across related strategies, reducing unexpected failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->