### PR TITLE
Improve template profile config handling

### DIFF
--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"bufio"
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"io/fs"
 	"os"
@@ -21,6 +23,7 @@ import (
 	stringsutil "github.com/projectdiscovery/utils/strings"
 	"github.com/rs/xid"
 	"gopkg.in/yaml.v2"
+	yamlv3 "gopkg.in/yaml.v3"
 
 	"github.com/projectdiscovery/goflags"
 	"github.com/projectdiscovery/gologger/levels"
@@ -51,10 +54,12 @@ var (
 	templateProfile string
 	memProfile      string // optional profile file path
 	options         = &types.Options{}
+	generatedFiles  []string
 )
 
 func main() {
 	options.Logger = gologger.DefaultLogger
+	defer cleanupGeneratedFiles()
 
 	// enables CLI specific configs mostly interactive behavior
 	config.CurrentAppMode = config.AppModeCLI
@@ -584,14 +589,19 @@ Additional documentation is available at: https://docs.nuclei.sh/getting-started
 		if !fileutil.FileExists(cfgFile) {
 			options.Logger.Fatal().Msgf("given config file '%s' does not exist", cfgFile)
 		}
+		preparedCfg, err := prepareConfigFileForMerge(cfgFile)
+		if err != nil {
+			options.Logger.Fatal().Msgf("Could not prepare config: %s\n", err)
+		}
 		// merge config file with flags
-		if err := flagSet.MergeConfigFile(cfgFile); err != nil {
+		if err := flagSet.MergeConfigFile(preparedCfg.Path); err != nil {
 			options.Logger.Fatal().Msgf("Could not read config: %s\n", err)
 		}
+		options.SecretsFile = append(options.SecretsFile, preparedCfg.SecretsFiles...)
 
 		if !options.Vars.IsEmpty() {
 			// Maybe we should add vars to the config file as well even if they are set via flags?
-			file, err := os.Open(cfgFile)
+			file, err := os.Open(preparedCfg.Path)
 			if err != nil {
 				gologger.Fatal().Msgf("Could not open config file: %s\n", err)
 			}
@@ -656,9 +666,14 @@ Additional documentation is available at: https://docs.nuclei.sh/getting-started
 		if !fileutil.FileExists(templateProfile) {
 			options.Logger.Fatal().Msgf("given template profile file '%s' does not exist", templateProfile)
 		}
-		if err := flagSet.MergeConfigFile(templateProfile); err != nil {
+		preparedProfile, err := prepareConfigFileForMerge(templateProfile)
+		if err != nil {
+			options.Logger.Fatal().Msgf("Could not prepare template profile: %s\n", err)
+		}
+		if err := flagSet.MergeConfigFile(preparedProfile.Path); err != nil {
 			options.Logger.Fatal().Msgf("Could not read template profile: %s\n", err)
 		}
+		options.SecretsFile = append(options.SecretsFile, preparedProfile.SecretsFiles...)
 	}
 
 	if len(options.SecretsFile) > 0 {
@@ -671,6 +686,118 @@ Additional documentation is available at: https://docs.nuclei.sh/getting-started
 
 	cleanupOldResumeFiles()
 	return flagSet
+}
+
+type preparedConfigFile struct {
+	Path         string
+	SecretsFiles []string
+}
+
+func prepareConfigFileForMerge(path string) (*preparedConfigFile, error) {
+	ext := strings.ToLower(filepath.Ext(path))
+	if ext != ".yaml" && ext != ".yml" && ext != ".json" {
+		return &preparedConfigFile{Path: path}, nil
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	root := map[string]interface{}{}
+	switch ext {
+	case ".json":
+		if err := json.Unmarshal(data, &root); err != nil {
+			return &preparedConfigFile{Path: path}, nil
+		}
+	default:
+		if err := yamlv3.Unmarshal(data, &root); err != nil {
+			return &preparedConfigFile{Path: path}, nil
+		}
+	}
+
+	prepared := &preparedConfigFile{Path: path}
+	changed := false
+	secrets, hasSecrets := root["secrets"]
+	if hasSecrets {
+		delete(root, "secrets")
+		secretPath, err := writePreparedSecretsFile(secrets)
+		if err != nil {
+			return nil, err
+		}
+		prepared.SecretsFiles = append(prepared.SecretsFiles, secretPath)
+		changed = true
+	}
+
+	for _, key := range []string{"id", "name", "purpose", "description", "info"} {
+		if _, ok := root[key]; ok {
+			delete(root, key)
+			changed = true
+		}
+	}
+
+	if !changed {
+		return prepared, nil
+	}
+
+	configPath, err := writePreparedConfigFile(ext, root)
+	if err != nil {
+		return nil, err
+	}
+	prepared.Path = configPath
+	return prepared, nil
+}
+
+func writePreparedConfigFile(ext string, root map[string]interface{}) (string, error) {
+	var (
+		data []byte
+		err  error
+	)
+	switch ext {
+	case ".json":
+		data, err = json.MarshalIndent(root, "", "  ")
+	default:
+		data, err = yamlv3.Marshal(root)
+	}
+	if err != nil {
+		return "", err
+	}
+	return writeGeneratedFile("nuclei-config-*"+ext, data)
+}
+
+func writePreparedSecretsFile(raw interface{}) (string, error) {
+	secretMap, ok := raw.(map[string]interface{})
+	if !ok {
+		return "", fmt.Errorf("embedded secrets must be an object")
+	}
+	data, err := yamlv3.Marshal(secretMap)
+	if err != nil {
+		return "", err
+	}
+	return writeGeneratedFile("nuclei-secrets-*.yaml", data)
+}
+
+func writeGeneratedFile(pattern string, data []byte) (string, error) {
+	file, err := os.CreateTemp("", pattern)
+	if err != nil {
+		return "", err
+	}
+	if _, err := bytes.NewReader(data).WriteTo(file); err != nil {
+		_ = file.Close()
+		return "", err
+	}
+	if err := file.Close(); err != nil {
+		return "", err
+	}
+	generatedFiles = append(generatedFiles, file.Name())
+	return file.Name(), nil
+}
+
+func cleanupGeneratedFiles() {
+	for _, path := range generatedFiles {
+		_ = os.Remove(path)
+	}
+	generatedFiles = nil
 }
 
 // cleanupOldResumeFiles cleans up resume files older than 10 days.

--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -783,10 +783,12 @@ func writeGeneratedFile(pattern string, data []byte) (string, error) {
 		return "", err
 	}
 	if _, err := bytes.NewReader(data).WriteTo(file); err != nil {
+		_ = os.Remove(file.Name())
 		_ = file.Close()
 		return "", err
 	}
 	if err := file.Close(); err != nil {
+		_ = os.Remove(file.Name())
 		return "", err
 	}
 	generatedFiles = append(generatedFiles, file.Name())
@@ -834,9 +836,15 @@ func readFlagsConfig(flagset *goflags.FlagSet) {
 		return
 	}
 	// if config file exists, merge it with the default config
-	if err = flagset.MergeConfigFile(cfgFile); err != nil {
+	preparedCfg, err := prepareConfigFileForMerge(cfgFile)
+	if err != nil {
+		options.Logger.Warning().Msgf("failed to prepare configfile for merge: %s\n", err)
+		return
+	}
+	if err = flagset.MergeConfigFile(preparedCfg.Path); err != nil {
 		options.Logger.Warning().Msgf("failed to merge configfile with flags got: %s\n", err)
 	}
+	options.SecretsFile = append(options.SecretsFile, preparedCfg.SecretsFiles...)
 }
 
 // disableUpdatesCallback disables the update check.

--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -708,10 +708,12 @@ func prepareConfigFileForMerge(path string) (*preparedConfigFile, error) {
 	switch ext {
 	case ".json":
 		if err := json.Unmarshal(data, &root); err != nil {
+			gologger.Warning().Msgf("Could not parse config file %q as json, leaving it unchanged: %s\n", path, err)
 			return &preparedConfigFile{Path: path}, nil
 		}
 	default:
 		if err := yamlv3.Unmarshal(data, &root); err != nil {
+			gologger.Warning().Msgf("Could not parse config file %q as yaml, leaving it unchanged: %s\n", path, err)
 			return &preparedConfigFile{Path: path}, nil
 		}
 	}
@@ -783,8 +785,8 @@ func writeGeneratedFile(pattern string, data []byte) (string, error) {
 		return "", err
 	}
 	if _, err := bytes.NewReader(data).WriteTo(file); err != nil {
-		_ = os.Remove(file.Name())
 		_ = file.Close()
+		_ = os.Remove(file.Name())
 		return "", err
 	}
 	if err := file.Close(); err != nil {

--- a/cmd/nuclei/main_config_test.go
+++ b/cmd/nuclei/main_config_test.go
@@ -62,6 +62,42 @@ rate-limit: 50
 	require.Empty(t, prepared.SecretsFiles)
 }
 
+func TestPrepareConfigFileForMerge_LeavesNonConfigFilesUntouched(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.txt")
+	require.NoError(t, os.WriteFile(configPath, []byte("id: ignored\n"), 0o644))
+
+	prepared, err := prepareConfigFileForMerge(configPath)
+	require.NoError(t, err)
+	require.Equal(t, configPath, prepared.Path)
+	require.Empty(t, prepared.SecretsFiles)
+}
+
+func TestPrepareConfigFileForMerge_StripsMetadataOnlyConfig(t *testing.T) {
+	t.Cleanup(cleanupGeneratedFiles)
+
+	configPath := filepath.Join(t.TempDir(), "profile.yaml")
+	config := `id: cloud-profile
+name: Cloud Scan
+purpose: Shared scan settings
+description: Example profile
+info:
+  name: remove me
+`
+	require.NoError(t, os.WriteFile(configPath, []byte(config), 0o644))
+
+	prepared, err := prepareConfigFileForMerge(configPath)
+	require.NoError(t, err)
+	require.NotEqual(t, configPath, prepared.Path)
+	require.Empty(t, prepared.SecretsFiles)
+
+	preparedConfig, err := os.ReadFile(prepared.Path)
+	require.NoError(t, err)
+	require.NotContains(t, string(preparedConfig), "cloud-profile")
+	require.NotContains(t, string(preparedConfig), "Cloud Scan")
+	require.NotContains(t, string(preparedConfig), "purpose:")
+	require.NotContains(t, string(preparedConfig), "info:")
+}
+
 func TestPrepareConfigFileForMerge_StripsProfileMetadataAndExtractsSecretsFromJSON(t *testing.T) {
 	t.Cleanup(cleanupGeneratedFiles)
 

--- a/cmd/nuclei/main_config_test.go
+++ b/cmd/nuclei/main_config_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/authprovider/authx"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrepareConfigFileForMerge_StripsProfileMetadataAndExtractsSecrets(t *testing.T) {
+	t.Cleanup(cleanupGeneratedFiles)
+
+	configPath := filepath.Join(t.TempDir(), "profile.yaml")
+	config := `id: cloud-profile
+name: Cloud Scan
+purpose: Shared scan settings
+description: Example profile
+tags:
+  - kev
+secrets:
+  static:
+    - type: Header
+      domains:
+        - api.projectdiscovery.io
+      headers:
+        - key: Authorization
+          value: Bearer test-token
+`
+	require.NoError(t, os.WriteFile(configPath, []byte(config), 0o644))
+
+	prepared, err := prepareConfigFileForMerge(configPath)
+	require.NoError(t, err)
+	require.NotEqual(t, configPath, prepared.Path)
+	require.Len(t, prepared.SecretsFiles, 1)
+
+	preparedConfig, err := os.ReadFile(prepared.Path)
+	require.NoError(t, err)
+	require.Contains(t, string(preparedConfig), "tags:")
+	require.NotContains(t, string(preparedConfig), "secrets:")
+	require.NotContains(t, string(preparedConfig), "purpose:")
+
+	authData, err := authx.GetAuthDataFromFile(prepared.SecretsFiles[0])
+	require.NoError(t, err)
+	require.Len(t, authData.Secrets, 1)
+	require.Equal(t, "Authorization", authData.Secrets[0].Headers[0].Key)
+}
+
+func TestPrepareConfigFileForMerge_LeavesPlainConfigUntouched(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	config := `tags:
+  - cves
+rate-limit: 50
+`
+	require.NoError(t, os.WriteFile(configPath, []byte(config), 0o644))
+
+	prepared, err := prepareConfigFileForMerge(configPath)
+	require.NoError(t, err)
+	require.Equal(t, configPath, prepared.Path)
+	require.Empty(t, prepared.SecretsFiles)
+}
+
+func TestPrepareConfigFileForMerge_RejectsInvalidEmbeddedSecrets(t *testing.T) {
+	t.Cleanup(cleanupGeneratedFiles)
+
+	configPath := filepath.Join(t.TempDir(), "profile.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte("secrets: invalid\n"), 0o644))
+
+	_, err := prepareConfigFileForMerge(configPath)
+	require.Error(t, err)
+	require.True(t, strings.Contains(err.Error(), "embedded secrets"))
+}

--- a/cmd/nuclei/main_config_test.go
+++ b/cmd/nuclei/main_config_test.go
@@ -62,6 +62,52 @@ rate-limit: 50
 	require.Empty(t, prepared.SecretsFiles)
 }
 
+func TestPrepareConfigFileForMerge_StripsProfileMetadataAndExtractsSecretsFromJSON(t *testing.T) {
+	t.Cleanup(cleanupGeneratedFiles)
+
+	configPath := filepath.Join(t.TempDir(), "profile.json")
+	config := `{
+  "id": "cloud-profile",
+  "name": "Cloud Scan",
+  "description": "Example profile",
+  "info": {
+    "name": "Should be removed"
+  },
+  "tags": ["kev"],
+  "secrets": {
+    "static": [
+      {
+        "type": "Header",
+        "domains": ["api.projectdiscovery.io"],
+        "headers": [
+          {
+            "key": "Authorization",
+            "value": "Bearer test-token"
+          }
+        ]
+      }
+    ]
+  }
+}`
+	require.NoError(t, os.WriteFile(configPath, []byte(config), 0o644))
+
+	prepared, err := prepareConfigFileForMerge(configPath)
+	require.NoError(t, err)
+	require.NotEqual(t, configPath, prepared.Path)
+	require.Len(t, prepared.SecretsFiles, 1)
+
+	preparedConfig, err := os.ReadFile(prepared.Path)
+	require.NoError(t, err)
+	require.Contains(t, string(preparedConfig), "\"tags\"")
+	require.NotContains(t, string(preparedConfig), "\"secrets\"")
+	require.NotContains(t, string(preparedConfig), "\"info\"")
+
+	authData, err := authx.GetAuthDataFromFile(prepared.SecretsFiles[0])
+	require.NoError(t, err)
+	require.Len(t, authData.Secrets, 1)
+	require.Equal(t, "Authorization", authData.Secrets[0].Headers[0].Key)
+}
+
 func TestPrepareConfigFileForMerge_RejectsInvalidEmbeddedSecrets(t *testing.T) {
 	t.Cleanup(cleanupGeneratedFiles)
 


### PR DESCRIPTION
## Summary
- allow template profiles and config files to carry descriptive metadata keys without breaking flag merging
- extract embedded `secrets` blocks into generated secret files and append them to `options.SecretsFile`
- add unit tests covering metadata stripping, embedded secrets extraction, and invalid embedded secrets

## Validation
- `git diff --check`

## Notes
- this machine does not have `go` or `gofmt`, so I could not run Go tests or format the files locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved config/profile handling: strips profile metadata, extracts embedded secrets into separate generated files, supports YAML and JSON, and preserves tags while keeping public behavior unchanged.
  * Prepared artifacts are written to temporary files that are tracked and cleaned up on exit.

* **Tests**
  * Added tests covering metadata stripping, secrets extraction for YAML/JSON, no-op cases, and error handling for invalid embedded secrets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->