### PR TITLE
fix(expressions): skip evaluation when nested variables are unresolved inside helper functions

### DIFF
--- a/pkg/protocols/common/expressions/expressions.go
+++ b/pkg/protocols/common/expressions/expressions.go
@@ -1,6 +1,7 @@
 package expressions
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 
@@ -73,8 +74,7 @@ func evaluate(data string, base map[string]interface{}) (string, error) {
 		// Note: we use a regex that requires an identifier character after {{
 		// so that legitimate literals like hex_encode('{{') are not blocked.
 		if unresolvedVarRe.MatchString(expression) {
-			gologger.Warning().Msgf("Skipping expression with unresolved variables: %s", expression)
-			continue
+			return "", fmt.Errorf("expression contains unresolved variables: %s", expression)
 		}
 
 		// turns expressions (either helper functions+base values or base values)

--- a/pkg/protocols/common/expressions/expressions.go
+++ b/pkg/protocols/common/expressions/expressions.go
@@ -1,6 +1,7 @@
 package expressions
 
 import (
+	"regexp"
 	"strings"
 
 	"github.com/Knetic/govaluate"
@@ -11,6 +12,13 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/replacer"
 	stringsutil "github.com/projectdiscovery/utils/strings"
 )
+
+// unresolvedVarRe matches complete {{identifier}} variable markers.
+// It is used to detect cases where a nested variable inside a helper-function
+// call was not substituted before evaluation (issue #7032).
+// The pattern deliberately excludes non-identifier characters after {{ so that
+// literal strings like `hex_encode('{{')` do not trigger a false positive.
+var unresolvedVarRe = regexp.MustCompile(`\{\{[a-zA-Z_][a-zA-Z0-9_.]*\}\}`)
 
 // Eval compiles the given expression and evaluate it with the given values preserving the return type
 func Eval(expression string, values map[string]interface{}) (interface{}, error) {
@@ -54,6 +62,21 @@ func evaluate(data string, base map[string]interface{}) (string, error) {
 	for _, expression := range expressions {
 		// replace variable placeholders with base values
 		expression = replacer.Replace(expression, base)
+
+		// Guard: if after variable substitution the expression still contains a
+		// complete {{identifier}} marker, at least one nested variable was not
+		// resolved (e.g. {{base64(rawhash)}} where rawhash itself contains
+		// {{contact_id}}).  Evaluating such an expression would silently encode
+		// the raw marker string, producing an opaque blob that the downstream
+		// ContainsUnresolvedVariables check cannot detect (issue #7032).
+		//
+		// Note: we use a regex that requires an identifier character after {{
+		// so that legitimate literals like hex_encode('{{') are not blocked.
+		if unresolvedVarRe.MatchString(expression) {
+			gologger.Warning().Msgf("Skipping expression with unresolved variables: %s", expression)
+			continue
+		}
+
 		// turns expressions (either helper functions+base values or base values)
 		compiled, err := govaluate.NewEvaluableExpressionWithFunctions(expression, dsl.HelperFunctions)
 		if err != nil {


### PR DESCRIPTION
Fixes #7032

When a template variable is passed through a helper function and itself contains unresolved `{{...}}` markers, the markers get encoded as an opaque blob and bypass the `ContainsUnresolvedVariables` check — causing requests to fire with garbage data.

## Root Cause

```yaml
variables:
  rawhash: |
    {"contact_id":"{{contact_id}}"}

path:
  - "{{base64(rawhash)}}"
```

After `replacer.Replace` substitutes `rawhash`, the expression becomes `base64({..."{{contact_id}}"...})`. The code evaluated this unconditionally, so `base64()` encoded the literal marker string into `eyJjb250YWN0X2lkIjoie3tjb250YWN0X2lkfX0ifQ==`. The downstream `ContainsUnresolvedVariables` check received the blob and returned false — the request fired.

## Fix

After `replacer.Replace`, check the expression for remaining `{{identifier}}` patterns with a compiled regexp:

```go
var unresolvedVarRe = regexp.MustCompile(`\{\{[a-zA-Z_][a-zA-Z0-9_.]*\}\}`)
```

The regex requires an identifier character immediately after `{{`, so legitimate literals like `hex_encode("{{")`  still evaluate correctly. When an unresolved variable is found, emit a warning and skip evaluation — leaving the outer `{{...}}` intact.

## Tests

```
ok  github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/expressions
```

All existing cases pass including the `hex_encode("{{")`  literal case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Expression evaluation now detects unresolved variable markers after substitution and returns an explicit error instead of continuing silently, preventing partially substituted expressions from proceeding unnoticed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->