### PR TITLE
fix: prefetch auth secrets when -secret-file is set (#6592)

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -684,7 +684,7 @@ func (r *Runner) RunEnumeration() error {
 	r.displayExecutionInfo(store)
 
 	// prefetch secrets if enabled
-	if executorOpts.AuthProvider != nil && r.options.PreFetchSecrets {
+	if executorOpts.AuthProvider != nil && (r.options.PreFetchSecrets || len(r.options.SecretsFile) > 0) {
 		r.Logger.Info().Msgf("Pre-fetching secrets from authprovider[s]")
 		if err := executorOpts.AuthProvider.PreFetchSecrets(); err != nil {
 			return errors.Wrap(err, "could not pre-fetch secrets")
@@ -1036,3 +1036,4 @@ func init() {
 	HideAutoSaveMsg = env.GetEnvOrDefault("DISABLE_CLOUD_UPLOAD_WRN", false)
 	EnableCloudUpload = env.GetEnvOrDefault("ENABLE_CLOUD_UPLOAD", false)
 }
+

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -684,7 +684,7 @@ func (r *Runner) RunEnumeration() error {
 	r.displayExecutionInfo(store)
 
 	// prefetch secrets if enabled
-	if executorOpts.AuthProvider != nil && (r.options.PreFetchSecrets || len(r.options.SecretsFile) > 0) {
+	if executorOpts.AuthProvider != nil && r.options.ShouldPrefetchSecrets() {
 		r.Logger.Info().Msgf("Pre-fetching secrets from authprovider[s]")
 		if err := executorOpts.AuthProvider.PreFetchSecrets(); err != nil {
 			return errors.Wrap(err, "could not pre-fetch secrets")
@@ -1036,4 +1036,5 @@ func init() {
 	HideAutoSaveMsg = env.GetEnvOrDefault("DISABLE_CLOUD_UPLOAD_WRN", false)
 	EnableCloudUpload = env.GetEnvOrDefault("ENABLE_CLOUD_UPLOAD", false)
 }
+
 

--- a/lib/sdk_private.go
+++ b/lib/sdk_private.go
@@ -229,7 +229,7 @@ func (e *NucleiEngine) init(ctx context.Context) error {
 	}
 
 	// prefetch secrets
-	if e.executerOpts.AuthProvider != nil && (e.opts.PreFetchSecrets || len(e.opts.SecretsFile) > 0) {
+	if e.executerOpts.AuthProvider != nil && e.opts.ShouldPrefetchSecrets() {
 		if err := e.executerOpts.AuthProvider.PreFetchSecrets(); err != nil {
 			return errors.Wrap(err, "could not prefetch secrets")
 		}
@@ -309,4 +309,5 @@ func (e *NucleiEngine) processUpdateCheckResults() error {
 	})
 	return err
 }
+
 

--- a/lib/sdk_private.go
+++ b/lib/sdk_private.go
@@ -229,7 +229,7 @@ func (e *NucleiEngine) init(ctx context.Context) error {
 	}
 
 	// prefetch secrets
-	if e.executerOpts.AuthProvider != nil && e.opts.PreFetchSecrets {
+	if e.executerOpts.AuthProvider != nil && (e.opts.PreFetchSecrets || len(e.opts.SecretsFile) > 0) {
 		if err := e.executerOpts.AuthProvider.PreFetchSecrets(); err != nil {
 			return errors.Wrap(err, "could not prefetch secrets")
 		}
@@ -309,3 +309,4 @@ func (e *NucleiEngine) processUpdateCheckResults() error {
 	})
 	return err
 }
+

--- a/pkg/types/prefetch_secrets_test.go
+++ b/pkg/types/prefetch_secrets_test.go
@@ -1,0 +1,30 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/projectdiscovery/goflags"
+)
+
+func TestShouldPrefetchSecrets(t *testing.T) {
+	t.Run("false by default", func(t *testing.T) {
+		opts := &Options{}
+		if opts.ShouldPrefetchSecrets() {
+			t.Fatalf("expected ShouldPrefetchSecrets to be false")
+		}
+	})
+
+	t.Run("true when explicit prefetch flag set", func(t *testing.T) {
+		opts := &Options{PreFetchSecrets: true}
+		if !opts.ShouldPrefetchSecrets() {
+			t.Fatalf("expected ShouldPrefetchSecrets to be true when PreFetchSecrets is set")
+		}
+	})
+
+	t.Run("true when secret-file is set", func(t *testing.T) {
+		opts := &Options{SecretsFile: goflags.StringSlice{"secrets.yaml"}}
+		if !opts.ShouldPrefetchSecrets() {
+			t.Fatalf("expected ShouldPrefetchSecrets to be true when SecretsFile is provided")
+		}
+	})
+}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -770,6 +770,13 @@ func (options *Options) ShouldSaveResume() bool {
 }
 
 // ShouldFollowHTTPRedirects determines if http redirects should be followed
+
+// ShouldPrefetchSecrets returns true when secrets should be prefetched before execution.
+// This is enabled explicitly with -prefetch-secrets, and also by default whenever
+// a secret-file is provided for authenticated scans.
+func (options *Options) ShouldPrefetchSecrets() bool {
+	return options.PreFetchSecrets || len(options.SecretsFile) > 0
+}
 func (options *Options) ShouldFollowHTTPRedirects() bool {
 	return options.FollowRedirects || options.FollowHostRedirects
 }
@@ -907,3 +914,5 @@ func isHomeDir(path string) bool {
 	homeDir := folderutil.HomeDirOrDefault("")
 	return strings.HasPrefix(path, homeDir)
 }
+
+


### PR DESCRIPTION
/claim #6592

## Proposed Changes
- prefetch auth secrets automatically when `-secret-file` is supplied (runner path)
- mirror same prefetch behavior in SDK path
- add regression test for prefetch decision logic (`ShouldPrefetchSecrets`) covering:
  - default false
  - explicit `-prefetch-secrets` true
  - implicit true when `-secret-file` is provided

## Prefetch Default Strategy (explicit)
- Default remains conservative unless auth context is required.
- When `-secret-file` is present, prefetch is now default to guarantee authenticated context is available before template execution.
- This prevents unauthenticated-first execution drift and keeps auth flow deterministic.

## Security Rationale
- Avoids sending requests before dynamic auth context is established.
- Reduces risk of running authenticated templates without secrets loaded.
- Keeps behavior explicit and test-backed for future changes.

## Proof
- `go test ./pkg/types -run TestShouldPrefetchSecrets -v` (pass)
- `go test ./internal/runner -run TestDoesNotExist -count=1` (compile pass)

## Checklist
- [x] narrow scope
- [x] tests/validation included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Secret pre-fetching now reliably activates when secret files are supplied or when prefetch is enabled, improving secret handling during runs.

* **Tests**
  * Added tests validating the pre-fetch secret behavior across default, explicit, and secrets-file scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->