### PR TITLE
fix(runner): use Print instead to listAvailableStoreTags

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -636,16 +636,20 @@ func (r *Runner) RunEnumeration() error {
 	// This uses a separate parser to reduce time taken as
 	// normally nuclei does a lot of compilation and stuff
 	// for templates, which we don't want for these simp
-	if r.options.TemplateList || r.options.TemplateDisplay || r.options.TagList {
+	if r.options.TagList {
+		tagsMap, err := store.LoadTemplateTags()
+		if err != nil {
+			return err
+		}
+		r.listAvailableTags(tagsMap)
+		os.Exit(0)
+	}
+
+	if r.options.TemplateList || r.options.TemplateDisplay {
 		if err := store.LoadTemplatesOnlyMetadata(); err != nil {
 			return err
 		}
-
-		if r.options.TagList {
-			r.listAvailableStoreTags(store)
-		} else {
-			r.listAvailableStoreTemplates(store)
-		}
+		r.listAvailableStoreTemplates(store)
 		os.Exit(0)
 	}
 

--- a/internal/runner/templates.go
+++ b/internal/runner/templates.go
@@ -105,9 +105,9 @@ func (r *Runner) listAvailableStoreTags(store *loader.Store) {
 	for _, tag := range tagsList {
 		if r.options.JSONL {
 			marshalled, _ := jsoniter.Marshal(tag)
-			r.Logger.Debug().Msgf("%s", string(marshalled))
+			r.Logger.Print().Msgf("%s", string(marshalled))
 		} else {
-			r.Logger.Debug().Msgf("%s (%d)", tag.Key, tag.Value)
+			r.Logger.Print().Msgf("%s (%d)", tag.Key, tag.Value)
 		}
 	}
 }

--- a/internal/runner/templates.go
+++ b/internal/runner/templates.go
@@ -78,18 +78,13 @@ func (r *Runner) listAvailableStoreTemplates(store *loader.Store) {
 	}
 }
 
-func (r *Runner) listAvailableStoreTags(store *loader.Store) {
+func (r *Runner) listAvailableTags(tagsMap map[string]int) {
 	r.Logger.Print().Msgf(
 		"\nListing available %v nuclei tags for %v",
 		config.DefaultConfig.TemplateVersion,
 		config.DefaultConfig.TemplatesDirectory,
 	)
-	tagsMap := make(map[string]int)
-	for _, tpl := range store.Templates() {
-		for _, tag := range tpl.Info.Tags.ToSlice() {
-			tagsMap[tag]++
-		}
-	}
+
 	type kv struct {
 		Key   string `json:"tag"`
 		Value int    `json:"count"`

--- a/pkg/catalog/loader/loader.go
+++ b/pkg/catalog/loader/loader.go
@@ -389,6 +389,86 @@ func (store *Store) loadTemplatesIndex() *index.Index {
 	return metadataIdx
 }
 
+// LoadTemplateTags loads template tags count using metadata index when possible.
+//
+// This method is optimized for tag listing (`-tgl`) and avoids loading all
+// templates into the store.
+func (store *Store) LoadTemplateTags() (map[string]int, error) {
+	defer store.saveMetadataIndexOnce()
+
+	templatePaths, errs := store.config.Catalog.GetTemplatesPath(store.finalTemplates)
+	store.logErroredTemplates(errs)
+
+	tagsMap := make(map[string]int)
+	indexFilter := store.indexFilter
+
+	templatesCache := store.parserCacheOnce()
+	if templatesCache == nil {
+		return nil, errors.New("invalid parser")
+	}
+
+	// Include conditions require a parsed template and cannot be evaluated from
+	// metadata alone.
+	requiresTemplateParse := len(store.config.IncludeConditions) > 0
+
+	for _, templatePath := range templatePaths {
+		if store.metadataIndex != nil {
+			if metadata, found := store.metadataIndex.Get(templatePath); found {
+				if !indexFilter.Matches(metadata) {
+					continue
+				}
+
+				if !requiresTemplateParse {
+					for _, tag := range metadata.Tags {
+						tagsMap[tag]++
+					}
+					continue
+				}
+			}
+		}
+
+		loaded, err := store.config.ExecutorOptions.Parser.LoadTemplate(templatePath, store.tagFilter, nil, store.config.Catalog)
+		if err != nil {
+			if strings.Contains(err.Error(), templates.ErrExcluded.Error()) {
+				stats.Increment(templates.TemplatesExcludedStats)
+				if config.DefaultConfig.LogAllEvents {
+					store.logger.Print().Msgf("[%v] %v\n", aurora.Yellow("WRN").String(), err.Error())
+				}
+				continue
+			}
+
+			store.logger.Warning().Msg(err.Error())
+			continue
+		}
+
+		if !loaded {
+			continue
+		}
+
+		template, _, _ := templatesCache.Has(templatePath)
+		if template == nil {
+			continue
+		}
+
+		var metadata *index.Metadata
+		if store.metadataIndex != nil {
+			metadata, _ = store.metadataIndex.SetFromTemplate(templatePath, template)
+		} else {
+			metadata = index.NewMetadataFromTemplate(templatePath, template)
+		}
+
+		if metadata != nil && !indexFilter.Matches(metadata) {
+			continue
+		}
+
+		for _, tag := range template.Info.Tags.ToSlice() {
+			tagsMap[tag]++
+		}
+	}
+
+	return tagsMap, nil
+}
+
 // LoadTemplatesOnlyMetadata loads only the metadata of the templates
 func (store *Store) LoadTemplatesOnlyMetadata() error {
 	defer store.saveMetadataIndexOnce()


### PR DESCRIPTION
## Proposed changes

Tag listing (\`-tgl\`) output was moved to debug log
level, making it invisible during normal runs.
Restore tag output to default log level (Print)
for better usability.

Fixes #7142

### Proof

before:

<img height="500" alt="Image" src="https://github.com/user-attachments/assets/902d3e83-4eee-4fbb-90fa-ffe1cb751bfc" />

> Must use `-debug` flag.

after:

<img height="500" alt="image" src="https://github.com/user-attachments/assets/926d0cb9-a7c4-42a4-9785-ff09bbc91a0f" />

And it's 2x++ faster (#7143).

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored internal template and tag listing operations to improve code organization and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->