### PR TITLE
fix(core): stop spawning template goroutines in host-spray once host is unresponsive

### DIFF
--- a/pkg/core/executors.go
+++ b/pkg/core/executors.go
@@ -201,6 +201,18 @@ func (e *Engine) executeTemplatesOnTarget(ctx context.Context, alltemplates []*t
 		default:
 		}
 
+		// In host-spray mode every template runs against the same target.
+		// Check whether the target has already been marked as permanently
+		// unresponsive by HostErrorsCache before spawning another goroutine.
+		// Without this guard the loop spawns O(templates) goroutines that each
+		// do nothing but write a "skipped — unresponsive" event, which with
+		// JSON output (-j/-je) can serialise thousands of writes and keep the
+		// process running for hours instead of the expected few minutes.
+		if e.executerOpts.HostErrorsCache != nil &&
+			e.executerOpts.HostErrorsCache.Check(e.executerOpts.ProtocolType.String(), contextargs.NewWithMetaInput(ctx, target)) {
+			break
+		}
+
 		// resize check point - nop if there are no changes
 		wp.RefreshWithConfig(e.GetWorkPoolConfig())
 

--- a/pkg/core/executors.go
+++ b/pkg/core/executors.go
@@ -201,15 +201,25 @@ func (e *Engine) executeTemplatesOnTarget(ctx context.Context, alltemplates []*t
 		default:
 		}
 
-		// In host-spray mode every template runs against the same target.
 		// Check whether the target has already been marked as permanently
 		// unresponsive by HostErrorsCache before spawning another goroutine.
-		// Without this guard the loop spawns O(templates) goroutines that each
-		// do nothing but write a "skipped — unresponsive" event, which with
-		// JSON output (-j/-je) can serialise thousands of writes and keep the
-		// process running for hours instead of the expected few minutes.
 		if e.executerOpts.HostErrorsCache != nil &&
 			e.executerOpts.HostErrorsCache.Check(e.executerOpts.ProtocolType.String(), contextargs.NewWithMetaInput(ctx, target)) {
+			skipEvent := &output.ResultEvent{
+				TemplateID:    tpl.ID,
+				TemplatePath:  tpl.Path,
+				Info:          tpl.Info,
+				Type:          e.executerOpts.ProtocolType.String(),
+				Host:          target.Input,
+				MatcherStatus: false,
+				Error:         "host was skipped as it was found unresponsive",
+				Timestamp:     time.Now(),
+			}
+			if e.Callback != nil {
+				e.Callback(skipEvent)
+			} else if e.executerOpts.Output != nil {
+				_ = e.executerOpts.Output.Write(skipEvent)
+			}
 			break
 		}
 


### PR DESCRIPTION
Fixes #7049

## Problem

With `-j`/`-je` (JSON output) and `-ss host-spray`, a scan against a down host runs for **hours** instead of minutes. Without JSON output the same scan finishes in ~3 minutes.

## Root Cause

`executeTemplatesOnTarget` iterates over **all** templates in a `for` loop and spawns a goroutine for each one, regardless of whether the host has already been marked as permanently unresponsive.

Each goroutine detects the unresponsive state and writes a `"skipped — unresponsive"` event. Without JSON output these writes are cheap. With `-j`/`-je` each write is a synchronous JSON file I/O operation — 18k templates × one blocking write per template = hours of wall time.

## Fix

Add a `HostErrorsCache.Check` guard at the top of the template-spawn loop in `executeTemplatesOnTarget` and `break` as soon as the host is known to be permanently unresponsive:

```go
if e.executerOpts.HostErrorsCache != nil &&
    e.executerOpts.HostErrorsCache.Check(proto, contextargs.NewWithMetaInput(ctx, target)) {
    break
}
```

This mirrors the identical guard already present in the **template-spray** path (`executeTemplateWithTargets`, line 153) that was missing from the host-spray equivalent.

## Tests

```
ok  github.com/projectdiscovery/nuclei/v3/pkg/core   0.956s
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced redundant skip notifications for unresponsive targets by stopping extra work once a target is marked permanently unresponsive.

* **Performance**
  * Improved efficiency when handling unresponsive targets, lowering runtime overhead and speeding up completion of template processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->