### PR TITLE
feat(scan): add honeypot detection to identify high-match-rate hosts

### DIFF
--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -436,7 +436,7 @@ on extensive configurability, massive extensibility and ease of use.`)
 		flagSet.BoolVarP(&options.DisableHTTPProbe, "no-httpx", "nh", false, "disable httpx probing for non-url input"),
 		flagSet.BoolVar(&options.DisableStdin, "no-stdin", false, "disable stdin processing"),
 		flagSet.BoolVarP(&options.HoneypotDetection, "honeypot-detection", "hpd", false, "detect and flag potential honeypots that match too many templates"),
-		flagSet.IntVarP(&options.HoneypotThreshold, "honeypot-threshold", "hpt", 100, "minimum number of unique template matches per host to flag as honeypot"),
+		flagSet.IntVarP(&options.HoneypotThreshold, "honeypot-threshold", "hpt", 100, "minimum unique template matches per host to flag as honeypot (also flags at 75%+ of loaded templates when >=10 match)"),
 	)
 
 	flagSet.CreateGroup("headless", "Headless",

--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -435,6 +435,8 @@ on extensive configurability, massive extensibility and ease of use.`)
 		flagSet.DurationVarP(&options.InputReadTimeout, "input-read-timeout", "irt", time.Duration(3*time.Minute), "timeout on input read"),
 		flagSet.BoolVarP(&options.DisableHTTPProbe, "no-httpx", "nh", false, "disable httpx probing for non-url input"),
 		flagSet.BoolVar(&options.DisableStdin, "no-stdin", false, "disable stdin processing"),
+		flagSet.BoolVarP(&options.HoneypotDetection, "honeypot-detection", "hpd", false, "detect and flag potential honeypots that match too many templates"),
+		flagSet.IntVarP(&options.HoneypotThreshold, "honeypot-threshold", "hpt", 100, "minimum number of unique template matches per host to flag as honeypot"),
 	)
 
 	flagSet.CreateGroup("headless", "Headless",

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -20,6 +20,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/loader/parser"
 	outputstats "github.com/projectdiscovery/nuclei/v3/pkg/output/stats"
 	"github.com/projectdiscovery/nuclei/v3/pkg/scan/events"
+	"github.com/projectdiscovery/nuclei/v3/pkg/scan/honeypot"
 	"github.com/projectdiscovery/nuclei/v3/pkg/utils/json"
 	uncoverlib "github.com/projectdiscovery/uncover"
 	pdcpauth "github.com/projectdiscovery/utils/auth/pdcp"
@@ -98,11 +99,12 @@ type Runner struct {
 	Logger             *gologger.Logger
 
 	//general purpose temporary directory
-	tmpDir          string
-	parser          parser.Parser
-	httpApiEndpoint *httpapi.Server
-	fuzzStats       *fuzzStats.Tracker
-	dastServer      *server.DASTServer
+	tmpDir           string
+	parser           parser.Parser
+	httpApiEndpoint  *httpapi.Server
+	fuzzStats        *fuzzStats.Tracker
+	dastServer       *server.DASTServer
+	honeypotTracker  *honeypot.Tracker
 }
 
 // New creates a new client for running the enumeration process.
@@ -278,6 +280,11 @@ func New(options *types.Options) (*Runner, error) {
 	if options.HTTPStats {
 		runner.httpStats = outputstats.NewTracker()
 		runner.output = output.NewMultiWriter(runner.output, output.NewTrackerWriter(runner.httpStats))
+	}
+	// setup honeypot detection writer if enabled
+	if options.HoneypotDetection {
+		runner.honeypotTracker = honeypot.NewTracker(options.HoneypotThreshold, runner.Logger)
+		runner.output = output.NewHoneypotWriter(runner.output, runner.honeypotTracker, runner.colorizer, runner.Logger)
 	}
 
 	if options.JSONL && options.EnableProgressBar {
@@ -680,6 +687,11 @@ func (r *Runner) RunEnumeration() error {
 			_ = r.inputProvider.SetWithExclusions(r.options.ExecutionId, host)
 		}
 	}
+	// set total template count for honeypot percentage-based detection
+	if r.honeypotTracker != nil {
+		r.honeypotTracker.SetTotalTemplates(len(store.Templates()) + len(store.Workflows()))
+	}
+
 	// display execution info like version , templates used etc
 	r.displayExecutionInfo(store)
 
@@ -750,6 +762,15 @@ func (r *Runner) RunEnumeration() error {
 
 	r.progress.Stop()
 	timeTaken := time.Since(now)
+
+	// display honeypot detection summary if enabled
+	if r.honeypotTracker != nil {
+		if summary := r.honeypotTracker.Summary(); summary != "" {
+			r.Logger.Warning().Msgf(summary)
+			r.Logger.Warning().Msgf("[honeypot] Results from flagged hosts may be unreliable. Consider excluding these hosts from your scan.")
+		}
+	}
+
 	// todo: error propagation without canonical straight error check is required by cloud?
 	// use safe dereferencing to avoid potential panics in case of previous unchecked errors
 	if v := ptrutil.Safe(results); !v.Load() {
@@ -917,6 +938,9 @@ func (r *Runner) displayExecutionInfo(store *loader.Store) {
 
 	if r.inputProvider.Count() > 0 {
 		r.Logger.Info().Msgf("Targets loaded for current scan: %d", r.inputProvider.Count())
+	}
+	if r.options.HoneypotDetection {
+		r.Logger.Info().Msgf("Honeypot detection enabled (threshold: %d unique template matches per host)", r.options.HoneypotThreshold)
 	}
 }
 

--- a/pkg/output/honeypot_writer.go
+++ b/pkg/output/honeypot_writer.go
@@ -1,9 +1,6 @@
 package output
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/logrusorgru/aurora"
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/nuclei/v3/pkg/scan/honeypot"
@@ -61,6 +58,7 @@ func (hw *HoneypotWriter) Write(event *ResultEvent) error {
 
 	// Only track successful matches (MatcherStatus true or non-error results).
 	if event.MatcherStatus || event.Error == "" {
+		// Resolve the effective host, falling back to IP for IP-only results.
 		host := event.Host
 		if host == "" {
 			host = event.IP
@@ -69,16 +67,15 @@ func (hw *HoneypotWriter) Write(event *ResultEvent) error {
 		templateID := event.TemplateID
 
 		if host != "" && templateID != "" {
-			// Record the match and check if this just triggered honeypot detection.
-			justFlagged := hw.tracker.RecordMatch(host, templateID)
-			if justFlagged {
-				hw.logHoneypotWarning(host)
-			}
+			// Record the match. The tracker handles first-flag logging
+			// internally, so no additional logging is needed here.
+			hw.tracker.RecordMatch(host, templateID)
 		}
 
 		// Annotate the result if the host is a known honeypot.
+		// Use the resolved host for consistent lookup.
 		if host != "" && hw.tracker.IsHoneypot(host) {
-			hw.annotateResult(event)
+			hw.annotateResult(event, host)
 		}
 	}
 
@@ -116,28 +113,16 @@ func (hw *HoneypotWriter) Tracker() *honeypot.Tracker {
 }
 
 // annotateResult adds honeypot warning metadata to the result event.
-func (hw *HoneypotWriter) annotateResult(event *ResultEvent) {
+// It uses the resolved host (which may be event.IP when event.Host is empty)
+// to look up the correct match count. The TemplateID is left unmodified
+// to avoid breaking JSONL, SARIF, or cloud consumers that key on it.
+func (hw *HoneypotWriter) annotateResult(event *ResultEvent, resolvedHost string) {
 	if event.Metadata == nil {
 		event.Metadata = make(map[string]interface{})
 	}
 
-	matchCount := hw.tracker.GetMatchCount(event.Host)
+	matchCount := hw.tracker.GetMatchCount(resolvedHost)
 	event.Metadata["honeypot_warning"] = true
 	event.Metadata["honeypot_match_count"] = matchCount
-
-	// Prepend warning to the template ID for screen output visibility.
-	if !strings.HasPrefix(event.TemplateID, "[HONEYPOT?] ") {
-		event.TemplateID = fmt.Sprintf("[HONEYPOT?] %s", event.TemplateID)
-	}
-}
-
-// logHoneypotWarning emits a visible warning when a host is first flagged.
-func (hw *HoneypotWriter) logHoneypotWarning(host string) {
-	matchCount := hw.tracker.GetMatchCount(host)
-	if hw.logger != nil {
-		hw.logger.Warning().Msgf(
-			"[honeypot] %s has matched %d unique templates and appears to be a honeypot - results may be unreliable",
-			host, matchCount,
-		)
-	}
+	event.Metadata["honeypot_host"] = resolvedHost
 }

--- a/pkg/output/honeypot_writer.go
+++ b/pkg/output/honeypot_writer.go
@@ -1,0 +1,143 @@
+package output
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/logrusorgru/aurora"
+	"github.com/projectdiscovery/gologger"
+	"github.com/projectdiscovery/nuclei/v3/pkg/scan/honeypot"
+)
+
+// HoneypotWriter wraps an output.Writer and intercepts Write calls to
+// track template matches per host for honeypot detection.
+//
+// When a host is detected as a potential honeypot, its results are annotated
+// with a warning marker in the output. The writer tracks unique template IDs
+// per normalized host and flags hosts that exceed the configured threshold.
+type HoneypotWriter struct {
+	// inner is the wrapped output writer.
+	inner Writer
+
+	// tracker is the honeypot detection tracker.
+	tracker *honeypot.Tracker
+
+	// colorizer is used for formatting warning output.
+	colorizer aurora.Aurora
+
+	// logger is used for warning messages.
+	logger *gologger.Logger
+}
+
+var _ Writer = &HoneypotWriter{}
+
+// NewHoneypotWriter creates a new HoneypotWriter wrapping the given writer.
+func NewHoneypotWriter(inner Writer, tracker *honeypot.Tracker, colorizer aurora.Aurora, logger *gologger.Logger) *HoneypotWriter {
+	return &HoneypotWriter{
+		inner:     inner,
+		tracker:   tracker,
+		colorizer: colorizer,
+		logger:    logger,
+	}
+}
+
+// Close closes the inner writer.
+func (hw *HoneypotWriter) Close() {
+	hw.inner.Close()
+}
+
+// Colorizer returns the colorizer instance.
+func (hw *HoneypotWriter) Colorizer() aurora.Aurora {
+	return hw.inner.Colorizer()
+}
+
+// Write intercepts result events to track template matches per host.
+// If the host has been flagged as a honeypot, the result is annotated
+// but still written to allow users to see the data.
+func (hw *HoneypotWriter) Write(event *ResultEvent) error {
+	if event == nil {
+		return nil
+	}
+
+	// Only track successful matches (MatcherStatus true or non-error results).
+	if event.MatcherStatus || event.Error == "" {
+		host := event.Host
+		if host == "" {
+			host = event.IP
+		}
+
+		templateID := event.TemplateID
+
+		if host != "" && templateID != "" {
+			// Record the match and check if this just triggered honeypot detection.
+			justFlagged := hw.tracker.RecordMatch(host, templateID)
+			if justFlagged {
+				hw.logHoneypotWarning(host)
+			}
+		}
+
+		// Annotate the result if the host is a known honeypot.
+		if host != "" && hw.tracker.IsHoneypot(host) {
+			hw.annotateResult(event)
+		}
+	}
+
+	return hw.inner.Write(event)
+}
+
+// WriteFailure passes failure events through to the inner writer.
+func (hw *HoneypotWriter) WriteFailure(event *InternalWrappedEvent) error {
+	return hw.inner.WriteFailure(event)
+}
+
+// Request passes request logs through to the inner writer.
+func (hw *HoneypotWriter) Request(templateID, url, requestType string, err error) {
+	hw.inner.Request(templateID, url, requestType, err)
+}
+
+// WriteStoreDebugData passes debug data through to the inner writer.
+func (hw *HoneypotWriter) WriteStoreDebugData(host, templateID, eventType string, data string) {
+	hw.inner.WriteStoreDebugData(host, templateID, eventType, data)
+}
+
+// RequestStatsLog passes stats log through to the inner writer.
+func (hw *HoneypotWriter) RequestStatsLog(statusCode, response string) {
+	hw.inner.RequestStatsLog(statusCode, response)
+}
+
+// ResultCount returns the result count from the inner writer.
+func (hw *HoneypotWriter) ResultCount() int {
+	return hw.inner.ResultCount()
+}
+
+// Tracker returns the underlying honeypot tracker for summary access.
+func (hw *HoneypotWriter) Tracker() *honeypot.Tracker {
+	return hw.tracker
+}
+
+// annotateResult adds honeypot warning metadata to the result event.
+func (hw *HoneypotWriter) annotateResult(event *ResultEvent) {
+	if event.Metadata == nil {
+		event.Metadata = make(map[string]interface{})
+	}
+
+	matchCount := hw.tracker.GetMatchCount(event.Host)
+	event.Metadata["honeypot_warning"] = true
+	event.Metadata["honeypot_match_count"] = matchCount
+
+	// Prepend warning to the template ID for screen output visibility.
+	if !strings.HasPrefix(event.TemplateID, "[HONEYPOT?] ") {
+		event.TemplateID = fmt.Sprintf("[HONEYPOT?] %s", event.TemplateID)
+	}
+}
+
+// logHoneypotWarning emits a visible warning when a host is first flagged.
+func (hw *HoneypotWriter) logHoneypotWarning(host string) {
+	matchCount := hw.tracker.GetMatchCount(host)
+	if hw.logger != nil {
+		hw.logger.Warning().Msgf(
+			"[honeypot] %s has matched %d unique templates and appears to be a honeypot - results may be unreliable",
+			host, matchCount,
+		)
+	}
+}

--- a/pkg/scan/honeypot/tracker.go
+++ b/pkg/scan/honeypot/tracker.go
@@ -170,8 +170,12 @@ func (t *Tracker) GetFlaggedHosts() []FlaggedHost {
 		}
 	}
 
-	// Sort for deterministic output.
+	// Sort for deterministic output: by match count descending,
+	// then by host name ascending to break ties.
 	sort.Slice(flagged, func(i, j int) bool {
+		if flagged[i].MatchCount == flagged[j].MatchCount {
+			return flagged[i].Host < flagged[j].Host
+		}
 		return flagged[i].MatchCount > flagged[j].MatchCount
 	})
 	return flagged
@@ -244,7 +248,16 @@ func normalizeHost(input string) string {
 
 // stripDefaultPort removes :80 and :443 from host:port strings only when
 // they are actual port suffixes (not part of an IPv6 address).
+// It also unwraps bare bracketed IPv6 literals (e.g. "[::1]" → "::1")
+// so that http://[::1]/ and http://[::1]:80/ normalize to the same key.
 func stripDefaultPort(hostport string) string {
+	// Handle bare bracketed IPv6 without port (e.g. "[2001:db8::1]").
+	// net.SplitHostPort won't parse these, but they should normalize
+	// to the same form as "[2001:db8::1]:80" → "2001:db8::1".
+	if strings.HasPrefix(hostport, "[") && strings.HasSuffix(hostport, "]") {
+		return hostport[1 : len(hostport)-1]
+	}
+
 	host, port, err := net.SplitHostPort(hostport)
 	if err != nil {
 		// No port present or invalid format; return as-is.

--- a/pkg/scan/honeypot/tracker.go
+++ b/pkg/scan/honeypot/tracker.go
@@ -1,0 +1,230 @@
+package honeypot
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/projectdiscovery/gologger"
+	urlutil "github.com/projectdiscovery/utils/url"
+)
+
+const (
+	// DefaultThreshold is the default number of unique template matches
+	// per host before flagging it as a potential honeypot.
+	DefaultThreshold = 100
+
+	// DefaultMatchPercentage is the default percentage of templates
+	// that must match before a host is considered a honeypot.
+	// This is used as a secondary check when total templates count is known.
+	DefaultMatchPercentage = 75.0
+)
+
+// hostStats tracks match statistics for a single host.
+type hostStats struct {
+	// templateIDs stores unique template IDs that matched this host.
+	templateIDs map[string]struct{}
+	// flagged indicates whether this host has been flagged as a honeypot.
+	flagged bool
+}
+
+// Tracker monitors per-host template match counts to detect
+// potential honeypots. Honeypots typically respond positively
+// to many different vulnerability checks, producing an abnormally
+// high match rate across diverse template categories.
+type Tracker struct {
+	mu sync.RWMutex
+
+	// hosts maps normalized host identifiers to their match statistics.
+	hosts map[string]*hostStats
+
+	// threshold is the absolute number of unique template matches
+	// that triggers honeypot detection for a host.
+	threshold int
+
+	// totalTemplates is the total number of templates being executed.
+	// When set, allows percentage-based detection as well.
+	totalTemplates int
+
+	// logger is used for warning/info messages.
+	logger *gologger.Logger
+}
+
+// NewTracker creates a new honeypot detection tracker.
+func NewTracker(threshold int, logger *gologger.Logger) *Tracker {
+	if threshold <= 0 {
+		threshold = DefaultThreshold
+	}
+	return &Tracker{
+		hosts:     make(map[string]*hostStats),
+		threshold: threshold,
+		logger:    logger,
+	}
+}
+
+// SetTotalTemplates sets the total number of templates for percentage-based detection.
+func (t *Tracker) SetTotalTemplates(count int) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.totalTemplates = count
+}
+
+// RecordMatch records a template match for a given host and template ID.
+// Returns true if the host is now flagged as a potential honeypot.
+func (t *Tracker) RecordMatch(host, templateID string) bool {
+	normalizedHost := normalizeHost(host)
+	if normalizedHost == "" {
+		return false
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	stats, ok := t.hosts[normalizedHost]
+	if !ok {
+		stats = &hostStats{
+			templateIDs: make(map[string]struct{}),
+		}
+		t.hosts[normalizedHost] = stats
+	}
+
+	// Track unique template IDs only.
+	stats.templateIDs[templateID] = struct{}{}
+	matchCount := len(stats.templateIDs)
+
+	// Check if the host should be flagged.
+	if !stats.flagged && t.shouldFlag(matchCount) {
+		stats.flagged = true
+		if t.logger != nil {
+			t.logger.Warning().Msgf(
+				"[honeypot] Host %s matched %d unique templates (threshold: %d) - potential honeypot detected",
+				normalizedHost, matchCount, t.threshold,
+			)
+		}
+		return true
+	}
+
+	return false
+}
+
+// IsHoneypot checks if a host has been flagged as a potential honeypot.
+func (t *Tracker) IsHoneypot(host string) bool {
+	normalizedHost := normalizeHost(host)
+	if normalizedHost == "" {
+		return false
+	}
+
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	if stats, ok := t.hosts[normalizedHost]; ok {
+		return stats.flagged
+	}
+	return false
+}
+
+// GetMatchCount returns the number of unique template matches for a host.
+func (t *Tracker) GetMatchCount(host string) int {
+	normalizedHost := normalizeHost(host)
+	if normalizedHost == "" {
+		return 0
+	}
+
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	if stats, ok := t.hosts[normalizedHost]; ok {
+		return len(stats.templateIDs)
+	}
+	return 0
+}
+
+// GetFlaggedHosts returns a list of all hosts flagged as potential honeypots
+// along with their match counts.
+func (t *Tracker) GetFlaggedHosts() []FlaggedHost {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	var flagged []FlaggedHost
+	for host, stats := range t.hosts {
+		if stats.flagged {
+			flagged = append(flagged, FlaggedHost{
+				Host:       host,
+				MatchCount: len(stats.templateIDs),
+			})
+		}
+	}
+
+	// Sort for deterministic output.
+	sort.Slice(flagged, func(i, j int) bool {
+		return flagged[i].MatchCount > flagged[j].MatchCount
+	})
+	return flagged
+}
+
+// Summary returns a human-readable summary of honeypot detection results.
+func (t *Tracker) Summary() string {
+	flagged := t.GetFlaggedHosts()
+	if len(flagged) == 0 {
+		return ""
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("[honeypot] %d potential honeypot(s) detected:\n", len(flagged)))
+	for _, h := range flagged {
+		sb.WriteString(fmt.Sprintf("  - %s (%d unique template matches)\n", h.Host, h.MatchCount))
+	}
+	return sb.String()
+}
+
+// FlaggedHost represents a host that has been flagged as a potential honeypot.
+type FlaggedHost struct {
+	Host       string `json:"host"`
+	MatchCount int    `json:"match_count"`
+}
+
+// shouldFlag determines if a host should be flagged based on match count.
+// Called with lock held.
+func (t *Tracker) shouldFlag(matchCount int) bool {
+	// Primary check: absolute threshold.
+	if matchCount >= t.threshold {
+		return true
+	}
+
+	// Secondary check: percentage of total templates (if known).
+	if t.totalTemplates > 0 {
+		percentage := (float64(matchCount) / float64(t.totalTemplates)) * 100
+		if percentage >= DefaultMatchPercentage && matchCount >= 10 {
+			// Only trigger percentage-based detection if at least 10 templates matched.
+			// This avoids false positives when scanning with very few templates.
+			return true
+		}
+	}
+
+	return false
+}
+
+// normalizeHost extracts a consistent host identifier from various input formats.
+// It strips protocol, path, and normalizes the host:port combination.
+func normalizeHost(input string) string {
+	if input == "" {
+		return ""
+	}
+
+	// Try to parse as URL first.
+	parsed, err := urlutil.Parse(input)
+	if err == nil && parsed.Host != "" {
+		host := parsed.Host
+		// Strip default ports for normalization.
+		host = strings.TrimSuffix(host, ":80")
+		host = strings.TrimSuffix(host, ":443")
+		return strings.ToLower(host)
+	}
+
+	// Fall back to treating it as a plain host.
+	input = strings.ToLower(strings.TrimSpace(input))
+	input = strings.TrimSuffix(input, ":80")
+	input = strings.TrimSuffix(input, ":443")
+	return input
+}

--- a/pkg/scan/honeypot/tracker.go
+++ b/pkg/scan/honeypot/tracker.go
@@ -2,6 +2,7 @@ package honeypot
 
 import (
 	"fmt"
+	"net"
 	"sort"
 	"strings"
 	"sync"
@@ -19,6 +20,10 @@ const (
 	// that must match before a host is considered a honeypot.
 	// This is used as a secondary check when total templates count is known.
 	DefaultMatchPercentage = 75.0
+
+	// DefaultMaxHosts is the maximum number of unique hosts tracked
+	// to prevent unbounded memory growth.
+	DefaultMaxHosts = 100000
 )
 
 // hostStats tracks match statistics for a single host.
@@ -47,6 +52,10 @@ type Tracker struct {
 	// When set, allows percentage-based detection as well.
 	totalTemplates int
 
+	// maxHosts is the maximum number of hosts to track to prevent
+	// unbounded memory growth from crafted target lists.
+	maxHosts int
+
 	// logger is used for warning/info messages.
 	logger *gologger.Logger
 }
@@ -59,6 +68,7 @@ func NewTracker(threshold int, logger *gologger.Logger) *Tracker {
 	return &Tracker{
 		hosts:     make(map[string]*hostStats),
 		threshold: threshold,
+		maxHosts:  DefaultMaxHosts,
 		logger:    logger,
 	}
 }
@@ -83,6 +93,10 @@ func (t *Tracker) RecordMatch(host, templateID string) bool {
 
 	stats, ok := t.hosts[normalizedHost]
 	if !ok {
+		// Prevent unbounded memory growth from very large target lists.
+		if len(t.hosts) >= t.maxHosts {
+			return false
+		}
 		stats = &hostStats{
 			templateIDs: make(map[string]struct{}),
 		}
@@ -216,15 +230,28 @@ func normalizeHost(input string) string {
 	parsed, err := urlutil.Parse(input)
 	if err == nil && parsed.Host != "" {
 		host := parsed.Host
-		// Strip default ports for normalization.
-		host = strings.TrimSuffix(host, ":80")
-		host = strings.TrimSuffix(host, ":443")
+		// Strip default ports safely using net.SplitHostPort to avoid
+		// corrupting IPv6 addresses like 2001:db8::80.
+		host = stripDefaultPort(host)
 		return strings.ToLower(host)
 	}
 
 	// Fall back to treating it as a plain host.
 	input = strings.ToLower(strings.TrimSpace(input))
-	input = strings.TrimSuffix(input, ":80")
-	input = strings.TrimSuffix(input, ":443")
+	input = stripDefaultPort(input)
 	return input
+}
+
+// stripDefaultPort removes :80 and :443 from host:port strings only when
+// they are actual port suffixes (not part of an IPv6 address).
+func stripDefaultPort(hostport string) string {
+	host, port, err := net.SplitHostPort(hostport)
+	if err != nil {
+		// No port present or invalid format; return as-is.
+		return hostport
+	}
+	if port == "80" || port == "443" {
+		return host
+	}
+	return hostport
 }

--- a/pkg/scan/honeypot/tracker.go
+++ b/pkg/scan/honeypot/tracker.go
@@ -26,6 +26,27 @@ const (
 	DefaultMaxHosts = 100000
 )
 
+// flagReason describes why a host was flagged as a potential honeypot.
+type flagReason int
+
+const (
+	notFlagged        flagReason = iota
+	flagAbsolute                         // absolute threshold exceeded
+	flagPercentage                       // percentage-of-templates threshold exceeded
+)
+
+// String returns a human-readable description of the flag reason.
+func (r flagReason) String() string {
+	switch r {
+	case flagAbsolute:
+		return "absolute threshold"
+	case flagPercentage:
+		return "percentage-of-templates threshold"
+	default:
+		return ""
+	}
+}
+
 // hostStats tracks match statistics for a single host.
 type hostStats struct {
 	// templateIDs stores unique template IDs that matched this host.
@@ -55,6 +76,13 @@ type Tracker struct {
 	// maxHosts is the maximum number of hosts to track to prevent
 	// unbounded memory growth from crafted target lists.
 	maxHosts int
+
+	// droppedHosts counts how many unique hosts were excluded because
+	// the maxHosts limit was reached.
+	droppedHosts int
+
+	// maxHostsWarned ensures the maxHosts warning is emitted only once.
+	maxHostsWarned bool
 
 	// logger is used for warning/info messages.
 	logger *gologger.Logger
@@ -95,6 +123,16 @@ func (t *Tracker) RecordMatch(host, templateID string) bool {
 	if !ok {
 		// Prevent unbounded memory growth from very large target lists.
 		if len(t.hosts) >= t.maxHosts {
+			t.droppedHosts++
+			if !t.maxHostsWarned {
+				t.maxHostsWarned = true
+				if t.logger != nil {
+					t.logger.Warning().Msgf(
+						"[honeypot] Maximum tracked hosts limit reached (%d); new hosts will be excluded from honeypot detection",
+						t.maxHosts,
+					)
+				}
+			}
 			return false
 		}
 		stats = &hostStats{
@@ -108,12 +146,20 @@ func (t *Tracker) RecordMatch(host, templateID string) bool {
 	matchCount := len(stats.templateIDs)
 
 	// Check if the host should be flagged.
-	if !stats.flagged && t.shouldFlag(matchCount) {
+	if reason := t.shouldFlag(matchCount); !stats.flagged && reason != notFlagged {
 		stats.flagged = true
 		if t.logger != nil {
+			var detail string
+			switch reason {
+			case flagAbsolute:
+				detail = fmt.Sprintf("threshold: %d", t.threshold)
+			case flagPercentage:
+				pct := (float64(matchCount) / float64(t.totalTemplates)) * 100
+				detail = fmt.Sprintf("%.0f%% of %d templates", pct, t.totalTemplates)
+			}
 			t.logger.Warning().Msgf(
-				"[honeypot] Host %s matched %d unique templates (threshold: %d) - potential honeypot detected",
-				normalizedHost, matchCount, t.threshold,
+				"[honeypot] Host %s matched %d unique templates (%s) - potential honeypot detected",
+				normalizedHost, matchCount, detail,
 			)
 		}
 		return true
@@ -181,17 +227,32 @@ func (t *Tracker) GetFlaggedHosts() []FlaggedHost {
 	return flagged
 }
 
+// DroppedHosts returns the number of unique hosts that were excluded from
+// honeypot tracking because the maxHosts limit was reached.
+func (t *Tracker) DroppedHosts() int {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.droppedHosts
+}
+
 // Summary returns a human-readable summary of honeypot detection results.
 func (t *Tracker) Summary() string {
 	flagged := t.GetFlaggedHosts()
-	if len(flagged) == 0 {
+	dropped := t.DroppedHosts()
+
+	if len(flagged) == 0 && dropped == 0 {
 		return ""
 	}
 
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("[honeypot] %d potential honeypot(s) detected:\n", len(flagged)))
-	for _, h := range flagged {
-		sb.WriteString(fmt.Sprintf("  - %s (%d unique template matches)\n", h.Host, h.MatchCount))
+	if len(flagged) > 0 {
+		sb.WriteString(fmt.Sprintf("[honeypot] %d potential honeypot(s) detected:\n", len(flagged)))
+		for _, h := range flagged {
+			sb.WriteString(fmt.Sprintf("  - %s (%d unique template matches)\n", h.Host, h.MatchCount))
+		}
+	}
+	if dropped > 0 {
+		sb.WriteString(fmt.Sprintf("[honeypot] %d host(s) excluded from tracking (max hosts limit: %d)\n", dropped, t.maxHosts))
 	}
 	return sb.String()
 }
@@ -202,12 +263,13 @@ type FlaggedHost struct {
 	MatchCount int    `json:"match_count"`
 }
 
-// shouldFlag determines if a host should be flagged based on match count.
-// Called with lock held.
-func (t *Tracker) shouldFlag(matchCount int) bool {
+// shouldFlag determines if a host should be flagged based on match count
+// and returns the reason for flagging (or notFlagged if the host should not
+// be flagged). Called with lock held.
+func (t *Tracker) shouldFlag(matchCount int) flagReason {
 	// Primary check: absolute threshold.
 	if matchCount >= t.threshold {
-		return true
+		return flagAbsolute
 	}
 
 	// Secondary check: percentage of total templates (if known).
@@ -216,11 +278,11 @@ func (t *Tracker) shouldFlag(matchCount int) bool {
 		if percentage >= DefaultMatchPercentage && matchCount >= 10 {
 			// Only trigger percentage-based detection if at least 10 templates matched.
 			// This avoids false positives when scanning with very few templates.
-			return true
+			return flagPercentage
 		}
 	}
 
-	return false
+	return notFlagged
 }
 
 // normalizeHost extracts a consistent host identifier from various input formats.

--- a/pkg/scan/honeypot/tracker.go
+++ b/pkg/scan/honeypot/tracker.go
@@ -77,8 +77,9 @@ type Tracker struct {
 	// unbounded memory growth from crafted target lists.
 	maxHosts int
 
-	// droppedHosts counts how many unique hosts were excluded because
-	// the maxHosts limit was reached.
+	// droppedHosts counts how many record attempts were excluded because
+	// the maxHosts limit was reached. Note: this counts all excluded
+	// attempts, not unique hosts, since excluded hosts are not tracked.
 	droppedHosts int
 
 	// maxHostsWarned ensures the maxHosts warning is emitted only once.
@@ -227,8 +228,9 @@ func (t *Tracker) GetFlaggedHosts() []FlaggedHost {
 	return flagged
 }
 
-// DroppedHosts returns the number of unique hosts that were excluded from
-// honeypot tracking because the maxHosts limit was reached.
+// DroppedHosts returns the number of record attempts that were excluded from
+// honeypot tracking because the maxHosts limit was reached. This counts all
+// excluded attempts, not unique hosts, since excluded hosts are not tracked.
 func (t *Tracker) DroppedHosts() int {
 	t.mu.RLock()
 	defer t.mu.RUnlock()

--- a/pkg/scan/honeypot/tracker_test.go
+++ b/pkg/scan/honeypot/tracker_test.go
@@ -1,0 +1,262 @@
+package honeypot
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/projectdiscovery/gologger"
+)
+
+func TestNewTracker(t *testing.T) {
+	tracker := NewTracker(50, nil)
+	if tracker.threshold != 50 {
+		t.Errorf("expected threshold 50, got %d", tracker.threshold)
+	}
+
+	// Test default threshold.
+	tracker = NewTracker(0, nil)
+	if tracker.threshold != DefaultThreshold {
+		t.Errorf("expected default threshold %d, got %d", DefaultThreshold, tracker.threshold)
+	}
+
+	// Test negative threshold.
+	tracker = NewTracker(-1, nil)
+	if tracker.threshold != DefaultThreshold {
+		t.Errorf("expected default threshold %d, got %d", DefaultThreshold, tracker.threshold)
+	}
+}
+
+func TestRecordMatchAndIsHoneypot(t *testing.T) {
+	tracker := NewTracker(3, nil)
+
+	// Record matches below threshold.
+	flagged := tracker.RecordMatch("http://example.com", "CVE-2021-0001")
+	if flagged {
+		t.Error("expected host not to be flagged after 1 match")
+	}
+	if tracker.IsHoneypot("http://example.com") {
+		t.Error("expected host not to be a honeypot after 1 match")
+	}
+
+	flagged = tracker.RecordMatch("http://example.com", "CVE-2021-0002")
+	if flagged {
+		t.Error("expected host not to be flagged after 2 matches")
+	}
+
+	// Third unique match should trigger flagging.
+	flagged = tracker.RecordMatch("http://example.com", "CVE-2021-0003")
+	if !flagged {
+		t.Error("expected host to be flagged after 3 matches")
+	}
+	if !tracker.IsHoneypot("http://example.com") {
+		t.Error("expected host to be a honeypot after 3 matches")
+	}
+
+	// Subsequent matches should not re-trigger (already flagged).
+	flagged = tracker.RecordMatch("http://example.com", "CVE-2021-0004")
+	if flagged {
+		t.Error("expected host not to re-trigger flagging")
+	}
+}
+
+func TestDuplicateTemplateIDs(t *testing.T) {
+	tracker := NewTracker(3, nil)
+
+	// Record the same template multiple times.
+	tracker.RecordMatch("http://example.com", "CVE-2021-0001")
+	tracker.RecordMatch("http://example.com", "CVE-2021-0001")
+	tracker.RecordMatch("http://example.com", "CVE-2021-0001")
+
+	if tracker.GetMatchCount("http://example.com") != 1 {
+		t.Errorf("expected 1 unique match, got %d", tracker.GetMatchCount("http://example.com"))
+	}
+	if tracker.IsHoneypot("http://example.com") {
+		t.Error("duplicate template IDs should not trigger honeypot detection")
+	}
+}
+
+func TestHostNormalization(t *testing.T) {
+	tracker := NewTracker(2, nil)
+
+	// Different URL forms for the same host should be tracked together.
+	tracker.RecordMatch("http://example.com/path1", "CVE-2021-0001")
+	tracker.RecordMatch("https://example.com/path2", "CVE-2021-0002")
+
+	if tracker.GetMatchCount("example.com") != 2 {
+		t.Errorf("expected 2 matches for normalized host, got %d", tracker.GetMatchCount("example.com"))
+	}
+}
+
+func TestHostNormalizationDefaultPorts(t *testing.T) {
+	tracker := NewTracker(3, nil)
+
+	tracker.RecordMatch("http://example.com:80", "CVE-2021-0001")
+	tracker.RecordMatch("http://example.com", "CVE-2021-0002")
+
+	count := tracker.GetMatchCount("example.com")
+	if count != 2 {
+		t.Errorf("expected 2 matches (port 80 normalized), got %d", count)
+	}
+}
+
+func TestMultipleHosts(t *testing.T) {
+	tracker := NewTracker(2, nil)
+
+	tracker.RecordMatch("http://host1.com", "CVE-2021-0001")
+	tracker.RecordMatch("http://host1.com", "CVE-2021-0002")
+	tracker.RecordMatch("http://host2.com", "CVE-2021-0001")
+
+	if !tracker.IsHoneypot("http://host1.com") {
+		t.Error("expected host1 to be flagged as honeypot")
+	}
+	if tracker.IsHoneypot("http://host2.com") {
+		t.Error("expected host2 not to be flagged")
+	}
+}
+
+func TestGetFlaggedHosts(t *testing.T) {
+	tracker := NewTracker(2, nil)
+
+	tracker.RecordMatch("http://host1.com", "CVE-2021-0001")
+	tracker.RecordMatch("http://host1.com", "CVE-2021-0002")
+	tracker.RecordMatch("http://host2.com", "CVE-2021-0001")
+	tracker.RecordMatch("http://host2.com", "CVE-2021-0002")
+	tracker.RecordMatch("http://host2.com", "CVE-2021-0003")
+	tracker.RecordMatch("http://host3.com", "CVE-2021-0001")
+
+	flagged := tracker.GetFlaggedHosts()
+	if len(flagged) != 2 {
+		t.Errorf("expected 2 flagged hosts, got %d", len(flagged))
+	}
+
+	// Results should be sorted by match count descending.
+	if len(flagged) >= 2 {
+		if flagged[0].MatchCount < flagged[1].MatchCount {
+			t.Error("expected flagged hosts to be sorted by match count descending")
+		}
+	}
+}
+
+func TestPercentageBasedDetection(t *testing.T) {
+	tracker := NewTracker(1000, nil) // High absolute threshold.
+	tracker.SetTotalTemplates(20)
+
+	// 75% of 20 = 15 templates, so 15 matches should trigger.
+	for i := 0; i < 14; i++ {
+		tracker.RecordMatch("http://example.com", fmt.Sprintf("template-%d", i))
+	}
+	if tracker.IsHoneypot("http://example.com") {
+		t.Error("expected host not to be flagged at 14/20 matches")
+	}
+
+	// 15th match should trigger percentage-based detection.
+	flagged := tracker.RecordMatch("http://example.com", "template-14")
+	if !flagged {
+		t.Error("expected host to be flagged at 15/20 matches (75%)")
+	}
+}
+
+func TestPercentageBasedDetectionMinimumThreshold(t *testing.T) {
+	tracker := NewTracker(1000, nil)
+	tracker.SetTotalTemplates(5)
+
+	// Even at 80% (4/5), should not trigger because minimum is 10 matches.
+	for i := 0; i < 4; i++ {
+		tracker.RecordMatch("http://example.com", fmt.Sprintf("template-%d", i))
+	}
+	if tracker.IsHoneypot("http://example.com") {
+		t.Error("should not trigger percentage detection with fewer than 10 matches")
+	}
+}
+
+func TestSummary(t *testing.T) {
+	tracker := NewTracker(2, nil)
+
+	// No flagged hosts.
+	if tracker.Summary() != "" {
+		t.Error("expected empty summary with no flagged hosts")
+	}
+
+	tracker.RecordMatch("http://host1.com", "CVE-2021-0001")
+	tracker.RecordMatch("http://host1.com", "CVE-2021-0002")
+
+	summary := tracker.Summary()
+	if summary == "" {
+		t.Error("expected non-empty summary after flagging a host")
+	}
+}
+
+func TestEmptyInput(t *testing.T) {
+	tracker := NewTracker(2, nil)
+
+	flagged := tracker.RecordMatch("", "CVE-2021-0001")
+	if flagged {
+		t.Error("empty host should not be flagged")
+	}
+
+	if tracker.IsHoneypot("") {
+		t.Error("empty host should not be a honeypot")
+	}
+
+	if tracker.GetMatchCount("") != 0 {
+		t.Error("empty host should have 0 match count")
+	}
+}
+
+func TestConcurrentAccess(t *testing.T) {
+	tracker := NewTracker(50, &gologger.Logger{})
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			host := fmt.Sprintf("http://host%d.com", idx%5)
+			templateID := fmt.Sprintf("CVE-2021-%04d", idx)
+			tracker.RecordMatch(host, templateID)
+			_ = tracker.IsHoneypot(host)
+			_ = tracker.GetMatchCount(host)
+		}(i)
+	}
+	wg.Wait()
+
+	// Just verify no panic occurred and data is consistent.
+	total := 0
+	for i := 0; i < 5; i++ {
+		host := fmt.Sprintf("http://host%d.com", i)
+		count := tracker.GetMatchCount(host)
+		if count < 0 || count > 100 {
+			t.Errorf("unexpected match count %d for %s", count, host)
+		}
+		total += count
+	}
+	if total != 100 {
+		t.Errorf("expected total 100 unique matches across hosts, got %d", total)
+	}
+}
+
+func TestNormalizeHost(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"http://example.com", "example.com"},
+		{"https://example.com", "example.com"},
+		{"http://example.com:80", "example.com"},
+		{"https://example.com:443", "example.com"},
+		{"http://example.com:8080", "example.com:8080"},
+		{"http://EXAMPLE.COM", "example.com"},
+		{"example.com", "example.com"},
+		{"192.168.1.1", "192.168.1.1"},
+		{"http://192.168.1.1:8080/path", "192.168.1.1:8080"},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		result := normalizeHost(tt.input)
+		if result != tt.expected {
+			t.Errorf("normalizeHost(%q) = %q, expected %q", tt.input, result, tt.expected)
+		}
+	}
+}

--- a/pkg/scan/honeypot/tracker_test.go
+++ b/pkg/scan/honeypot/tracker_test.go
@@ -272,6 +272,8 @@ func TestNormalizeHostIPv6Safety(t *testing.T) {
 		{"http://[::1]:443/path", "::1"},
 		// IPv6 with non-default port should be preserved.
 		{"http://[::1]:8080/path", "[::1]:8080"},
+		// IPv6 without port should unwrap brackets for consistency.
+		{"http://[2001:db8::1]/path", "2001:db8::1"},
 	}
 
 	for _, tt := range tests {
@@ -323,6 +325,9 @@ func TestStripDefaultPort(t *testing.T) {
 		{"[::1]:443", "::1"},
 		// IPv6 with brackets and non-default port.
 		{"[::1]:8080", "[::1]:8080"},
+		// Bare bracketed IPv6 without port — brackets should be unwrapped.
+		{"[::1]", "::1"},
+		{"[2001:db8::1]", "2001:db8::1"},
 	}
 
 	for _, tt := range tests {

--- a/pkg/scan/honeypot/tracker_test.go
+++ b/pkg/scan/honeypot/tracker_test.go
@@ -236,6 +236,52 @@ func TestConcurrentAccess(t *testing.T) {
 	}
 }
 
+func TestMaxHostsLimit(t *testing.T) {
+	tracker := NewTracker(100, nil)
+	// Override maxHosts to a small value for testing.
+	tracker.maxHosts = 3
+
+	tracker.RecordMatch("http://host1.com", "CVE-2021-0001")
+	tracker.RecordMatch("http://host2.com", "CVE-2021-0001")
+	tracker.RecordMatch("http://host3.com", "CVE-2021-0001")
+
+	// Fourth host should be silently dropped.
+	tracker.RecordMatch("http://host4.com", "CVE-2021-0001")
+	if tracker.GetMatchCount("http://host4.com") != 0 {
+		t.Error("expected host4 to be dropped due to max hosts limit")
+	}
+
+	// Existing hosts should still accept new matches.
+	tracker.RecordMatch("http://host1.com", "CVE-2021-0002")
+	if tracker.GetMatchCount("http://host1.com") != 2 {
+		t.Errorf("expected 2 matches for host1, got %d", tracker.GetMatchCount("http://host1.com"))
+	}
+}
+
+func TestNormalizeHostIPv6Safety(t *testing.T) {
+	// Ensure IPv6 addresses ending in :80 are not corrupted.
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		// IPv6 address that ends with ::80 should NOT be stripped.
+		{"2001:db8::80", "2001:db8::80"},
+		// IPv6 with explicit port 80 in brackets should be stripped.
+		{"http://[::1]:80/path", "::1"},
+		// IPv6 with explicit port 443 in brackets should be stripped.
+		{"http://[::1]:443/path", "::1"},
+		// IPv6 with non-default port should be preserved.
+		{"http://[::1]:8080/path", "[::1]:8080"},
+	}
+
+	for _, tt := range tests {
+		result := normalizeHost(tt.input)
+		if result != tt.expected {
+			t.Errorf("normalizeHost(%q) = %q, expected %q", tt.input, result, tt.expected)
+		}
+	}
+}
+
 func TestNormalizeHost(t *testing.T) {
 	tests := []struct {
 		input    string
@@ -257,6 +303,32 @@ func TestNormalizeHost(t *testing.T) {
 		result := normalizeHost(tt.input)
 		if result != tt.expected {
 			t.Errorf("normalizeHost(%q) = %q, expected %q", tt.input, result, tt.expected)
+		}
+	}
+}
+
+func TestStripDefaultPort(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"example.com:80", "example.com"},
+		{"example.com:443", "example.com"},
+		{"example.com:8080", "example.com:8080"},
+		{"example.com", "example.com"},
+		// IPv6 without brackets — no valid host:port split, returned as-is.
+		{"2001:db8::80", "2001:db8::80"},
+		// IPv6 with brackets and default port.
+		{"[::1]:80", "::1"},
+		{"[::1]:443", "::1"},
+		// IPv6 with brackets and non-default port.
+		{"[::1]:8080", "[::1]:8080"},
+	}
+
+	for _, tt := range tests {
+		result := stripDefaultPort(tt.input)
+		if result != tt.expected {
+			t.Errorf("stripDefaultPort(%q) = %q, expected %q", tt.input, result, tt.expected)
 		}
 	}
 }

--- a/pkg/scan/honeypot/tracker_test.go
+++ b/pkg/scan/honeypot/tracker_test.go
@@ -2,6 +2,7 @@ package honeypot
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 
@@ -245,7 +246,7 @@ func TestMaxHostsLimit(t *testing.T) {
 	tracker.RecordMatch("http://host2.com", "CVE-2021-0001")
 	tracker.RecordMatch("http://host3.com", "CVE-2021-0001")
 
-	// Fourth host should be silently dropped.
+	// Fourth host should be dropped.
 	tracker.RecordMatch("http://host4.com", "CVE-2021-0001")
 	if tracker.GetMatchCount("http://host4.com") != 0 {
 		t.Error("expected host4 to be dropped due to max hosts limit")
@@ -255,6 +256,132 @@ func TestMaxHostsLimit(t *testing.T) {
 	tracker.RecordMatch("http://host1.com", "CVE-2021-0002")
 	if tracker.GetMatchCount("http://host1.com") != 2 {
 		t.Errorf("expected 2 matches for host1, got %d", tracker.GetMatchCount("http://host1.com"))
+	}
+}
+
+func TestMaxHostsDroppedCounter(t *testing.T) {
+	tracker := NewTracker(100, nil)
+	tracker.maxHosts = 2
+
+	tracker.RecordMatch("http://host1.com", "CVE-2021-0001")
+	tracker.RecordMatch("http://host2.com", "CVE-2021-0001")
+
+	// These should be dropped and counted.
+	tracker.RecordMatch("http://host3.com", "CVE-2021-0001")
+	tracker.RecordMatch("http://host4.com", "CVE-2021-0001")
+	tracker.RecordMatch("http://host5.com", "CVE-2021-0001")
+
+	dropped := tracker.DroppedHosts()
+	if dropped != 3 {
+		t.Errorf("expected 3 dropped hosts, got %d", dropped)
+	}
+
+	// Summary should include the dropped hosts count.
+	summary := tracker.Summary()
+	if summary == "" {
+		t.Error("expected non-empty summary when hosts are dropped")
+	}
+	if !strings.Contains(summary, "3 host(s) excluded") {
+		t.Errorf("expected summary to mention 3 excluded hosts, got: %s", summary)
+	}
+	if !strings.Contains(summary, "max hosts limit: 2") {
+		t.Errorf("expected summary to mention max hosts limit of 2, got: %s", summary)
+	}
+}
+
+func TestSummaryDroppedHostsOnly(t *testing.T) {
+	// Verify Summary returns content when there are dropped hosts but no flagged hosts.
+	tracker := NewTracker(1000, nil) // High threshold so nothing gets flagged.
+	tracker.maxHosts = 1
+
+	tracker.RecordMatch("http://host1.com", "CVE-2021-0001")
+	tracker.RecordMatch("http://host2.com", "CVE-2021-0001") // Dropped.
+
+	if tracker.DroppedHosts() != 1 {
+		t.Errorf("expected 1 dropped host, got %d", tracker.DroppedHosts())
+	}
+
+	summary := tracker.Summary()
+	if summary == "" {
+		t.Error("expected non-empty summary when hosts are dropped (even with no flagged hosts)")
+	}
+	if !strings.Contains(summary, "1 host(s) excluded") {
+		t.Errorf("expected summary to mention excluded hosts, got: %s", summary)
+	}
+}
+
+func TestShouldFlagReason(t *testing.T) {
+	// Test that shouldFlag returns the correct reason.
+	tracker := NewTracker(5, nil)
+
+	// Below threshold: not flagged.
+	reason := tracker.shouldFlag(3)
+	if reason != notFlagged {
+		t.Errorf("expected notFlagged for 3 matches, got %v", reason)
+	}
+
+	// At absolute threshold: flagAbsolute.
+	reason = tracker.shouldFlag(5)
+	if reason != flagAbsolute {
+		t.Errorf("expected flagAbsolute for 5 matches, got %v", reason)
+	}
+
+	// Test percentage-based detection.
+	tracker2 := NewTracker(1000, nil) // High absolute threshold.
+	tracker2.SetTotalTemplates(20)
+
+	// 14/20 = 70% -- below 75%.
+	reason = tracker2.shouldFlag(14)
+	if reason != notFlagged {
+		t.Errorf("expected notFlagged for 14/20 (70%%), got %v", reason)
+	}
+
+	// 15/20 = 75% -- should trigger percentage.
+	reason = tracker2.shouldFlag(15)
+	if reason != flagPercentage {
+		t.Errorf("expected flagPercentage for 15/20 (75%%), got %v", reason)
+	}
+}
+
+func TestFlagReasonString(t *testing.T) {
+	tests := []struct {
+		reason   flagReason
+		expected string
+	}{
+		{notFlagged, ""},
+		{flagAbsolute, "absolute threshold"},
+		{flagPercentage, "percentage-of-templates threshold"},
+	}
+	for _, tt := range tests {
+		got := tt.reason.String()
+		if got != tt.expected {
+			t.Errorf("flagReason(%d).String() = %q, expected %q", tt.reason, got, tt.expected)
+		}
+	}
+}
+
+func TestGetFlaggedHostsSortTieBreaker(t *testing.T) {
+	tracker := NewTracker(2, nil)
+
+	// Create multiple hosts with the same match count.
+	tracker.RecordMatch("http://charlie.com", "CVE-2021-0001")
+	tracker.RecordMatch("http://charlie.com", "CVE-2021-0002")
+	tracker.RecordMatch("http://alpha.com", "CVE-2021-0001")
+	tracker.RecordMatch("http://alpha.com", "CVE-2021-0002")
+	tracker.RecordMatch("http://bravo.com", "CVE-2021-0001")
+	tracker.RecordMatch("http://bravo.com", "CVE-2021-0002")
+
+	flagged := tracker.GetFlaggedHosts()
+	if len(flagged) != 3 {
+		t.Fatalf("expected 3 flagged hosts, got %d", len(flagged))
+	}
+
+	// All have same match count, so should be sorted by host name ascending.
+	expectedOrder := []string{"alpha.com", "bravo.com", "charlie.com"}
+	for i, expected := range expectedOrder {
+		if flagged[i].Host != expected {
+			t.Errorf("flagged[%d].Host = %q, expected %q", i, flagged[i].Host, expected)
+		}
 	}
 }
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -465,6 +465,10 @@ type Options struct {
 	ExecutionId string
 	// Parser is a cached parser for the template store
 	Parser any
+	// HoneypotDetection enables honeypot detection to identify hosts matching too many templates
+	HoneypotDetection bool
+	// HoneypotThreshold is the number of template matches per host that triggers honeypot detection
+	HoneypotThreshold int
 	// timeouts contains various types of timeouts used in nuclei
 	// these timeouts are derived from dial-timeout (-timeout) with known multipliers
 	// This is internally managed and does not need to be set by user by explicitly setting
@@ -684,6 +688,8 @@ func (options *Options) Copy() *Options {
 		DoNotCacheTemplates:            options.DoNotCacheTemplates,
 		ExecutionId:                    options.ExecutionId,
 		Parser:                         options.Parser,
+		HoneypotDetection:             options.HoneypotDetection,
+		HoneypotThreshold:             options.HoneypotThreshold,
 	}
 	optCopy.SetTimeouts(options.timeouts)
 	return optCopy


### PR DESCRIPTION
## Summary

Adds per-host template match tracking to detect potential honeypots — hosts that respond positively to an abnormally high number of vulnerability checks, producing unreliable scan results.

- **`pkg/scan/honeypot/tracker.go`** — Thread-safe per-host match counter with absolute threshold and percentage-based detection modes
- **`pkg/output/honeypot_writer.go`** — Writer wrapper implementing `output.Writer` that intercepts results, tracks matches, and annotates flagged hosts with `[HONEYPOT?]` prefix + metadata
- **`--honeypot-detection` (`-hpd`)** and **`--honeypot-threshold` (`-hpt`)** CLI flags in the Input group
- Post-scan summary listing all flagged hosts and their match counts
- 13 unit tests including concurrency safety and host normalization

### How it works

1. `HoneypotWriter` wraps the existing output writer and intercepts `Write()` calls
2. Each successful match records the `(host, templateID)` pair in the tracker
3. When a host exceeds the threshold (default: 100 unique templates, or 75%+ of total templates with ≥10 matches), it's flagged
4. Flagged results are annotated with `[HONEYPOT?]` prefix and `honeypot_warning`/`honeypot_match_count` metadata
5. Post-scan summary warns about flagged hosts

### Usage

```bash
nuclei -l targets.txt -honeypot-detection
nuclei -l targets.txt -hpd -hpt 50  # custom threshold
```

## Test plan

- [x] `go build ./...` compiles clean
- [x] `go test ./pkg/scan/honeypot/` — 13/13 tests pass
- [x] Tests cover: threshold detection, percentage-based detection, duplicate dedup, host normalization (URL/IP/ports), concurrent access, empty input, summary output

Closes #6403

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional honeypot detection with CLI flags to enable it and set match thresholds.
  * Scan output annotated to mark hosts identified as honeypots; summary shown at scan completion.
  * Concurrent, per-host detection with absolute and percentage-based thresholding and configurable limits; integrates into runtime output.

* **Tests**
  * Comprehensive unit tests covering detection rules, host normalization, concurrency, edge cases, ordering, and summary output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->