### PR TITLE
fix(fuzz): path-based fuzzing skips numeric path segments

### DIFF
--- a/pkg/fuzz/component/path.go
+++ b/pkg/fuzz/component/path.go
@@ -14,7 +14,11 @@ import (
 type Path struct {
 	value *Value
 
-	req *retryablehttp.Request
+	req          *retryablehttp.Request
+	originalPath string // stored at Parse time; Rebuild must not use q.req.Path
+	// because retryablehttp.Request.Clone() performs a shallow copy of the
+	// embedded *urlutil.URL pointer, so UpdateRelPath on a cloned request
+	// mutates the shared URL and corrupts q.req.Path for subsequent Rebuild calls.
 }
 
 var _ Component = &Path{}
@@ -33,6 +37,7 @@ func (q *Path) Name() string {
 // parsed component
 func (q *Path) Parse(req *retryablehttp.Request) (bool, error) {
 	q.req = req
+	q.originalPath = req.Path // snapshot before any Clone/UpdateRelPath can corrupt req.Path
 	q.value = NewValue("")
 
 	splitted := strings.Split(req.Path, "/")
@@ -87,8 +92,12 @@ func (q *Path) Delete(key string) error {
 // Rebuild returns a new request with the
 // component rebuilt
 func (q *Path) Rebuild() (*retryablehttp.Request, error) {
-	// Get the original path segments
-	originalSplitted := strings.Split(q.req.Path, "/")
+	// Use the path snapshot taken at Parse time rather than q.req.Path.
+	// retryablehttp.Request.Clone() shallow-copies the *urlutil.URL pointer,
+	// so UpdateRelPath on a previous cloned request mutates the shared URL
+	// and would silently corrupt q.req.Path for subsequent Rebuild calls if
+	// we read it here (see https://github.com/projectdiscovery/nuclei/issues/6398).
+	originalSplitted := strings.Split(q.originalPath, "/")
 
 	// Create a new slice to hold the rebuilt segments
 	rebuiltSegments := make([]string, 0, len(originalSplitted))
@@ -141,7 +150,8 @@ func (q *Path) Rebuild() (*retryablehttp.Request, error) {
 // Clones current state to a new component
 func (q *Path) Clone() Component {
 	return &Path{
-		value: q.value.Clone(),
-		req:   q.req.Clone(context.Background()),
+		value:        q.value.Clone(),
+		req:          q.req.Clone(context.Background()),
+		originalPath: q.originalPath,
 	}
 }


### PR DESCRIPTION
## Problem

Path-based fuzzing with templates like `fuzz-path-sqli.yaml` skips numeric path segments. For a URL like `/user/55/profile`, only segments `user` and `profile` get fuzzed—the numeric segment `55` is silently skipped.

Fixes #6398

## Root Cause

`retryablehttp.Request.Clone()` performs a **shallow copy** of the embedded `*urlutil.URL` pointer:

```go
func (r *Request) Clone(ctx context.Context) *Request {
    ux := r.URL  // ← shallow copy of pointer!
    req := r.Request.Clone(ctx)
    req.URL = ux.URL
    return &Request{URL: ux, ...}
}
```

When `Rebuild()` calls `cloned.UpdateRelPath(rebuiltPath, true)`, it mutates the **shared** URL object. This corrupts `q.req.Path` for all subsequent `Rebuild()` calls in the same fuzzing iteration.

After fuzzing the first segment (say `profile`), `q.req.Path` becomes `/user/55/profile OR True` instead of `/user/55/profile`. When the fuzzer then tries to fuzz `55`, the corrupted path causes segment indices to shift—`55` is no longer at index 2, so it gets skipped.

## Fix

Store the original path string at `Parse()` time in a new `originalPath` field, and use that immutable snapshot in `Rebuild()` instead of reading `q.req.Path`.

```go
type Path struct {
    value        *Value
    req          *retryablehttp.Request
    originalPath string  // ← new field
}

func (q *Path) Parse(req *retryablehttp.Request) (bool, error) {
    q.originalPath = req.Path  // snapshot before Clone corrupts it
    ...
}

func (q *Path) Rebuild() (*retryablehttp.Request, error) {
    originalSplitted := strings.Split(q.originalPath, "/")  // use snapshot
    ...
}
```

## Testing

Before fix:
```
/user OR True/55/profile     ✓ (segment 1 fuzzed)
/user/55/profile OR True     ✓ (segment 3 fuzzed)
/user/55/profile             ✗ (segment 2 NOT fuzzed - skipped!)
```

After fix:
```
/user OR True/55/profile     ✓
/user/55 OR True/profile     ✓  ← now works!
/user/55/profile OR True     ✓
```

All existing `pkg/fuzz/...` tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed path handling to preserve consistent path snapshots across clone and update operations, preventing potential data corruption issues during path transformations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->