### PR TITLE
fix(fuzz): propagate custom headers to time_delay analyzer follow-up requests

### DIFF
--- a/pkg/fuzz/analyzers/time/analyzer.go
+++ b/pkg/fuzz/analyzers/time/analyzer.go
@@ -123,6 +123,17 @@ func (a *Analyzer) Analyze(options *analyzers.Options) (bool, string, error) {
 		if err != nil {
 			return 0, errors.Wrap(err, "could not rebuild request")
 		}
+
+		// The component base request is parsed from the rule's BaseRequest
+		// before any post-parse header injection (custom -H flags, auth
+		// provider headers, etc.) is applied.  Copy the full header set from
+		// the original fuzz-generated request so that every follow-up
+		// time-delay request carries the same headers — including cookies and
+		// auth tokens — as the request that triggered the initial delay.
+		for k, vs := range gr.Request.Header {
+			rebuilt.Header[k] = vs
+		}
+
 		gologger.Verbose().Msgf("[%s] Sending request with %d delay for: %s", a.Name(), delay, rebuilt.String())
 
 		timeTaken, err := doHTTPRequestWithTimeTracing(rebuilt, options.HttpClient)

--- a/pkg/fuzz/analyzers/time/analyzer.go
+++ b/pkg/fuzz/analyzers/time/analyzer.go
@@ -131,6 +131,10 @@ func (a *Analyzer) Analyze(options *analyzers.Options) (bool, string, error) {
 		// time-delay request carries the same headers — including cookies and
 		// auth tokens — as the request that triggered the initial delay.
 		for k, vs := range gr.Request.Header {
+			// Skip the header being fuzzed to avoid overwriting the time-delay payload
+			if gr.Component.Name() == "header" && k == gr.Key {
+				continue
+			}
 			rebuilt.Header[k] = vs
 		}
 

--- a/pkg/fuzz/analyzers/time/analyzer.go
+++ b/pkg/fuzz/analyzers/time/analyzer.go
@@ -124,14 +124,9 @@ func (a *Analyzer) Analyze(options *analyzers.Options) (bool, string, error) {
 			return 0, errors.Wrap(err, "could not rebuild request")
 		}
 
-		// The component base request is parsed from the rule's BaseRequest
-		// before any post-parse header injection (custom -H flags, auth
-		// provider headers, etc.) is applied.  Copy the full header set from
-		// the original fuzz-generated request so that every follow-up
-		// time-delay request carries the same headers — including cookies and
-		// auth tokens — as the request that triggered the initial delay.
+		// copy headers from the original request since Rebuild() only
+		// carries headers present at parse time, not post-parse injections
 		for k, vs := range gr.Request.Header {
-			// Skip the header being fuzzed to avoid overwriting the time-delay payload
 			if gr.Component.Name() == "header" && k == gr.Key {
 				continue
 			}

--- a/pkg/fuzz/analyzers/time/time_delay_test.go
+++ b/pkg/fuzz/analyzers/time/time_delay_test.go
@@ -498,3 +498,16 @@ func TestSmallErrorDependence(t *testing.T) {
 		t.Fatalf("Expected match for small error case. Reason: %s", reason)
 	}
 }
+
+// TestReqSenderPreservesCustomHeaders verifies that follow-up requests sent
+// by the time_delay analyzer carry the same headers as the original fuzz
+// request (e.g. custom Cookie/Auth set via -H flag).
+// Regression test for https://github.com/projectdiscovery/nuclei/issues/7106
+func TestReqSenderPreservesCustomHeaders(t *testing.T) {
+	// This test validates the fix at the unit level: after Rebuild() the
+	// analyzer copies gr.Request.Header into the rebuilt request.
+	// We verify by inspecting what the Analyze call passes to doHTTPRequest,
+	// which is checked by confirming the header copy loop is present in the
+	// implementation — a full integration test would require a live server.
+	t.Skip("integration test: run manually with a live DVWA instance")
+}

--- a/pkg/fuzz/analyzers/time/time_delay_test.go
+++ b/pkg/fuzz/analyzers/time/time_delay_test.go
@@ -7,6 +7,10 @@ import (
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz/component"
+	"github.com/projectdiscovery/retryablehttp-go"
+	"github.com/stretchr/testify/require"
 )
 
 // This test suite verifies the timing dependency detection algorithm by testing various scenarios:
@@ -499,15 +503,109 @@ func TestSmallErrorDependence(t *testing.T) {
 	}
 }
 
-// TestReqSenderPreservesCustomHeaders verifies that follow-up requests sent
-// by the time_delay analyzer carry the same headers as the original fuzz
-// request (e.g. custom Cookie/Auth set via -H flag).
-// Regression test for https://github.com/projectdiscovery/nuclei/issues/7106
-func TestReqSenderPreservesCustomHeaders(t *testing.T) {
-	// This test validates the fix at the unit level: after Rebuild() the
-	// analyzer copies gr.Request.Header into the rebuilt request.
-	// We verify by inspecting what the Analyze call passes to doHTTPRequest,
-	// which is checked by confirming the header copy loop is present in the
-	// implementation — a full integration test would require a live server.
-	t.Skip("integration test: run manually with a live DVWA instance")
+// copyHeaders replicates the header-copy logic from Analyze's reqSender closure.
+// It copies all headers from src to dst, skipping the fuzzed key when the
+// component is a header component.
+func copyHeaders(dst, src *retryablehttp.Request, componentName, fuzzedKey string) {
+	for k, vs := range src.Header {
+		if componentName == "header" && k == fuzzedKey {
+			continue
+		}
+		dst.Header[k] = vs
+	}
+}
+
+func TestRebuildFromClonedComponentLosesPostParseHeaders(t *testing.T) {
+	rawReq, _ := retryablehttp.NewRequest("GET", "http://example.com/?id=1", nil)
+
+	q := component.NewQuery()
+	parsed, err := q.Parse(rawReq)
+	require.True(t, parsed)
+	require.NoError(t, err)
+
+	// in the real flow the component is cloned before custom headers are
+	// injected, so the clone's internal request has no custom headers
+	cloned := q.Clone()
+
+	rawReq.Header.Set("Cookie", "session=abc123")
+	rawReq.Header.Set("Authorization", "Bearer tok")
+
+	err = cloned.SetValue("id", "2")
+	require.NoError(t, err)
+
+	rebuilt, err := cloned.Rebuild()
+	require.NoError(t, err)
+
+	require.Empty(t, rebuilt.Header.Get("Cookie"), "cloned component rebuild should not have post-parse headers")
+	require.Empty(t, rebuilt.Header.Get("Authorization"))
+}
+
+func TestHeaderCopyRestoresCustomHeaders(t *testing.T) {
+	rawReq, _ := retryablehttp.NewRequest("GET", "http://example.com/?id=1", nil)
+
+	q := component.NewQuery()
+	parsed, err := q.Parse(rawReq)
+	require.True(t, parsed)
+	require.NoError(t, err)
+
+	cloned := q.Clone()
+
+	// simulate post-parse header injection on the live request
+	rawReq.Header.Set("Cookie", "session=abc123")
+	rawReq.Header.Set("Authorization", "Bearer tok")
+	rawReq.Header.Set("X-Custom", "value")
+
+	err = cloned.SetValue("id", "2")
+	require.NoError(t, err)
+	rebuilt, err := cloned.Rebuild()
+	require.NoError(t, err)
+
+	copyHeaders(rebuilt, rawReq, cloned.Name(), "")
+
+	require.Equal(t, "session=abc123", rebuilt.Header.Get("Cookie"))
+	require.Equal(t, "Bearer tok", rebuilt.Header.Get("Authorization"))
+	require.Equal(t, "value", rebuilt.Header.Get("X-Custom"))
+}
+
+func TestHeaderCopySkipsFuzzedKey(t *testing.T) {
+	rawReq, _ := retryablehttp.NewRequest("GET", "http://example.com/", nil)
+	rawReq.Header.Set("X-Inject", "original-value")
+	rawReq.Header.Set("Cookie", "session=abc123")
+
+	h := component.NewHeader()
+	parsed, err := h.Parse(rawReq)
+	require.True(t, parsed)
+	require.NoError(t, err)
+
+	fuzzedKey := "X-Inject"
+	err = h.SetValue(fuzzedKey, "sleep(5)")
+	require.NoError(t, err)
+	rebuilt, err := h.Rebuild()
+	require.NoError(t, err)
+
+	copyHeaders(rebuilt, rawReq, h.Name(), fuzzedKey)
+
+	require.Equal(t, "sleep(5)", rebuilt.Header.Get("X-Inject"), "fuzzed header should keep the payload")
+	require.Equal(t, "session=abc123", rebuilt.Header.Get("Cookie"), "non-fuzzed headers should be copied")
+}
+
+func TestHeaderCopyWithMultipleValues(t *testing.T) {
+	rawReq, _ := retryablehttp.NewRequest("GET", "http://example.com/?q=1", nil)
+
+	q := component.NewQuery()
+	parsed, err := q.Parse(rawReq)
+	require.True(t, parsed)
+	require.NoError(t, err)
+
+	cloned := q.Clone()
+
+	rawReq.Header.Add("X-Multi", "val1")
+	rawReq.Header.Add("X-Multi", "val2")
+
+	rebuilt, err := cloned.Rebuild()
+	require.NoError(t, err)
+
+	copyHeaders(rebuilt, rawReq, cloned.Name(), "")
+
+	require.Equal(t, []string{"val1", "val2"}, rebuilt.Header.Values("X-Multi"))
 }


### PR DESCRIPTION
## Problem

Fixes #7106

The `time_delay` analyzer sends several follow-up requests to confirm a timing-based injection. These requests are built with `gr.Component.Rebuild()`, which clones the component's **base request**.

The base request is parsed from `rule.BaseRequest` in `fuzz/execute.go` — **before** any post-parse header injection takes place. Custom headers added later (e.g. `-H "Cookie: PHPSESSID=..."`, auth provider headers) are stored on the original `gr.Request` but never reach the cloned base inside the component.

Result: the server sees the follow-up requests without session cookies / auth tokens and rejects them, so the timing difference disappears and the injection is missed.

## Root Cause

```go
// fuzz/execute.go — component parsed from BaseRequest (no custom headers yet)
component.Parse(input.BaseRequest)

// request.go — custom headers added to generatedRequest.request AFTER parse
request.setCustomHeaders(generatedRequest)

// time_delay analyzer — Rebuild clones base request → custom headers absent
rebuilt, err := gr.Component.Rebuild()
```

## Fix

After `Rebuild()`, copy the full header set from `gr.Request` (which has all injected headers) into the rebuilt request:

```go
rebuilt, err := gr.Component.Rebuild()
// ...
for k, vs := range gr.Request.Header {
    rebuilt.Header[k] = vs
}
```

This matches the behaviour of every other path in the request pipeline and ensures time-delay follow-up requests are authenticated/cookied identically to the triggering request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Follow-up requests now preserve original request headers (cookies, auth tokens, multi-valued headers) while still allowing a specific header to be intentionally fuzzed.

* **Tests**
  * Added regression tests covering header preservation, multi-value headers, restoration of custom headers, and ensuring the fuzzed header is not overwritten.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->