### PR TITLE
feat(profile): implement inline target and secret materialization

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"context"
 	"fmt"
+	yamlv3 "gopkg.in/yaml.v3"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -261,8 +262,63 @@ func New(options *types.Options) (*Runner, error) {
 		}
 	}()
 
-	// create the input provider and load the inputs
-	inputProvider, err := provider.NewInputProvider(provider.InputOptions{Options: options, TempDir: runner.tmpDir})
+	// We catch the target if it's in List, Targets, OR incorrectly sitting in TargetsFilePath
+	// --- Task 2 & 3: Materialize Inline Targets and Secrets (#5567) ---
+
+	// 1. Resolve Target Content
+	targetContent := options.List
+	if targetContent == "" && len(options.Targets) > 0 {
+		targetContent = strings.Join(options.Targets, "\n")
+	}
+
+	// Check if TargetsFilePath is actually raw input (common in profile materialization)
+	// We verify this by checking if the path does not exist as a physical file on disk
+	if targetContent == "" && options.TargetsFilePath != "" {
+		if !fileutil.FileExists(options.TargetsFilePath) || strings.Contains(options.TargetsFilePath, "\n") {
+			targetContent = options.TargetsFilePath
+		}
+	}
+
+	if targetContent != "" {
+		// Use system temp dir if runner.tmpDir isn't initialized yet
+		tDir := runner.tmpDir
+		if tDir == "" {
+			tDir = os.TempDir()
+		}
+
+		tempFile, err := os.CreateTemp(tDir, "nuclei-targets-*.txt")
+		if err == nil {
+			defer tempFile.Close()
+			_, _ = tempFile.WriteString(targetContent)
+			options.TargetsFilePath = tempFile.Name()
+			runner.Logger.Info().Msgf("Materialized profile targets to: %s", tempFile.Name())
+		}
+	}
+
+	// 2. Resolve Secrets
+	if len(options.Secrets) > 0 {
+		secretBytes, err := yamlv3.Marshal(options.Secrets)
+		if err == nil {
+			tDir := runner.tmpDir
+			if tDir == "" {
+				tDir = os.TempDir()
+			}
+
+			tempSecret, err := os.CreateTemp(tDir, "nuclei-secrets-*.yaml")
+			if err == nil {
+				defer tempSecret.Close()
+				_, _ = tempSecret.Write(secretBytes)
+				options.SecretsFile = append(options.SecretsFile, tempSecret.Name())
+				runner.Logger.Info().Msgf("Materialized profile secrets to: %s", tempSecret.Name())
+			}
+		}
+	}
+
+	// 3. Create the input provider (only once!)
+	inputProvider, err := provider.NewInputProvider(provider.InputOptions{
+		Options: options,
+		TempDir: runner.tmpDir,
+	})
 	if err != nil {
 		return nil, errors.Wrap(err, "could not create input provider")
 	}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -33,6 +33,12 @@ type LoadHelperFileFunction func(helperFile, templatePath string, catalog catalo
 
 // Options contains the configuration options for nuclei scanner.
 type Options struct {
+	Secrets            map[string]interface{} `yaml:"secrets,omitempty" json:"secrets,omitempty"`
+	List               string                 `yaml:"list,omitempty" json:"list,omitempty"`
+	ProfileID          string                 `yaml:"id,omitempty" json:"id,omitempty"`
+	ProfileName        string                 `yaml:"name,omitempty" json:"name,omitempty"`
+	ProfileDescription string                 `yaml:"description,omitempty" json:"description,omitempty"`
+	// ... existing fields (Tags, ExcludeTags, etc.)
 	// Tags contains a list of tags to execute templates for. Multiple paths
 	// can be specified with -l flag and -tags can be used in combination with
 	// the -l flag.
@@ -475,7 +481,19 @@ type Options struct {
 }
 
 func (options *Options) Copy() *Options {
+	var secretsCopy map[string]interface{}
+	if options.Secrets != nil {
+		secretsCopy = make(map[string]interface{})
+		for k, v := range options.Secrets {
+			secretsCopy[k] = v
+		}
+	}
 	optCopy := &Options{
+		Secrets:                        secretsCopy,
+		List:                           options.List,
+		ProfileID:                      options.ProfileID,
+		ProfileName:                    options.ProfileName,
+		ProfileDescription:             options.ProfileDescription,
 		Tags:                           options.Tags,
 		ExcludeTags:                    options.ExcludeTags,
 		Workflows:                      options.Workflows,


### PR DESCRIPTION
This PR implements the requested profile enhancements for Task 2 and Task 3.

### Changes:
- **Inline Targets:** Implemented materialization of `list` strings into temporary files within the runner's temporary directory. This ensures the input provider can process raw target strings from profiles.
- **Inline Secrets:** Added support for marshaling secret maps into temporary YAML files, allowing dynamic secret injection from profiles.
- **Metadata Support:** Integrated ID, Name, and Description fields into the Options structure.

Closes #5567
/claim #5567

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for inline materialization of targets and secrets to streamline configuration input.
  * New profile configuration fields (ID, name, description) for improved profile management.
* **Bug Fixes / Reliability**
  * Safer copying of secret data during option duplication to avoid shared references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->