### PR TITLE
fix: replace panic with proper error handling when GetDialersWithId returns nil

### DIFF
--- a/pkg/input/provider/list/hmap.go
+++ b/pkg/input/provider/list/hmap.go
@@ -171,7 +171,8 @@ func (i *ListInputProvider) Set(executionId string, value string) {
 		// scan all ips
 		dialers := protocolstate.GetDialersWithId(executionId)
 		if dialers == nil {
-			panic("dialers with executionId " + executionId + " not found")
+			gologger.Error().Msgf("dialers with executionId %s not found", executionId)
+			return
 		}
 
 		dnsData, err := dialers.Fastdialer.GetDNSData(urlx.Hostname())
@@ -208,7 +209,8 @@ func (i *ListInputProvider) Set(executionId string, value string) {
 	if i.ipOptions.IPV6 {
 		dialers := protocolstate.GetDialersWithId(executionId)
 		if dialers == nil {
-			panic("dialers with executionId " + executionId + " not found")
+			gologger.Error().Msgf("dialers with executionId %s not found", executionId)
+			return
 		}
 
 		dnsData, err := dialers.Fastdialer.GetDNSData(urlx.Hostname())
@@ -415,7 +417,8 @@ func (i *ListInputProvider) Del(executionId string, value string) {
 		// scan all ips
 		dialers := protocolstate.GetDialersWithId(executionId)
 		if dialers == nil {
-			panic("dialers with executionId " + executionId + " not found")
+			gologger.Error().Msgf("dialers with executionId %s not found", executionId)
+			return
 		}
 
 		dnsData, err := dialers.Fastdialer.GetDNSData(urlx.Hostname())
@@ -452,7 +455,8 @@ func (i *ListInputProvider) Del(executionId string, value string) {
 	if i.ipOptions.IPV6 {
 		dialers := protocolstate.GetDialersWithId(executionId)
 		if dialers == nil {
-			panic("dialers with executionId " + executionId + " not found")
+			gologger.Error().Msgf("dialers with executionId %s not found", executionId)
+			return
 		}
 
 		dnsData, err := dialers.Fastdialer.GetDNSData(urlx.Hostname())

--- a/pkg/js/global/scripts.go
+++ b/pkg/js/global/scripts.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"embed"
+	"fmt"
 	"math/rand"
 	"net"
 	"reflect"
@@ -125,7 +126,7 @@ func initBuiltInFunc(runtime *goja.Runtime) {
 			executionId := ctx.Value("executionId").(string)
 			dialer := protocolstate.GetDialersWithId(executionId)
 			if dialer == nil {
-				panic("dialers with executionId " + executionId + " not found")
+				return false, fmt.Errorf("dialers with executionId %s not found", executionId)
 			}
 
 			conn, err := dialer.Fastdialer.Dial(ctx, "tcp", net.JoinHostPort(host, port))
@@ -156,7 +157,7 @@ func initBuiltInFunc(runtime *goja.Runtime) {
 			executionId := ctx.Value("executionId").(string)
 			dialer := protocolstate.GetDialersWithId(executionId)
 			if dialer == nil {
-				panic("dialers with executionId " + executionId + " not found")
+				return false, fmt.Errorf("dialers with executionId %s not found", executionId)
 			}
 
 			conn, err := dialer.Fastdialer.Dial(ctx, "udp", net.JoinHostPort(host, port))

--- a/pkg/js/libs/ldap/ldap.go
+++ b/pkg/js/libs/ldap/ldap.go
@@ -88,9 +88,7 @@ func NewClient(call goja.ConstructorCall, runtime *goja.Runtime) *goja.Object {
 
 	executionId := c.nj.ExecutionId()
 	dialers := protocolstate.GetDialersWithId(executionId)
-	if dialers == nil {
-		panic("dialers with executionId " + executionId + " not found")
-	}
+	c.nj.Require(dialers != nil, "dialers with executionId "+executionId+" not found")
 
 	var conn net.Conn
 	if u.Scheme == "ldapi" {

--- a/pkg/protocols/http/http.go
+++ b/pkg/protocols/http/http.go
@@ -378,7 +378,11 @@ func (request *Request) Compile(options *protocols.ExecutorOptions) error {
 				request.Raw[i] = strings.ReplaceAll(raw, "\n", "\r\n")
 			}
 		}
-		request.rawhttpClient = httpclientpool.GetRawHTTP(options)
+		var rawHTTPErr error
+		request.rawhttpClient, rawHTTPErr = httpclientpool.GetRawHTTP(options)
+		if rawHTTPErr != nil {
+			return errors.Wrap(rawHTTPErr, "could not create rawhttp client")
+		}
 	}
 	if len(request.Matchers) > 0 || len(request.Extractors) > 0 {
 		compiled := &request.Operators

--- a/pkg/protocols/http/httpclientpool/clientpool.go
+++ b/pkg/protocols/http/httpclientpool/clientpool.go
@@ -140,10 +140,10 @@ func (c *Configuration) HasStandardOptions() bool {
 }
 
 // GetRawHTTP returns the rawhttp request client
-func GetRawHTTP(options *protocols.ExecutorOptions) *rawhttp.Client {
+func GetRawHTTP(options *protocols.ExecutorOptions) (*rawhttp.Client, error) {
 	dialers := protocolstate.GetDialersWithId(options.Options.ExecutionId)
 	if dialers == nil {
-		panic("dialers not initialized for execution id: " + options.Options.ExecutionId)
+		return nil, fmt.Errorf("dialers not initialized for execution id: %s", options.Options.ExecutionId)
 	}
 
 	// Lock the dialers to avoid a race when setting RawHTTPClient
@@ -151,7 +151,7 @@ func GetRawHTTP(options *protocols.ExecutorOptions) *rawhttp.Client {
 	defer dialers.Unlock()
 
 	if dialers.RawHTTPClient != nil {
-		return dialers.RawHTTPClient
+		return dialers.RawHTTPClient, nil
 	}
 
 	rawHttpOptionsCopy := *rawhttp.DefaultOptions
@@ -164,7 +164,7 @@ func GetRawHTTP(options *protocols.ExecutorOptions) *rawhttp.Client {
 	}
 	rawHttpOptionsCopy.Timeout = options.Options.GetTimeouts().HttpTimeout
 	dialers.RawHTTPClient = rawhttp.NewClient(&rawHttpOptionsCopy)
-	return dialers.RawHTTPClient
+	return dialers.RawHTTPClient, nil
 }
 
 // Get creates or gets a client for the protocol based on custom configuration

--- a/pkg/protocols/javascript/js.go
+++ b/pkg/protocols/javascript/js.go
@@ -401,7 +401,10 @@ func (request *Request) executeWithResults(port string, target *contextargs.Cont
 			results := map[string]interface{}(result)
 			results["error"] = outError.Error()
 			// generate and return failed event
-			data := request.generateEventData(input, results, hostPort)
+			data, eventErr := request.generateEventData(input, results, hostPort)
+			if eventErr != nil {
+				return eventErr
+			}
 			data = generators.MergeMaps(data, payloadValues)
 			event := eventcreator.CreateEventWithAdditionalOptions(request, data, request.options.Options.Debug || request.options.Options.DebugResponse, func(wrappedEvent *output.InternalWrappedEvent) {
 				allVars := argsCopy.Map()
@@ -586,7 +589,10 @@ func (request *Request) executeRequestWithPayloads(hostPort string, input *conte
 
 	values := mapsutil.Merge(payloadValues, results)
 	// generate event data
-	data := request.generateEventData(input, values, hostPort)
+	data, eventErr := request.generateEventData(input, values, hostPort)
+	if eventErr != nil {
+		return eventErr
+	}
 
 	// add and get values from templatectx
 	request.options.AddTemplateVars(input.MetaInput, request.Type(), request.GetID(), data)
@@ -634,10 +640,10 @@ func (request *Request) executeRequestWithPayloads(hostPort string, input *conte
 }
 
 // generateEventData generates event data for the request
-func (request *Request) generateEventData(input *contextargs.Context, values map[string]interface{}, matched string) map[string]interface{} {
+func (request *Request) generateEventData(input *contextargs.Context, values map[string]interface{}, matched string) (map[string]interface{}, error) {
 	dialers := protocolstate.GetDialersWithId(request.options.Options.ExecutionId)
 	if dialers == nil {
-		panic(fmt.Sprintf("dialers not initialized for %s", request.options.Options.ExecutionId))
+		return nil, fmt.Errorf("dialers not initialized for %s", request.options.Options.ExecutionId)
 	}
 
 	data := make(map[string]interface{})
@@ -692,7 +698,7 @@ func (request *Request) generateEventData(input *contextargs.Context, values map
 			}
 		}
 	}
-	return data
+	return data, nil
 }
 
 func (request *Request) getArgsCopy(input *contextargs.Context, payloadValues map[string]interface{}, requestOptions *protocols.ExecutorOptions, ignoreErrors bool) (*compiler.ExecuteArgs, error) {


### PR DESCRIPTION
Fixes #6674

Replace all remaining panic calls when GetDialersWithId returns nil with proper error handling.

5 files, 9 panics removed. Each replaced with context-appropriate handling: error returns, gologger + early return, or goja Require.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling throughout the application to prevent crashes. Replaced panic conditions with proper error logging and graceful returns when dialers or client resources are unavailable.
  * Added error checking for HTTP client initialization to catch and report issues early rather than causing runtime failures.
  * Enhanced stability by converting unchecked error conditions into logged warnings and controlled exits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->