### PR TITLE
fix(fuzz): stabilize path fuzzing for numeric segments

### DIFF
--- a/pkg/fuzz/component/path.go
+++ b/pkg/fuzz/component/path.go
@@ -135,8 +135,12 @@ func (q *Path) Rebuild() (*retryablehttp.Request, error) {
 		rebuiltPath = unescaped
 	}
 
-	// Clone the request and update the path
+	// Clone the request and deep-copy the underlying URL before mutating it.
+	// retryablehttp.Request.Clone() reuses the wrapped URL pointer, so updating the
+	// cloned path directly would also mutate q.req.
 	cloned := q.req.Clone(context.Background())
+	cloned.URL = cloned.URL.Clone()
+	cloned.Request.URL = cloned.URL.URL
 	if err := cloned.UpdateRelPath(rebuiltPath, true); err != nil {
 		cloned.RawPath = rebuiltPath
 	}

--- a/pkg/fuzz/component/path.go
+++ b/pkg/fuzz/component/path.go
@@ -108,7 +108,8 @@ func (q *Path) Rebuild() (*retryablehttp.Request, error) {
 	for i := 1; i < len(originalSplitted); i++ {
 		originalSegment := originalSplitted[i]
 		if originalSegment == "" {
-			// Skip empty segments
+			// Preserve empty segments so repeated or trailing slashes survive rebuilds.
+			rebuiltSegments = append(rebuiltSegments, "")
 			continue
 		}
 

--- a/pkg/fuzz/component/path.go
+++ b/pkg/fuzz/component/path.go
@@ -115,7 +115,8 @@ func (q *Path) Rebuild() (*retryablehttp.Request, error) {
 
 		// Check if we have a replacement for this segment
 		key := strconv.Itoa(segmentIndex)
-		if newValue, ok := q.value.parsed.Get(key).(string); ok && newValue != "" {
+		if newValue, ok := q.value.parsed.Get(key).(string); ok {
+			// Use the replacement even if it's an empty string (explicit empty replacement)
 			rebuiltSegments = append(rebuiltSegments, newValue)
 		} else {
 			rebuiltSegments = append(rebuiltSegments, originalSegment)
@@ -140,8 +141,10 @@ func (q *Path) Rebuild() (*retryablehttp.Request, error) {
 	// retryablehttp.Request.Clone() reuses the wrapped URL pointer, so updating the
 	// cloned path directly would also mutate q.req.
 	cloned := q.req.Clone(context.Background())
-	cloned.URL = cloned.URL.Clone()
-	cloned.Request.URL = cloned.URL.URL
+	// Deep-copy the URL to ensure UpdateRelPath cannot mutate the original request
+	newURL := cloned.URL.Clone()
+	cloned.URL = newURL
+	cloned.Request.URL = newURL.URL
 	if err := cloned.UpdateRelPath(rebuiltPath, true); err != nil {
 		cloned.RawPath = rebuiltPath
 	}

--- a/pkg/fuzz/component/path.go
+++ b/pkg/fuzz/component/path.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz/dataformat"
 	"github.com/projectdiscovery/retryablehttp-go"
+	mapsutil "github.com/projectdiscovery/utils/maps"
 	urlutil "github.com/projectdiscovery/utils/url"
 )
 
@@ -14,7 +15,8 @@ import (
 type Path struct {
 	value *Value
 
-	req *retryablehttp.Request
+	req          *retryablehttp.Request
+	originalPath string
 }
 
 var _ Component = &Path{}
@@ -33,10 +35,12 @@ func (q *Path) Name() string {
 // parsed component
 func (q *Path) Parse(req *retryablehttp.Request) (bool, error) {
 	q.req = req
+	q.originalPath = req.Path
 	q.value = NewValue("")
 
 	splitted := strings.Split(req.Path, "/")
-	values := make(map[string]interface{})
+	values := mapsutil.NewOrderedMap[string, any]()
+	segmentIndex := 1
 	for i, segment := range splitted {
 		if segment == "" && i == 0 {
 			// Skip the first empty segment from leading "/"
@@ -46,11 +50,12 @@ func (q *Path) Parse(req *retryablehttp.Request) (bool, error) {
 			// Skip any other empty segments
 			continue
 		}
-		// Use 1-based indexing and store individual segments
-		key := strconv.Itoa(len(values) + 1)
-		values[key] = segment
+		// Use 1-based indexing and store individual segments in insertion order.
+		key := strconv.Itoa(segmentIndex)
+		values.Set(key, segment)
+		segmentIndex++
 	}
-	q.value.SetParsed(dataformat.KVMap(values), "")
+	q.value.SetParsed(dataformat.KVOrderedMap(&values), "")
 	return true, nil
 }
 
@@ -87,8 +92,8 @@ func (q *Path) Delete(key string) error {
 // Rebuild returns a new request with the
 // component rebuilt
 func (q *Path) Rebuild() (*retryablehttp.Request, error) {
-	// Get the original path segments
-	originalSplitted := strings.Split(q.req.Path, "/")
+	// Get the original path segments from the immutable snapshot captured at parse time.
+	originalSplitted := strings.Split(q.originalPath, "/")
 
 	// Create a new slice to hold the rebuilt segments
 	rebuiltSegments := make([]string, 0, len(originalSplitted))
@@ -109,7 +114,7 @@ func (q *Path) Rebuild() (*retryablehttp.Request, error) {
 
 		// Check if we have a replacement for this segment
 		key := strconv.Itoa(segmentIndex)
-		if newValue, exists := q.value.parsed.Map.GetOrDefault(key, "").(string); exists && newValue != "" {
+		if newValue, ok := q.value.parsed.Get(key).(string); ok && newValue != "" {
 			rebuiltSegments = append(rebuiltSegments, newValue)
 		} else {
 			rebuiltSegments = append(rebuiltSegments, originalSegment)
@@ -141,7 +146,8 @@ func (q *Path) Rebuild() (*retryablehttp.Request, error) {
 // Clones current state to a new component
 func (q *Path) Clone() Component {
 	return &Path{
-		value: q.value.Clone(),
-		req:   q.req.Clone(context.Background()),
+		value:        q.value.Clone(),
+		req:          q.req.Clone(context.Background()),
+		originalPath: q.originalPath,
 	}
 }

--- a/pkg/fuzz/component/path_test.go
+++ b/pkg/fuzz/component/path_test.go
@@ -127,3 +127,45 @@ func TestPathComponent_SQLInjection(t *testing.T) {
 	// Let's also test what the actual URL looks like
 	t.Logf("Full URL: %s", newReq.String())
 }
+
+func TestPathComponent_DeterministicOrder(t *testing.T) {
+	for i := 0; i < 50; i++ {
+		req, err := retryablehttp.NewRequest(http.MethodGet, "https://example.com/user/55/profile", nil)
+		require.NoError(t, err)
+
+		path := NewPath()
+		found, err := path.Parse(req)
+		require.NoError(t, err)
+		require.True(t, found)
+
+		var values []string
+		err = path.Iterate(func(_ string, value interface{}) error {
+			values = append(values, value.(string))
+			return nil
+		})
+		require.NoError(t, err)
+		require.Equal(t, []string{"user", "55", "profile"}, values)
+	}
+}
+
+func TestPathComponent_RebuildUsesOriginalPathSnapshot(t *testing.T) {
+	path := NewPath()
+	req, err := retryablehttp.NewRequest(http.MethodGet, "https://example.com/user/55/profile", nil)
+	require.NoError(t, err)
+
+	found, err := path.Parse(req)
+	require.NoError(t, err)
+	require.True(t, found)
+
+	require.NoError(t, path.SetValue("3", "profile OR True"))
+	newReq, err := path.Rebuild()
+	require.NoError(t, err)
+	require.Equal(t, "/user/55/profile OR True", newReq.Path)
+
+	// Rebuilding after a prior mutation should still use the original path layout.
+	require.NoError(t, path.SetValue("3", "profile"))
+	require.NoError(t, path.SetValue("2", "55 OR True"))
+	newReq, err = path.Rebuild()
+	require.NoError(t, err)
+	require.Equal(t, "/user/55 OR True/profile", newReq.Path)
+}

--- a/pkg/fuzz/component/path_test.go
+++ b/pkg/fuzz/component/path_test.go
@@ -172,3 +172,19 @@ func TestPathComponent_RebuildUsesOriginalPathSnapshot(t *testing.T) {
 	require.Equal(t, "/user/55 OR True/profile", newReq.Path)
 	require.Equal(t, "/user/55/profile", req.Path)
 }
+
+func TestPathComponent_RebuildPreservesEmptySegments(t *testing.T) {
+	path := NewPath()
+	req, err := retryablehttp.NewRequest(http.MethodGet, "https://example.com/a//b/", nil)
+	require.NoError(t, err)
+
+	found, err := path.Parse(req)
+	require.NoError(t, err)
+	require.True(t, found)
+
+	require.NoError(t, path.SetValue("2", "mutated"))
+	newReq, err := path.Rebuild()
+	require.NoError(t, err)
+	require.Equal(t, "/a//mutated/", newReq.Path)
+	require.Equal(t, "/a//b/", req.Path)
+}

--- a/pkg/fuzz/component/path_test.go
+++ b/pkg/fuzz/component/path_test.go
@@ -157,11 +157,14 @@ func TestPathComponent_RebuildUsesOriginalPathSnapshot(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, found)
 
+	// Capture original path before any mutations
+	originalPath := req.Path
+
 	require.NoError(t, path.SetValue("3", "profile OR True"))
 	newReq, err := path.Rebuild()
 	require.NoError(t, err)
 	require.Equal(t, "/user/55/profile OR True", newReq.Path)
-	require.Equal(t, "/user/55/profile", req.Path)
+	require.Equal(t, originalPath, req.Path, "original request path should remain unchanged after Rebuild")
 
 	// Rebuilding after a prior mutation should still use the original path layout
 	// without mutating the original request.
@@ -170,7 +173,7 @@ func TestPathComponent_RebuildUsesOriginalPathSnapshot(t *testing.T) {
 	newReq, err = path.Rebuild()
 	require.NoError(t, err)
 	require.Equal(t, "/user/55 OR True/profile", newReq.Path)
-	require.Equal(t, "/user/55/profile", req.Path)
+	require.Equal(t, originalPath, req.Path, "original request path should remain unchanged after multiple Rebuilds")
 }
 
 func TestPathComponent_RebuildPreservesEmptySegments(t *testing.T) {
@@ -182,9 +185,12 @@ func TestPathComponent_RebuildPreservesEmptySegments(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, found)
 
+	// Capture original path before mutation
+	originalPath := req.Path
+
 	require.NoError(t, path.SetValue("2", "mutated"))
 	newReq, err := path.Rebuild()
 	require.NoError(t, err)
 	require.Equal(t, "/a//mutated/", newReq.Path)
-	require.Equal(t, "/a//b/", req.Path)
+	require.Equal(t, originalPath, req.Path, "original request path should remain unchanged")
 }

--- a/pkg/fuzz/component/path_test.go
+++ b/pkg/fuzz/component/path_test.go
@@ -161,11 +161,14 @@ func TestPathComponent_RebuildUsesOriginalPathSnapshot(t *testing.T) {
 	newReq, err := path.Rebuild()
 	require.NoError(t, err)
 	require.Equal(t, "/user/55/profile OR True", newReq.Path)
+	require.Equal(t, "/user/55/profile", req.Path)
 
-	// Rebuilding after a prior mutation should still use the original path layout.
+	// Rebuilding after a prior mutation should still use the original path layout
+	// without mutating the original request.
 	require.NoError(t, path.SetValue("3", "profile"))
 	require.NoError(t, path.SetValue("2", "55 OR True"))
 	newReq, err = path.Rebuild()
 	require.NoError(t, err)
 	require.Equal(t, "/user/55 OR True/profile", newReq.Path)
+	require.Equal(t, "/user/55/profile", req.Path)
 }

--- a/pkg/fuzz/parts.go
+++ b/pkg/fuzz/parts.go
@@ -162,7 +162,7 @@ func (rule *Rule) execWithInput(input *ExecuteRuleInput, httpReq *retryablehttp.
 	// If the parameter is frequent, skip it if the option is enabled
 	if rule.options.FuzzParamsFrequency != nil {
 		if rule.options.FuzzParamsFrequency.IsParameterFrequent(
-			parameter,
+			actualParameter,
 			httpReq.String(),
 			rule.options.TemplateID,
 		) {

--- a/pkg/fuzz/parts_frequency_test.go
+++ b/pkg/fuzz/parts_frequency_test.go
@@ -31,14 +31,12 @@ func TestExecWithInputUsesActualParameterForFrequency(t *testing.T) {
 		Progress:            &testutils.MockProgressClient{},
 	}
 
-	// Mark a different numeric path segment as frequent on the same target.
-	// With the old code, both values collided on the raw index key "2".
-	targetReq, err := retryablehttp.NewRequest(http.MethodGet, "https://example.com/blog/99/post", nil)
-	require.NoError(t, err)
-	rule.options.FuzzParamsFrequency.MarkParameter("99", targetReq.String(), rule.options.TemplateID)
-
 	baseReq, err := retryablehttp.NewRequest(http.MethodGet, "https://example.com/user/55/profile", nil)
 	require.NoError(t, err)
+
+	// Mark a different numeric path segment as frequent on the same target.
+	// With the old code, both values collided on the raw index key "2".
+	rule.options.FuzzParamsFrequency.MarkParameter("99", baseReq.String(), rule.options.TemplateID)
 
 	input := &ExecuteRuleInput{
 		Input:       &contextargs.Context{},

--- a/pkg/fuzz/parts_frequency_test.go
+++ b/pkg/fuzz/parts_frequency_test.go
@@ -1,0 +1,59 @@
+package fuzz
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/projectdiscovery/goflags"
+	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz/frequency"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/contextargs"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/variables"
+	"github.com/projectdiscovery/nuclei/v3/pkg/testutils"
+	"github.com/projectdiscovery/nuclei/v3/pkg/types"
+	"github.com/projectdiscovery/nuclei/v3/pkg/utils"
+	"github.com/projectdiscovery/retryablehttp-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecWithInputUsesActualParameterForFrequency(t *testing.T) {
+	rule := &Rule{Part: "path", Type: "replace", Mode: "single"}
+
+	options := &types.Options{}
+	options.Vars = goflags.RuntimeMap{}
+
+	rule.options = &protocols.ExecutorOptions{
+		TemplateID:          "test-template",
+		Options:             options,
+		Variables:           variables.Variable{InsertionOrderedStringMap: *utils.NewEmptyInsertionOrderedStringMap(0)},
+		Constants:           map[string]interface{}{},
+		FuzzParamsFrequency: frequency.New(100, 1),
+		Progress:            &testutils.MockProgressClient{},
+	}
+
+	// Mark a different numeric path segment as frequent on the same target.
+	// With the old code, both values collided on the raw index key "2".
+	targetReq, err := retryablehttp.NewRequest(http.MethodGet, "https://example.com/blog/99/post", nil)
+	require.NoError(t, err)
+	rule.options.FuzzParamsFrequency.MarkParameter("99", targetReq.String(), rule.options.TemplateID)
+
+	baseReq, err := retryablehttp.NewRequest(http.MethodGet, "https://example.com/user/55/profile", nil)
+	require.NoError(t, err)
+
+	input := &ExecuteRuleInput{
+		Input:       &contextargs.Context{},
+		BaseRequest: baseReq,
+		Values:      map[string]interface{}{},
+	}
+
+	called := false
+	input.Callback = func(gr GeneratedRequest) bool {
+		called = true
+		require.Equal(t, "55", gr.Parameter)
+		return true
+	}
+
+	err = rule.execWithInput(input, baseReq, nil, nil, "2", "55", "", "", "", "")
+	require.NoError(t, err)
+	require.True(t, called, "expected callback to run; frequency tracking should key by actual path value, not index")
+}


### PR DESCRIPTION
## Proposed Changes

Fixes #6398 — path-based fuzzing still skips numeric segments on `dev` under some runs.

This keeps the fix minimal and addresses the remaining root causes together:

1. **Deterministic path segment iteration**
   - `Path.Parse()` used a plain Go map, so segment iteration order was unstable.
   - Switch it to ordered storage so `/user/55/profile` is always iterated as `user`, `55`, `profile`.

2. **Preserve the original path across rebuilds**
   - `retryablehttp.Request.Clone()` shares the underlying URL pointer, so `UpdateRelPath()` mutates the original request path too.
   - Snapshot the original path at parse time and rebuild from that immutable value.

3. **Frequency tracking uses the effective path parameter**
   - Frequency dedup checked the numeric index (`"2"`) instead of the effective path value (`"55"`).
   - Use `actualParameter` so different numeric segments do not collide on the same path position.

## Proof

Reproduced on current `dev`:

- `Path.Parse()+Iterate()` on `/user/55/profile` produced different orders across runs, including:
  - `[1=user 2=55 3=profile]`
  - `[2=55 3=profile 1=user]`
  - `[3=profile 1=user 2=55]`
- `Path.Rebuild()` mutated the original request path after cloning:
  - before: `/user/55/profile`
  - after rebuilding a clone: original request became `/user/55/profile OR True`
- frequency dedup still keyed on the raw numeric path index instead of the effective segment value.

Focused regression tests added:

```bash
go test ./pkg/fuzz/component -run 'TestURLComponent|TestPathComponent' -count=1 -v
go test ./pkg/fuzz -run 'TestExecWithInputUsesActualParameterForFrequency|TestRuleMatchKeyOrValue|TestEvaluateVariables|TestEvaluateVarsWithInteractsh_RaceCondition' -count=1 -v
go test ./pkg/fuzz/... -count=1
```

All passed locally.

## Summary

- ordered path storage in `pkg/fuzz/component/path.go`
- immutable original-path snapshot for rebuilds
- frequency dedup fixed to use effective path values
- focused regressions for:
  - deterministic path iteration
  - rebuilds using original path snapshot
  - frequency tracking on actual path values

## Checklist

- [x] PR created against `dev`
- [x] Focused regression tests added
- [x] Relevant fuzz package tests passed locally

/claim #6398


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Path reconstruction now preserves deterministic segment order and keeps an immutable original-path snapshot for rebuilds.

* **Bug Fixes**
  * Rebuilds preserve original and empty segments and avoid mutating the original request URL.
  * Parameter frequency tracking now keys on actual substituted values, preventing incorrect skips.

* **Tests**
  * Added tests for path ordering, rebuild snapshot behavior, empty-segment preservation, and frequency-tracking with substituted parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->