### PR TITLE
feat(profile): add template profile preprocessing — metadata, inline targets, and inline secrets (#5567)

### DIFF
--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -129,9 +129,13 @@ func main() {
 		memProfile = strings.TrimSuffix(memProfile, filepath.Ext(memProfile))
 
 		createProfileFile := func(ext, profileType string) *os.File {
-			f, err := os.Create(memProfile + ext)
+			// Compute the path before os.Create so we can safely reference it
+			// in the error message. os.Create returns a nil *os.File on failure;
+			// calling f.Name() on nil would panic before fatalWithCleanup runs.
+			filePath := memProfile + ext
+			f, err := os.Create(filePath)
 			if err != nil {
-				fatalWithCleanup("profile: could not create %s profile %q file: %v", profileType, f.Name(), err)
+				fatalWithCleanup("profile: could not create %s profile %q file: %v", profileType, filePath, err)
 			}
 			return f
 		}

--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -51,10 +51,24 @@ var (
 	templateProfile string
 	memProfile      string // optional profile file path
 	options         = &types.Options{}
+
+	// profilePreprocessResults tracks preprocessing results from config/profile
+	// files so that temporary files (inline targets, inline secrets) can be
+	// cleaned up at program exit.
+	profilePreprocessResults []*types.ProfilePreprocessResult
 )
 
 func main() {
 	options.Logger = gologger.DefaultLogger
+
+	// Cleanup temporary files created by profile preprocessing (inline targets/secrets)
+	defer func() {
+		for _, r := range profilePreprocessResults {
+			if r != nil {
+				r.Cleanup()
+			}
+		}
+	}()
 
 	// enables CLI specific configs mostly interactive behavior
 	config.CurrentAppMode = config.AppModeCLI
@@ -584,8 +598,17 @@ Additional documentation is available at: https://docs.nuclei.sh/getting-started
 		if !fileutil.FileExists(cfgFile) {
 			options.Logger.Fatal().Msgf("given config file '%s' does not exist", cfgFile)
 		}
-		// merge config file with flags
-		if err := flagSet.MergeConfigFile(cfgFile); err != nil {
+
+		// Preprocess config file to handle extra fields, inline targets, and inline secrets (#5567)
+		ppResult, ppErr := types.PreprocessProfileFile(cfgFile)
+		if ppErr != nil {
+			options.Logger.Fatal().Msgf("Could not preprocess config file: %s\n", ppErr)
+		}
+		profilePreprocessResults = append(profilePreprocessResults, ppResult)
+		mergeConfigPath := ppResult.CleanedConfigPath
+
+		// merge cleaned config file with flags
+		if err := flagSet.MergeConfigFile(mergeConfigPath); err != nil {
 			options.Logger.Fatal().Msgf("Could not read config: %s\n", err)
 		}
 
@@ -656,7 +679,15 @@ Additional documentation is available at: https://docs.nuclei.sh/getting-started
 		if !fileutil.FileExists(templateProfile) {
 			options.Logger.Fatal().Msgf("given template profile file '%s' does not exist", templateProfile)
 		}
-		if err := flagSet.MergeConfigFile(templateProfile); err != nil {
+
+		// Preprocess template profile to handle extra fields, inline targets, and inline secrets (#5567)
+		ppResult, ppErr := types.PreprocessProfileFile(templateProfile)
+		if ppErr != nil {
+			options.Logger.Fatal().Msgf("Could not preprocess template profile: %s\n", ppErr)
+		}
+		profilePreprocessResults = append(profilePreprocessResults, ppResult)
+
+		if err := flagSet.MergeConfigFile(ppResult.CleanedConfigPath); err != nil {
 			options.Logger.Fatal().Msgf("Could not read template profile: %s\n", err)
 		}
 	}

--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -211,6 +211,11 @@ func main() {
 		options.Logger.Info().Msgf("CTRL+C pressed: Exiting\n")
 		if options.DASTServer {
 			nucleiRunner.Close()
+			// profileCleanup must be called explicitly here because os.Exit
+			// bypasses all deferred functions registered in main(). Without this
+			// call, any temporary files created during profile preprocessing
+			// (inline targets, inline secrets) would be left on disk after Ctrl+C.
+			profileCleanup()
 			os.Exit(1)
 		}
 
@@ -226,6 +231,11 @@ func main() {
 				options.Logger.Error().Msgf("Couldn't create resume file: %s\n", err)
 			}
 		}
+		// profileCleanup must be called explicitly here because os.Exit
+		// bypasses all deferred functions registered in main(). Without this
+		// call, any temporary files created during profile preprocessing
+		// (inline targets, inline secrets) would be left on disk after Ctrl+C.
+		profileCleanup()
 		os.Exit(1)
 	}()
 
@@ -622,7 +632,9 @@ Additional documentation is available at: https://docs.nuclei.sh/getting-started
 
 		if !options.Vars.IsEmpty() {
 			// Maybe we should add vars to the config file as well even if they are set via flags?
-			file, err := os.Open(cfgFile)
+			// Open the cleaned config path (extra fields already stripped) so
+			// yaml.Decoder does not encounter unknown keys like id/name/purpose.
+			file, err := os.Open(ppResult.CleanedConfigPath)
 			if err != nil {
 				gologger.Fatal().Msgf("Could not open config file: %s\n", err)
 			}
@@ -746,8 +758,16 @@ func readFlagsConfig(flagset *goflags.FlagSet) {
 		}
 		return
 	}
-	// if config file exists, merge it with the default config
-	if err = flagset.MergeConfigFile(cfgFile); err != nil {
+	// if config file exists, merge it with the default config.
+	// Preprocess first to strip extra metadata fields and materialize
+	// any inline targets/secrets to temp files. (#5567)
+	ppResult, ppErr := types.PreprocessProfileFile(cfgFile)
+	if ppErr != nil {
+		options.Logger.Warning().Msgf("Could not preprocess flags config file: %s\n", ppErr)
+		return
+	}
+	defer ppResult.Cleanup()
+	if err = flagset.MergeConfigFile(ppResult.CleanedConfigPath); err != nil {
 		options.Logger.Warning().Msgf("failed to merge configfile with flags got: %s\n", err)
 	}
 }

--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -51,24 +51,10 @@ var (
 	templateProfile string
 	memProfile      string // optional profile file path
 	options         = &types.Options{}
-
-	// profilePreprocessResults tracks preprocessing results from config/profile
-	// files so that temporary files (inline targets, inline secrets) can be
-	// cleaned up at program exit.
-	profilePreprocessResults []*types.ProfilePreprocessResult
 )
 
 func main() {
 	options.Logger = gologger.DefaultLogger
-
-	// Cleanup temporary files created by profile preprocessing (inline targets/secrets)
-	defer func() {
-		for _, r := range profilePreprocessResults {
-			if r != nil {
-				r.Cleanup()
-			}
-		}
-	}()
 
 	// enables CLI specific configs mostly interactive behavior
 	config.CurrentAppMode = config.AppModeCLI
@@ -76,7 +62,12 @@ func main() {
 	if err := runner.ConfigureOptions(); err != nil {
 		options.Logger.Fatal().Msgf("Could not initialize options: %s\n", err)
 	}
-	_ = readConfig()
+
+	// readConfig returns a cleanup function that removes any temporary files
+	// created during profile preprocessing (inline targets / inline secrets).
+	// The cleanup is deferred here so it runs on every exit path from main().
+	_, profileCleanup := readConfig()
+	defer profileCleanup()
 
 	if options.ListDslSignatures {
 		options.Logger.Info().Msgf("The available custom DSL functions are:")
@@ -252,7 +243,24 @@ func main() {
 	}
 }
 
-func readConfig() *goflags.FlagSet {
+// readConfig parses all CLI flags and merges config/profile files.
+// It returns the parsed FlagSet and a cleanup function. The cleanup function
+// removes any temporary files that were created during profile preprocessing
+// (e.g. materialized inline targets or inline secrets). The caller MUST defer
+// the cleanup function.
+func readConfig() (*goflags.FlagSet, func()) {
+
+	// preprocessResults is local to this function. We capture it in the
+	// returned cleanup closure — no global state required.
+	var preprocessResults []*types.ProfilePreprocessResult
+
+	cleanupFn := func() {
+		for _, r := range preprocessResults {
+			if r != nil {
+				r.Cleanup()
+			}
+		}
+	}
 
 	// when true updates nuclei binary to latest version
 	var updateNucleiBinary bool
@@ -599,16 +607,16 @@ Additional documentation is available at: https://docs.nuclei.sh/getting-started
 			options.Logger.Fatal().Msgf("given config file '%s' does not exist", cfgFile)
 		}
 
-		// Preprocess config file to handle extra fields, inline targets, and inline secrets (#5567)
+		// Preprocess config file: strip extra metadata fields, materialize
+		// inline targets and inline secrets to temp files. (#5567)
 		ppResult, ppErr := types.PreprocessProfileFile(cfgFile)
 		if ppErr != nil {
 			options.Logger.Fatal().Msgf("Could not preprocess config file: %s\n", ppErr)
 		}
-		profilePreprocessResults = append(profilePreprocessResults, ppResult)
-		mergeConfigPath := ppResult.CleanedConfigPath
+		preprocessResults = append(preprocessResults, ppResult)
 
-		// merge cleaned config file with flags
-		if err := flagSet.MergeConfigFile(mergeConfigPath); err != nil {
+		// merge the cleaned config with flags
+		if err := flagSet.MergeConfigFile(ppResult.CleanedConfigPath); err != nil {
 			options.Logger.Fatal().Msgf("Could not read config: %s\n", err)
 		}
 
@@ -680,12 +688,13 @@ Additional documentation is available at: https://docs.nuclei.sh/getting-started
 			options.Logger.Fatal().Msgf("given template profile file '%s' does not exist", templateProfile)
 		}
 
-		// Preprocess template profile to handle extra fields, inline targets, and inline secrets (#5567)
+		// Preprocess template profile: strip extra metadata fields, materialize
+		// inline targets and inline secrets to temp files. (#5567)
 		ppResult, ppErr := types.PreprocessProfileFile(templateProfile)
 		if ppErr != nil {
 			options.Logger.Fatal().Msgf("Could not preprocess template profile: %s\n", ppErr)
 		}
-		profilePreprocessResults = append(profilePreprocessResults, ppResult)
+		preprocessResults = append(preprocessResults, ppResult)
 
 		if err := flagSet.MergeConfigFile(ppResult.CleanedConfigPath); err != nil {
 			options.Logger.Fatal().Msgf("Could not read template profile: %s\n", err)
@@ -701,7 +710,7 @@ Additional documentation is available at: https://docs.nuclei.sh/getting-started
 	}
 
 	cleanupOldResumeFiles()
-	return flagSet
+	return flagSet, cleanupFn
 }
 
 // cleanupOldResumeFiles cleans up resume files older than 10 days.

--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -609,7 +609,12 @@ Additional documentation is available at: https://docs.nuclei.sh/getting-started
 	}
 	if customConfigDir := os.Getenv(config.NucleiConfigDirEnv); customConfigDir != "" {
 		config.DefaultConfig.SetConfigDir(customConfigDir)
-		readFlagsConfig(flagSet)
+		// Accumulate the preprocessing result so temp files (inline secrets,
+		// inline targets) survive until program exit — readFlagsConfig no longer
+		// defers cleanup internally for this reason.
+		if ppResult := readFlagsConfig(flagSet); ppResult != nil {
+			preprocessResults = append(preprocessResults, ppResult)
+		}
 	}
 
 	if cfgFile != "" {
@@ -627,6 +632,7 @@ Additional documentation is available at: https://docs.nuclei.sh/getting-started
 
 		// merge the cleaned config with flags
 		if err := flagSet.MergeConfigFile(ppResult.CleanedConfigPath); err != nil {
+			cleanupFn() // remove any temp files already accumulated before fatal exit
 			options.Logger.Fatal().Msgf("Could not read config: %s\n", err)
 		}
 
@@ -709,6 +715,7 @@ Additional documentation is available at: https://docs.nuclei.sh/getting-started
 		preprocessResults = append(preprocessResults, ppResult)
 
 		if err := flagSet.MergeConfigFile(ppResult.CleanedConfigPath); err != nil {
+			cleanupFn() // remove any temp files already accumulated before fatal exit
 			options.Logger.Fatal().Msgf("Could not read template profile: %s\n", err)
 		}
 	}
@@ -736,40 +743,50 @@ func cleanupOldResumeFiles() {
 }
 
 // readFlagsConfig reads the config file from the default config dir and copies it to the current config dir.
-func readFlagsConfig(flagset *goflags.FlagSet) {
+// It returns the ProfilePreprocessResult if preprocessing was performed so the caller can accumulate it
+// into preprocessResults for deferred cleanup at program exit. The caller MUST NOT call Cleanup() early —
+// the returned result (if non-nil) must stay alive until the scan finishes.
+func readFlagsConfig(flagset *goflags.FlagSet) *types.ProfilePreprocessResult {
 	// check if config.yaml file exists
 	defaultCfgFile, err := flagset.GetConfigFilePath()
 	if err != nil {
 		// something went wrong either dir is not readable or something else went wrong upstream in `goflags`
 		// warn and exit in this case
 		options.Logger.Warning().Msgf("Could not read config file: %s\n", err)
-		return
+		return nil
 	}
 	cfgFile := config.DefaultConfig.GetFlagsConfigFilePath()
 	if !fileutil.FileExists(cfgFile) {
 		if !fileutil.FileExists(defaultCfgFile) {
 			// if default config does not exist, warn and exit
 			options.Logger.Warning().Msgf("missing default config file : %s", defaultCfgFile)
-			return
+			return nil
 		}
 		// if does not exist copy it from the default config
 		if err = fileutil.CopyFile(defaultCfgFile, cfgFile); err != nil {
 			options.Logger.Warning().Msgf("Could not copy config file: %s\n", err)
 		}
-		return
+		return nil
 	}
 	// if config file exists, merge it with the default config.
 	// Preprocess first to strip extra metadata fields and materialize
 	// any inline targets/secrets to temp files. (#5567)
+	// NOTE: do NOT defer ppResult.Cleanup() here — that would delete the temp
+	// files (inline secrets, inline targets) as soon as this function returns,
+	// which is long before the scan actually reads them. Instead return the
+	// result so the caller can accumulate it in preprocessResults and clean up
+	// at program exit via the top-level cleanupFn / profileCleanup().
 	ppResult, ppErr := types.PreprocessProfileFile(cfgFile)
 	if ppErr != nil {
 		options.Logger.Warning().Msgf("Could not preprocess flags config file: %s\n", ppErr)
-		return
+		return nil
 	}
-	defer ppResult.Cleanup()
 	if err = flagset.MergeConfigFile(ppResult.CleanedConfigPath); err != nil {
+		ppResult.Cleanup() // preprocessing succeeded but merge failed — safe to clean up now
 		options.Logger.Warning().Msgf("failed to merge configfile with flags got: %s\n", err)
+		return nil
 	}
+	return ppResult
 }
 
 // disableUpdatesCallback disables the update check.

--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -69,6 +69,17 @@ func main() {
 	_, profileCleanup := readConfig()
 	defer profileCleanup()
 
+	// fatalWithCleanup invokes profileCleanup() before terminating the process.
+	// All calls to options.Logger.Fatal() after this point must go through this
+	// helper, because Fatal() calls os.Exit internally which skips every deferred
+	// function — including the defer profileCleanup() above. Without this, any
+	// temp files materialized for inline secrets/targets would be left on disk.
+	fatalWithCleanup := func(format string, args ...interface{}) {
+		profileCleanup()
+		options.Logger.Error().Msgf(format, args...)
+		os.Exit(1)
+	}
+
 	if options.ListDslSignatures {
 		options.Logger.Info().Msgf("The available custom DSL functions are:")
 		fmt.Println(dsl.GetPrintableDslFunctionSignatures(options.NoColor))
@@ -81,7 +92,7 @@ func main() {
 		templates.UseOptionsForSigner(options)
 		tsigner, err := signer.NewTemplateSigner(nil, nil) // will read from env , config or generate new keys
 		if err != nil {
-			options.Logger.Fatal().Msgf("couldn't initialize signer crypto engine: %s\n", err)
+			fatalWithCleanup("couldn't initialize signer crypto engine: %s\n", err)
 		}
 
 		successCounter := 0
@@ -120,7 +131,7 @@ func main() {
 		createProfileFile := func(ext, profileType string) *os.File {
 			f, err := os.Create(memProfile + ext)
 			if err != nil {
-				options.Logger.Fatal().Msgf("profile: could not create %s profile %q file: %v", profileType, f.Name(), err)
+				fatalWithCleanup("profile: could not create %s profile %q file: %v", profileType, f.Name(), err)
 			}
 			return f
 		}
@@ -134,18 +145,18 @@ func main() {
 
 		// Start tracing
 		if err := trace.Start(traceFile); err != nil {
-			options.Logger.Fatal().Msgf("profile: could not start trace: %v", err)
+			fatalWithCleanup("profile: could not start trace: %v", err)
 		}
 
 		// Start CPU profiling
 		if err := pprof.StartCPUProfile(cpuProfileFile); err != nil {
-			options.Logger.Fatal().Msgf("profile: could not start CPU profile: %v", err)
+			fatalWithCleanup("profile: could not start CPU profile: %v", err)
 		}
 
 		defer func() {
 			// Start heap memory snapshot
 			if err := pprof.WriteHeapProfile(memProfileFile); err != nil {
-				options.Logger.Fatal().Msgf("profile: could not write memory profile: %v", err)
+				fatalWithCleanup("profile: could not write memory profile: %v", err)
 			}
 
 			pprof.StopCPUProfile()
@@ -167,14 +178,14 @@ func main() {
 
 	if options.ScanUploadFile != "" {
 		if err := runner.UploadResultsToCloud(options); err != nil {
-			options.Logger.Fatal().Msgf("could not upload scan results to cloud dashboard: %s\n", err)
+			fatalWithCleanup("could not upload scan results to cloud dashboard: %s\n", err)
 		}
 		return
 	}
 
 	nucleiRunner, err := runner.New(options)
 	if err != nil {
-		options.Logger.Fatal().Msgf("Could not create runner: %s\n", err)
+		fatalWithCleanup("Could not create runner: %s\n", err)
 	}
 	if nucleiRunner == nil {
 		return
@@ -241,9 +252,9 @@ func main() {
 
 	if err := nucleiRunner.RunEnumeration(); err != nil {
 		if options.Validate {
-			options.Logger.Fatal().Msgf("Could not validate templates: %s\n", err)
+			fatalWithCleanup("Could not validate templates: %s\n", err)
 		} else {
-			options.Logger.Fatal().Msgf("Could not run nuclei: %s\n", err)
+			fatalWithCleanup("Could not run nuclei: %s\n", err)
 		}
 	}
 	nucleiRunner.Close()
@@ -270,6 +281,17 @@ func readConfig() (*goflags.FlagSet, func()) {
 				r.Cleanup()
 			}
 		}
+	}
+
+	// fatalWithCleanup calls cleanupFn to remove any materialized temp files
+	// (inline secrets, inline targets) and then terminates the process.
+	// Use this instead of options.Logger.Fatal() for every fatal exit inside
+	// readConfig that is reachable after the first preprocessResults append,
+	// because Fatal() calls os.Exit which bypasses all deferred functions and
+	// the returned cleanupFn would never be invoked by the caller.
+	fatalWithCleanup := func(format string, args ...interface{}) {
+		cleanupFn()
+		options.Logger.Fatal().Msgf(format, args...)
 	}
 
 	// when true updates nuclei binary to latest version
@@ -619,21 +641,20 @@ Additional documentation is available at: https://docs.nuclei.sh/getting-started
 
 	if cfgFile != "" {
 		if !fileutil.FileExists(cfgFile) {
-			options.Logger.Fatal().Msgf("given config file '%s' does not exist", cfgFile)
+			fatalWithCleanup("given config file '%s' does not exist", cfgFile)
 		}
 
 		// Preprocess config file: strip extra metadata fields, materialize
 		// inline targets and inline secrets to temp files. (#5567)
 		ppResult, ppErr := types.PreprocessProfileFile(cfgFile)
 		if ppErr != nil {
-			options.Logger.Fatal().Msgf("Could not preprocess config file: %s\n", ppErr)
+			fatalWithCleanup("Could not preprocess config file: %s\n", ppErr)
 		}
 		preprocessResults = append(preprocessResults, ppResult)
 
 		// merge the cleaned config with flags
 		if err := flagSet.MergeConfigFile(ppResult.CleanedConfigPath); err != nil {
-			cleanupFn() // remove any temp files already accumulated before fatal exit
-			options.Logger.Fatal().Msgf("Could not read config: %s\n", err)
+			fatalWithCleanup("Could not read config: %s\n", err)
 		}
 
 		if !options.Vars.IsEmpty() {
@@ -642,7 +663,7 @@ Additional documentation is available at: https://docs.nuclei.sh/getting-started
 			// yaml.Decoder does not encounter unknown keys like id/name/purpose.
 			file, err := os.Open(ppResult.CleanedConfigPath)
 			if err != nil {
-				gologger.Fatal().Msgf("Could not open config file: %s\n", err)
+				fatalWithCleanup("Could not open config file: %s\n", err)
 			}
 			defer func() {
 				_ = file.Close()
@@ -650,7 +671,7 @@ Additional documentation is available at: https://docs.nuclei.sh/getting-started
 			data := make(map[string]interface{})
 			err = yaml.NewDecoder(file).Decode(&data)
 			if err != nil {
-				gologger.Fatal().Msgf("Could not decode config file: %s\n", err)
+				fatalWithCleanup("Could not decode config file: %s\n", err)
 			}
 
 			variables := data["var"]
@@ -688,7 +709,7 @@ Additional documentation is available at: https://docs.nuclei.sh/getting-started
 			if tp := findProfilePathById(templateProfile, defaultProfilesPath); tp != "" {
 				templateProfile = tp
 			} else {
-				options.Logger.Fatal().Msgf("'%s' is not a profile-id or profile path", templateProfile)
+				fatalWithCleanup("'%s' is not a profile-id or profile path", templateProfile)
 			}
 		}
 		if !filepath.IsAbs(templateProfile) {
@@ -703,27 +724,26 @@ Additional documentation is available at: https://docs.nuclei.sh/getting-started
 			}
 		}
 		if !fileutil.FileExists(templateProfile) {
-			options.Logger.Fatal().Msgf("given template profile file '%s' does not exist", templateProfile)
+			fatalWithCleanup("given template profile file '%s' does not exist", templateProfile)
 		}
 
 		// Preprocess template profile: strip extra metadata fields, materialize
 		// inline targets and inline secrets to temp files. (#5567)
 		ppResult, ppErr := types.PreprocessProfileFile(templateProfile)
 		if ppErr != nil {
-			options.Logger.Fatal().Msgf("Could not preprocess template profile: %s\n", ppErr)
+			fatalWithCleanup("Could not preprocess template profile: %s\n", ppErr)
 		}
 		preprocessResults = append(preprocessResults, ppResult)
 
 		if err := flagSet.MergeConfigFile(ppResult.CleanedConfigPath); err != nil {
-			cleanupFn() // remove any temp files already accumulated before fatal exit
-			options.Logger.Fatal().Msgf("Could not read template profile: %s\n", err)
+			fatalWithCleanup("Could not read template profile: %s\n", err)
 		}
 	}
 
 	if len(options.SecretsFile) > 0 {
 		for _, secretFile := range options.SecretsFile {
 			if !fileutil.FileExists(secretFile) {
-				options.Logger.Fatal().Msgf("given secrets file '%s' does not exist", secretFile)
+				fatalWithCleanup("given secrets file '%s' does not exist", secretFile)
 			}
 		}
 	}

--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -611,7 +611,7 @@ Additional documentation is available at: https://docs.nuclei.sh/getting-started
 		h := &pdcp.PDCPCredHandler{}
 		_, err := h.GetCreds()
 		if err != nil {
-			options.Logger.Fatal().Msg("To utilize the `-ai` flag, please configure your API key with the `-auth` flag or set the `PDCP_API_KEY` environment variable")
+			fatalWithCleanup("To utilize the `-ai` flag, please configure your API key with the `-auth` flag or set the `PDCP_API_KEY` environment variable")
 		}
 	}
 

--- a/pkg/types/profile.go
+++ b/pkg/types/profile.go
@@ -1,0 +1,291 @@
+package types
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// profileExtraFields are metadata fields that are allowed in template profiles
+// and config files but are not recognized goflags options. These fields are
+// silently ignored during preprocessing so that users can annotate profiles
+// with human-readable metadata without triggering parse errors.
+var profileExtraFields = map[string]bool{
+	"id":          true,
+	"name":        true,
+	"purpose":     true,
+	"description": true,
+}
+
+// ProfilePreprocessResult holds the results of preprocessing a template profile
+// or config file. It contains the path to the cleaned config file suitable for
+// goflags.MergeConfigFile and any temporary files that were created during
+// preprocessing (for inline targets and inline secrets).
+type ProfilePreprocessResult struct {
+	// CleanedConfigPath is the path to the cleaned YAML config file
+	// that can be passed to goflags.MergeConfigFile. Extra fields are
+	// removed and inline targets/secrets are replaced with file references.
+	CleanedConfigPath string
+
+	// TempFiles holds paths to all temporary files created during
+	// preprocessing. The caller is responsible for cleaning these up
+	// when they are no longer needed (typically at program exit).
+	TempFiles []string
+
+	// InlineSecretsFile is the path to the temporary secrets file
+	// generated from inline secrets data, or empty if no inline
+	// secrets were present.
+	InlineSecretsFile string
+
+	// InlineTargetsFile is the path to the temporary targets file
+	// generated from inline target list data, or empty if no inline
+	// targets were present.
+	InlineTargetsFile string
+}
+
+// Cleanup removes all temporary files created during preprocessing.
+func (p *ProfilePreprocessResult) Cleanup() {
+	for _, f := range p.TempFiles {
+		_ = os.Remove(f)
+	}
+}
+
+// PreprocessProfileFile reads a template profile or config YAML file and
+// preprocesses it to support three features from issue #5567:
+//
+//  1. Extra fields (id, name, purpose, description) are silently removed
+//     so that goflags.MergeConfigFile does not error on unknown keys.
+//
+//  2. Inline targets: if the "list" key contains a multiline string (YAML
+//     block scalar) instead of a file path, the targets are written to a
+//     temporary file and the "list" value is replaced with the temp file path.
+//
+//  3. Inline secrets: if a "secrets" key exists, its content (static/dynamic)
+//     is serialized as a proper authx YAML secrets file in a temp file, and a
+//     "secret-file" entry is added (or appended) to the cleaned config.
+//
+// The function returns a ProfilePreprocessResult. The caller should use
+// CleanedConfigPath with goflags.MergeConfigFile and call Cleanup() when done.
+func PreprocessProfileFile(filePath string) (*ProfilePreprocessResult, error) {
+	result := &ProfilePreprocessResult{}
+
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse YAML into an ordered map to preserve key order
+	var rawConfig map[string]interface{}
+	if err := yaml.Unmarshal(data, &rawConfig); err != nil {
+		return nil, err
+	}
+
+	// If there are no special keys to process, return the original file path
+	if !hasSpecialKeys(rawConfig) {
+		result.CleanedConfigPath = filePath
+		return result, nil
+	}
+
+	// --- Feature 1: Remove extra metadata fields ---
+	for field := range profileExtraFields {
+		delete(rawConfig, field)
+	}
+
+	// --- Feature 2: Handle inline targets (list key with multiline content) ---
+	if err := handleInlineTargets(rawConfig, result); err != nil {
+		result.Cleanup()
+		return nil, err
+	}
+
+	// --- Feature 3: Handle inline secrets ---
+	if err := handleInlineSecrets(rawConfig, result); err != nil {
+		result.Cleanup()
+		return nil, err
+	}
+
+	// Write the cleaned config to a temporary file
+	cleanedData, err := yaml.Marshal(rawConfig)
+	if err != nil {
+		result.Cleanup()
+		return nil, err
+	}
+
+	tmpFile, err := os.CreateTemp("", "nuclei-profile-*.yaml")
+	if err != nil {
+		result.Cleanup()
+		return nil, err
+	}
+
+	if _, err := tmpFile.Write(cleanedData); err != nil {
+		_ = tmpFile.Close()
+		_ = os.Remove(tmpFile.Name())
+		result.Cleanup()
+		return nil, err
+	}
+	_ = tmpFile.Close()
+
+	result.CleanedConfigPath = tmpFile.Name()
+	result.TempFiles = append(result.TempFiles, tmpFile.Name())
+
+	return result, nil
+}
+
+// hasSpecialKeys checks whether the raw config contains any keys that
+// require preprocessing (extra metadata fields, inline targets, or inline secrets).
+func hasSpecialKeys(rawConfig map[string]interface{}) bool {
+	for field := range profileExtraFields {
+		if _, ok := rawConfig[field]; ok {
+			return true
+		}
+	}
+	if _, ok := rawConfig["secrets"]; ok {
+		return true
+	}
+	if listVal, ok := rawConfig["list"]; ok {
+		if strVal, isStr := listVal.(string); isStr {
+			if strings.Contains(strVal, "\n") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// handleInlineTargets checks if the "list" key contains a multiline string
+// (inline target list). If so, it writes the targets to a temp file and
+// replaces the "list" value with the temp file path.
+func handleInlineTargets(rawConfig map[string]interface{}, result *ProfilePreprocessResult) error {
+	listVal, ok := rawConfig["list"]
+	if !ok {
+		return nil
+	}
+
+	strVal, isStr := listVal.(string)
+	if !isStr {
+		return nil
+	}
+
+	// Only treat as inline targets if the value contains newlines
+	// (i.e., it's a YAML block scalar with multiple targets, not a file path)
+	if !strings.Contains(strVal, "\n") {
+		return nil
+	}
+
+	// Parse targets from the multiline string: split by newlines, trim whitespace,
+	// and skip empty lines
+	var targets []string
+	for _, line := range strings.Split(strVal, "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			targets = append(targets, line)
+		}
+	}
+
+	if len(targets) == 0 {
+		delete(rawConfig, "list")
+		return nil
+	}
+
+	// Write targets to a temporary file (one per line)
+	tmpFile, err := os.CreateTemp("", "nuclei-targets-*.txt")
+	if err != nil {
+		return err
+	}
+
+	content := strings.Join(targets, "\n") + "\n"
+	if _, err := tmpFile.WriteString(content); err != nil {
+		_ = tmpFile.Close()
+		_ = os.Remove(tmpFile.Name())
+		return err
+	}
+	_ = tmpFile.Close()
+
+	result.InlineTargetsFile = tmpFile.Name()
+	result.TempFiles = append(result.TempFiles, tmpFile.Name())
+
+	// Replace the multiline string with the temp file path so goflags
+	// can parse it as a normal file path for the -list flag
+	rawConfig["list"] = tmpFile.Name()
+
+	return nil
+}
+
+// handleInlineSecrets checks if a "secrets" key exists in the config.
+// If so, it extracts the secrets data, writes it to a temporary YAML file
+// in the authx format (with "static" and "dynamic" top-level keys), and
+// adds the temp file path to the "secret-file" list in the cleaned config.
+func handleInlineSecrets(rawConfig map[string]interface{}, result *ProfilePreprocessResult) error {
+	secretsVal, ok := rawConfig["secrets"]
+	if !ok {
+		return nil
+	}
+
+	// Remove the "secrets" key from the config since goflags doesn't know about it
+	delete(rawConfig, "secrets")
+
+	secretsMap, isMap := secretsVal.(map[string]interface{})
+	if !isMap {
+		// If secrets is not a map, skip silently
+		return nil
+	}
+
+	// Build the authx-compatible secrets file content.
+	// The authx format expects top-level "static" and "dynamic" keys.
+	authxData := make(map[string]interface{})
+	if staticVal, ok := secretsMap["static"]; ok {
+		authxData["static"] = staticVal
+	}
+	if dynamicVal, ok := secretsMap["dynamic"]; ok {
+		authxData["dynamic"] = dynamicVal
+	}
+
+	if len(authxData) == 0 {
+		return nil
+	}
+
+	// Serialize to YAML
+	secretsYAML, err := yaml.Marshal(authxData)
+	if err != nil {
+		return err
+	}
+
+	// Write to a temporary file
+	tmpFile, err := os.CreateTemp("", "nuclei-secrets-*.yaml")
+	if err != nil {
+		return err
+	}
+
+	if _, err := tmpFile.Write(secretsYAML); err != nil {
+		_ = tmpFile.Close()
+		_ = os.Remove(tmpFile.Name())
+		return err
+	}
+	_ = tmpFile.Close()
+
+	result.InlineSecretsFile = tmpFile.Name()
+	result.TempFiles = append(result.TempFiles, tmpFile.Name())
+
+	// Add the temp secrets file to the "secret-file" list in the config.
+	// The "secret-file" flag accepts a comma-separated list of file paths.
+	secretFilePath := filepath.ToSlash(tmpFile.Name())
+	if existing, ok := rawConfig["secret-file"]; ok {
+		switch v := existing.(type) {
+		case string:
+			if v != "" {
+				rawConfig["secret-file"] = v + "," + secretFilePath
+			} else {
+				rawConfig["secret-file"] = secretFilePath
+			}
+		case []interface{}:
+			rawConfig["secret-file"] = append(v, secretFilePath)
+		default:
+			rawConfig["secret-file"] = secretFilePath
+		}
+	} else {
+		rawConfig["secret-file"] = secretFilePath
+	}
+
+	return nil
+}

--- a/pkg/types/profile.go
+++ b/pkg/types/profile.go
@@ -341,3 +341,4 @@ func handleInlineSecrets(rawConfig map[string]interface{}, result *ProfilePrepro
 
 	return nil
 }
+ 

--- a/pkg/types/profile.go
+++ b/pkg/types/profile.go
@@ -337,6 +337,9 @@ func handleInlineSecrets(rawConfig map[string]interface{}, result *ProfilePrepro
 	if existing, ok := rawConfig["secret-file"]; ok {
 		switch v := existing.(type) {
 		case string:
+			// Trim trailing commas and whitespace to prevent double-comma
+			// artifacts from malformed user input (e.g. "file1.yaml,").
+			v = strings.TrimRight(v, ", ")
 			if v != "" {
 				rawConfig["secret-file"] = v + "," + secretFilePath
 			} else {

--- a/pkg/types/profile.go
+++ b/pkg/types/profile.go
@@ -327,26 +327,41 @@ func handleInlineSecrets(rawConfig map[string]interface{}, result *ProfilePrepro
 	}
 	_ = tmpFile.Close()
 
-	// Add the temp secrets file to the "secret-file" list in the config.
-	// We always write a YAML sequence ([]interface{}) so that goflags'
-	// CommaSeparatedStringSliceOptions can parse it reliably, regardless of
-	// spacing or quoting that might exist in an existing "secret-file" value.
+	// Add the temp secrets file to the "secret-file" entry in the config.
+	// We store the value as a plain string (or comma-separated string when
+	// appending to an existing value) so that goflags' CommaSeparatedStringSliceOptions
+	// can parse it reliably after a YAML round-trip. Using a []interface{} list would
+	// survive yaml.Marshal but fail string type-assertions when the cleaned config is
+	// read back as a map[string]interface{}.
 	secretFilePath := filepath.ToSlash(tmpFile.Name())
 	if existing, ok := rawConfig["secret-file"]; ok {
 		switch v := existing.(type) {
 		case string:
 			if v != "" {
-				rawConfig["secret-file"] = []interface{}{v, secretFilePath}
+				rawConfig["secret-file"] = v + "," + secretFilePath
 			} else {
-				rawConfig["secret-file"] = []interface{}{secretFilePath}
+				rawConfig["secret-file"] = secretFilePath
 			}
 		case []interface{}:
-			rawConfig["secret-file"] = append(v, secretFilePath)
+			// Convert existing YAML list to a comma-separated string and append
+			// the new inline secrets path. goflags parses comma-separated values
+			// for FileCommaSeparatedStringSliceOptions, so a flat string is the
+			// safest representation after a YAML round-trip (a []interface{} would
+			// survive marshal but type-assert to string would fail in tests and in
+			// any code that reads the cleaned config as a plain map).
+			parts := make([]string, 0, len(v)+1)
+			for _, item := range v {
+				if s, ok := item.(string); ok && s != "" {
+					parts = append(parts, s)
+				}
+			}
+			parts = append(parts, secretFilePath)
+			rawConfig["secret-file"] = strings.Join(parts, ",")
 		default:
-			rawConfig["secret-file"] = []interface{}{secretFilePath}
+			rawConfig["secret-file"] = secretFilePath
 		}
 	} else {
-		rawConfig["secret-file"] = []interface{}{secretFilePath}
+		rawConfig["secret-file"] = secretFilePath
 	}
 
 	return nil

--- a/pkg/types/profile.go
+++ b/pkg/types/profile.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"gopkg.in/yaml.v3"
 )
@@ -43,14 +44,23 @@ type ProfilePreprocessResult struct {
 	// generated from inline target list data, or empty if no inline
 	// targets were present.
 	InlineTargetsFile string
+
+	// cleanupOnce ensures Cleanup() is idempotent and safe to call
+	// concurrently — e.g. from a signal handler goroutine and a deferred
+	// call in main() at the same time.
+	cleanupOnce sync.Once
 }
 
 // Cleanup removes all temporary files created during preprocessing.
-// It is safe to call multiple times; errors from os.Remove are ignored.
+// It is idempotent and safe to call concurrently from multiple goroutines;
+// the actual removal is performed at most once regardless of how many
+// times Cleanup is invoked.
 func (p *ProfilePreprocessResult) Cleanup() {
-	for _, f := range p.TempFiles {
-		_ = os.Remove(f)
-	}
+	p.cleanupOnce.Do(func() {
+		for _, f := range p.TempFiles {
+			_ = os.Remove(f)
+		}
+	})
 }
 
 // PreprocessProfileFile reads a template profile or config YAML file and
@@ -341,4 +351,3 @@ func handleInlineSecrets(rawConfig map[string]interface{}, result *ProfilePrepro
 
 	return nil
 }
- 

--- a/pkg/types/profile.go
+++ b/pkg/types/profile.go
@@ -46,6 +46,7 @@ type ProfilePreprocessResult struct {
 }
 
 // Cleanup removes all temporary files created during preprocessing.
+// It is safe to call multiple times; errors from os.Remove are ignored.
 func (p *ProfilePreprocessResult) Cleanup() {
 	for _, f := range p.TempFiles {
 		_ = os.Remove(f)
@@ -65,6 +66,8 @@ func (p *ProfilePreprocessResult) Cleanup() {
 //  3. Inline secrets: if a "secrets" key exists, its content (static/dynamic)
 //     is serialized as a proper authx YAML secrets file in a temp file, and a
 //     "secret-file" entry is added (or appended) to the cleaned config.
+//     Only non-empty static/dynamic sections are written to avoid producing
+//     an authx file that pkg/authprovider/file.go would reject with ErrNoSecrets.
 //
 // The function returns a ProfilePreprocessResult. The caller should use
 // CleanedConfigPath with goflags.MergeConfigFile and call Cleanup() when done.
@@ -76,19 +79,23 @@ func PreprocessProfileFile(filePath string) (*ProfilePreprocessResult, error) {
 		return nil, err
 	}
 
-	// Parse YAML into an ordered map to preserve key order
+	// Parse YAML into a map. An empty file will produce a nil map, which is
+	// safe to pass to hasSpecialKeys (nil map range is a no-op in Go).
 	var rawConfig map[string]interface{}
 	if err := yaml.Unmarshal(data, &rawConfig); err != nil {
 		return nil, err
 	}
 
 	// If there are no special keys to process, return the original file path
+	// with no temp files created — fast path for normal config files.
 	if !hasSpecialKeys(rawConfig) {
 		result.CleanedConfigPath = filePath
 		return result, nil
 	}
 
 	// --- Feature 1: Remove extra metadata fields ---
+	// Keys like id, name, purpose, description are stripped so goflags
+	// does not error on unrecognised flag names.
 	for field := range profileExtraFields {
 		delete(rawConfig, field)
 	}
@@ -105,35 +112,40 @@ func PreprocessProfileFile(filePath string) (*ProfilePreprocessResult, error) {
 		return nil, err
 	}
 
-	// Write the cleaned config to a temporary file
+	// Serialize the cleaned config (extra fields removed, inline values
+	// replaced with temp file paths) to a new temporary YAML file so that
+	// goflags.MergeConfigFile only sees standard flag names.
 	cleanedData, err := yaml.Marshal(rawConfig)
 	if err != nil {
 		result.Cleanup()
 		return nil, err
 	}
 
+	// os.CreateTemp creates the file with 0600 permissions, ensuring that
+	// the cleaned config (which may reference secrets paths) is not world-readable.
 	tmpFile, err := os.CreateTemp("", "nuclei-profile-*.yaml")
 	if err != nil {
 		result.Cleanup()
 		return nil, err
 	}
+	// Register path in TempFiles and CleanedConfigPath BEFORE writing so that
+	// Cleanup() always removes this file even if the subsequent write fails.
+	result.CleanedConfigPath = tmpFile.Name()
+	result.TempFiles = append(result.TempFiles, tmpFile.Name())
 
 	if _, err := tmpFile.Write(cleanedData); err != nil {
 		_ = tmpFile.Close()
-		_ = os.Remove(tmpFile.Name())
 		result.Cleanup()
 		return nil, err
 	}
 	_ = tmpFile.Close()
 
-	result.CleanedConfigPath = tmpFile.Name()
-	result.TempFiles = append(result.TempFiles, tmpFile.Name())
-
 	return result, nil
 }
 
-// hasSpecialKeys checks whether the raw config contains any keys that
-// require preprocessing (extra metadata fields, inline targets, or inline secrets).
+// hasSpecialKeys reports whether rawConfig contains any key that requires
+// preprocessing: extra metadata fields, an inline secrets block, or an inline
+// targets list (multiline "list" value).
 func hasSpecialKeys(rawConfig map[string]interface{}) bool {
 	for field := range profileExtraFields {
 		if _, ok := rawConfig[field]; ok {
@@ -153,9 +165,27 @@ func hasSpecialKeys(rawConfig map[string]interface{}) bool {
 	return false
 }
 
+// isNonEmptySlice returns true if v is a []interface{} with at least one element.
+// It is used to guard against YAML null values (nil) and empty lists ([]interface{}{})
+// when checking inline secrets sections.
+//
+// This guard is required because pkg/authprovider/file.go (NewFileAuthProvider)
+// returns ErrNoSecrets when both store.Secrets and store.Dynamic are empty.
+// Writing a temp authx file from static: null / static: [] / dynamic: null /
+// dynamic: [] would create a file that passes parsing but fails that check,
+// turning a harmless no-op profile entry into a startup error.
+func isNonEmptySlice(v interface{}) bool {
+	if v == nil {
+		return false
+	}
+	slice, ok := v.([]interface{})
+	return ok && len(slice) > 0
+}
+
 // handleInlineTargets checks if the "list" key contains a multiline string
 // (inline target list). If so, it writes the targets to a temp file and
-// replaces the "list" value with the temp file path.
+// replaces the "list" value with the temp file path, so goflags can treat
+// it as a normal -list file path.
 func handleInlineTargets(rawConfig map[string]interface{}, result *ProfilePreprocessResult) error {
 	listVal, ok := rawConfig["list"]
 	if !ok {
@@ -167,14 +197,14 @@ func handleInlineTargets(rawConfig map[string]interface{}, result *ProfilePrepro
 		return nil
 	}
 
-	// Only treat as inline targets if the value contains newlines
-	// (i.e., it's a YAML block scalar with multiple targets, not a file path)
+	// Only treat as inline targets if the value contains newlines.
+	// A plain file path (e.g. "/path/to/targets.txt") must not be treated
+	// as an inline list even if it somehow appears as a string value.
 	if !strings.Contains(strVal, "\n") {
 		return nil
 	}
 
-	// Parse targets from the multiline string: split by newlines, trim whitespace,
-	// and skip empty lines
+	// Parse targets: split by newlines, trim whitespace, skip empty lines.
 	var targets []string
 	for _, line := range strings.Split(strVal, "\n") {
 		line = strings.TrimSpace(line)
@@ -183,30 +213,32 @@ func handleInlineTargets(rawConfig map[string]interface{}, result *ProfilePrepro
 		}
 	}
 
+	// Whitespace-only block scalar → remove the key entirely; no temp file needed.
 	if len(targets) == 0 {
 		delete(rawConfig, "list")
 		return nil
 	}
 
-	// Write targets to a temporary file (one per line)
+	// os.CreateTemp creates the file with 0600 permissions by default.
 	tmpFile, err := os.CreateTemp("", "nuclei-targets-*.txt")
 	if err != nil {
 		return err
 	}
+	// Register path BEFORE writing so Cleanup() handles removal on write failure.
+	result.InlineTargetsFile = tmpFile.Name()
+	result.TempFiles = append(result.TempFiles, tmpFile.Name())
 
 	content := strings.Join(targets, "\n") + "\n"
 	if _, err := tmpFile.WriteString(content); err != nil {
 		_ = tmpFile.Close()
-		_ = os.Remove(tmpFile.Name())
+		// Do NOT call os.Remove here — result.TempFiles already holds the path
+		// and the caller's result.Cleanup() will handle removal.
 		return err
 	}
 	_ = tmpFile.Close()
 
-	result.InlineTargetsFile = tmpFile.Name()
-	result.TempFiles = append(result.TempFiles, tmpFile.Name())
-
 	// Replace the multiline string with the temp file path so goflags
-	// can parse it as a normal file path for the -list flag
+	// can parse it as a normal file path for the -list flag.
 	rawConfig["list"] = tmpFile.Name()
 
 	return nil
@@ -216,75 +248,95 @@ func handleInlineTargets(rawConfig map[string]interface{}, result *ProfilePrepro
 // If so, it extracts the secrets data, writes it to a temporary YAML file
 // in the authx format (with "static" and "dynamic" top-level keys), and
 // adds the temp file path to the "secret-file" list in the cleaned config.
+//
+// The "secrets" key is always removed from rawConfig because goflags must
+// never see it; the information is forwarded via "secret-file" instead.
+//
+// Only non-nil, non-empty static and dynamic sections are included in the
+// written authx file. If both sections are empty or null after filtering,
+// no temp file is created. This prevents pkg/authprovider/file.go from
+// returning ErrNoSecrets on startup due to a vacuous secrets: block.
 func handleInlineSecrets(rawConfig map[string]interface{}, result *ProfilePreprocessResult) error {
 	secretsVal, ok := rawConfig["secrets"]
 	if !ok {
 		return nil
 	}
 
-	// Remove the "secrets" key from the config since goflags doesn't know about it
+	// Remove the "secrets" key unconditionally — goflags must never see it.
 	delete(rawConfig, "secrets")
 
 	secretsMap, isMap := secretsVal.(map[string]interface{})
 	if !isMap {
-		// If secrets is not a map, skip silently
+		// Value is present but not a map (e.g. a plain string). Skip silently
+		// rather than erroring, to stay backwards-compatible.
 		return nil
 	}
 
 	// Build the authx-compatible secrets file content.
-	// The authx format expects top-level "static" and "dynamic" keys.
+	// The authx provider expects top-level "static" and "dynamic" keys.
+	//
+	// IMPORTANT: We only add a section when its value is a non-nil, non-empty
+	// slice. YAML null (nil interface{}) and empty lists ([]interface{}{}) are
+	// filtered out here. Writing such values would produce an authx file where
+	// both store.Secrets and store.Dynamic are empty, causing NewFileAuthProvider
+	// to return ErrNoSecrets and aborting the scan at startup.
 	authxData := make(map[string]interface{})
-	if staticVal, ok := secretsMap["static"]; ok {
+
+	if staticVal, ok := secretsMap["static"]; ok && isNonEmptySlice(staticVal) {
 		authxData["static"] = staticVal
 	}
-	if dynamicVal, ok := secretsMap["dynamic"]; ok {
+	if dynamicVal, ok := secretsMap["dynamic"]; ok && isNonEmptySlice(dynamicVal) {
 		authxData["dynamic"] = dynamicVal
 	}
 
+	// No usable secrets sections — nothing to write.
 	if len(authxData) == 0 {
 		return nil
 	}
 
-	// Serialize to YAML
 	secretsYAML, err := yaml.Marshal(authxData)
 	if err != nil {
 		return err
 	}
 
-	// Write to a temporary file
+	// os.CreateTemp creates the file with 0600 permissions by default,
+	// protecting sensitive auth data from other users on the system.
 	tmpFile, err := os.CreateTemp("", "nuclei-secrets-*.yaml")
 	if err != nil {
 		return err
 	}
+	// Register path BEFORE writing so Cleanup() handles removal on write failure.
+	result.InlineSecretsFile = tmpFile.Name()
+	result.TempFiles = append(result.TempFiles, tmpFile.Name())
 
 	if _, err := tmpFile.Write(secretsYAML); err != nil {
 		_ = tmpFile.Close()
-		_ = os.Remove(tmpFile.Name())
+		// Do NOT call os.Remove here — result.TempFiles already holds the path
+		// and the caller's result.Cleanup() will handle removal.
 		return err
 	}
 	_ = tmpFile.Close()
 
-	result.InlineSecretsFile = tmpFile.Name()
-	result.TempFiles = append(result.TempFiles, tmpFile.Name())
-
 	// Add the temp secrets file to the "secret-file" list in the config.
-	// The "secret-file" flag accepts a comma-separated list of file paths.
+	// We always write a YAML sequence ([]interface{}) so that goflags'
+	// CommaSeparatedStringSliceOptions can parse it reliably, regardless of
+	// spacing or quoting that might exist in an existing "secret-file" value.
 	secretFilePath := filepath.ToSlash(tmpFile.Name())
 	if existing, ok := rawConfig["secret-file"]; ok {
 		switch v := existing.(type) {
 		case string:
 			if v != "" {
-				rawConfig["secret-file"] = v + "," + secretFilePath
+				rawConfig["secret-file"] = []interface{}{v, secretFilePath}
 			} else {
-				rawConfig["secret-file"] = secretFilePath
+				rawConfig["secret-file"] = []interface{}{secretFilePath}
 			}
 		case []interface{}:
 			rawConfig["secret-file"] = append(v, secretFilePath)
 		default:
-			rawConfig["secret-file"] = secretFilePath
+			rawConfig["secret-file"] = []interface{}{secretFilePath}
 		}
 	} else {
-		rawConfig["secret-file"] = secretFilePath
+		rawConfig["secret-file"] = []interface{}{secretFilePath}
 	}
 
 	return nil

--- a/pkg/types/profile_test.go
+++ b/pkg/types/profile_test.go
@@ -1,0 +1,761 @@
+package types
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// TestPreprocessProfileFile_NoSpecialKeys verifies that when a profile has
+// no extra fields, no inline targets, and no inline secrets, the original
+// file path is returned unchanged with no temporary files created.
+func TestPreprocessProfileFile_NoSpecialKeys(t *testing.T) {
+	content := `tags:
+  - kev
+timeout: 30
+`
+	tmpFile := writeTempYAML(t, content)
+	defer os.Remove(tmpFile)
+
+	result, err := PreprocessProfileFile(tmpFile)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	defer result.Cleanup()
+
+	// Should return original path since no preprocessing was needed
+	require.Equal(t, tmpFile, result.CleanedConfigPath)
+	require.Empty(t, result.TempFiles)
+	require.Empty(t, result.InlineTargetsFile)
+	require.Empty(t, result.InlineSecretsFile)
+}
+
+// TestPreprocessProfileFile_ExtraFieldsRemoved verifies Feature 1:
+// extra metadata fields (id, name, purpose, description) are silently
+// stripped from the cleaned config so goflags won't error on unknown keys.
+func TestPreprocessProfileFile_ExtraFieldsRemoved(t *testing.T) {
+	content := `id: my-scan-profile
+name: projectdiscovery-scan
+purpose: Config File for Scanning
+description: single config file for scanning a specific target
+tags:
+  - kev
+timeout: 30
+stats: true
+`
+	tmpFile := writeTempYAML(t, content)
+	defer os.Remove(tmpFile)
+
+	result, err := PreprocessProfileFile(tmpFile)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	defer result.Cleanup()
+
+	// Should have created a cleaned config (different path from original)
+	require.NotEqual(t, tmpFile, result.CleanedConfigPath)
+	require.FileExists(t, result.CleanedConfigPath)
+
+	// Read and parse the cleaned config
+	cleanedData, err := os.ReadFile(result.CleanedConfigPath)
+	require.NoError(t, err)
+
+	var cleaned map[string]interface{}
+	err = yaml.Unmarshal(cleanedData, &cleaned)
+	require.NoError(t, err)
+
+	// Extra fields must be absent
+	_, hasID := cleaned["id"]
+	require.False(t, hasID, "id field should have been removed")
+	_, hasName := cleaned["name"]
+	require.False(t, hasName, "name field should have been removed")
+	_, hasPurpose := cleaned["purpose"]
+	require.False(t, hasPurpose, "purpose field should have been removed")
+	_, hasDesc := cleaned["description"]
+	require.False(t, hasDesc, "description field should have been removed")
+
+	// Regular fields must still be present
+	_, hasTags := cleaned["tags"]
+	require.True(t, hasTags, "tags field should be preserved")
+	_, hasTimeout := cleaned["timeout"]
+	require.True(t, hasTimeout, "timeout field should be preserved")
+	_, hasStats := cleaned["stats"]
+	require.True(t, hasStats, "stats field should be preserved")
+}
+
+// TestPreprocessProfileFile_InlineTargets verifies Feature 2:
+// a multiline `list` value is extracted to a temp file and the
+// `list` key in the cleaned config points to that temp file.
+func TestPreprocessProfileFile_InlineTargets(t *testing.T) {
+	content := `list: |
+  cve.projectdiscovery.io
+  chaos.projectdiscovery.io
+  api.projectdiscovery.io
+tags:
+  - kev
+`
+	tmpFile := writeTempYAML(t, content)
+	defer os.Remove(tmpFile)
+
+	result, err := PreprocessProfileFile(tmpFile)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	defer result.Cleanup()
+
+	// Should have created an inline targets temp file
+	require.NotEmpty(t, result.InlineTargetsFile)
+	require.FileExists(t, result.InlineTargetsFile)
+
+	// Read the targets file and verify contents
+	targetsData, err := os.ReadFile(result.InlineTargetsFile)
+	require.NoError(t, err)
+
+	targets := parseLines(string(targetsData))
+	require.Equal(t, 3, len(targets))
+	require.Contains(t, targets, "cve.projectdiscovery.io")
+	require.Contains(t, targets, "chaos.projectdiscovery.io")
+	require.Contains(t, targets, "api.projectdiscovery.io")
+
+	// The cleaned config's "list" value should be the temp file path
+	cleanedData, err := os.ReadFile(result.CleanedConfigPath)
+	require.NoError(t, err)
+
+	var cleaned map[string]interface{}
+	err = yaml.Unmarshal(cleanedData, &cleaned)
+	require.NoError(t, err)
+
+	listVal, ok := cleaned["list"]
+	require.True(t, ok, "list key should still exist in cleaned config")
+	listStr, ok := listVal.(string)
+	require.True(t, ok, "list value should be a string (temp file path)")
+	require.Equal(t, result.InlineTargetsFile, listStr)
+}
+
+// TestPreprocessProfileFile_SingleLineListUnchanged verifies that a
+// single-line `list` value (a normal file path) is NOT treated as
+// inline targets and is left untouched.
+func TestPreprocessProfileFile_SingleLineListUnchanged(t *testing.T) {
+	content := `name: test-profile
+list: /path/to/targets.txt
+tags:
+  - kev
+`
+	tmpFile := writeTempYAML(t, content)
+	defer os.Remove(tmpFile)
+
+	result, err := PreprocessProfileFile(tmpFile)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	defer result.Cleanup()
+
+	// No inline targets file should be created
+	require.Empty(t, result.InlineTargetsFile)
+
+	// The list value should remain unchanged (still a file path)
+	cleanedData, err := os.ReadFile(result.CleanedConfigPath)
+	require.NoError(t, err)
+
+	var cleaned map[string]interface{}
+	err = yaml.Unmarshal(cleanedData, &cleaned)
+	require.NoError(t, err)
+
+	listVal, ok := cleaned["list"]
+	require.True(t, ok, "list key should still exist")
+	require.Equal(t, "/path/to/targets.txt", listVal)
+}
+
+// TestPreprocessProfileFile_InlineSecrets verifies Feature 3:
+// a `secrets` key with static/dynamic sub-keys is extracted to a
+// temp file in authx format and linked via `secret-file`.
+func TestPreprocessProfileFile_InlineSecrets(t *testing.T) {
+	content := `tags:
+  - kev
+secrets:
+  static:
+    - type: header
+      domains:
+        - api.projectdiscovery.io
+      headers:
+        - key: x-pdcp-key
+          value: test-api-key
+  dynamic:
+    - template: custom-oauth-flow.yaml
+      variables:
+        - name: username
+          value: pdteam
+        - name: password
+          value: nuclei-fuzz
+      type: cookie
+      domains:
+        - scanme.sh
+      cookies:
+        - raw: "{{session-cookie}}"
+`
+	tmpFile := writeTempYAML(t, content)
+	defer os.Remove(tmpFile)
+
+	result, err := PreprocessProfileFile(tmpFile)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	defer result.Cleanup()
+
+	// Should have created an inline secrets temp file
+	require.NotEmpty(t, result.InlineSecretsFile)
+	require.FileExists(t, result.InlineSecretsFile)
+
+	// Read and parse the secrets file — it should be valid authx YAML
+	secretsData, err := os.ReadFile(result.InlineSecretsFile)
+	require.NoError(t, err)
+
+	var authxData map[string]interface{}
+	err = yaml.Unmarshal(secretsData, &authxData)
+	require.NoError(t, err)
+
+	// Verify static key exists
+	_, hasStatic := authxData["static"]
+	require.True(t, hasStatic, "secrets file should contain static key")
+
+	// Verify dynamic key exists
+	_, hasDynamic := authxData["dynamic"]
+	require.True(t, hasDynamic, "secrets file should contain dynamic key")
+
+	// The cleaned config should NOT have a "secrets" key
+	cleanedData, err := os.ReadFile(result.CleanedConfigPath)
+	require.NoError(t, err)
+
+	var cleaned map[string]interface{}
+	err = yaml.Unmarshal(cleanedData, &cleaned)
+	require.NoError(t, err)
+
+	_, hasSecrets := cleaned["secrets"]
+	require.False(t, hasSecrets, "secrets key should have been removed from cleaned config")
+
+	// The cleaned config should have a "secret-file" key pointing to the temp file
+	sfVal, hasSF := cleaned["secret-file"]
+	require.True(t, hasSF, "secret-file key should exist in cleaned config")
+	sfStr, ok := sfVal.(string)
+	require.True(t, ok, "secret-file value should be a string")
+	require.Contains(t, sfStr, filepath.ToSlash(result.InlineSecretsFile))
+}
+
+// TestPreprocessProfileFile_InlineSecretsAppendToExisting verifies that
+// when a profile already has a `secret-file` value, the inline secrets
+// temp file path is appended (comma-separated) rather than replacing it.
+func TestPreprocessProfileFile_InlineSecretsAppendToExisting(t *testing.T) {
+	content := `secret-file: /existing/secrets.yaml
+secrets:
+  static:
+    - type: header
+      domains:
+        - example.com
+      headers:
+        - key: Authorization
+          value: Bearer existing-token
+`
+	tmpFile := writeTempYAML(t, content)
+	defer os.Remove(tmpFile)
+
+	result, err := PreprocessProfileFile(tmpFile)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	defer result.Cleanup()
+
+	require.NotEmpty(t, result.InlineSecretsFile)
+
+	cleanedData, err := os.ReadFile(result.CleanedConfigPath)
+	require.NoError(t, err)
+
+	var cleaned map[string]interface{}
+	err = yaml.Unmarshal(cleanedData, &cleaned)
+	require.NoError(t, err)
+
+	sfVal, hasSF := cleaned["secret-file"]
+	require.True(t, hasSF)
+	sfStr, ok := sfVal.(string)
+	require.True(t, ok)
+
+	// Should contain both the original path and the new inline secrets path
+	require.Contains(t, sfStr, "/existing/secrets.yaml")
+	require.Contains(t, sfStr, filepath.ToSlash(result.InlineSecretsFile))
+	require.Contains(t, sfStr, ",", "should be comma-separated")
+}
+
+// TestPreprocessProfileFile_FullProfile verifies the complete end-to-end
+// scenario from the GitHub issue: a profile with metadata fields, inline
+// targets, inline secrets, and regular nuclei flags all at once.
+func TestPreprocessProfileFile_FullProfile(t *testing.T) {
+	content := `name: projectdiscovery-scan
+purpose: Config File for Scanning
+description: single config file that contains every config related to scanning
+
+list: |
+  cve.projectdiscovery.io
+  chaos.projectdiscovery.io
+  api.projectdiscovery.io
+
+type:
+  - http
+  - tcp
+  - javascript
+  - dns
+  - ssl
+
+exclude-tags:
+  - dos
+  - fuzz
+  - osint
+
+concurrency: 5
+bulk-size: 100
+stats: true
+timeout: 30
+
+secrets:
+  static:
+    - type: header
+      domains:
+        - api.projectdiscovery.io
+        - cve.projectdiscovery.io
+        - chaos.projectdiscovery.io
+      headers:
+        - key: x-pdcp-key
+          value: test-api-key-here
+  dynamic:
+    - template: custom-oauth-flow.yaml
+      variables:
+        - name: username
+          value: pdteam
+        - name: password
+          value: nuclei-fuzz
+      type: cookie
+      domains:
+        - scanme.sh
+      cookies:
+        - raw: "{{session-cookie}}"
+`
+	tmpFile := writeTempYAML(t, content)
+	defer os.Remove(tmpFile)
+
+	result, err := PreprocessProfileFile(tmpFile)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	defer result.Cleanup()
+
+	// All three features should have produced results
+	require.NotEqual(t, tmpFile, result.CleanedConfigPath)
+	require.NotEmpty(t, result.InlineTargetsFile)
+	require.NotEmpty(t, result.InlineSecretsFile)
+
+	// Verify targets file
+	targetsData, err := os.ReadFile(result.InlineTargetsFile)
+	require.NoError(t, err)
+	targets := parseLines(string(targetsData))
+	require.Equal(t, 3, len(targets))
+
+	// Verify secrets file has both static and dynamic
+	secretsData, err := os.ReadFile(result.InlineSecretsFile)
+	require.NoError(t, err)
+	var authx map[string]interface{}
+	err = yaml.Unmarshal(secretsData, &authx)
+	require.NoError(t, err)
+	_, hasStatic := authx["static"]
+	require.True(t, hasStatic)
+	_, hasDynamic := authx["dynamic"]
+	require.True(t, hasDynamic)
+
+	// Verify cleaned config
+	cleanedData, err := os.ReadFile(result.CleanedConfigPath)
+	require.NoError(t, err)
+	var cleaned map[string]interface{}
+	err = yaml.Unmarshal(cleanedData, &cleaned)
+	require.NoError(t, err)
+
+	// Extra fields removed
+	for field := range profileExtraFields {
+		_, exists := cleaned[field]
+		require.False(t, exists, "field %q should have been removed", field)
+	}
+
+	// secrets key removed
+	_, hasSecrets := cleaned["secrets"]
+	require.False(t, hasSecrets, "secrets key should have been removed")
+
+	// Regular flags preserved
+	_, hasType := cleaned["type"]
+	require.True(t, hasType, "type field should be preserved")
+	_, hasExcludeTags := cleaned["exclude-tags"]
+	require.True(t, hasExcludeTags, "exclude-tags field should be preserved")
+	_, hasStats := cleaned["stats"]
+	require.True(t, hasStats, "stats field should be preserved")
+	_, hasTimeout := cleaned["timeout"]
+	require.True(t, hasTimeout, "timeout field should be preserved")
+	_, hasConcurrency := cleaned["concurrency"]
+	require.True(t, hasConcurrency, "concurrency field should be preserved")
+	_, hasBulkSize := cleaned["bulk-size"]
+	require.True(t, hasBulkSize, "bulk-size field should be preserved")
+
+	// list key should now be the temp file path
+	listVal, hasList := cleaned["list"]
+	require.True(t, hasList)
+	listStr, ok := listVal.(string)
+	require.True(t, ok)
+	require.Equal(t, result.InlineTargetsFile, listStr)
+
+	// secret-file key should reference the temp secrets file
+	sfVal, hasSF := cleaned["secret-file"]
+	require.True(t, hasSF)
+	sfStr, ok := sfVal.(string)
+	require.True(t, ok)
+	require.Contains(t, sfStr, filepath.ToSlash(result.InlineSecretsFile))
+}
+
+// TestPreprocessProfileFile_Cleanup verifies that Cleanup() removes
+// all temporary files that were created during preprocessing.
+func TestPreprocessProfileFile_Cleanup(t *testing.T) {
+	content := `name: cleanup-test
+list: |
+  example.com
+  test.com
+secrets:
+  static:
+    - type: header
+      domains:
+        - example.com
+      headers:
+        - key: X-Token
+          value: test
+`
+	tmpFile := writeTempYAML(t, content)
+	defer os.Remove(tmpFile)
+
+	result, err := PreprocessProfileFile(tmpFile)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Gather all temp file paths before cleanup
+	allTempFiles := make([]string, len(result.TempFiles))
+	copy(allTempFiles, result.TempFiles)
+
+	// All temp files should exist before cleanup
+	for _, f := range allTempFiles {
+		require.FileExists(t, f)
+	}
+
+	// Run cleanup
+	result.Cleanup()
+
+	// All temp files should be gone after cleanup
+	for _, f := range allTempFiles {
+		_, err := os.Stat(f)
+		require.True(t, os.IsNotExist(err), "temp file %q should have been removed by Cleanup()", f)
+	}
+}
+
+// TestPreprocessProfileFile_EmptyInlineTargets verifies that when the
+// `list` multiline block contains only whitespace/empty lines, the
+// `list` key is removed entirely and no temp file is created.
+func TestPreprocessProfileFile_EmptyInlineTargets(t *testing.T) {
+	content := `name: empty-targets
+list: |
+
+
+`
+	tmpFile := writeTempYAML(t, content)
+	defer os.Remove(tmpFile)
+
+	result, err := PreprocessProfileFile(tmpFile)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	defer result.Cleanup()
+
+	// No inline targets file should be created for empty content
+	require.Empty(t, result.InlineTargetsFile)
+
+	// The cleaned config should not have the list key
+	cleanedData, err := os.ReadFile(result.CleanedConfigPath)
+	require.NoError(t, err)
+	var cleaned map[string]interface{}
+	err = yaml.Unmarshal(cleanedData, &cleaned)
+	require.NoError(t, err)
+
+	_, hasList := cleaned["list"]
+	require.False(t, hasList, "empty inline list should be removed")
+}
+
+// TestPreprocessProfileFile_SecretsNotMap verifies that if the `secrets`
+// value is not a map (e.g., a string or scalar), it is silently ignored
+// and no temp file is created.
+func TestPreprocessProfileFile_SecretsNotMap(t *testing.T) {
+	content := `name: bad-secrets
+secrets: not-a-map-value
+tags:
+  - kev
+`
+	tmpFile := writeTempYAML(t, content)
+	defer os.Remove(tmpFile)
+
+	result, err := PreprocessProfileFile(tmpFile)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	defer result.Cleanup()
+
+	// No inline secrets file since secrets was not a map
+	require.Empty(t, result.InlineSecretsFile)
+}
+
+// TestPreprocessProfileFile_SecretsStaticOnly verifies that secrets with
+// only a "static" key (no "dynamic") works correctly.
+func TestPreprocessProfileFile_SecretsStaticOnly(t *testing.T) {
+	content := `secrets:
+  static:
+    - type: header
+      domains:
+        - example.com
+      headers:
+        - key: X-API-Key
+          value: my-key
+`
+	tmpFile := writeTempYAML(t, content)
+	defer os.Remove(tmpFile)
+
+	result, err := PreprocessProfileFile(tmpFile)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	defer result.Cleanup()
+
+	require.NotEmpty(t, result.InlineSecretsFile)
+
+	secretsData, err := os.ReadFile(result.InlineSecretsFile)
+	require.NoError(t, err)
+
+	var authx map[string]interface{}
+	err = yaml.Unmarshal(secretsData, &authx)
+	require.NoError(t, err)
+
+	_, hasStatic := authx["static"]
+	require.True(t, hasStatic, "static key should be present")
+	_, hasDynamic := authx["dynamic"]
+	require.False(t, hasDynamic, "dynamic key should not be present")
+}
+
+// TestPreprocessProfileFile_SecretsDynamicOnly verifies that secrets with
+// only a "dynamic" key (no "static") works correctly.
+func TestPreprocessProfileFile_SecretsDynamicOnly(t *testing.T) {
+	content := `secrets:
+  dynamic:
+    - template: login-flow.yaml
+      variables:
+        - name: user
+          value: admin
+      type: cookie
+      domains:
+        - example.com
+      cookies:
+        - raw: "{{auth-cookie}}"
+`
+	tmpFile := writeTempYAML(t, content)
+	defer os.Remove(tmpFile)
+
+	result, err := PreprocessProfileFile(tmpFile)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	defer result.Cleanup()
+
+	require.NotEmpty(t, result.InlineSecretsFile)
+
+	secretsData, err := os.ReadFile(result.InlineSecretsFile)
+	require.NoError(t, err)
+
+	var authx map[string]interface{}
+	err = yaml.Unmarshal(secretsData, &authx)
+	require.NoError(t, err)
+
+	_, hasStatic := authx["static"]
+	require.False(t, hasStatic, "static key should not be present")
+	_, hasDynamic := authx["dynamic"]
+	require.True(t, hasDynamic, "dynamic key should be present")
+}
+
+// TestPreprocessProfileFile_SecretsEmptyStaticDynamic verifies that when
+// both static and dynamic are absent from the secrets map, no temp file
+// is created.
+func TestPreprocessProfileFile_SecretsEmptyStaticDynamic(t *testing.T) {
+	content := `name: empty-secrets
+secrets:
+  something-else: true
+`
+	tmpFile := writeTempYAML(t, content)
+	defer os.Remove(tmpFile)
+
+	result, err := PreprocessProfileFile(tmpFile)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	defer result.Cleanup()
+
+	// No secrets file because neither static nor dynamic were present
+	require.Empty(t, result.InlineSecretsFile)
+}
+
+// TestPreprocessProfileFile_NonExistentFile verifies that a non-existent
+// file path returns an error.
+func TestPreprocessProfileFile_NonExistentFile(t *testing.T) {
+	result, err := PreprocessProfileFile("/non/existent/path/profile.yaml")
+	require.Error(t, err)
+	require.Nil(t, result)
+}
+
+// TestPreprocessProfileFile_InvalidYAML verifies that an invalid YAML file
+// returns an error.
+func TestPreprocessProfileFile_InvalidYAML(t *testing.T) {
+	content := `{{{invalid yaml content!!!`
+	tmpFile := writeTempYAML(t, content)
+	defer os.Remove(tmpFile)
+
+	result, err := PreprocessProfileFile(tmpFile)
+	require.Error(t, err)
+	require.Nil(t, result)
+}
+
+// TestPreprocessProfileFile_OnlyExtraFields verifies that a profile with
+// ONLY extra fields (and nothing else) produces a cleaned config that is
+// essentially empty.
+func TestPreprocessProfileFile_OnlyExtraFields(t *testing.T) {
+	content := `id: test-id
+name: test-name
+purpose: testing
+description: a test profile with only metadata
+`
+	tmpFile := writeTempYAML(t, content)
+	defer os.Remove(tmpFile)
+
+	result, err := PreprocessProfileFile(tmpFile)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	defer result.Cleanup()
+
+	// Should have preprocessed since extra fields were present
+	require.NotEqual(t, tmpFile, result.CleanedConfigPath)
+
+	cleanedData, err := os.ReadFile(result.CleanedConfigPath)
+	require.NoError(t, err)
+
+	var cleaned map[string]interface{}
+	err = yaml.Unmarshal(cleanedData, &cleaned)
+	require.NoError(t, err)
+
+	// All extra fields should be gone, resulting in an empty map
+	require.Empty(t, cleaned)
+}
+
+// TestPreprocessProfileFile_TempFileCount verifies the correct number
+// of temp files are tracked for a full profile scenario.
+func TestPreprocessProfileFile_TempFileCount(t *testing.T) {
+	content := `name: temp-count-test
+list: |
+  target1.com
+  target2.com
+secrets:
+  static:
+    - type: header
+      domains:
+        - example.com
+      headers:
+        - key: X-Key
+          value: val
+`
+	tmpFile := writeTempYAML(t, content)
+	defer os.Remove(tmpFile)
+
+	result, err := PreprocessProfileFile(tmpFile)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	defer result.Cleanup()
+
+	// Should have 3 temp files: cleaned config, targets, secrets
+	require.Equal(t, 3, len(result.TempFiles))
+}
+
+// TestHasSpecialKeys verifies the hasSpecialKeys helper function.
+func TestHasSpecialKeys(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   map[string]interface{}
+		expected bool
+	}{
+		{
+			name:     "no special keys",
+			config:   map[string]interface{}{"tags": []string{"kev"}, "timeout": 30},
+			expected: false,
+		},
+		{
+			name:     "has id",
+			config:   map[string]interface{}{"id": "test", "tags": []string{"kev"}},
+			expected: true,
+		},
+		{
+			name:     "has name",
+			config:   map[string]interface{}{"name": "test"},
+			expected: true,
+		},
+		{
+			name:     "has purpose",
+			config:   map[string]interface{}{"purpose": "test"},
+			expected: true,
+		},
+		{
+			name:     "has description",
+			config:   map[string]interface{}{"description": "test"},
+			expected: true,
+		},
+		{
+			name:     "has secrets",
+			config:   map[string]interface{}{"secrets": map[string]interface{}{}},
+			expected: true,
+		},
+		{
+			name:     "has multiline list",
+			config:   map[string]interface{}{"list": "target1\ntarget2"},
+			expected: true,
+		},
+		{
+			name:     "has single-line list (file path)",
+			config:   map[string]interface{}{"list": "/path/to/file.txt"},
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := hasSpecialKeys(tc.config)
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+// --- helpers ---
+
+// writeTempYAML creates a temporary YAML file with the given content
+// and returns its path. The caller is responsible for removing it.
+func writeTempYAML(t *testing.T, content string) string {
+	t.Helper()
+	tmpFile, err := os.CreateTemp("", "nuclei-test-profile-*.yaml")
+	require.NoError(t, err)
+	_, err = tmpFile.WriteString(content)
+	require.NoError(t, err)
+	_ = tmpFile.Close()
+	return tmpFile.Name()
+}
+
+// parseLines splits text by newlines and returns non-empty trimmed lines.
+func parseLines(text string) []string {
+	var lines []string
+	for _, line := range strings.Split(text, "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			lines = append(lines, line)
+		}
+	}
+	return lines
+}

--- a/pkg/types/profile_test.go
+++ b/pkg/types/profile_test.go
@@ -759,3 +759,4 @@ func parseLines(text string) []string {
 	}
 	return lines
 }
+ 

--- a/pkg/types/profile_test.go
+++ b/pkg/types/profile_test.go
@@ -736,6 +736,35 @@ func TestHasSpecialKeys(t *testing.T) {
 
 // --- helpers ---
 
+// TestPreprocessProfileFile_CleanupIdempotent verifies that calling Cleanup()
+// multiple times on the same result does not panic and only removes files once.
+// This is important because main() defers profileCleanup() while signal handlers
+// also call profileCleanup() explicitly — both paths may run near-simultaneously.
+func TestPreprocessProfileFile_CleanupIdempotent(t *testing.T) {
+	content := `name: idempotent-test
+list: |
+  example.com
+  test.com
+`
+	tmpFile := writeTempYAML(t, content)
+	defer os.Remove(tmpFile)
+
+	result, err := PreprocessProfileFile(tmpFile)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotEmpty(t, result.TempFiles)
+
+	// First cleanup removes the files.
+	result.Cleanup()
+	for _, f := range result.TempFiles {
+		_, statErr := os.Stat(f)
+		require.True(t, os.IsNotExist(statErr), "temp file %q should be removed after first Cleanup()", f)
+	}
+
+	// Second cleanup must not panic even though files are already gone.
+	require.NotPanics(t, result.Cleanup, "Cleanup() must be idempotent — second call must not panic")
+}
+
 // writeTempYAML creates a temporary YAML file with the given content
 // and returns its path. The caller is responsible for removing it.
 func writeTempYAML(t *testing.T, content string) string {
@@ -759,4 +788,3 @@ func parseLines(text string) []string {
 	}
 	return lines
 }
- 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -33,12 +33,6 @@ type LoadHelperFileFunction func(helperFile, templatePath string, catalog catalo
 
 // Options contains the configuration options for nuclei scanner.
 type Options struct {
-	// Template Profile Metadata (Issue #5567)
-	ProfileID          string `yaml:"id,omitempty" json:"id,omitempty" description:"ID of the template profile"`
-	ProfileName        string `yaml:"name,omitempty" json:"name,omitempty" description:"Name of the template profile"`
-	ProfilePurpose     string `yaml:"purpose,omitempty" json:"purpose,omitempty" description:"Purpose of the template profile"`
-	ProfileDescription string `yaml:"description,omitempty" json:"description,omitempty" description:"Description of the template profile"`
-
 	// Tags contains a list of tags to execute templates for. Multiple paths
 	// can be specified with -l flag and -tags can be used in combination with
 	// the -l flag.
@@ -344,7 +338,7 @@ type Options struct {
 	IPVersion goflags.StringSlice
 	// PublicTemplateDisableDownload disables downloading templates from the nuclei-templates public repository
 	PublicTemplateDisableDownload bool
-	// GitHubToken used to clone/pull from private repos for custom templates
+	// GitHub token used to clone/pull from private repos for custom templates
 	GitHubToken string
 	// GitHubTemplateRepo is the list of custom public/private templates GitHub repos
 	GitHubTemplateRepo []string
@@ -409,81 +403,79 @@ type Options struct {
 	// EnableSelfContainedTemplates enables processing of self-contained templates
 	EnableSelfContainedTemplates bool
 	// EnableGlobalMatchersTemplates enables processing of global-matchers templates
-	EnableFileTemplates           bool
+	EnableGlobalMatchersTemplates bool
+	// EnableFileTemplates enables file templates
+	EnableFileTemplates bool
 	// Disables cloud upload
-	EnableCloudUpload             bool
+	EnableCloudUpload bool
 	// ScanID is the scan ID to use for cloud upload
-	ScanID                        string
+	ScanID string
 	// ScanName is the name of the scan to be uploaded
-	ScanName                      string
+	ScanName string
 	// ScanUploadFile is the jsonl file to upload scan results to cloud
-	ScanUploadFile                string
+	ScanUploadFile string
 	// TeamID is the team ID to use for cloud upload
-	TeamID                        string
+	TeamID string
 	// JsConcurrency is the number of concurrent js routines to run
-	JsConcurrency                 int
+	JsConcurrency int
 	// SecretsFile is file containing secrets for nuclei
-	SecretsFile                   goflags.StringSlice
+	SecretsFile goflags.StringSlice
 	// PreFetchSecrets pre-fetches the secrets from the auth provider
-	PreFetchSecrets               bool
+	PreFetchSecrets bool
 	// FormatUseRequiredOnly only uses required fields when generating requests
-	FormatUseRequiredOnly         bool
+	FormatUseRequiredOnly bool
 	// SkipFormatValidation is used to skip format validation
-	SkipFormatValidation          bool
+	SkipFormatValidation bool
 	// VarsTextTemplating is used to inject variables into yaml input files
-	VarsTextTemplating            bool
+	VarsTextTemplating bool
 	// VarsFilePaths is  used to inject variables into yaml input files from a file
-	VarsFilePaths                 goflags.StringSlice
+	VarsFilePaths goflags.StringSlice
 	// PayloadConcurrency is the number of concurrent payloads to run per template
-	PayloadConcurrency            int
+	PayloadConcurrency int
 	// ProbeConcurrency is the number of concurrent http probes to run with httpx
-	ProbeConcurrency              int
+	ProbeConcurrency int
 	// TemplateLoadingConcurrency is the number of concurrent template loading operations
-	TemplateLoadingConcurrency    int
+	TemplateLoadingConcurrency int
 	// Dast only runs DAST templates
-	DAST                          bool
+	DAST bool
 	// DASTServer is the flag to start nuclei as a DAST server
-	DASTServer                    bool
+	DASTServer bool
 	// DASTServerToken is the token optional for the dast server
-	DASTServerToken               string
+	DASTServerToken string
 	// DASTServerAddress is the address for the dast server
-	DASTServerAddress             string
+	DASTServerAddress string
 	// DASTReport enables dast report server & final report generation
-	DASTReport                    bool
+	DASTReport bool
 	// Scope contains a list of regexes for in-scope URLS
-	Scope                         goflags.StringSlice
+	Scope goflags.StringSlice
 	// OutOfScope contains a list of regexes for out-scope URLS
-	OutOfScope                    goflags.StringSlice
+	OutOfScope goflags.StringSlice
 	// HttpApiEndpoint is the experimental http api endpoint
-	HttpApiEndpoint               string
+	HttpApiEndpoint string
 	// ListTemplateProfiles lists all available template profiles
-	ListTemplateProfiles          bool
+	ListTemplateProfiles bool
 	// LoadHelperFileFunction is a function that will be used to execute LoadHelperFile.
 	// If none is provided, then the default implementation will be used.
-	LoadHelperFileFunction        LoadHelperFileFunction
+	LoadHelperFileFunction LoadHelperFileFunction
 	// Logger is the gologger instance for this optionset
-	Logger                        *gologger.Logger
+	Logger *gologger.Logger
 	// NoCacheTemplates disables caching of templates
-	DoNotCacheTemplates           bool
+	DoNotCacheTemplates bool
 	// Unique identifier of the execution session
-	ExecutionId                   string
+	ExecutionId string
 	// Parser is a cached parser for the template store
-	Parser                        any
+	Parser any
 	// timeouts contains various types of timeouts used in nuclei
 	// these timeouts are derived from dial-timeout (-timeout) with known multipliers
 	// This is internally managed and does not need to be set by user by explicitly setting
 	// this overrides the default/derived one
-	timeouts                      *Timeouts
+	timeouts *Timeouts
 	// m is a mutex to protect timeouts from concurrent access
-	m                             sync.Mutex
+	m sync.Mutex
 }
 
 func (options *Options) Copy() *Options {
 	optCopy := &Options{
-		ProfileID:                      options.ProfileID,
-		ProfileName:                    options.ProfileName,
-		ProfilePurpose:                 options.ProfilePurpose,
-		ProfileDescription:             options.ProfileDescription,
 		Tags:                           options.Tags,
 		ExcludeTags:                    options.ExcludeTags,
 		Workflows:                      options.Workflows,
@@ -676,11 +668,8 @@ func (options *Options) Copy() *Options {
 		PreFetchSecrets:                options.PreFetchSecrets,
 		FormatUseRequiredOnly:          options.FormatUseRequiredOnly,
 		SkipFormatValidation:           options.SkipFormatValidation,
-		VarsTextTemplating:             options.VarsTextTemplating,
-		VarsFilePaths:                  options.VarsFilePaths,
 		PayloadConcurrency:             options.PayloadConcurrency,
 		ProbeConcurrency:               options.ProbeConcurrency,
-		TemplateLoadingConcurrency:     options.TemplateLoadingConcurrency,
 		DAST:                           options.DAST,
 		DASTServer:                     options.DASTServer,
 		DASTServerToken:                options.DASTServerToken,

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -33,6 +33,12 @@ type LoadHelperFileFunction func(helperFile, templatePath string, catalog catalo
 
 // Options contains the configuration options for nuclei scanner.
 type Options struct {
+	// Template Profile Metadata (Issue #5567)
+	ProfileID          string `yaml:"id,omitempty" json:"id,omitempty" description:"ID of the template profile"`
+	ProfileName        string `yaml:"name,omitempty" json:"name,omitempty" description:"Name of the template profile"`
+	ProfilePurpose     string `yaml:"purpose,omitempty" json:"purpose,omitempty" description:"Purpose of the template profile"`
+	ProfileDescription string `yaml:"description,omitempty" json:"description,omitempty" description:"Description of the template profile"`
+
 	// Tags contains a list of tags to execute templates for. Multiple paths
 	// can be specified with -l flag and -tags can be used in combination with
 	// the -l flag.
@@ -338,7 +344,7 @@ type Options struct {
 	IPVersion goflags.StringSlice
 	// PublicTemplateDisableDownload disables downloading templates from the nuclei-templates public repository
 	PublicTemplateDisableDownload bool
-	// GitHub token used to clone/pull from private repos for custom templates
+	// GitHubToken used to clone/pull from private repos for custom templates
 	GitHubToken string
 	// GitHubTemplateRepo is the list of custom public/private templates GitHub repos
 	GitHubTemplateRepo []string
@@ -403,79 +409,81 @@ type Options struct {
 	// EnableSelfContainedTemplates enables processing of self-contained templates
 	EnableSelfContainedTemplates bool
 	// EnableGlobalMatchersTemplates enables processing of global-matchers templates
-	EnableGlobalMatchersTemplates bool
-	// EnableFileTemplates enables file templates
-	EnableFileTemplates bool
+	EnableFileTemplates           bool
 	// Disables cloud upload
-	EnableCloudUpload bool
+	EnableCloudUpload             bool
 	// ScanID is the scan ID to use for cloud upload
-	ScanID string
+	ScanID                        string
 	// ScanName is the name of the scan to be uploaded
-	ScanName string
+	ScanName                      string
 	// ScanUploadFile is the jsonl file to upload scan results to cloud
-	ScanUploadFile string
+	ScanUploadFile                string
 	// TeamID is the team ID to use for cloud upload
-	TeamID string
+	TeamID                        string
 	// JsConcurrency is the number of concurrent js routines to run
-	JsConcurrency int
+	JsConcurrency                 int
 	// SecretsFile is file containing secrets for nuclei
-	SecretsFile goflags.StringSlice
+	SecretsFile                   goflags.StringSlice
 	// PreFetchSecrets pre-fetches the secrets from the auth provider
-	PreFetchSecrets bool
+	PreFetchSecrets               bool
 	// FormatUseRequiredOnly only uses required fields when generating requests
-	FormatUseRequiredOnly bool
+	FormatUseRequiredOnly         bool
 	// SkipFormatValidation is used to skip format validation
-	SkipFormatValidation bool
+	SkipFormatValidation          bool
 	// VarsTextTemplating is used to inject variables into yaml input files
-	VarsTextTemplating bool
+	VarsTextTemplating            bool
 	// VarsFilePaths is  used to inject variables into yaml input files from a file
-	VarsFilePaths goflags.StringSlice
+	VarsFilePaths                 goflags.StringSlice
 	// PayloadConcurrency is the number of concurrent payloads to run per template
-	PayloadConcurrency int
+	PayloadConcurrency            int
 	// ProbeConcurrency is the number of concurrent http probes to run with httpx
-	ProbeConcurrency int
+	ProbeConcurrency              int
 	// TemplateLoadingConcurrency is the number of concurrent template loading operations
-	TemplateLoadingConcurrency int
+	TemplateLoadingConcurrency    int
 	// Dast only runs DAST templates
-	DAST bool
+	DAST                          bool
 	// DASTServer is the flag to start nuclei as a DAST server
-	DASTServer bool
+	DASTServer                    bool
 	// DASTServerToken is the token optional for the dast server
-	DASTServerToken string
+	DASTServerToken               string
 	// DASTServerAddress is the address for the dast server
-	DASTServerAddress string
+	DASTServerAddress             string
 	// DASTReport enables dast report server & final report generation
-	DASTReport bool
+	DASTReport                    bool
 	// Scope contains a list of regexes for in-scope URLS
-	Scope goflags.StringSlice
+	Scope                         goflags.StringSlice
 	// OutOfScope contains a list of regexes for out-scope URLS
-	OutOfScope goflags.StringSlice
+	OutOfScope                    goflags.StringSlice
 	// HttpApiEndpoint is the experimental http api endpoint
-	HttpApiEndpoint string
+	HttpApiEndpoint               string
 	// ListTemplateProfiles lists all available template profiles
-	ListTemplateProfiles bool
+	ListTemplateProfiles          bool
 	// LoadHelperFileFunction is a function that will be used to execute LoadHelperFile.
 	// If none is provided, then the default implementation will be used.
-	LoadHelperFileFunction LoadHelperFileFunction
+	LoadHelperFileFunction        LoadHelperFileFunction
 	// Logger is the gologger instance for this optionset
-	Logger *gologger.Logger
+	Logger                        *gologger.Logger
 	// NoCacheTemplates disables caching of templates
-	DoNotCacheTemplates bool
+	DoNotCacheTemplates           bool
 	// Unique identifier of the execution session
-	ExecutionId string
+	ExecutionId                   string
 	// Parser is a cached parser for the template store
-	Parser any
+	Parser                        any
 	// timeouts contains various types of timeouts used in nuclei
 	// these timeouts are derived from dial-timeout (-timeout) with known multipliers
 	// This is internally managed and does not need to be set by user by explicitly setting
 	// this overrides the default/derived one
-	timeouts *Timeouts
+	timeouts                      *Timeouts
 	// m is a mutex to protect timeouts from concurrent access
-	m sync.Mutex
+	m                             sync.Mutex
 }
 
 func (options *Options) Copy() *Options {
 	optCopy := &Options{
+		ProfileID:                      options.ProfileID,
+		ProfileName:                    options.ProfileName,
+		ProfilePurpose:                 options.ProfilePurpose,
+		ProfileDescription:             options.ProfileDescription,
 		Tags:                           options.Tags,
 		ExcludeTags:                    options.ExcludeTags,
 		Workflows:                      options.Workflows,
@@ -668,8 +676,11 @@ func (options *Options) Copy() *Options {
 		PreFetchSecrets:                options.PreFetchSecrets,
 		FormatUseRequiredOnly:          options.FormatUseRequiredOnly,
 		SkipFormatValidation:           options.SkipFormatValidation,
+		VarsTextTemplating:             options.VarsTextTemplating,
+		VarsFilePaths:                  options.VarsFilePaths,
 		PayloadConcurrency:             options.PayloadConcurrency,
 		ProbeConcurrency:               options.ProbeConcurrency,
+		TemplateLoadingConcurrency:     options.TemplateLoadingConcurrency,
 		DAST:                           options.DAST,
 		DASTServer:                     options.DASTServer,
 		DASTServerToken:                options.DASTServerToken,


### PR DESCRIPTION
## Proposed changes

This PR implements the complete Template Profile Improvements spec from #5567 via a **backward-compatible preprocessing layer** that runs before `goflags.MergeConfigFile`, requiring zero modifications to upstream `goflags` or any other dependency.

### Architecture

Rather than forking or patching `goflags` to understand new YAML keys (an approach that broke CI/CD in several competing PRs), this implementation introduces a single preprocessing stage in `pkg/types/profile.go` that intercepts the raw profile YAML, extracts non-standard constructs, and emits a cleaned config that `goflags` can parse natively. This keeps the change surface minimal and entirely self-contained within Nuclei.

### Feature Breakdown

**1. Metadata Field Stripping**
Extra fields (`id`, `name`, `purpose`, `description`) are silently removed from the config map before serialization. Users can now annotate profiles with human-readable metadata without triggering unknown-flag parse errors.

**2. Inline Target Lists**
When the `list` key contains a YAML block scalar (multiline string) instead of a file path, the preprocessor materializes the targets into a secure temp file (`0600` via `os.CreateTemp`) and replaces the `list` value with the temp path. Single-line file paths pass through untouched. Whitespace-only blocks are gracefully discarded.

**3. Inline Secrets**
A `secrets:` block with `static` and/or `dynamic` sub-keys is extracted, serialized into an authx-compatible YAML temp file, and injected into the cleaned config via the `secret-file` flag. The `secrets` key is unconditionally removed so `goflags` never encounters it.

A strict **`isNonEmptySlice` validation guard** ensures that `nil`, empty, or non-list values under `static`/`dynamic` are filtered out before file generation. This prevents producing a vacuous authx file that `pkg/authprovider/file.go` (`NewFileAuthProvider`) would reject with `ErrNoSecrets`, which was a startup crash vector that other implementations did not account for.

**4. Bulletproof Lifecycle & Cleanup**
All temporary artifacts are tracked in `ProfilePreprocessResult.TempFiles` and cleaned up via a `sync.Once`-guarded `Cleanup()` method that is both idempotent and concurrency-safe.

Critical cleanup paths fixed in this PR:

- **`defer profileCleanup()` in `main()`** — covers normal return and panic-recovery paths.
- **`fatalWithCleanup()` wrapper** — every `options.Logger.Fatal()` call reachable after temp file creation has been replaced with this helper, which invokes cleanup before `os.Exit(1)`. This is necessary because Go's `os.Exit` (and by extension `gologger.Fatal`) **skips all deferred functions**.
- **Signal handler (`SIGINT`)** — `profileCleanup()` is explicitly called before `os.Exit(1)` in both the DAST-server and graceful-shutdown branches, ensuring `Ctrl+C` never leaves artifacts on disk.
- **`readFlagsConfig` return-not-defer** — the preprocessing result from `NUCLEI_CONFIG_DIR` configs is returned to the caller and accumulated in `preprocessResults`, not deferred locally (which would delete temp files before the scan reads them).

**5. `NUCLEI_CONFIG_DIR` Parity**
Custom config directories specified via the `NUCLEI_CONFIG_DIR` environment variable now go through the identical `PreprocessProfileFile` pipeline, ensuring inline targets and secrets work regardless of how the config file is loaded.

**6. Security Posture**
All temp files are created with `0600` permissions via `os.CreateTemp`. No secrets data is written to world-readable paths. This fully satisfies the hardening notes raised by the Neo Security Bot review.

### Files Changed

| File | Purpose |
|---|---|
| `pkg/types/profile.go` | New: preprocessing engine, `ProfilePreprocessResult`, `Cleanup()`, inline target/secret handlers, `isNonEmptySlice` guard |
| `pkg/types/profile_test.go` | New: 18 unit tests covering all features, edge cases, error paths, cleanup idempotency |
| `cmd/nuclei/main.go` | Modified: `readConfig` returns cleanup function, `fatalWithCleanup` wrappers, signal handler cleanup, `readFlagsConfig` accumulation |

## Proof

- **CI/CD**: All platform checks pass — Ubuntu, macOS, Windows.
- **CodeRabbit AI**: All actionable findings resolved across 4 review rounds. Zero outstanding issues.
- **Neo Security Bot**: `No security issues found`. All hardening notes addressed (secure temp file permissions, `sync.Once` thread safety, comprehensive cleanup paths).
- **Unit Tests**: 18 tests cover the full matrix — no-op passthrough, metadata stripping, inline targets (multiline, single-line, empty), inline secrets (static-only, dynamic-only, both, empty, non-map), append-to-existing `secret-file`, full end-to-end profile, cleanup verification, cleanup idempotency, `hasSpecialKeys` helper, non-existent file, invalid YAML, and only-extra-fields edge case.

## Checklist

- [x] Pull request is created against the `dev` branch
- [x] All checks passed (lint, unit/integration/regression tests) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

/claim #5567

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preprocesses profile YAMLs to strip extra metadata, inline multiline targets, and extract secrets into temporary authx-formatted files.
  * Exposes preprocessing results to callers so cleaned paths are used throughout merges.

* **Bug Fixes**
  * Adds a program-wide deferred cleanup flow that removes preprocessing artifacts on normal exit, interrupts, and fatal errors.

* **Tests**
  * Adds comprehensive tests covering preprocessing scenarios, temp-file handling, and idempotent cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->