### PR TITLE
feat(profiles): support extra metadata fields and inline secrets

### DIFF
--- a/cmd/integration-test/profile-loader.go
+++ b/cmd/integration-test/profile-loader.go
@@ -11,6 +11,7 @@ var profileLoaderTestcases = []TestCaseInfo{
 	{Path: "profile-loader/load-with-filename", TestCase: &profileLoaderByRelFile{}},
 	{Path: "profile-loader/load-with-id", TestCase: &profileLoaderById{}},
 	{Path: "profile-loader/basic.yml", TestCase: &customProfileLoader{}},
+	{Path: "profile-loader/with-extras.yml", TestCase: &profileWithExtrasLoader{}},
 }
 
 type profileLoaderByRelFile struct{}
@@ -46,6 +47,21 @@ func (h *customProfileLoader) Execute(filepath string) error {
 	results, err := testutils.RunNucleiWithArgsAndGetResults(debug, "-tl", "-tp", filepath)
 	if err != nil {
 		return errkit.Wrap(err, "failed to load template with id")
+	}
+	if len(results) < 1 {
+		return fmt.Errorf("incorrect result: expected more results than %d, got %v", 1, len(results))
+	}
+	return nil
+}
+
+// profileWithExtrasLoader tests that profiles with extra metadata fields
+// (id, name, purpose, description) are loaded without errors
+type profileWithExtrasLoader struct{}
+
+func (h *profileWithExtrasLoader) Execute(filepath string) error {
+	results, err := testutils.RunNucleiWithArgsAndGetResults(debug, "-tl", "-tp", filepath)
+	if err != nil {
+		return errkit.Wrap(err, "failed to load profile with extra metadata fields")
 	}
 	if len(results) < 1 {
 		return fmt.Errorf("incorrect result: expected more results than %d, got %v", 1, len(results))

--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -720,16 +720,12 @@ Additional documentation is available at: https://docs.nuclei.sh/getting-started
 func processProfileExtras(profilePath string) error {
 	profileData, err := os.ReadFile(profilePath)
 	if err != nil {
-		options.Logger.Warning().Msgf("Could not read profile for extras: %s", err)
-		return nil
+		return fmt.Errorf("could not read profile extras from %s: %w", profilePath, err)
 	}
 
 	var profileMap map[string]interface{}
 	if err := yaml.Unmarshal(profileData, &profileMap); err != nil {
-		// The YAML was already successfully parsed by MergeConfigFile,
-		// so this error is unexpected. Log and continue.
-		options.Logger.Warning().Msgf("Could not parse profile extras: %s", err)
-		return nil
+		return fmt.Errorf("could not parse profile extras from %s: %w", profilePath, err)
 	}
 
 	// Clear previous profile metadata so that a later file that omits
@@ -857,9 +853,9 @@ func readFlagsConfig(flagset *goflags.FlagSet) {
 	// Process profile extras (metadata and inline secrets) for the
 	// auto-loaded config file so that secrets and metadata are not
 	// silently ignored when loaded via NUCLEI_CONFIG_DIR.
+	// Non-fatal here since the settings config may not contain profile extras.
 	if err := processProfileExtras(cfgFile); err != nil {
-		cleanupTempFiles() // Fatal calls os.Exit which skips defers
-		options.Logger.Fatal().Msgf("Could not process profile extras from auto-loaded config: %s\n", err)
+		options.Logger.Warning().Msgf("Could not process profile extras from auto-loaded config: %s\n", err)
 	}
 }
 

--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -603,7 +603,10 @@ Additional documentation is available at: https://docs.nuclei.sh/getting-started
 			options.Logger.Fatal().Msgf("Could not read config: %s\n", err)
 		}
 		// Extract metadata and inline secrets from the config file
-		processProfileExtras(cfgFile)
+		if err := processProfileExtras(cfgFile); err != nil {
+			cleanupTempFiles() // Fatal calls os.Exit which skips defers
+			options.Logger.Fatal().Msgf("Could not process profile extras from config: %s\n", err)
+		}
 
 		if !options.Vars.IsEmpty() {
 			// Maybe we should add vars to the config file as well even if they are set via flags?
@@ -682,7 +685,10 @@ Additional documentation is available at: https://docs.nuclei.sh/getting-started
 		}
 		// Read the profile YAML to extract metadata fields and inline secrets
 		// that goflags does not handle (since they are not registered CLI flags).
-		processProfileExtras(templateProfile)
+		if err := processProfileExtras(templateProfile); err != nil {
+			cleanupTempFiles() // Fatal calls os.Exit which skips defers
+			options.Logger.Fatal().Msgf("Could not process profile extras: %s\n", err)
+		}
 	}
 
 	if len(options.SecretsFile) > 0 {
@@ -704,11 +710,15 @@ Additional documentation is available at: https://docs.nuclei.sh/getting-started
 //     in options for informational purposes.
 //   - Inline secrets (secrets key) which are extracted and written to a
 //     temporary file so the auth provider can consume them.
-func processProfileExtras(profilePath string) {
+//
+// Returns an error if inline secrets are present but cannot be processed,
+// since silently dropping authentication would cause the user to believe
+// their secrets are being used when they are not.
+func processProfileExtras(profilePath string) error {
 	profileData, err := os.ReadFile(profilePath)
 	if err != nil {
 		options.Logger.Warning().Msgf("Could not read profile for extras: %s", err)
-		return
+		return nil
 	}
 
 	var profileMap map[string]interface{}
@@ -716,7 +726,7 @@ func processProfileExtras(profilePath string) {
 		// The YAML was already successfully parsed by MergeConfigFile,
 		// so this error is unexpected. Log and continue.
 		options.Logger.Warning().Msgf("Could not parse profile extras: %s", err)
-		return
+		return nil
 	}
 
 	// Feature A: Extract profile metadata fields.
@@ -750,11 +760,14 @@ func processProfileExtras(profilePath string) {
 	// When a profile YAML contains a "secrets" key with embedded auth configuration,
 	// we extract it, write it to a temp file, and add that file to SecretsFile
 	// so the existing auth provider pipeline can process it.
+	//
+	// Errors in this section are returned (not just logged) because silently
+	// dropping secrets would cause scans to run without authentication,
+	// which the user would not expect.
 	if secrets, ok := profileMap["secrets"]; ok && secrets != nil {
 		secretsYAML, err := yaml.Marshal(secrets)
 		if err != nil {
-			options.Logger.Warning().Msgf("Could not marshal inline secrets: %s", err)
-			return
+			return fmt.Errorf("could not marshal inline secrets: %w", err)
 		}
 
 		// Store the raw YAML for potential programmatic use
@@ -763,23 +776,27 @@ func processProfileExtras(profilePath string) {
 		// Write to a temp file so the file-based auth provider can consume it
 		tmpFile, err := os.CreateTemp("", "nuclei-inline-secrets-*.yaml")
 		if err != nil {
-			options.Logger.Warning().Msgf("Could not create temp file for inline secrets: %s", err)
-			return
+			return fmt.Errorf("could not create temp file for inline secrets: %w", err)
 		}
 
 		if _, err := tmpFile.Write(secretsYAML); err != nil {
 			_ = tmpFile.Close()
 			_ = os.Remove(tmpFile.Name())
-			options.Logger.Warning().Msgf("Could not write inline secrets to temp file: %s", err)
-			return
+			return fmt.Errorf("could not write inline secrets to temp file: %w", err)
 		}
-		_ = tmpFile.Close()
+
+		if err := tmpFile.Close(); err != nil {
+			_ = os.Remove(tmpFile.Name())
+			return fmt.Errorf("could not close inline secrets temp file: %w", err)
+		}
 
 		options.Logger.Debug().Msg("Extracted inline secrets from profile to temp file")
 		options.SecretsFile = append(options.SecretsFile, tmpFile.Name())
 		// Track for cleanup on exit
 		tempFiles = append(tempFiles, tmpFile.Name())
 	}
+
+	return nil
 }
 
 // cleanupTempFiles removes temporary files created during profile processing.

--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -51,6 +51,9 @@ var (
 	templateProfile string
 	memProfile      string // optional profile file path
 	options         = &types.Options{}
+	// tempFiles tracks temporary files created during profile processing
+	// that should be cleaned up on exit.
+	tempFiles []string
 )
 
 func main() {
@@ -63,6 +66,9 @@ func main() {
 		options.Logger.Fatal().Msgf("Could not initialize options: %s\n", err)
 	}
 	_ = readConfig()
+
+	// Clean up any temp files created during profile processing on exit
+	defer cleanupTempFiles()
 
 	if options.ListDslSignatures {
 		options.Logger.Info().Msgf("The available custom DSL functions are:")
@@ -584,10 +590,14 @@ Additional documentation is available at: https://docs.nuclei.sh/getting-started
 		if !fileutil.FileExists(cfgFile) {
 			options.Logger.Fatal().Msgf("given config file '%s' does not exist", cfgFile)
 		}
-		// merge config file with flags
+		// MergeConfigFile only processes known flags and silently ignores
+		// extra fields. This allows users to add metadata or other custom
+		// fields to their config YAML without causing errors.
 		if err := flagSet.MergeConfigFile(cfgFile); err != nil {
 			options.Logger.Fatal().Msgf("Could not read config: %s\n", err)
 		}
+		// Extract metadata and inline secrets from the config file
+		processProfileExtras(cfgFile)
 
 		if !options.Vars.IsEmpty() {
 			// Maybe we should add vars to the config file as well even if they are set via flags?
@@ -656,9 +666,15 @@ Additional documentation is available at: https://docs.nuclei.sh/getting-started
 		if !fileutil.FileExists(templateProfile) {
 			options.Logger.Fatal().Msgf("given template profile file '%s' does not exist", templateProfile)
 		}
+		// MergeConfigFile only processes known flags and silently ignores
+		// extra fields like id, name, purpose, description. This allows
+		// users to add metadata to their profile YAML without errors.
 		if err := flagSet.MergeConfigFile(templateProfile); err != nil {
 			options.Logger.Fatal().Msgf("Could not read template profile: %s\n", err)
 		}
+		// Read the profile YAML to extract metadata fields and inline secrets
+		// that goflags does not handle (since they are not registered CLI flags).
+		processProfileExtras(templateProfile)
 	}
 
 	if len(options.SecretsFile) > 0 {
@@ -671,6 +687,97 @@ Additional documentation is available at: https://docs.nuclei.sh/getting-started
 
 	cleanupOldResumeFiles()
 	return flagSet
+}
+
+// processProfileExtras reads the profile YAML file to extract extra fields
+// that are not registered as goflags CLI flags. This includes:
+//   - Profile metadata (id, name, purpose, description) which are stored
+//     in options for informational purposes.
+//   - Inline secrets (secrets key) which are extracted and written to a
+//     temporary file so the auth provider can consume them.
+func processProfileExtras(profilePath string) {
+	profileData, err := os.ReadFile(profilePath)
+	if err != nil {
+		options.Logger.Warning().Msgf("Could not read profile for extras: %s", err)
+		return
+	}
+
+	var profileMap map[string]interface{}
+	if err := yaml.Unmarshal(profileData, &profileMap); err != nil {
+		// The YAML was already successfully parsed by MergeConfigFile,
+		// so this error is unexpected. Log and continue.
+		options.Logger.Warning().Msgf("Could not parse profile extras: %s", err)
+		return
+	}
+
+	// Feature A: Extract profile metadata fields.
+	// These allow users to document their profiles with descriptive fields.
+	if id, ok := profileMap["id"]; ok {
+		if s, ok := id.(string); ok {
+			options.ProfileID = s
+		}
+	}
+	if name, ok := profileMap["name"]; ok {
+		if s, ok := name.(string); ok {
+			options.ProfileName = s
+		}
+	}
+	if purpose, ok := profileMap["purpose"]; ok {
+		if s, ok := purpose.(string); ok {
+			options.ProfilePurpose = s
+		}
+	}
+	if description, ok := profileMap["description"]; ok {
+		if s, ok := description.(string); ok {
+			options.ProfileDescription = s
+		}
+	}
+
+	if options.ProfileName != "" {
+		options.Logger.Info().Msgf("Loaded profile: %s", options.ProfileName)
+	}
+
+	// Feature B: Extract inline secrets and create a temp file for the auth provider.
+	// When a profile YAML contains a "secrets" key with embedded auth configuration,
+	// we extract it, write it to a temp file, and add that file to SecretsFile
+	// so the existing auth provider pipeline can process it.
+	if secrets, ok := profileMap["secrets"]; ok && secrets != nil {
+		secretsYAML, err := yaml.Marshal(secrets)
+		if err != nil {
+			options.Logger.Warning().Msgf("Could not marshal inline secrets: %s", err)
+			return
+		}
+
+		// Store the raw YAML for potential programmatic use
+		options.InlineSecretsYAML = secretsYAML
+
+		// Write to a temp file so the file-based auth provider can consume it
+		tmpFile, err := os.CreateTemp("", "nuclei-inline-secrets-*.yaml")
+		if err != nil {
+			options.Logger.Warning().Msgf("Could not create temp file for inline secrets: %s", err)
+			return
+		}
+
+		if _, err := tmpFile.Write(secretsYAML); err != nil {
+			_ = tmpFile.Close()
+			_ = os.Remove(tmpFile.Name())
+			options.Logger.Warning().Msgf("Could not write inline secrets to temp file: %s", err)
+			return
+		}
+		_ = tmpFile.Close()
+
+		options.Logger.Info().Msgf("Extracted inline secrets from profile to: %s", tmpFile.Name())
+		options.SecretsFile = append(options.SecretsFile, tmpFile.Name())
+		// Track for cleanup on exit
+		tempFiles = append(tempFiles, tmpFile.Name())
+	}
+}
+
+// cleanupTempFiles removes temporary files created during profile processing.
+func cleanupTempFiles() {
+	for _, f := range tempFiles {
+		_ = os.Remove(f)
+	}
 }
 
 // cleanupOldResumeFiles cleans up resume files older than 10 days.

--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -172,6 +172,7 @@ func main() {
 
 	if options.ScanUploadFile != "" {
 		if err := runner.UploadResultsToCloud(options); err != nil {
+			cleanupTempFiles() // Fatal calls os.Exit which skips defers
 			options.Logger.Fatal().Msgf("could not upload scan results to cloud dashboard: %s\n", err)
 		}
 		return
@@ -179,6 +180,7 @@ func main() {
 
 	nucleiRunner, err := runner.New(options)
 	if err != nil {
+		cleanupTempFiles() // Fatal calls os.Exit which skips defers
 		options.Logger.Fatal().Msgf("Could not create runner: %s\n", err)
 	}
 	if nucleiRunner == nil {
@@ -237,6 +239,7 @@ func main() {
 	}()
 
 	if err := nucleiRunner.RunEnumeration(); err != nil {
+		cleanupTempFiles() // Fatal calls os.Exit which skips defers
 		if options.Validate {
 			options.Logger.Fatal().Msgf("Could not validate templates: %s\n", err)
 		} else {
@@ -729,6 +732,14 @@ func processProfileExtras(profilePath string) error {
 		return nil
 	}
 
+	// Clear previous profile metadata so that a later file that omits
+	// a field does not inherit stale values from an earlier file.
+	// This matters when both --config and --profile are used.
+	options.ProfileID = ""
+	options.ProfileName = ""
+	options.ProfilePurpose = ""
+	options.ProfileDescription = ""
+
 	// Feature A: Extract profile metadata fields.
 	// These allow users to document their profiles with descriptive fields.
 	if id, ok := profileMap["id"]; ok {
@@ -840,12 +851,15 @@ func readFlagsConfig(flagset *goflags.FlagSet) {
 		return
 	}
 	// if config file exists, merge it with the default config.
-	// Note: processProfileExtras is intentionally NOT called here because
-	// this is the nuclei settings config file, not a user profile. Profile
-	// extras (id, name, purpose, description, inline secrets) are only
-	// processed for explicit --config and --profile inputs.
 	if err = flagset.MergeConfigFile(cfgFile); err != nil {
 		options.Logger.Warning().Msgf("failed to merge configfile with flags got: %s\n", err)
+	}
+	// Process profile extras (metadata and inline secrets) for the
+	// auto-loaded config file so that secrets and metadata are not
+	// silently ignored when loaded via NUCLEI_CONFIG_DIR.
+	if err := processProfileExtras(cfgFile); err != nil {
+		cleanupTempFiles() // Fatal calls os.Exit which skips defers
+		options.Logger.Fatal().Msgf("Could not process profile extras from auto-loaded config: %s\n", err)
 	}
 }
 

--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -65,10 +65,14 @@ func main() {
 	if err := runner.ConfigureOptions(); err != nil {
 		options.Logger.Fatal().Msgf("Could not initialize options: %s\n", err)
 	}
-	_ = readConfig()
 
-	// Clean up any temp files created during profile processing on exit
+	// Register temp file cleanup before readConfig, which may create
+	// inline-secrets temp files via processProfileExtras. Note: defer
+	// only runs on normal return; Fatal()/os.Exit() paths have explicit
+	// cleanupTempFiles() calls to ensure secrets are never left on disk.
 	defer cleanupTempFiles()
+
+	_ = readConfig()
 
 	if options.ListDslSignatures {
 		options.Logger.Info().Msgf("The available custom DSL functions are:")
@@ -605,6 +609,7 @@ Additional documentation is available at: https://docs.nuclei.sh/getting-started
 			// Maybe we should add vars to the config file as well even if they are set via flags?
 			file, err := os.Open(cfgFile)
 			if err != nil {
+				cleanupTempFiles() // Fatal calls os.Exit which skips defers
 				gologger.Fatal().Msgf("Could not open config file: %s\n", err)
 			}
 			defer func() {
@@ -613,6 +618,7 @@ Additional documentation is available at: https://docs.nuclei.sh/getting-started
 			data := make(map[string]interface{})
 			err = yaml.NewDecoder(file).Decode(&data)
 			if err != nil {
+				cleanupTempFiles() // Fatal calls os.Exit which skips defers
 				gologger.Fatal().Msgf("Could not decode config file: %s\n", err)
 			}
 
@@ -682,6 +688,7 @@ Additional documentation is available at: https://docs.nuclei.sh/getting-started
 	if len(options.SecretsFile) > 0 {
 		for _, secretFile := range options.SecretsFile {
 			if !fileutil.FileExists(secretFile) {
+				cleanupTempFiles() // Fatal calls os.Exit which skips defers
 				options.Logger.Fatal().Msgf("given secrets file '%s' does not exist", secretFile)
 			}
 		}

--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -212,6 +212,7 @@ func main() {
 		options.Logger.Info().Msgf("CTRL+C pressed: Exiting\n")
 		if options.DASTServer {
 			nucleiRunner.Close()
+			cleanupTempFiles()
 			os.Exit(1)
 		}
 
@@ -227,6 +228,7 @@ func main() {
 				options.Logger.Error().Msgf("Couldn't create resume file: %s\n", err)
 			}
 		}
+		cleanupTempFiles()
 		os.Exit(1)
 	}()
 
@@ -766,7 +768,7 @@ func processProfileExtras(profilePath string) {
 		}
 		_ = tmpFile.Close()
 
-		options.Logger.Info().Msgf("Extracted inline secrets from profile to: %s", tmpFile.Name())
+		options.Logger.Debug().Msg("Extracted inline secrets from profile to temp file")
 		options.SecretsFile = append(options.SecretsFile, tmpFile.Name())
 		// Track for cleanup on exit
 		tempFiles = append(tempFiles, tmpFile.Name())
@@ -813,7 +815,11 @@ func readFlagsConfig(flagset *goflags.FlagSet) {
 		}
 		return
 	}
-	// if config file exists, merge it with the default config
+	// if config file exists, merge it with the default config.
+	// Note: processProfileExtras is intentionally NOT called here because
+	// this is the nuclei settings config file, not a user profile. Profile
+	// extras (id, name, purpose, description, inline secrets) are only
+	// processed for explicit --config and --profile inputs.
 	if err = flagset.MergeConfigFile(cfgFile); err != nil {
 		options.Logger.Warning().Msgf("failed to merge configfile with flags got: %s\n", err)
 	}

--- a/cmd/nuclei/profile_extras_test.go
+++ b/cmd/nuclei/profile_extras_test.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/projectdiscovery/gologger"
+	"github.com/projectdiscovery/nuclei/v3/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProcessProfileExtras_MetadataFields(t *testing.T) {
+	// Save and restore global options
+	origOptions := options
+	origTempFiles := tempFiles
+	defer func() {
+		// Clean up any temp files created during the test
+		for _, f := range tempFiles {
+			_ = os.Remove(f)
+		}
+		options = origOptions
+		tempFiles = origTempFiles
+	}()
+
+	options = &types.Options{Logger: gologger.DefaultLogger}
+	tempFiles = nil
+
+	processProfileExtras("testdata/test-profile-with-extras.yaml")
+
+	require.Equal(t, "test-profile", options.ProfileID, "ProfileID should be extracted")
+	require.Equal(t, "Test Profile", options.ProfileName, "ProfileName should be extracted")
+	require.Equal(t, "Testing profile improvements", options.ProfilePurpose, "ProfilePurpose should be extracted")
+	require.Equal(t, "This profile demonstrates metadata fields and inline secrets", options.ProfileDescription, "ProfileDescription should be extracted")
+}
+
+func TestProcessProfileExtras_InlineSecrets(t *testing.T) {
+	origOptions := options
+	origTempFiles := tempFiles
+	defer func() {
+		options = origOptions
+		tempFiles = origTempFiles
+	}()
+
+	options = &types.Options{Logger: gologger.DefaultLogger}
+	tempFiles = nil
+
+	processProfileExtras("testdata/test-profile-with-extras.yaml")
+
+	// InlineSecretsYAML should be populated
+	require.NotEmpty(t, options.InlineSecretsYAML, "InlineSecretsYAML should be populated")
+
+	// A temp file should have been created and added to SecretsFile
+	require.Len(t, options.SecretsFile, 1, "SecretsFile should have one entry for inline secrets")
+
+	// Verify the temp file exists and contains valid YAML
+	tmpPath := string(options.SecretsFile[0])
+	_, err := os.Stat(tmpPath)
+	require.NoError(t, err, "temp secrets file should exist")
+
+	// The temp file should also be tracked for cleanup
+	require.Len(t, tempFiles, 1, "tempFiles should track the created file")
+	require.Equal(t, tmpPath, tempFiles[0])
+
+	// Clean up
+	_ = os.Remove(tmpPath)
+}
+
+func TestProcessProfileExtras_NoSecretsField(t *testing.T) {
+	origOptions := options
+	defer func() { options = origOptions }()
+
+	// Create a temp profile without secrets
+	tmpFile, err := os.CreateTemp("", "test-profile-*.yaml")
+	require.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+
+	_, err = tmpFile.WriteString(`
+id: simple-profile
+name: Simple Profile
+tags:
+  - cve
+timeout: 30
+`)
+	require.NoError(t, err)
+	_ = tmpFile.Close()
+
+	options = &types.Options{Logger: gologger.DefaultLogger}
+
+	processProfileExtras(tmpFile.Name())
+
+	require.Equal(t, "simple-profile", options.ProfileID)
+	require.Equal(t, "Simple Profile", options.ProfileName)
+	require.Empty(t, options.SecretsFile, "SecretsFile should be empty when no secrets in profile")
+	require.Empty(t, options.InlineSecretsYAML, "InlineSecretsYAML should be empty when no secrets in profile")
+}
+
+func TestProcessProfileExtras_InvalidFile(t *testing.T) {
+	origOptions := options
+	defer func() { options = origOptions }()
+
+	options = &types.Options{Logger: gologger.DefaultLogger}
+
+	// Should not panic on non-existent file
+	processProfileExtras("/nonexistent/path/profile.yaml")
+
+	require.Empty(t, options.ProfileID)
+	require.Empty(t, options.ProfileName)
+}
+
+func TestProcessProfileExtras_ExtraUnknownFields(t *testing.T) {
+	origOptions := options
+	defer func() { options = origOptions }()
+
+	// Create a temp profile with many unknown fields
+	tmpFile, err := os.CreateTemp("", "test-profile-extras-*.yaml")
+	require.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+
+	_, err = tmpFile.WriteString(`
+id: extras-profile
+name: Extras Profile
+purpose: Test extra fields tolerance
+description: Profile with many custom fields
+custom-field-1: value1
+custom-field-2: value2
+organization: acme-corp
+scan-owner: john@example.com
+version: 2
+tags:
+  - cve
+`)
+	require.NoError(t, err)
+	_ = tmpFile.Close()
+
+	options = &types.Options{Logger: gologger.DefaultLogger}
+
+	processProfileExtras(tmpFile.Name())
+
+	// Known metadata fields should be extracted
+	require.Equal(t, "extras-profile", options.ProfileID)
+	require.Equal(t, "Extras Profile", options.ProfileName)
+	require.Equal(t, "Test extra fields tolerance", options.ProfilePurpose)
+	require.Equal(t, "Profile with many custom fields", options.ProfileDescription)
+
+	// No errors, no secrets
+	require.Empty(t, options.SecretsFile)
+}
+
+func TestCleanupTempFiles(t *testing.T) {
+	// Create a temp file
+	tmpFile, err := os.CreateTemp("", "test-cleanup-*.yaml")
+	require.NoError(t, err)
+	_ = tmpFile.Close()
+
+	// Add to tempFiles list
+	origTempFiles := tempFiles
+	defer func() { tempFiles = origTempFiles }()
+
+	tempFiles = []string{tmpFile.Name()}
+
+	// Verify file exists
+	_, err = os.Stat(tmpFile.Name())
+	require.NoError(t, err)
+
+	// Run cleanup
+	cleanupTempFiles()
+
+	// Verify file was removed
+	_, err = os.Stat(tmpFile.Name())
+	require.True(t, os.IsNotExist(err), "temp file should have been removed")
+}

--- a/cmd/nuclei/profile_extras_test.go
+++ b/cmd/nuclei/profile_extras_test.go
@@ -103,13 +103,11 @@ func TestProcessProfileExtras_InvalidFile(t *testing.T) {
 
 	options = &types.Options{Logger: gologger.DefaultLogger}
 
-	// Should not panic or return error on non-existent file
-	// (file read failure is a warning, not an error — no secrets to silently drop)
+	// Should return error on non-existent file to fail fast and prevent
+	// silently running without expected profile extras
 	err := processProfileExtras("/nonexistent/path/profile.yaml")
-	require.NoError(t, err, "non-existent file should not return an error (only warns)")
-
-	require.Empty(t, options.ProfileID)
-	require.Empty(t, options.ProfileName)
+	require.Error(t, err, "non-existent file should return an error")
+	require.Contains(t, err.Error(), "could not read profile extras")
 }
 
 func TestProcessProfileExtras_ExtraUnknownFields(t *testing.T) {

--- a/cmd/nuclei/profile_extras_test.go
+++ b/cmd/nuclei/profile_extras_test.go
@@ -25,7 +25,8 @@ func TestProcessProfileExtras_MetadataFields(t *testing.T) {
 	options = &types.Options{Logger: gologger.DefaultLogger}
 	tempFiles = nil
 
-	processProfileExtras("testdata/test-profile-with-extras.yaml")
+	err := processProfileExtras("testdata/test-profile-with-extras.yaml")
+	require.NoError(t, err, "processProfileExtras should not return an error for a valid profile")
 
 	require.Equal(t, "test-profile", options.ProfileID, "ProfileID should be extracted")
 	require.Equal(t, "Test Profile", options.ProfileName, "ProfileName should be extracted")
@@ -44,7 +45,8 @@ func TestProcessProfileExtras_InlineSecrets(t *testing.T) {
 	options = &types.Options{Logger: gologger.DefaultLogger}
 	tempFiles = nil
 
-	processProfileExtras("testdata/test-profile-with-extras.yaml")
+	err := processProfileExtras("testdata/test-profile-with-extras.yaml")
+	require.NoError(t, err, "processProfileExtras should not return an error for valid inline secrets")
 
 	// InlineSecretsYAML should be populated
 	require.NotEmpty(t, options.InlineSecretsYAML, "InlineSecretsYAML should be populated")
@@ -54,7 +56,7 @@ func TestProcessProfileExtras_InlineSecrets(t *testing.T) {
 
 	// Verify the temp file exists and contains valid YAML
 	tmpPath := string(options.SecretsFile[0])
-	_, err := os.Stat(tmpPath)
+	_, err = os.Stat(tmpPath)
 	require.NoError(t, err, "temp secrets file should exist")
 
 	// The temp file should also be tracked for cleanup
@@ -86,7 +88,8 @@ timeout: 30
 
 	options = &types.Options{Logger: gologger.DefaultLogger}
 
-	processProfileExtras(tmpFile.Name())
+	err = processProfileExtras(tmpFile.Name())
+	require.NoError(t, err, "processProfileExtras should not return an error for a profile without secrets")
 
 	require.Equal(t, "simple-profile", options.ProfileID)
 	require.Equal(t, "Simple Profile", options.ProfileName)
@@ -100,8 +103,10 @@ func TestProcessProfileExtras_InvalidFile(t *testing.T) {
 
 	options = &types.Options{Logger: gologger.DefaultLogger}
 
-	// Should not panic on non-existent file
-	processProfileExtras("/nonexistent/path/profile.yaml")
+	// Should not panic or return error on non-existent file
+	// (file read failure is a warning, not an error — no secrets to silently drop)
+	err := processProfileExtras("/nonexistent/path/profile.yaml")
+	require.NoError(t, err, "non-existent file should not return an error (only warns)")
 
 	require.Empty(t, options.ProfileID)
 	require.Empty(t, options.ProfileName)
@@ -134,7 +139,8 @@ tags:
 
 	options = &types.Options{Logger: gologger.DefaultLogger}
 
-	processProfileExtras(tmpFile.Name())
+	err = processProfileExtras(tmpFile.Name())
+	require.NoError(t, err, "processProfileExtras should not return an error for a profile with extra unknown fields")
 
 	// Known metadata fields should be extracted
 	require.Equal(t, "extras-profile", options.ProfileID)

--- a/cmd/nuclei/testdata/test-profile-with-extras.yaml
+++ b/cmd/nuclei/testdata/test-profile-with-extras.yaml
@@ -1,0 +1,35 @@
+# Test profile with metadata fields and inline secrets
+id: test-profile
+name: Test Profile
+purpose: Testing profile improvements
+description: This profile demonstrates metadata fields and inline secrets
+
+# Standard nuclei flags
+tags:
+  - cve
+  - default-login
+exclude-tags:
+  - dos
+  - fuzz
+timeout: 30
+stats: true
+
+# Inline secrets
+secrets:
+  static:
+    - type: header
+      domains:
+        - api.example.com
+      headers:
+        - key: x-api-key
+          value: test-api-key-12345
+  dynamic:
+    - template: /path/to/oauth-flow.yaml
+      variables:
+        - name: username
+          value: testuser
+      type: Cookie
+      domains:
+        - example.com
+      cookies:
+        - raw: "{{session-cookie}}"

--- a/integration_tests/profile-loader/with-extras.yml
+++ b/integration_tests/profile-loader/with-extras.yml
@@ -1,0 +1,8 @@
+# Profile with extra metadata fields - should not cause errors
+id: test-extras
+name: Test Profile With Extras
+purpose: Integration test for extra fields tolerance
+description: This profile has metadata fields that should be silently handled
+
+tags:
+  - kev

--- a/pkg/authprovider/authx/file.go
+++ b/pkg/authprovider/authx/file.go
@@ -255,3 +255,34 @@ func GetAuthDataFromJSON(data []byte) (*Authx, error) {
 	}
 	return &auth, nil
 }
+
+// ExtractSecretsYAMLFromConfig extracts the secrets section from config YAML
+func ExtractSecretsYAMLFromConfig(configData []byte) ([]byte, error) {
+	var configMap map[string]interface{}
+	if err := yaml.Unmarshal(configData, &configMap); err != nil {
+		return nil, errkit.Wrapf(err, "failed to parse config YAML")
+	}
+
+	secrets, exists := configMap["secrets"]
+	if !exists {
+		return nil, fmt.Errorf("no secrets section found in config")
+	}
+
+	// Re-marshal just the secrets section
+	secretsYAML, err := yaml.Marshal(secrets)
+	if err != nil {
+		return nil, errkit.Wrapf(err, "failed to marshal secrets section")
+	}
+
+	return secretsYAML, nil
+}
+
+// ExtractAuthDataFromConfig extracts and parses auth data from config YAML
+func ExtractAuthDataFromConfig(configData []byte) (*Authx, error) {
+	secretsYAML, err := ExtractSecretsYAMLFromConfig(configData)
+	if err != nil {
+		return nil, errkit.Wrapf(err, "failed to extract secrets from config")
+	}
+
+	return GetAuthDataFromYAML(secretsYAML)
+}

--- a/pkg/authprovider/authx/file_test.go
+++ b/pkg/authprovider/authx/file_test.go
@@ -18,3 +18,112 @@ func TestSecretsUnmarshal(t *testing.T) {
 		require.Nil(t, d.Validate(), "could not validate dynamic")
 	}
 }
+
+func TestExtractSecretsYAMLFromConfig(t *testing.T) {
+	t.Run("extracts secrets section from config YAML", func(t *testing.T) {
+		configYAML := []byte(`
+name: test-profile
+purpose: testing
+tags:
+  - cve
+secrets:
+  static:
+    - type: header
+      domains:
+        - api.example.com
+      headers:
+        - key: x-api-key
+          value: test-key
+  dynamic:
+    - template: /path/to/auth.yaml
+      variables:
+        - name: username
+          value: admin
+      type: Cookie
+      domains:
+        - example.com
+      cookies:
+        - raw: "{{session-cookie}}"
+`)
+		secretsYAML, err := ExtractSecretsYAMLFromConfig(configYAML)
+		require.NoError(t, err, "should extract secrets section")
+		require.NotEmpty(t, secretsYAML, "secrets YAML should not be empty")
+
+		// Verify the extracted YAML can be parsed as auth data
+		authData, err := GetAuthDataFromYAML(secretsYAML)
+		require.NoError(t, err, "should parse extracted secrets YAML")
+		require.NotNil(t, authData, "auth data should not be nil")
+		require.Len(t, authData.Secrets, 1, "should have 1 static secret")
+		require.Equal(t, "header", authData.Secrets[0].Type)
+		require.Equal(t, []string{"api.example.com"}, authData.Secrets[0].Domains)
+		require.Len(t, authData.Secrets[0].Headers, 1)
+		require.Equal(t, "x-api-key", authData.Secrets[0].Headers[0].Key)
+		require.Len(t, authData.Dynamic, 1, "should have 1 dynamic secret")
+		require.Equal(t, "/path/to/auth.yaml", authData.Dynamic[0].TemplatePath)
+	})
+
+	t.Run("returns error when no secrets section", func(t *testing.T) {
+		configYAML := []byte(`
+name: test-profile
+tags:
+  - cve
+timeout: 30
+`)
+		_, err := ExtractSecretsYAMLFromConfig(configYAML)
+		require.Error(t, err, "should error when no secrets section")
+		require.Contains(t, err.Error(), "no secrets section")
+	})
+
+	t.Run("returns error for invalid YAML", func(t *testing.T) {
+		configYAML := []byte(`invalid: yaml: [`)
+		_, err := ExtractSecretsYAMLFromConfig(configYAML)
+		require.Error(t, err, "should error on invalid YAML")
+	})
+}
+
+func TestExtractAuthDataFromConfig(t *testing.T) {
+	configYAML := []byte(`
+name: test-profile
+purpose: scan with auth
+secrets:
+  static:
+    - type: BearerToken
+      domains:
+        - api.example.com
+      token: my-bearer-token
+`)
+	authData, err := ExtractAuthDataFromConfig(configYAML)
+	require.NoError(t, err, "should extract auth data from config")
+	require.NotNil(t, authData, "auth data should not be nil")
+	require.Len(t, authData.Secrets, 1, "should have 1 secret")
+	require.Equal(t, "BearerToken", authData.Secrets[0].Type)
+	require.Equal(t, "my-bearer-token", authData.Secrets[0].Token)
+	require.NoError(t, authData.Secrets[0].Validate(), "secret should be valid")
+}
+
+func TestConfigWithExtraFieldsDoesNotAffectSecrets(t *testing.T) {
+	// Verify that extra fields like id, name, purpose, description
+	// in the config YAML do not interfere with secrets extraction
+	configYAML := []byte(`
+id: my-profile-id
+name: My Profile
+purpose: Testing extra fields
+description: This profile has metadata and secrets
+custom-field: some-value
+another-extra: 123
+secrets:
+  static:
+    - type: header
+      domains:
+        - example.com
+      headers:
+        - key: Authorization
+          value: Bearer test123
+`)
+	authData, err := ExtractAuthDataFromConfig(configYAML)
+	require.NoError(t, err, "extra fields should not interfere with secrets extraction")
+	require.NotNil(t, authData)
+	require.Len(t, authData.Secrets, 1)
+	require.Equal(t, "header", authData.Secrets[0].Type)
+	require.NoError(t, authData.Secrets[0].Validate())
+}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -33,6 +33,12 @@ type LoadHelperFileFunction func(helperFile, templatePath string, catalog catalo
 
 // Options contains the configuration options for nuclei scanner.
 type Options struct {
+	// Profile metadata fields (allows additional info without errors)
+	ProfileID          string `yaml:"id,omitempty" json:"id,omitempty"`
+	ProfileName        string `yaml:"name,omitempty" json:"name,omitempty"`
+	ProfilePurpose     string `yaml:"purpose,omitempty" json:"purpose,omitempty"`
+	ProfileDescription string `yaml:"description,omitempty" json:"description,omitempty"`
+	
 	// Tags contains a list of tags to execute templates for. Multiple paths
 	// can be specified with -l flag and -tags can be used in combination with
 	// the -l flag.
@@ -420,6 +426,8 @@ type Options struct {
 	JsConcurrency int
 	// SecretsFile is file containing secrets for nuclei
 	SecretsFile goflags.StringSlice
+	// InlineSecretsYAML contains raw YAML bytes for inline secrets in profile
+	InlineSecretsYAML []byte
 	// PreFetchSecrets pre-fetches the secrets from the auth provider
 	PreFetchSecrets bool
 	// FormatUseRequiredOnly only uses required fields when generating requests
@@ -476,6 +484,10 @@ type Options struct {
 
 func (options *Options) Copy() *Options {
 	optCopy := &Options{
+		ProfileID:                      options.ProfileID,
+		ProfileName:                    options.ProfileName,
+		ProfilePurpose:                 options.ProfilePurpose,
+		ProfileDescription:             options.ProfileDescription,
 		Tags:                           options.Tags,
 		ExcludeTags:                    options.ExcludeTags,
 		Workflows:                      options.Workflows,
@@ -665,6 +677,7 @@ func (options *Options) Copy() *Options {
 		TeamID:                         options.TeamID,
 		JsConcurrency:                  options.JsConcurrency,
 		SecretsFile:                    options.SecretsFile,
+		InlineSecretsYAML:              options.InlineSecretsYAML,
 		PreFetchSecrets:                options.PreFetchSecrets,
 		FormatUseRequiredOnly:          options.FormatUseRequiredOnly,
 		SkipFormatValidation:           options.SkipFormatValidation,

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -426,8 +426,9 @@ type Options struct {
 	JsConcurrency int
 	// SecretsFile is file containing secrets for nuclei
 	SecretsFile goflags.StringSlice
-	// InlineSecretsYAML contains raw YAML bytes for inline secrets in profile
-	InlineSecretsYAML []byte
+	// InlineSecretsYAML contains raw YAML bytes for inline secrets in profile.
+	// Excluded from marshaling to prevent accidental secret leakage in dumps.
+	InlineSecretsYAML []byte `json:"-" yaml:"-"`
 	// PreFetchSecrets pre-fetches the secrets from the auth provider
 	PreFetchSecrets bool
 	// FormatUseRequiredOnly only uses required fields when generating requests


### PR DESCRIPTION
## Summary

Implements template profile improvements so that extra/unknown fields in profile YAML files are gracefully handled instead of causing errors, and inline secrets can be embedded directly in profiles.

- **Feature A: Ignore extra fields** — `processProfileExtras()` extracts recognized metadata (`id`, `name`, `purpose`, `description`) from profile YAML while silently ignoring unknown fields, since `goflags.MergeConfigFile` already handles this
- **Feature B: Inline secrets** — Extracts `secrets` key from profile YAML, writes to a temp file, and appends to `options.SecretsFile` so the existing auth provider pipeline processes it seamlessly
- **`ExtractSecretsYAMLFromConfig`** and **`ExtractAuthDataFromConfig`** helpers in `pkg/authprovider/authx/file.go`
- Profile metadata stored in `Options.ProfileID/Name/Purpose/Description` for downstream use
- Temp file cleanup on exit via `cleanupTempFiles()`
- 9 unit tests + integration test

### How it works

1. After `goflags.MergeConfigFile` loads the profile, `processProfileExtras()` re-reads the YAML
2. Metadata fields are extracted into Options struct fields
3. If a `secrets` section exists, it's marshaled to YAML, written to a temp file, and the path is appended to `options.SecretsFile`
4. The existing auth provider pipeline (`GetAuthDataFromFile`) picks up the temp file automatically
5. All temp files are cleaned up on exit

### Example profile with extras

```yaml
id: my-scan-profile
name: "Web App Security Scan"
purpose: "Full vulnerability assessment"
severity: critical,high
tags: cve,oast

secrets:
  - type: basicauth
    domains: ["*.example.com"]
    username: admin
    password: "${PASSWORD}"
```

## Test plan

- [x] `go build ./...` compiles clean
- [x] `go test ./cmd/nuclei/ -run TestProcessProfileExtras` — 5/5 pass
- [x] `go test ./cmd/nuclei/ -run TestCleanupTempFiles` — 1/1 pass
- [x] `go test ./pkg/authprovider/authx/ -run TestExtract` — 2/2 pass (with subtests)
- [x] `go test ./pkg/authprovider/authx/ -run TestConfigWithExtraFields` — 1/1 pass
- [x] Integration test added for profile loading with extras

Closes #5567

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Profile extras: runtime exposure of profile metadata (ID, name, purpose, description) in options.
  * Inline secrets: embedded secrets in profiles are extracted to temporary files and kept as raw YAML; helper utilities added to extract/parse secrets from YAML configs.

* **Bug Fixes / Reliability**
  * Temporary secret files are cleaned up on errors, exits and on CTRL+C; logging added for profile/load events.

* **Tests**
  * Added tests for profile extras, inline secrets lifecycle/cleanup, and secrets extraction/parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->