### PR TITLE
Integrate typos into CI

### DIFF
--- a/.github/workflows/typos.yaml
+++ b/.github/workflows/typos.yaml
@@ -1,0 +1,31 @@
+name: Typos
+
+on:
+  push:
+    branches: ["dev"]
+    paths:
+      - "**.go"
+      - "**.md"
+      - "**.json"
+      - "**.yaml"
+      - "**.yml"
+      - ".typos.toml"
+      - ".github/workflows/typos.yaml"
+  pull_request:
+    paths:
+      - "**.go"
+      - "**.md"
+      - "**.json"
+      - "**.yaml"
+      - "**.yml"
+      - ".typos.toml"
+      - ".github/workflows/typos.yaml"
+  workflow_dispatch:
+
+jobs:
+  typos:
+    name: Typos
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: crate-ci/typos@v1.38.1

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,30 @@
+[files]
+extend-exclude = [
+  "README*.md",
+  "integration_tests/**",
+  "pkg/input/formats/testdata/**",
+  "pkg/output/stats/waf/regexes.json",
+  "pkg/protocols/common/helpers/deserialization/testdata/**",
+  "pkg/testutils/fuzzplayground/db.go",
+  "pkg/testutils/integration.go",
+]
+
+[default.extend-words]
+Allowd = "Allowd"
+Exluded = "Exluded"
+Iif = "Iif"
+Mis = "Mis"
+MisMatched = "MisMatched"
+SELEC = "SELEC"
+abd = "abd"
+alo = "alo"
+ba = "ba"
+fo = "fo"
+hae = "hae"
+ine = "ine"
+ines = "ines"
+ot = "ot"
+splitted = "splitted"
+ue = "ue"
+up = "up"
+worflow = "worflow"

--- a/cmd/tmc/main.go
+++ b/cmd/tmc/main.go
@@ -196,14 +196,14 @@ func process(opts options) error {
 		}
 
 		if opts.format {
-			formatedTemplateData, isFormated, err := formatTemplate(dataString)
+			formattedTemplateData, isFormatted, err := formatTemplate(dataString)
 			if err != nil {
 				gologger.Info().Label("format").Msg(logErrMsg(path, err, opts.debug, errFile))
 			} else {
-				if isFormated {
-					_ = os.WriteFile(path, []byte(formatedTemplateData), 0644)
-					dataString = formatedTemplateData
-					gologger.Info().Label("format").Msgf("✅ formated template: %s\n", path)
+				if isFormatted {
+					_ = os.WriteFile(path, []byte(formattedTemplateData), 0644)
+					dataString = formattedTemplateData
+					gologger.Info().Label("format").Msgf("✅ formatted template: %s\n", path)
 				}
 			}
 		}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -185,7 +185,7 @@ func (s *DASTServer) Start() error {
 	return nil
 }
 
-// PostReuestsHandlerRequest is the request body for the /fuzz POST handler.
+// PostRequestsHandlerRequest is the request body for the /fuzz POST handler.
 type PostRequestsHandlerRequest struct {
 	RawHTTP string `json:"raw_http"`
 	URL     string `json:"url"`

--- a/lib/config.go
+++ b/lib/config.go
@@ -52,7 +52,7 @@ type TemplateFilters struct {
 	ExcludeSeverities    string   // filter by excluding severities (accepts CSV values of info, low, medium, high, critical)
 	ProtocolTypes        string   // filter by protocol types
 	ExcludeProtocolTypes string   // filter by excluding protocol types
-	Authors              []string // fiter by author
+	Authors              []string // filter by author
 	Tags                 []string // filter by tags present in template
 	ExcludeTags          []string // filter by excluding tags present in template
 	IncludeTags          []string // filter by including tags present in template

--- a/lib/tests/sdk_test.go
+++ b/lib/tests/sdk_test.go
@@ -42,7 +42,7 @@ func TestSimpleNuclei(t *testing.T) {
 		defer ne.Close()
 	}
 
-	// this is shared test so needs to be run as seperate process
+		// this is a shared test, so it needs to be run as a separate process
 	if env.GetEnvOrDefault("TestSimpleNuclei", false) {
 		// run as new process
 		cmd := exec.Command(os.Args[0], "-test.run=TestSimpleNuclei")
@@ -81,7 +81,7 @@ func TestSimpleNucleiRemote(t *testing.T) {
 		require.Nil(t, err)
 		defer ne.Close()
 	}
-	// this is shared test so needs to be run as seperate process
+		// this is a shared test, so it needs to be run as a separate process
 	if env.GetEnvOrDefault("TestSimpleNucleiRemote", false) {
 		cmd := exec.Command(os.Args[0], "-test.run=TestSimpleNucleiRemote")
 		cmd.Env = append(os.Environ(), "TestSimpleNucleiRemote=true")
@@ -155,7 +155,7 @@ func TestWithVarsNuclei(t *testing.T) {
 		require.Nil(t, err)
 		defer ne.Close()
 	}
-	// this is shared test so needs to be run as seperate process
+		// this is a shared test, so it needs to be run as a separate process
 	if env.GetEnvOrDefault("TestWithVarsNuclei", false) {
 		cmd := exec.Command(os.Args[0], "-test.run=TestWithVarsNuclei")
 		cmd.Env = append(os.Environ(), "TestWithVarsNuclei=true")

--- a/lib/tests/sdk_test.go
+++ b/lib/tests/sdk_test.go
@@ -42,7 +42,7 @@ func TestSimpleNuclei(t *testing.T) {
 		defer ne.Close()
 	}
 
-		// this is a shared test, so it needs to be run as a separate process
+	// this is a shared test, so it needs to be run as a separate process
 	if env.GetEnvOrDefault("TestSimpleNuclei", false) {
 		// run as new process
 		cmd := exec.Command(os.Args[0], "-test.run=TestSimpleNuclei")
@@ -81,7 +81,7 @@ func TestSimpleNucleiRemote(t *testing.T) {
 		require.Nil(t, err)
 		defer ne.Close()
 	}
-		// this is a shared test, so it needs to be run as a separate process
+	// this is a shared test, so it needs to be run as a separate process
 	if env.GetEnvOrDefault("TestSimpleNucleiRemote", false) {
 		cmd := exec.Command(os.Args[0], "-test.run=TestSimpleNucleiRemote")
 		cmd.Env = append(os.Environ(), "TestSimpleNucleiRemote=true")
@@ -155,7 +155,7 @@ func TestWithVarsNuclei(t *testing.T) {
 		require.Nil(t, err)
 		defer ne.Close()
 	}
-		// this is a shared test, so it needs to be run as a separate process
+	// this is a shared test, so it needs to be run as a separate process
 	if env.GetEnvOrDefault("TestWithVarsNuclei", false) {
 		cmd := exec.Command(os.Args[0], "-test.run=TestWithVarsNuclei")
 		cmd.Env = append(os.Environ(), "TestWithVarsNuclei=true")

--- a/pkg/testutils/testutils.go
+++ b/pkg/testutils/testutils.go
@@ -115,7 +115,7 @@ func NewMockExecuterOptions(options *types.Options, info *TemplateInfo) *protoco
 	return executerOpts
 }
 
-// NoopWriter is a NooP gologger writer.
+// NoopWriter is a noop gologger writer.
 type NoopWriter struct{}
 
 // Write writes the data to an output writer.

--- a/pkg/tmplexec/flow/flow_executor_test.go
+++ b/pkg/tmplexec/flow/flow_executor_test.go
@@ -118,7 +118,7 @@ func TestFlowWithConditionNegative(t *testing.T) {
 
 	input := contextargs.NewWithInput(context.Background(), "scanme.sh")
 	ctx := scan.NewScanContext(context.Background(), input)
-	// expect no results and verify thant dns request is executed and http is not
+	// expect no results and verify that dns request is executed and http is not
 	gotresults, err := Template.Executer.Execute(ctx)
 	require.Nil(t, err, "could not execute template")
 	require.False(t, gotresults)


### PR DESCRIPTION
## Summary
- add a repo-level typos configuration with targeted excludes for generated fixtures and known binary-like assets
- add a dedicated GitHub Actions workflow to run typos on pushes and pull requests
- clean up a few obvious spelling issues in code comments and local variable names so the initial rollout passes cleanly

## Validation
- `/Users/zhaochen/Documents/2603/bountyking/_tmp/typos-gh/typos .`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a project-wide typo/spelling configuration to enforce consistent wording and ignore specified files.

* **Bug Fixes**
  * Corrected various spelling and grammar in UI/log messages, comments, and tests to improve clarity and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->