### PR TITLE
fix(xss): fix context misclassification for javascript: URIs, JSON script blocks, srcdoc, and reflection detection

### DIFF
--- a/pkg/js/global/js/xss_context_analyzer.js
+++ b/pkg/js/global/js/xss_context_analyzer.js
@@ -1,0 +1,267 @@
+// xss_context_analyzer.js
+// Fixes for XSS context classification edge cases described in issue #7086:
+// 1. javascript: URIs must be treated as executable script context (ContextScript)
+// 2. <script type="application/json"> (and similar non-executable types) must NOT be treated as executable
+// 3. Reflection detection must be case-insensitive and entity-normalized
+// 4. srcdoc attributes must be treated as HTML injection context
+
+// Context constants
+var ContextUnknown   = 'ContextUnknown';
+var ContextHTML      = 'ContextHTML';
+var ContextAttribute = 'ContextAttribute';
+var ContextScript    = 'ContextScript';
+var ContextStyle     = 'ContextStyle';
+var ContextSrcdoc    = 'ContextSrcdoc';  // NEW: full HTML injection via srcdoc
+
+// NON_EXECUTABLE_SCRIPT_TYPES lists MIME types for <script> tags that browsers
+// do NOT execute. Content inside these blocks is data, not code.
+// Reference: https://html.spec.whatwg.org/multipage/scripting.html#attr-script-type
+var NON_EXECUTABLE_SCRIPT_TYPES = [
+  'application/json',
+  'application/ld+json',
+  'text/plain',
+  'text/template',
+  'text/x-template',
+  'text/x-handlebars-template',
+  'text/ng-template',
+  'module',  // treated as module, not classic script — keep for completeness
+];
+
+// JAVASCRIPT_URI_SCHEMES lists URI scheme prefixes that result in script execution
+// when used in href/src/action/etc. attributes.
+// Normalized to lowercase before comparison to handle case variations like
+// "JavaScript:" or "jAvAsCrIpT:" which browsers treat identically.
+var JAVASCRIPT_URI_SCHEMES = [
+  'javascript:',
+  'vbscript:',  // IE legacy, still relevant for completeness
+];
+
+/**
+ * normalizeForReflection decodes common HTML entity encodings and lowercases
+ * a string so that reflection detection is not fooled by case transforms
+ * or entity encoding in the response.
+ *
+ * WHY: Servers may reflect input as &amp;alert or &#97;lert or ALert —
+ * all of which represent the same payload. Without normalization, a naive
+ * string-equality check would miss them.
+ */
+function normalizeForReflection(str) {
+  if (!str) return '';
+  // Decode named HTML entities for common XSS characters
+  var s = str
+    .replace(/&amp;/gi, '&')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#x27;/gi, "'")
+    .replace(/&#39;/gi, "'")
+    .replace(/&#x2F;/gi, '/')
+    .replace(/&#47;/gi, '/')
+    // Decode decimal numeric entities like &#97; -> 'a'
+    .replace(/&#(\d+);/gi, function(_, dec) {
+      return String.fromCharCode(parseInt(dec, 10));
+    })
+    // Decode hex numeric entities like &#x61; -> 'a'
+    .replace(/&#x([0-9a-f]+);/gi, function(_, hex) {
+      return String.fromCharCode(parseInt(hex, 16));
+    });
+  return s.toLowerCase();
+}
+
+/**
+ * isNonExecutableScriptType returns true if the given <script> type attribute
+ * value indicates the block is NOT executable JavaScript.
+ *
+ * WHY: <script type="application/json"> is commonly used to embed structured
+ * data in HTML. Its content is never executed by the browser. Classifying it
+ * as ContextScript causes false positives — a reflected payload inside a JSON
+ * block is not exploitable as XSS.
+ *
+ * @param {string} typeAttr - the raw value of the type= attribute
+ * @returns {boolean}
+ */
+function isNonExecutableScriptType(typeAttr) {
+  if (!typeAttr) return false;
+  // Normalize: trim whitespace, lowercase, strip parameters (e.g. charset)
+  var normalized = typeAttr.trim().toLowerCase().split(';')[0].trim();
+  for (var i = 0; i < NON_EXECUTABLE_SCRIPT_TYPES.length; i++) {
+    if (normalized === NON_EXECUTABLE_SCRIPT_TYPES[i]) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * isJavaScriptURI returns true if the given attribute value is a
+ * javascript: or vbscript: URI — both of which cause script execution
+ * when the browser navigates to the href/src/action value.
+ *
+ * WHY: href="javascript:alert(1)" is a classic XSS vector. If the context
+ * analyzer only looks at the fact that the canary appears inside an attribute
+ * value, it will classify this as ContextAttribute. But the attribute VALUE
+ * is itself executable, so the correct classification is ContextScript.
+ *
+ * Normalization handles protocol variations:
+ *   JavaScript:   -> javascript:
+ *   jAvAsCrIpT:   -> javascript:
+ *   \tjavascript:  -> javascript:  (leading whitespace is stripped by browsers)
+ *
+ * @param {string} attrValue - the raw attribute value string
+ * @returns {boolean}
+ */
+function isJavaScriptURI(attrValue) {
+  if (!attrValue) return false;
+  // Browsers strip leading whitespace and some control characters before
+  // parsing the URI scheme, so we do the same here.
+  var normalized = attrValue.replace(/^[\s\t\n\r\0]+/, '').toLowerCase();
+  for (var i = 0; i < JAVASCRIPT_URI_SCHEMES.length; i++) {
+    if (normalized.indexOf(JAVASCRIPT_URI_SCHEMES[i]) === 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * isSrcdocAttribute returns true if the attribute name is srcdoc.
+ *
+ * WHY: The srcdoc attribute on <iframe> receives a full HTML document as its
+ * value. Injection into srcdoc is equivalent to injecting into the document
+ * body — any HTML including <script> tags will be parsed. It should be
+ * classified as ContextSrcdoc (HTML injection), not plain ContextAttribute.
+ *
+ * @param {string} attrName - the attribute name, case-insensitive
+ * @returns {boolean}
+ */
+function isSrcdocAttribute(attrName) {
+  return attrName && attrName.trim().toLowerCase() === 'srcdoc';
+}
+
+/**
+ * classifyContext determines the injection context for a reflected XSS canary
+ * found in an HTML response fragment.
+ *
+ * Context classification drives which payloads nuclei will attempt:
+ *   - ContextScript   -> direct JS execution payloads (alert(), etc.)
+ *   - ContextSrcdoc   -> full HTML payloads
+ *   - ContextAttribute-> attribute escape payloads (">...)
+ *   - ContextStyle    -> CSS-based payloads
+ *   - ContextHTML     -> tag injection payloads (<script>...)
+ *   - ContextUnknown  -> fallback
+ *
+ * @param {string} fragment     - the HTML fragment surrounding the canary
+ * @param {string} canary       - the canary string to locate
+ * @param {string} attrName     - (optional) the attribute name in which canary appears
+ * @param {string} attrValue    - (optional) the full attribute value
+ * @param {string} scriptType   - (optional) the type= attribute of the enclosing <script>
+ * @returns {string} one of the Context* constants
+ */
+function classifyContext(fragment, canary, attrName, attrValue, scriptType) {
+  // --- 1. JSON / non-executable script blocks ---
+  // Must be checked BEFORE the generic ContextScript check.
+  // If the canary is inside a <script type="application/json"> block,
+  // the content is never executed, so this is NOT an exploitable XSS context.
+  if (scriptType !== undefined && scriptType !== null) {
+    if (isNonExecutableScriptType(scriptType)) {
+      // Return ContextUnknown: the reflection exists but is not exploitable
+      // as a script injection. Callers should treat this as low/informational.
+      return ContextUnknown;
+    }
+    // Any other (or empty) script type is treated as executable JavaScript.
+    return ContextScript;
+  }
+
+  // --- 2. javascript: / vbscript: URI in attribute value ---
+  // If the canary appears inside an attribute whose value starts with a
+  // JavaScript URI scheme, the attribute value is executable code.
+  // Upgrade the context from ContextAttribute to ContextScript.
+  if (attrValue !== undefined && attrValue !== null) {
+    if (isJavaScriptURI(attrValue)) {
+      return ContextScript;
+    }
+    // --- 3. srcdoc attribute -> HTML injection context ---
+    if (isSrcdocAttribute(attrName)) {
+      return ContextSrcdoc;
+    }
+    // Generic attribute context
+    return ContextAttribute;
+  }
+
+  // --- 4. Fallback: scan the fragment for contextual clues ---
+  // This path is used when structured attribute info is not available.
+  if (!fragment) return ContextUnknown;
+
+  var frag = fragment.toLowerCase();
+
+  // Inside an executable <script> block (no type, or type="text/javascript")
+  if (frag.indexOf('<script') !== -1) {
+    // Check for non-executable type within the fragment
+    var typeMatch = fragment.match(/<script[^>]+type\s*=\s*["']?([^"'\s>]+)["']?/i);
+    if (typeMatch && isNonExecutableScriptType(typeMatch[1])) {
+      return ContextUnknown;
+    }
+    return ContextScript;
+  }
+
+  // Inside a style block or attribute
+  if (frag.indexOf('<style') !== -1 || frag.indexOf('style=') !== -1) {
+    return ContextStyle;
+  }
+
+  // Inside a tag attribute (heuristic: look for open tag before canary)
+  if (frag.match(/=["'][^"']*$/) || frag.match(/=["'][^"']*$/)) {
+    // Check for javascript: in the attribute value portion
+    var attrValMatch = fragment.match(/=\s*["']([^"']*)/i);
+    if (attrValMatch && isJavaScriptURI(attrValMatch[1])) {
+      return ContextScript;
+    }
+    // Check for srcdoc
+    var srcdocMatch = fragment.match(/srcdoc\s*=\s*["'][^"']*/i);
+    if (srcdocMatch) {
+      return ContextSrcdoc;
+    }
+    return ContextAttribute;
+  }
+
+  // Default: treat as HTML context
+  return ContextHTML;
+}
+
+/**
+ * isReflected returns true if the canary string appears in the response body,
+ * using case-insensitive, entity-normalized comparison.
+ *
+ * WHY: Servers may transform reflected input (e.g., uppercase it, entity-encode
+ * parts of it). A case-sensitive indexOf would miss these transformed reflections,
+ * leading to false negatives.
+ *
+ * @param {string} responseBody - full HTTP response body
+ * @param {string} canary       - the injected canary string to search for
+ * @returns {boolean}
+ */
+function isReflected(responseBody, canary) {
+  if (!responseBody || !canary) return false;
+  // Normalize both sides: decode entities then lowercase
+  var normBody   = normalizeForReflection(responseBody);
+  var normCanary = normalizeForReflection(canary);
+  return normBody.indexOf(normCanary) !== -1;
+}
+
+// Export for use in nuclei JS runtime and tests
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {
+    classifyContext: classifyContext,
+    isReflected: isReflected,
+    isJavaScriptURI: isJavaScriptURI,
+    isNonExecutableScriptType: isNonExecutableScriptType,
+    isSrcdocAttribute: isSrcdocAttribute,
+    normalizeForReflection: normalizeForReflection,
+    ContextUnknown: ContextUnknown,
+    ContextHTML: ContextHTML,
+    ContextAttribute: ContextAttribute,
+    ContextScript: ContextScript,
+    ContextStyle: ContextStyle,
+    ContextSrcdoc: ContextSrcdoc,
+  };
+}

--- a/pkg/js/global/js/xss_context_analyzer.js
+++ b/pkg/js/global/js/xss_context_analyzer.js
@@ -16,6 +16,8 @@ var ContextSrcdoc    = 'ContextSrcdoc';  // NEW: full HTML injection via srcdoc
 // NON_EXECUTABLE_SCRIPT_TYPES lists MIME types for <script> tags that browsers
 // do NOT execute. Content inside these blocks is data, not code.
 // Reference: https://html.spec.whatwg.org/multipage/scripting.html#attr-script-type
+// NOTE: 'module' is intentionally excluded — <script type="module"> IS executable
+// in all modern browsers (deferred, strict mode, but still runs JS).
 var NON_EXECUTABLE_SCRIPT_TYPES = [
   'application/json',
   'application/ld+json',
@@ -24,16 +26,16 @@ var NON_EXECUTABLE_SCRIPT_TYPES = [
   'text/x-template',
   'text/x-handlebars-template',
   'text/ng-template',
-  'module',  // treated as module, not classic script — keep for completeness
 ];
 
-// JAVASCRIPT_URI_SCHEMES lists URI scheme prefixes that result in script execution
+// EXECUTABLE_URI_SCHEMES lists URI scheme prefixes that result in script execution
 // when used in href/src/action/etc. attributes.
-// Normalized to lowercase before comparison to handle case variations like
-// "JavaScript:" or "jAvAsCrIpT:" which browsers treat identically.
-var JAVASCRIPT_URI_SCHEMES = [
+// Also includes data: URIs that embed HTML documents.
+var EXECUTABLE_URI_SCHEMES = [
   'javascript:',
-  'vbscript:',  // IE legacy, still relevant for completeness
+  'vbscript:',      // IE legacy, still relevant for completeness
+  'data:text/html', // <iframe src="data:text/html,..."> executes embedded scripts
+  'data:application/xhtml+xml', // same as above, XHTML variant
 ];
 
 /**
@@ -57,8 +59,13 @@ function normalizeForReflection(str) {
     .replace(/&#39;/gi, "'")
     .replace(/&#x2F;/gi, '/')
     .replace(/&#47;/gi, '/')
-    // Decode decimal numeric entities like &#97; -> 'a'
+    // Decode decimal numeric entities WITH semicolon: &#97; -> 'a'
     .replace(/&#(\d+);/gi, function(_, dec) {
+      return String.fromCharCode(parseInt(dec, 10));
+    })
+    // Decode decimal numeric entities WITHOUT semicolon: &#97 -> 'a'
+    // Browsers accept these in certain contexts (e.g. &#110ucleXSS)
+    .replace(/&#(\d+)(?=[^;0-9]|$)/gi, function(_, dec) {
       return String.fromCharCode(parseInt(dec, 10));
     })
     // Decode hex numeric entities like &#x61; -> 'a'
@@ -94,7 +101,7 @@ function isNonExecutableScriptType(typeAttr) {
 
 /**
  * isJavaScriptURI returns true if the given attribute value is a
- * javascript: or vbscript: URI — both of which cause script execution
+ * javascript:, vbscript:, or data: URI that causes script execution
  * when the browser navigates to the href/src/action value.
  *
  * WHY: href="javascript:alert(1)" is a classic XSS vector. If the context
@@ -102,21 +109,31 @@ function isNonExecutableScriptType(typeAttr) {
  * value, it will classify this as ContextAttribute. But the attribute VALUE
  * is itself executable, so the correct classification is ContextScript.
  *
- * Normalization handles protocol variations:
- *   JavaScript:   -> javascript:
- *   jAvAsCrIpT:   -> javascript:
- *   \tjavascript:  -> javascript:  (leading whitespace is stripped by browsers)
+ * Normalization handles:
+ *   - Case variations:     JavaScript: -> javascript:
+ *   - Leading whitespace:  \tjavascript: -> javascript:
+ *   - URL encoding:        %6aavascript: -> javascript: (browsers decode before scheme check)
  *
  * @param {string} attrValue - the raw attribute value string
  * @returns {boolean}
  */
 function isJavaScriptURI(attrValue) {
   if (!attrValue) return false;
-  // Browsers strip leading whitespace and some control characters before
-  // parsing the URI scheme, so we do the same here.
-  var normalized = attrValue.replace(/^[\s\t\n\r\0]+/, '').toLowerCase();
-  for (var i = 0; i < JAVASCRIPT_URI_SCHEMES.length; i++) {
-    if (normalized.indexOf(JAVASCRIPT_URI_SCHEMES[i]) === 0) {
+  // Browsers strip leading whitespace/control chars before parsing the URI scheme
+  var trimmed = attrValue.replace(/^[\s\t\n\r\0]+/, '');
+  // Decode URL percent-encoding so %6aavascript: is caught
+  var decoded = trimmed;
+  try {
+    decoded = decodeURIComponent(trimmed);
+  } catch (_) {
+    // decodeURIComponent throws on malformed sequences — fall back to trimmed
+    decoded = trimmed.replace(/%([0-9a-f]{2})/gi, function(_, hex) {
+      return String.fromCharCode(parseInt(hex, 16));
+    });
+  }
+  var normalized = decoded.toLowerCase();
+  for (var i = 0; i < EXECUTABLE_URI_SCHEMES.length; i++) {
+    if (normalized.indexOf(EXECUTABLE_URI_SCHEMES[i]) === 0) {
       return true;
     }
   }
@@ -160,43 +177,36 @@ function isSrcdocAttribute(attrName) {
 function classifyContext(fragment, canary, attrName, attrValue, scriptType) {
   // --- 1. JSON / non-executable script blocks ---
   // Must be checked BEFORE the generic ContextScript check.
-  // If the canary is inside a <script type="application/json"> block,
-  // the content is never executed, so this is NOT an exploitable XSS context.
   if (scriptType !== undefined && scriptType !== null) {
     if (isNonExecutableScriptType(scriptType)) {
-      // Return ContextUnknown: the reflection exists but is not exploitable
-      // as a script injection. Callers should treat this as low/informational.
       return ContextUnknown;
     }
-    // Any other (or empty) script type is treated as executable JavaScript.
     return ContextScript;
   }
 
-  // --- 2. javascript: / vbscript: URI in attribute value ---
-  // If the canary appears inside an attribute whose value starts with a
-  // JavaScript URI scheme, the attribute value is executable code.
-  // Upgrade the context from ContextAttribute to ContextScript.
+  // --- 2. Attribute context ---
   if (attrValue !== undefined && attrValue !== null) {
-    if (isJavaScriptURI(attrValue)) {
-      return ContextScript;
-    }
-    // --- 3. srcdoc attribute -> HTML injection context ---
+    // 2a. srcdoc attribute -> HTML injection context
+    // Check BEFORE javascript: URI check — srcdoc content is HTML, not a URL.
+    // "javascript:alert(1)" inside srcdoc is literal text, not an executable URI.
     if (isSrcdocAttribute(attrName)) {
       return ContextSrcdoc;
+    }
+    // 2b. javascript:/vbscript:/data: URI in attribute value -> executable context
+    if (isJavaScriptURI(attrValue)) {
+      return ContextScript;
     }
     // Generic attribute context
     return ContextAttribute;
   }
 
-  // --- 4. Fallback: scan the fragment for contextual clues ---
-  // This path is used when structured attribute info is not available.
+  // --- 3. Fallback: scan the fragment for contextual clues ---
   if (!fragment) return ContextUnknown;
 
   var frag = fragment.toLowerCase();
 
-  // Inside an executable <script> block (no type, or type="text/javascript")
+  // Inside an executable <script> block
   if (frag.indexOf('<script') !== -1) {
-    // Check for non-executable type within the fragment
     var typeMatch = fragment.match(/<script[^>]+type\s*=\s*["']?([^"'\s>]+)["']?/i);
     if (typeMatch && isNonExecutableScriptType(typeMatch[1])) {
       return ContextUnknown;
@@ -209,16 +219,15 @@ function classifyContext(fragment, canary, attrName, attrValue, scriptType) {
     return ContextStyle;
   }
 
-  // Inside a tag attribute (heuristic: look for open tag before canary)
-  if (frag.match(/=["'][^"']*$/) || frag.match(/=["'][^"']*$/)) {
+  // Inside a tag attribute — match both quoted and unquoted attribute values
+  if (frag.match(/=["'][^"']*$/) || frag.match(/=\S*$/)) {
     // Check for javascript: in the attribute value portion
-    var attrValMatch = fragment.match(/=\s*["']([^"']*)/i);
+    var attrValMatch = fragment.match(/=\s*["']?([^"'\s>]*)/i);
     if (attrValMatch && isJavaScriptURI(attrValMatch[1])) {
       return ContextScript;
     }
     // Check for srcdoc
-    var srcdocMatch = fragment.match(/srcdoc\s*=\s*["'][^"']*/i);
-    if (srcdocMatch) {
+    if (/srcdoc\s*=/i.test(fragment)) {
       return ContextSrcdoc;
     }
     return ContextAttribute;
@@ -232,17 +241,12 @@ function classifyContext(fragment, canary, attrName, attrValue, scriptType) {
  * isReflected returns true if the canary string appears in the response body,
  * using case-insensitive, entity-normalized comparison.
  *
- * WHY: Servers may transform reflected input (e.g., uppercase it, entity-encode
- * parts of it). A case-sensitive indexOf would miss these transformed reflections,
- * leading to false negatives.
- *
  * @param {string} responseBody - full HTTP response body
  * @param {string} canary       - the injected canary string to search for
  * @returns {boolean}
  */
 function isReflected(responseBody, canary) {
   if (!responseBody || !canary) return false;
-  // Normalize both sides: decode entities then lowercase
   var normBody   = normalizeForReflection(responseBody);
   var normCanary = normalizeForReflection(canary);
   return normBody.indexOf(normCanary) !== -1;

--- a/pkg/js/global/js/xss_context_analyzer.test.js
+++ b/pkg/js/global/js/xss_context_analyzer.test.js
@@ -1,0 +1,250 @@
+// xss_context_analyzer.test.js
+// Focused regression tests for the four edge cases in issue #7086.
+// Run with: node xss_context_analyzer.test.js
+
+'use strict';
+
+var analyzer = require('./xss_context_analyzer');
+
+var passed = 0;
+var failed = 0;
+
+function assert(condition, message) {
+  if (condition) {
+    console.log('  PASS:', message);
+    passed++;
+  } else {
+    console.error('  FAIL:', message);
+    failed++;
+  }
+}
+
+function assertEqual(actual, expected, message) {
+  var ok = actual === expected;
+  if (ok) {
+    console.log('  PASS:', message);
+    passed++;
+  } else {
+    console.error('  FAIL:', message, '| expected:', expected, '| got:', actual);
+    failed++;
+  }
+}
+
+console.log('\n=== Issue #7086: XSS Context Analyzer Edge Cases ===\n');
+
+// ---------------------------------------------------------------------------
+// 1. javascript: URI should be classified as ContextScript
+// ---------------------------------------------------------------------------
+console.log('1. javascript: URI classification');
+
+// Basic case: standard lowercase
+equal_test(
+  analyzer.classifyContext(null, 'nucleiXSScanary', 'href', 'javascript:alert(nucleiXSScanary)'),
+  analyzer.ContextScript,
+  'href="javascript:alert(...)" should be ContextScript'
+);
+
+// Protocol case variation: mixed case (browsers normalize before executing)
+equal_test(
+  analyzer.classifyContext(null, 'nucleiXSScanary', 'href', 'JavaScript:alert(nucleiXSScanary)'),
+  analyzer.ContextScript,
+  'href="JavaScript:..." mixed-case should still be ContextScript'
+);
+
+// Protocol case variation: all caps
+equal_test(
+  analyzer.classifyContext(null, 'nucleiXSScanary', 'href', 'JAVASCRIPT:alert(nucleiXSScanary)'),
+  analyzer.ContextScript,
+  'href="JAVASCRIPT:..." uppercase should still be ContextScript'
+);
+
+// vbscript: URI (IE legacy vector, must not be missed)
+equal_test(
+  analyzer.classifyContext(null, 'nucleiXSScanary', 'href', 'vbscript:alert(nucleiXSScanary)'),
+  analyzer.ContextScript,
+  'href="vbscript:..." should be ContextScript'
+);
+
+// Leading whitespace (browsers ignore leading whitespace before scheme)
+equal_test(
+  analyzer.classifyContext(null, 'nucleiXSScanary', 'href', '  javascript:alert(nucleiXSScanary)'),
+  analyzer.ContextScript,
+  'href with leading spaces before javascript: should be ContextScript'
+);
+
+// Confirm a plain URL is NOT ContextScript (regression guard)
+equal_test(
+  analyzer.classifyContext(null, 'nucleiXSScanary', 'href', 'https://example.com/nucleiXSScanary'),
+  analyzer.ContextAttribute,
+  'href with https: URL should remain ContextAttribute'
+);
+
+// ---------------------------------------------------------------------------
+// 2. <script type="application/json"> should NOT be ContextScript
+// ---------------------------------------------------------------------------
+console.log('\n2. Non-executable <script> type classification');
+
+equal_test(
+  analyzer.classifyContext(null, 'nucleiXSScanary', null, null, 'application/json'),
+  analyzer.ContextUnknown,
+  '<script type="application/json"> should be ContextUnknown (not executable)'
+);
+
+equal_test(
+  analyzer.classifyContext(null, 'nucleiXSScanary', null, null, 'application/ld+json'),
+  analyzer.ContextUnknown,
+  '<script type="application/ld+json"> should be ContextUnknown (not executable)'
+);
+
+equal_test(
+  analyzer.classifyContext(null, 'nucleiXSScanary', null, null, 'text/plain'),
+  analyzer.ContextUnknown,
+  '<script type="text/plain"> should be ContextUnknown (not executable)'
+);
+
+// Type with charset parameter should still be recognized
+equal_test(
+  analyzer.classifyContext(null, 'nucleiXSScanary', null, null, 'application/json; charset=utf-8'),
+  analyzer.ContextUnknown,
+  '<script type="application/json; charset=utf-8"> should be ContextUnknown'
+);
+
+// Case-insensitive type matching
+equal_test(
+  analyzer.classifyContext(null, 'nucleiXSScanary', null, null, 'Application/JSON'),
+  analyzer.ContextUnknown,
+  '<script type="Application/JSON"> mixed case should be ContextUnknown'
+);
+
+// Executable script (no type) must still be ContextScript
+equal_test(
+  analyzer.classifyContext(null, 'nucleiXSScanary', null, null, ''),
+  analyzer.ContextScript,
+  '<script> with empty type should be ContextScript (executable)'
+);
+
+equal_test(
+  analyzer.classifyContext(null, 'nucleiXSScanary', null, null, 'text/javascript'),
+  analyzer.ContextScript,
+  '<script type="text/javascript"> should be ContextScript'
+);
+
+// ---------------------------------------------------------------------------
+// 3. Case-insensitive reflection detection
+// ---------------------------------------------------------------------------
+console.log('\n3. Case-insensitive reflection detection');
+
+// Canary reflected as-is
+assert(
+  analyzer.isReflected('<div>nucleiXSScanary</div>', 'nucleiXSScanary'),
+  'Exact-case canary should be detected'
+);
+
+// Canary uppercased by server
+assert(
+  analyzer.isReflected('<div>NUCLEIXSSCANARY</div>', 'nucleiXSScanary'),
+  'Uppercased canary should be detected (case-insensitive)'
+);
+
+// Canary mixed-case
+assert(
+  analyzer.isReflected('<div>NuClEiXsScAnArY</div>', 'nucleiXSScanary'),
+  'Mixed-case canary should be detected'
+);
+
+// Canary entity-encoded: &#110;ucleIXSScanary  (n -> &#110;)
+assert(
+  analyzer.isReflected('<div>&#110;ucleIXSScanary</div>', 'nucleiXSScanary'),
+  'Entity-encoded canary (&#110; for n) should be detected after normalization'
+);
+
+// Canary with &amp; instead of &
+assert(
+  analyzer.isReflected('<div>nucleiXSScan&amp;ary</div>', 'nucleiXSScan&ary'),
+  'Entity-encoded & in canary should be detected'
+);
+
+// Absent canary must NOT match (regression guard)
+assert(
+  !analyzer.isReflected('<div>something else entirely</div>', 'nucleiXSScanary'),
+  'Non-reflected canary must NOT be detected'
+);
+
+// Empty inputs
+assert(
+  !analyzer.isReflected('', 'nucleiXSScanary'),
+  'Empty body must not match'
+);
+assert(
+  !analyzer.isReflected('<html></html>', ''),
+  'Empty canary must not match'
+);
+
+// ---------------------------------------------------------------------------
+// 4. srcdoc attribute should be ContextSrcdoc
+// ---------------------------------------------------------------------------
+console.log('\n4. srcdoc attribute classification');
+
+equal_test(
+  analyzer.classifyContext(null, 'nucleiXSScanary', 'srcdoc', '<script>nucleiXSScanary</script>'),
+  analyzer.ContextSrcdoc,
+  'srcdoc attribute should be ContextSrcdoc'
+);
+
+// Case-insensitive attribute name
+equal_test(
+  analyzer.classifyContext(null, 'nucleiXSScanary', 'SRCDOC', 'nucleiXSScanary'),
+  analyzer.ContextSrcdoc,
+  'SRCDOC (uppercase) should also be ContextSrcdoc'
+);
+
+// Plain href is not srcdoc
+equal_test(
+  analyzer.classifyContext(null, 'nucleiXSScanary', 'href', 'https://example.com/nucleiXSScanary'),
+  analyzer.ContextAttribute,
+  'href with plain URL must not be ContextSrcdoc'
+);
+
+// ---------------------------------------------------------------------------
+// 5. Helper unit tests
+// ---------------------------------------------------------------------------
+console.log('\n5. Helper function unit tests');
+
+assert(analyzer.isJavaScriptURI('javascript:alert(1)'), 'isJavaScriptURI: javascript:');
+assert(analyzer.isJavaScriptURI('JAVASCRIPT:alert(1)'), 'isJavaScriptURI: JAVASCRIPT:');
+assert(analyzer.isJavaScriptURI('  javascript:alert(1)'), 'isJavaScriptURI: leading spaces');
+assert(analyzer.isJavaScriptURI('vbscript:msgbox(1)'), 'isJavaScriptURI: vbscript:');
+assert(!analyzer.isJavaScriptURI('https://example.com'), 'isJavaScriptURI: https is not JS URI');
+assert(!analyzer.isJavaScriptURI(''), 'isJavaScriptURI: empty string is false');
+
+assert(analyzer.isNonExecutableScriptType('application/json'), 'isNonExec: application/json');
+assert(analyzer.isNonExecutableScriptType('Application/JSON'), 'isNonExec: case-insensitive');
+assert(analyzer.isNonExecutableScriptType('application/json; charset=utf-8'), 'isNonExec: with params');
+assert(!analyzer.isNonExecutableScriptType('text/javascript'), 'isNonExec: text/javascript is executable');
+assert(!analyzer.isNonExecutableScriptType(''), 'isNonExec: empty type is executable');
+
+assert(analyzer.isSrcdocAttribute('srcdoc'), 'isSrcdoc: srcdoc');
+assert(analyzer.isSrcdocAttribute('SRCDOC'), 'isSrcdoc: SRCDOC uppercase');
+assert(!analyzer.isSrcdocAttribute('href'), 'isSrcdoc: href is not srcdoc');
+assert(!analyzer.isSrcdocAttribute('src'), 'isSrcdoc: src is not srcdoc');
+
+var norm = analyzer.normalizeForReflection;
+assert(norm('&lt;') === '<', 'normalizeForReflection: &lt; -> <');
+assert(norm('&amp;') === '&', 'normalizeForReflection: &amp; -> &');
+assert(norm('&#110;') === 'n', 'normalizeForReflection: &#110; -> n');
+assert(norm('&#x6E;') === 'n', 'normalizeForReflection: &#x6E; -> n');
+assert(norm('HELLO') === 'hello', 'normalizeForReflection: lowercases');
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+function equal_test(actual, expected, message) {
+  assertEqual(actual, expected, message);
+}
+
+console.log('\n=== Results ===');
+console.log('Passed:', passed);
+console.log('Failed:', failed);
+if (failed > 0) {
+  process.exit(1);
+}


### PR DESCRIPTION
## Problem

The XSS context analyzer incorrectly classifies `javascript:` URI attributes as `ContextAttribute` instead of `ContextScript`, and treats `<script type="application/json">` blocks as executable JavaScript, causing both false negatives and false positives in XSS detection.

## Solution

Added `isJavaScriptURI()` to detect `javascript:`/`vbscript:` URI schemes (with protocol case normalization and leading-whitespace stripping), `isNonExecutableScriptType()` to classify `application/json` and similar MIME types as non-executable, `isSrcdocAttribute()` to upgrade `srcdoc` to a full HTML-injection context (`ContextSrcdoc`), and `normalizeForReflection()` + updated `isReflected()` to perform case-insensitive, HTML-entity-decoded canary matching. Each fix is guarded against the documented bypass variants (mixed-case protocol, charset parameters, numeric/hex entity encoding).

## Testing

- Added `pkg/js/global/js/xss_context_analyzer.test.js` with focused regression tests covering all four edge cases from the issue
- Tests cover bypass variants: mixed-case `JavaScript:`, `JAVASCRIPT:`, leading whitespace, `application/json; charset=utf-8`, `Application/JSON`, `&#110;` entity encoding, uppercased reflected canary
- Regression guards confirm plain `https:` URLs remain `ContextAttribute` and absent canaries are not matched

Closes #7086

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added enhanced XSS context analysis and public utilities to classify contexts (HTML, attributes, scripts, styles, srcdoc), detect executable URIs and non-executable script types, and normalize/reflection-check input for robust detection.
* **Tests**
  * Added comprehensive regression tests covering edge cases: case-insensitivity, entity-encoded inputs, script-type variations, srcdoc handling, URI variants, and reflection detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->