### PR TITLE
fix(fuzz): include numeric path segments in URL fuzzing

### DIFF
--- a/pkg/fuzz/component/path.go
+++ b/pkg/fuzz/component/path.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz/dataformat"
 	"github.com/projectdiscovery/retryablehttp-go"
+	mapsutil "github.com/projectdiscovery/utils/maps"
 	urlutil "github.com/projectdiscovery/utils/url"
 )
 
@@ -14,7 +15,8 @@ import (
 type Path struct {
 	value *Value
 
-	req *retryablehttp.Request
+	req          *retryablehttp.Request
+	originalPath string
 }
 
 var _ Component = &Path{}
@@ -33,10 +35,12 @@ func (q *Path) Name() string {
 // parsed component
 func (q *Path) Parse(req *retryablehttp.Request) (bool, error) {
 	q.req = req
+	q.originalPath = req.Path
 	q.value = NewValue("")
 
 	splitted := strings.Split(req.Path, "/")
-	values := make(map[string]interface{})
+	values := mapsutil.NewOrderedMap[string, any]()
+	segmentIndex := 1
 	for i, segment := range splitted {
 		if segment == "" && i == 0 {
 			// Skip the first empty segment from leading "/"
@@ -46,11 +50,12 @@ func (q *Path) Parse(req *retryablehttp.Request) (bool, error) {
 			// Skip any other empty segments
 			continue
 		}
-		// Use 1-based indexing and store individual segments
-		key := strconv.Itoa(len(values) + 1)
-		values[key] = segment
+		// Use 1-based indexing and store individual segments in insertion order.
+		key := strconv.Itoa(segmentIndex)
+		values.Set(key, segment)
+		segmentIndex++
 	}
-	q.value.SetParsed(dataformat.KVMap(values), "")
+	q.value.SetParsed(dataformat.KVOrderedMap(&values), "")
 	return true, nil
 }
 
@@ -87,8 +92,8 @@ func (q *Path) Delete(key string) error {
 // Rebuild returns a new request with the
 // component rebuilt
 func (q *Path) Rebuild() (*retryablehttp.Request, error) {
-	// Get the original path segments
-	originalSplitted := strings.Split(q.req.Path, "/")
+	// Get the original path segments from the immutable snapshot captured at parse time.
+	originalSplitted := strings.Split(q.originalPath, "/")
 
 	// Create a new slice to hold the rebuilt segments
 	rebuiltSegments := make([]string, 0, len(originalSplitted))
@@ -103,13 +108,15 @@ func (q *Path) Rebuild() (*retryablehttp.Request, error) {
 	for i := 1; i < len(originalSplitted); i++ {
 		originalSegment := originalSplitted[i]
 		if originalSegment == "" {
-			// Skip empty segments
+			// Preserve empty segments so repeated or trailing slashes survive rebuilds.
+			rebuiltSegments = append(rebuiltSegments, "")
 			continue
 		}
 
 		// Check if we have a replacement for this segment
 		key := strconv.Itoa(segmentIndex)
-		if newValue, exists := q.value.parsed.Map.GetOrDefault(key, "").(string); exists && newValue != "" {
+		if newValue, ok := q.value.parsed.Get(key).(string); ok {
+			// Use the replacement even if it's an empty string (explicit empty replacement)
 			rebuiltSegments = append(rebuiltSegments, newValue)
 		} else {
 			rebuiltSegments = append(rebuiltSegments, originalSegment)
@@ -130,8 +137,14 @@ func (q *Path) Rebuild() (*retryablehttp.Request, error) {
 		rebuiltPath = unescaped
 	}
 
-	// Clone the request and update the path
+	// Clone the request and deep-copy the underlying URL before mutating it.
+	// retryablehttp.Request.Clone() reuses the wrapped URL pointer, so updating the
+	// cloned path directly would also mutate q.req.
 	cloned := q.req.Clone(context.Background())
+	// Deep-copy the URL to ensure UpdateRelPath cannot mutate the original request
+	newURL := cloned.URL.Clone()
+	cloned.URL = newURL
+	cloned.Request.URL = newURL.URL
 	if err := cloned.UpdateRelPath(rebuiltPath, true); err != nil {
 		cloned.RawPath = rebuiltPath
 	}
@@ -141,7 +154,8 @@ func (q *Path) Rebuild() (*retryablehttp.Request, error) {
 // Clones current state to a new component
 func (q *Path) Clone() Component {
 	return &Path{
-		value: q.value.Clone(),
-		req:   q.req.Clone(context.Background()),
+		value:        q.value.Clone(),
+		req:          q.req.Clone(context.Background()),
+		originalPath: q.originalPath,
 	}
 }

--- a/pkg/fuzz/component/path_test.go
+++ b/pkg/fuzz/component/path_test.go
@@ -127,3 +127,102 @@ func TestPathComponent_SQLInjection(t *testing.T) {
 	// Let's also test what the actual URL looks like
 	t.Logf("Full URL: %s", newReq.String())
 }
+
+func TestPathComponent_DeterministicOrder(t *testing.T) {
+	for i := 0; i < 50; i++ {
+		req, err := retryablehttp.NewRequest(http.MethodGet, "https://example.com/user/55/profile", nil)
+		require.NoError(t, err)
+
+		path := NewPath()
+		found, err := path.Parse(req)
+		require.NoError(t, err)
+		require.True(t, found)
+
+		var values []string
+		err = path.Iterate(func(_ string, value interface{}) error {
+			values = append(values, value.(string))
+			return nil
+		})
+		require.NoError(t, err)
+		require.Equal(t, []string{"user", "55", "profile"}, values,
+			"iteration %d: path segments must be returned in deterministic order", i)
+	}
+}
+
+func TestPathComponent_RebuildUsesOriginalPathSnapshot(t *testing.T) {
+	path := NewPath()
+	req, err := retryablehttp.NewRequest(http.MethodGet, "https://example.com/user/55/profile", nil)
+	require.NoError(t, err)
+
+	found, err := path.Parse(req)
+	require.NoError(t, err)
+	require.True(t, found)
+
+	// Capture original path before any mutations
+	originalPath := req.Path
+
+	require.NoError(t, path.SetValue("3", "profile OR True"))
+	newReq, err := path.Rebuild()
+	require.NoError(t, err)
+	require.Equal(t, "/user/55/profile OR True", newReq.Path)
+	require.Equal(t, originalPath, req.Path, "original request path should remain unchanged after Rebuild")
+
+	// Rebuilding after a prior mutation should still use the original path layout
+	// without mutating the original request.
+	require.NoError(t, path.SetValue("3", "profile"))
+	require.NoError(t, path.SetValue("2", "55 OR True"))
+	newReq, err = path.Rebuild()
+	require.NoError(t, err)
+	require.Equal(t, "/user/55 OR True/profile", newReq.Path)
+	require.Equal(t, originalPath, req.Path, "original request path should remain unchanged after multiple Rebuilds")
+}
+
+func TestPathComponent_NumericSegmentsAllFuzzed(t *testing.T) {
+	testCases := []struct {
+		name     string
+		url      string
+		wantKeys []string
+		wantVals []string
+	}{
+		{
+			name:     "numeric ID in middle",
+			url:      "https://example.com/user/55/profile",
+			wantKeys: []string{"1", "2", "3"},
+			wantVals: []string{"user", "55", "profile"},
+		},
+		{
+			name:     "multiple numeric segments",
+			url:      "https://example.com/api/123/items/456",
+			wantKeys: []string{"1", "2", "3", "4"},
+			wantVals: []string{"api", "123", "items", "456"},
+		},
+		{
+			name:     "version and numeric ID",
+			url:      "https://example.com/api/v2/users/789/orders",
+			wantKeys: []string{"1", "2", "3", "4", "5"},
+			wantVals: []string{"api", "v2", "users", "789", "orders"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := retryablehttp.NewRequest(http.MethodGet, tc.url, nil)
+			require.NoError(t, err)
+
+			path := NewPath()
+			found, err := path.Parse(req)
+			require.NoError(t, err)
+			require.True(t, found)
+
+			var gotKeys, gotVals []string
+			err = path.Iterate(func(key string, value interface{}) error {
+				gotKeys = append(gotKeys, key)
+				gotVals = append(gotVals, value.(string))
+				return nil
+			})
+			require.NoError(t, err)
+			require.Equal(t, tc.wantKeys, gotKeys, "unexpected keys for %s", tc.url)
+			require.Equal(t, tc.wantVals, gotVals, "unexpected values for %s", tc.url)
+		})
+	}
+}

--- a/pkg/fuzz/parts.go
+++ b/pkg/fuzz/parts.go
@@ -162,7 +162,7 @@ func (rule *Rule) execWithInput(input *ExecuteRuleInput, httpReq *retryablehttp.
 	// If the parameter is frequent, skip it if the option is enabled
 	if rule.options.FuzzParamsFrequency != nil {
 		if rule.options.FuzzParamsFrequency.IsParameterFrequent(
-			parameter,
+			actualParameter,
 			httpReq.String(),
 			rule.options.TemplateID,
 		) {


### PR DESCRIPTION
## Root Cause

Three separate root causes were identified that together caused numeric path segments (e.g. `/api/users/123/profile`) to be skipped during path fuzzing:

### 1. Non-deterministic path segment iteration
`Path.Parse()` stored segments in a plain Go map (`map[string]interface{}`). Go maps have non-deterministic iteration order, so on some runs the segment at key `"2"` (e.g. `55` in `/user/55/profile`) would be iterated after the rule had already stopped at first match. Fixed by using an ordered map (`KVOrderedMap`) for deterministic insertion-order iteration.

### 2. Path clone mutation across Rebuild() calls
`retryablehttp.Request.Clone()` reuses the wrapped URL pointer. When `UpdateRelPath()` was called on a clone, it also mutated the original request's path. Subsequent `Rebuild()` calls would use the already-mutated path as the `originalPath`, corrupting later fuzz requests. Fixed by:
- Snapshotting `originalPath` at parse time
- Deep-copying the URL pointer before calling `UpdateRelPath()` on clones

### 3. Frequency dedup keyed on position index not segment value
`FuzzParamsFrequency.IsParameterFrequent` was called with `parameter` (the numeric position key like `"2"`) instead of `actualParameter` (the effective value like `"55"`). Different path segments at the same position across different URLs could incorrectly trigger frequency-based skipping. Fixed by passing `actualParameter`.

## Fix

- `pkg/fuzz/component/path.go`: Use `KVOrderedMap`, snapshot `originalPath`, deep-copy URL on clone
- `pkg/fuzz/parts.go`: Pass `actualParameter` to frequency dedup

## Impact

Endpoints like `/api/v2/users/456/items` will now have numeric segments (`456`) consistently fuzzed for injection vulnerabilities.

## Tests

Added regression tests covering:
- Deterministic iteration order over 50 runs (`TestPathComponent_DeterministicOrder`)
- Rebuild from immutable path snapshot (`TestPathComponent_RebuildUsesOriginalPathSnapshot`)
- All numeric/mixed/versioned path segments parsed and available for fuzzing (`TestPathComponent_NumericSegmentsAllFuzzed`)

Closes #6398

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed path fuzzing to correctly preserve empty and trailing path segments during reconstruction
  * Prevented original request mutations during path rebuild operations

* **Improvements**
  * Enhanced deterministic ordering in path segment processing
  * Refined parameter frequency detection logic during fuzzing operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->