### PR TITLE
fix(workflow): clone Input in subtemplate goroutine to prevent race condition

### DIFF
--- a/pkg/core/workflow_execute.go
+++ b/pkg/core/workflow_execute.go
@@ -163,7 +163,7 @@ func (e *Engine) runWorkflowStep(template *workflows.WorkflowTemplate, ctx *scan
 
 			go func(template *workflows.WorkflowTemplate) {
 				// create a new context with the same input but with unset callbacks
-				subCtx := scan.NewScanContext(ctx.Context(), ctx.Input)
+				subCtx := scan.NewScanContext(ctx.Context(), ctx.Input.Clone())
 				if err := e.runWorkflowStep(template, subCtx, results, swg, w); err != nil {
 					gologger.Warning().Msgf(workflowStepExecutionError, template.Template, err)
 				}


### PR DESCRIPTION
## Summary

Fixes a race condition in `runWorkflowStep` where the second goroutine path does not clone `ctx.Input` before spawning parallel subtemplates.

## Problem

In `pkg/core/workflow_execute.go`, there are two goroutine paths that run subtemplates:

1. **Line ~140**: `ctx.Input.Clone()` (correct)
2. **Line ~166**: `ctx.Input` (missing clone!)

Both paths have the same comment: "clone the Input so that other parallel executions won't overwrite the shared variables" but only the first path actually clones.

## Impact

When workflows execute multiple subtemplates in parallel via the second path, they share the same `ctx.Input` object. This causes:
- Race condition when subtemplates modify input variables
- Non-deterministic scan results
- Potential data corruption between parallel template executions

## Fix

Add `.Clone()` call to match the first goroutine path, ensuring each subtemplate gets its own copy of the input data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* **Improved parallel workflow reliability** – Fixed a race condition in parallel workflow execution that could cause data corruption when multiple branches simultaneously modified shared input state. Ensures proper isolation of input data across parallel workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->