### PR TITLE
fix(http): detect unresolved variables before encoding functions obscure them

### DIFF
--- a/pkg/core/workflow_execute.go
+++ b/pkg/core/workflow_execute.go
@@ -163,7 +163,7 @@ func (e *Engine) runWorkflowStep(template *workflows.WorkflowTemplate, ctx *scan
 
 			go func(template *workflows.WorkflowTemplate) {
 				// create a new context with the same input but with unset callbacks
-				subCtx := scan.NewScanContext(ctx.Context(), ctx.Input)
+				subCtx := scan.NewScanContext(ctx.Context(), ctx.Input.Clone())
 				if err := e.runWorkflowStep(template, subCtx, results, swg, w); err != nil {
 					gologger.Warning().Msgf(workflowStepExecutionError, template.Template, err)
 				}

--- a/pkg/protocols/http/build_request.go
+++ b/pkg/protocols/http/build_request.go
@@ -213,6 +213,19 @@ func (r *requestGenerator) Make(ctx context.Context, input *contextargs.Context,
 	if len(interactURLs) > 0 {
 		r.interactshURLs = append(r.interactshURLs, interactURLs...)
 	}
+	// Check for unresolved template variables BEFORE they get encoded by helper
+	// functions (e.g. base64). Once encoded, ContainsUnresolvedVariables cannot
+	// detect them in the final dumped request. See: github.com/projectdiscovery/nuclei/issues/7032
+	if !r.request.SkipVariablesCheck {
+		for varName, varValue := range variablesMap {
+			varStr := types.ToString(varValue)
+			if varErr := expressions.ContainsUnresolvedVariables(varStr); varErr != nil {
+				gologger.Warning().Msgf("[%s] Template variable \"%s\" has unresolved references: %v (use -var %s=<value>)\n",
+					r.request.options.TemplateID, varName, varErr, varName)
+				return nil, ErrMissingVars
+			}
+		}
+	}
 	// allVars contains all variables from all sources
 	allVars := generators.MergeMaps(dynamicValues, defaultReqVars, optionVars, variablesMap, r.options.Constants)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed concurrent mutation issues in parallel workflow executions by ensuring input isolation between workflow steps.

* **New Features**
  * Added pre-execution validation for template variables, detecting unresolved references early with warning logs before request generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->