### PR TITLE
fix(http): use actual request URL for host field so http_N_host is correct in multi-request templates

### DIFF
--- a/pkg/protocols/http/request.go
+++ b/pkg/protocols/http/request.go
@@ -900,7 +900,9 @@ func (request *Request) executeRequest(input *contextargs.Context, generatedRequ
 		// In case of interactsh markers and request times out, still send
 		// a callback event so in case we receive an interaction, correlation is possible.
 		// Also, to log failed use-cases.
-		outputEvent := request.responseToDSLMap(&http.Response{}, input.MetaInput.Input, formedURL, convUtil.String(dumpedRequest), "", "", "", 0, generatedRequest.meta)
+		// Use formedURL (the actual request URL) as host so that http_N_host
+		// variables reflect the correct domain on error paths too (issue #7062).
+		outputEvent := request.responseToDSLMap(&http.Response{}, formedURL, formedURL, convUtil.String(dumpedRequest), "", "", "", 0, generatedRequest.meta)
 		if i := strings.LastIndex(hostname, ":"); i != -1 {
 			hostname = hostname[:i]
 		}
@@ -1024,7 +1026,15 @@ func (request *Request) executeRequest(input *contextargs.Context, generatedRequ
 			}
 		}
 
-		outputEvent := request.responseToDSLMap(respChain.Response(), input.MetaInput.Input, matchedURL, convUtil.String(dumpedRequest), fullResponseStr, bodyStr, headersStr, duration, generatedRequest.meta)
+		// Use matchedURL (the actual request URL) as the host argument so that
+		// the "host" field in the event — and consequently the prefixed
+		// http_N_host variables populated by FillPreviousEvent — reflect the
+		// URL of *this* request rather than the original scan target
+		// (input.MetaInput.Input).  In multi-request templates where subsequent
+		// requests target a different domain the two values diverge and using
+		// the original target was causing http_2_host to inherit the value of
+		// http_1_host (issue #7062).
+		outputEvent := request.responseToDSLMap(respChain.Response(), matchedURL, matchedURL, convUtil.String(dumpedRequest), fullResponseStr, bodyStr, headersStr, duration, generatedRequest.meta)
 		// add response fields to template context and merge templatectx variables to output event
 		request.options.AddTemplateVars(input.MetaInput, request.Type(), request.ID, outputEvent)
 		if request.options.HasTemplateCtx(input.MetaInput) {


### PR DESCRIPTION
Fixes #7062

## Root Cause

`responseToDSLMap` receives a `host` parameter that was always set to `input.MetaInput.Input` — the **original scan target** — on both the success and error paths:

```go
// before fix
outputEvent := request.responseToDSLMap(resp, input.MetaInput.Input, matchedURL, ...)
```

In a multi-request template where request 2 sends to `https://google.com`, `input.MetaInput.Input` is still `https://example.com/?a=1`. So `data["host"] = "https://example.com/?a=1"` — wrong.

`FillPreviousEvent` then prefixes all event keys for the current request:
```go
previous.Set("http_2_" + "host", "https://example.com/?a=1")  // wrong
```

The query string `?a=1` also leaked into the second request URL for the same reason.

## Fix

Pass the actual request URL (`matchedURL` on success, `formedURL` on error) as the `host` argument:

```go
// after fix
outputEvent := request.responseToDSLMap(resp, matchedURL, matchedURL, ...)
```

For single-request templates and templates where all requests use `{{BaseURL}}`, `matchedURL == input.MetaInput.Input`, so behaviour is unchanged.

## Tests

```
ok  github.com/projectdiscovery/nuclei/v3/pkg/protocols/http   12.742s
ok  github.com/projectdiscovery/nuclei/v3/pkg/protocols/http/raw  1.304s
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved issue where HTTP host field did not accurately reflect the actual request URL in both successful and failed requests; now correctly represents the URL used for each request
  * Enhanced support for multi-request templates that target different domains; host information now properly aligns with the actual request URL used

<!-- end of auto-generated comment: release notes by coderabbit.ai -->