### PR TITLE
fix(fuzz): prevent fatal concurrent map-write crash in MultiPartForm when scanning multiple targets

### DIFF
--- a/pkg/fuzz/dataformat/dataformat.go
+++ b/pkg/fuzz/dataformat/dataformat.go
@@ -5,8 +5,14 @@ import (
 	"fmt"
 )
 
-// dataformats is a list of dataformats
+// dataformats is a list of stateless dataformat singletons.
+// Stateful formats (MultiPartForm) must NOT be stored here — see Get().
 var dataformats map[string]DataFormat
+
+// dataformatFactories maps format names to constructor functions.
+// Get() uses a factory when one is registered, so each caller receives an
+// independent instance and concurrent goroutines never share mutable state.
+var dataformatFactories map[string]func() DataFormat
 
 const (
 	// DefaultKey is the key i.e used when given
@@ -16,13 +22,18 @@ const (
 
 func init() {
 	dataformats = make(map[string]DataFormat)
+	dataformatFactories = make(map[string]func() DataFormat)
 
 	// register the default data formats
 	RegisterDataFormat(NewJSON())
 	RegisterDataFormat(NewXML())
 	RegisterDataFormat(NewRaw())
 	RegisterDataFormat(NewForm())
-	RegisterDataFormat(NewMultiPartForm())
+	// MultiPartForm is stateful (boundary + filesMetadata fields mutated per
+	// request) — register it as a factory so each Get() call returns a fresh
+	// instance, preventing the fatal concurrent-map-write crash that occurs
+	// when multiple goroutines share the singleton (issue #7028).
+	RegisterDataFormatFactory(MultiPartFormDataFormat, func() DataFormat { return NewMultiPartForm() })
 }
 
 const (
@@ -38,14 +49,28 @@ const (
 	MultiPartFormDataFormat = "multipart/form-data"
 )
 
-// Get returns the dataformat by name
+// Get returns the dataformat by name.
+//
+// For formats registered via RegisterDataFormatFactory a new instance is
+// created on every call, so concurrent goroutines each get their own copy and
+// never race on shared mutable state.
 func Get(name string) DataFormat {
+	if factory, ok := dataformatFactories[name]; ok {
+		return factory()
+	}
 	return dataformats[name]
 }
 
-// RegisterEncoder registers an encoder
+// RegisterDataFormat registers a stateless dataformat singleton.
 func RegisterDataFormat(dataformat DataFormat) {
 	dataformats[dataformat.Name()] = dataformat
+}
+
+// RegisterDataFormatFactory registers a constructor for a stateful dataformat.
+// Each call to Get() will invoke the factory and return a fresh instance,
+// preventing data races between concurrent goroutines.
+func RegisterDataFormatFactory(name string, factory func() DataFormat) {
+	dataformatFactories[name] = factory
 }
 
 // DataFormat is an interface for encoding and decoding

--- a/pkg/fuzz/dataformat/dataformat.go
+++ b/pkg/fuzz/dataformat/dataformat.go
@@ -116,7 +116,8 @@ func Encode(data KV, dataformat string) (string, error) {
 	if dataformat == "" {
 		return "", errors.New("dataformat is required")
 	}
-	if encoder, ok := dataformats[dataformat]; ok {
+	encoder := Get(dataformat)
+	if encoder != nil {
 		return encoder.Encode(data)
 	}
 	return "", fmt.Errorf("dataformat %s is not supported", dataformat)


### PR DESCRIPTION
## Problem

Fixes #7028

Scanning multiple targets with a `multipart/form-data` template crashes with:
```
fatal error: concurrent map writes
```
or (with `-race`):
```
WARNING: DATA RACE
Write at ... MultiPartForm.ParseBoundary()
```

## Root Cause

`MultiPartForm` is the **only stateful** `DataFormat` — it stores a mutable `boundary` string and a `filesMetadata` map that are written on every `Decode`/`ParseBoundary` call. It is registered as a **singleton** in `dataformat.init()`, so every goroutine that calls `dataformat.Get("multipart/form-data")` receives the **same pointer**.

When N > 1 targets are scanned concurrently, goroutines race to write the same fields:
```
dataformat.Get("multipart/form-data")   ← all goroutines get same *MultiPartForm
singleton.ParseBoundary(contentType)    ← goroutine A writes m.boundary
singleton.Decode(body)                  ← goroutine B writes m.filesMetadata
→ fatal error: concurrent map writes
```

## Fix

Add a `RegisterDataFormatFactory(name, func() DataFormat)` alongside the existing `RegisterDataFormat()`. `Get()` checks the factory map first and calls the constructor to return a **fresh instance per invocation**.

MultiPartForm is re-registered as a factory. All other DataFormats (JSON, XML, Raw, Form) remain singletons — they have no mutable state.

```go
// Before — singleton, crashes with concurrent access
RegisterDataFormat(NewMultiPartForm())

// After — factory, each Get() returns independent instance
RegisterDataFormatFactory(MultiPartFormDataFormat, func() DataFormat { return NewMultiPartForm() })
```

## Verification
```bash
go test -race ./pkg/fuzz/dataformat/...
# ok  github.com/projectdiscovery/nuclei/v3/pkg/fuzz/dataformat  1.655s
```

The SDK reproduction test from #7028 also passes without `-race` detecting any race.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Data format handling reworked so stateful formats are created per use, preventing shared-state issues and improving reliability.
* **Bug Fixes**
  * Encoding flow made safer with per-call retrieval and nil checks to avoid runtime errors with stateful formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->