### PR TITLE
feat(profiles): improve template profile management

### DIFF
--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -680,7 +680,23 @@ Additional documentation is available at: https://docs.nuclei.sh/getting-started
 			options.Logger.Fatal().Msgf("Could not materialize inline targets from profile %q: %s", templateProfile, err)
 		} else if targetsFile != "" {
 			options.Logger.Debug().Msgf("Profile inline targets written to %s", targetsFile)
-			options.Targets = append(options.Targets, targetsFile)
+			// Use TargetsFilePath so the file is opened and read as a target list.
+			// options.Targets holds literal host strings; appending a filename there
+			// would attempt to scan the path itself rather than its contents.
+			if options.TargetsFilePath == "" {
+				options.TargetsFilePath = targetsFile
+			} else {
+				// TargetsFilePath already set — expand the materialized file into Targets.
+				data, readErr := os.ReadFile(targetsFile)
+				if readErr != nil {
+					options.Logger.Fatal().Msgf("Could not read materialized targets file %q: %s", targetsFile, readErr)
+				}
+				for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+					if line = strings.TrimSpace(line); line != "" {
+						options.Targets = append(options.Targets, line)
+					}
+				}
+			}
 		}
 
 		// Materialize inline secrets if present.

--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -704,7 +704,12 @@ Additional documentation is available at: https://docs.nuclei.sh/getting-started
 
 		// Register temp files for deferred cleanup.
 		for _, tmp := range prof.TempFiles() {
-			_ = tmp // cleanup handled by OS on process exit; temp files use os.CreateTemp
+			tmp := tmp // capture loop variable
+			defer func() {
+				if err := os.Remove(tmp); err != nil && !os.IsNotExist(err) {
+					options.Logger.Debug().Msgf("Could not remove profile temp file %s: %s", tmp, err)
+				}
+			}()
 		}
 	}
 

--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -39,6 +39,7 @@ import (
 	templateTypes "github.com/projectdiscovery/nuclei/v3/pkg/templates/types"
 	"github.com/projectdiscovery/nuclei/v3/pkg/types"
 	"github.com/projectdiscovery/nuclei/v3/pkg/types/scanstrategy"
+	"github.com/projectdiscovery/nuclei/v3/pkg/profile"
 	"github.com/projectdiscovery/nuclei/v3/pkg/utils/monitor"
 	"github.com/projectdiscovery/utils/errkit"
 	fileutil "github.com/projectdiscovery/utils/file"
@@ -639,7 +640,7 @@ Additional documentation is available at: https://docs.nuclei.sh/getting-started
 			if tp := findProfilePathById(templateProfile, defaultProfilesPath); tp != "" {
 				templateProfile = tp
 			} else {
-				options.Logger.Fatal().Msgf("'%s' is not a profile-id or profile path", templateProfile)
+				options.Logger.Fatal().Msgf("template profile %q not found — use 'nuclei -tpl' to list available profiles, or provide a file path", templateProfile)
 			}
 		}
 		if !filepath.IsAbs(templateProfile) {
@@ -654,10 +655,56 @@ Additional documentation is available at: https://docs.nuclei.sh/getting-started
 			}
 		}
 		if !fileutil.FileExists(templateProfile) {
-			options.Logger.Fatal().Msgf("given template profile file '%s' does not exist", templateProfile)
+			options.Logger.Fatal().Msgf("template profile file %q does not exist — run 'nuclei -update-templates' to download community profiles, or check the path", templateProfile)
 		}
-		if err := flagSet.MergeConfigFile(templateProfile); err != nil {
-			options.Logger.Fatal().Msgf("Could not read template profile: %s\n", err)
+
+		// Parse the profile using the profile package so we can:
+		//   1. Strip metadata fields (id, name, purpose, description) that goflags doesn't understand.
+		//   2. Materialize inline targets (list: |...) into a temp file.
+		//   3. Materialize inline secrets (secrets: ...) into a temp file.
+		prof, err := profile.Load(templateProfile)
+		if err != nil {
+			options.Logger.Fatal().Msgf("Could not load template profile %q: %s", templateProfile, err)
+		}
+		if err := prof.Validate(); err != nil {
+			options.Logger.Fatal().Msgf("Invalid template profile %q: %s", templateProfile, err)
+		}
+
+		if prof.Name != "" || prof.ID != "" {
+			options.Logger.Info().Msgf("Loading template profile: %s", prof.Summary())
+		}
+
+		// Materialize inline target list if present.
+		tmpDir := os.TempDir()
+		if targetsFile, err := prof.MaterializeTargets(tmpDir); err != nil {
+			options.Logger.Fatal().Msgf("Could not materialize inline targets from profile %q: %s", templateProfile, err)
+		} else if targetsFile != "" {
+			options.Logger.Debug().Msgf("Profile inline targets written to %s", targetsFile)
+			options.Targets = append(options.Targets, targetsFile)
+		}
+
+		// Materialize inline secrets if present.
+		if secretsFile, err := prof.MaterializeSecrets(tmpDir); err != nil {
+			options.Logger.Fatal().Msgf("Could not materialize inline secrets from profile %q: %s", templateProfile, err)
+		} else if secretsFile != "" {
+			options.Logger.Debug().Msgf("Profile inline secrets written to %s", secretsFile)
+			options.SecretsFile = append(options.SecretsFile, secretsFile)
+		}
+
+		// Write a clean flags-only YAML (without metadata/list/secrets) for goflags.
+		flagsFile, err := prof.WriteFlagsFile(tmpDir)
+		if err != nil {
+			options.Logger.Fatal().Msgf("Could not prepare profile flags for %q: %s", templateProfile, err)
+		}
+		if flagsFile != "" {
+			if mergeErr := flagSet.MergeConfigFile(flagsFile); mergeErr != nil {
+				options.Logger.Fatal().Msgf("Could not merge template profile flags from %q: %s", templateProfile, mergeErr)
+			}
+		}
+
+		// Register temp files for deferred cleanup.
+		for _, tmp := range prof.TempFiles() {
+			_ = tmp // cleanup handled by OS on process exit; temp files use os.CreateTemp
 		}
 	}
 

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -3,7 +3,6 @@ package runner
 import (
 	"bufio"
 	"fmt"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -18,6 +17,7 @@ import (
 	"github.com/projectdiscovery/gologger/formatter"
 	"github.com/projectdiscovery/gologger/levels"
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/config"
+	"github.com/projectdiscovery/nuclei/v3/pkg/profile"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolinit"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/utils/vardump"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/headless/engine"
@@ -26,7 +26,6 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/reporting/exporters/jsonl"
 	"github.com/projectdiscovery/nuclei/v3/pkg/reporting/exporters/markdown"
 	"github.com/projectdiscovery/nuclei/v3/pkg/reporting/exporters/sarif"
-	"github.com/projectdiscovery/nuclei/v3/pkg/templates/extensions"
 	"github.com/projectdiscovery/nuclei/v3/pkg/types"
 	"github.com/projectdiscovery/nuclei/v3/pkg/utils/yaml"
 	fileutil "github.com/projectdiscovery/utils/file"
@@ -82,24 +81,33 @@ func ParseOptions(options *types.Options) {
 	defaultProfilesPath := filepath.Join(config.DefaultConfig.GetTemplateDir(), "profiles")
 	if options.ListTemplateProfiles {
 		options.Logger.Print().Msgf(
-			"Listing available %v nuclei template profiles for %v",
+			"Listing available %v nuclei template profiles for %v\n",
 			config.DefaultConfig.TemplateVersion,
 			config.DefaultConfig.TemplatesDirectory,
 		)
 		templatesRootDir := config.DefaultConfig.GetTemplateDir()
-		err := filepath.WalkDir(defaultProfilesPath, func(iterItem string, d fs.DirEntry, err error) error {
-			ext := filepath.Ext(iterItem)
-			isYaml := ext == extensions.YAML || ext == extensions.YML
-			if err != nil || d.IsDir() || !isYaml {
-				return nil
-			}
-			if profileRelPath, err := filepath.Rel(templatesRootDir, iterItem); err == nil {
-				options.Logger.Print().Msgf("%s (%s)\n", profileRelPath, strings.TrimSuffix(filepath.Base(iterItem), ext))
-			}
-			return nil
-		})
+		entries, err := profile.ListProfiles(defaultProfilesPath, templatesRootDir)
 		if err != nil {
-			options.Logger.Error().Msgf("%s\n", err)
+			options.Logger.Error().Msgf("could not list profiles: %s\n", err)
+		}
+		if len(entries) == 0 {
+			options.Logger.Print().Msgf("No profiles found in %s\n", defaultProfilesPath)
+			options.Logger.Print().Msgf("Tip: run 'nuclei -update-templates' to download community profiles\n")
+		}
+		for _, e := range entries {
+			if e.Metadata.Name != "" || e.Metadata.Purpose != "" {
+				desc := e.Metadata.Name
+				if e.Metadata.Purpose != "" {
+					if desc != "" {
+						desc += " — " + e.Metadata.Purpose
+					} else {
+						desc = e.Metadata.Purpose
+					}
+				}
+				options.Logger.Print().Msgf("%-50s %-20s  %s\n", e.RelPath, "("+e.ProfileID+")", desc)
+			} else {
+				options.Logger.Print().Msgf("%-50s %-20s\n", e.RelPath, "("+e.ProfileID+")")
+			}
 		}
 		os.Exit(0)
 	}

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -88,11 +88,16 @@ func ParseOptions(options *types.Options) {
 		templatesRootDir := config.DefaultConfig.GetTemplateDir()
 		entries, err := profile.ListProfiles(defaultProfilesPath, templatesRootDir)
 		if err != nil {
-			options.Logger.Error().Msgf("could not list profiles: %s\n", err)
+			if os.IsNotExist(err) {
+				options.Logger.Silent().Msgf("No profiles found in %s\n", defaultProfilesPath)
+				options.Logger.Silent().Msgf("Tip: run 'nuclei -update-templates' to download community profiles\n")
+				os.Exit(0)
+			}
+			options.Logger.Fatal().Msgf("could not list profiles: %s\n", err)
 		}
 		if len(entries) == 0 {
-			options.Logger.Print().Msgf("No profiles found in %s\n", defaultProfilesPath)
-			options.Logger.Print().Msgf("Tip: run 'nuclei -update-templates' to download community profiles\n")
+			options.Logger.Silent().Msgf("No profiles found in %s\n", defaultProfilesPath)
+			options.Logger.Silent().Msgf("Tip: run 'nuclei -update-templates' to download community profiles\n")
 		}
 		for _, e := range entries {
 			if e.Metadata.Name != "" || e.Metadata.Purpose != "" {
@@ -104,9 +109,9 @@ func ParseOptions(options *types.Options) {
 						desc = e.Metadata.Purpose
 					}
 				}
-				options.Logger.Print().Msgf("%-50s %-20s  %s\n", e.RelPath, "("+e.ProfileID+")", desc)
+				options.Logger.Silent().Msgf("%-50s %-20s  %s\n", e.RelPath, "("+e.ProfileID+")", desc)
 			} else {
-				options.Logger.Print().Msgf("%-50s %-20s\n", e.RelPath, "("+e.ProfileID+")")
+				options.Logger.Silent().Msgf("%-50s %-20s\n", e.RelPath, "("+e.ProfileID+")")
 			}
 		}
 		os.Exit(0)

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -89,15 +89,15 @@ func ParseOptions(options *types.Options) {
 		entries, err := profile.ListProfiles(defaultProfilesPath, templatesRootDir)
 		if err != nil {
 			if os.IsNotExist(err) {
-				options.Logger.Silent().Msgf("No profiles found in %s\n", defaultProfilesPath)
-				options.Logger.Silent().Msgf("Tip: run 'nuclei -update-templates' to download community profiles\n")
+				options.Logger.Print().Msgf("No profiles found in %s\n", defaultProfilesPath)
+				options.Logger.Print().Msgf("Tip: run 'nuclei -update-templates' to download community profiles\n")
 				os.Exit(0)
 			}
 			options.Logger.Fatal().Msgf("could not list profiles: %s\n", err)
 		}
 		if len(entries) == 0 {
-			options.Logger.Silent().Msgf("No profiles found in %s\n", defaultProfilesPath)
-			options.Logger.Silent().Msgf("Tip: run 'nuclei -update-templates' to download community profiles\n")
+			options.Logger.Print().Msgf("No profiles found in %s\n", defaultProfilesPath)
+			options.Logger.Print().Msgf("Tip: run 'nuclei -update-templates' to download community profiles\n")
 		}
 		for _, e := range entries {
 			if e.Metadata.Name != "" || e.Metadata.Purpose != "" {
@@ -109,9 +109,9 @@ func ParseOptions(options *types.Options) {
 						desc = e.Metadata.Purpose
 					}
 				}
-				options.Logger.Silent().Msgf("%-50s %-20s  %s\n", e.RelPath, "("+e.ProfileID+")", desc)
+				options.Logger.Print().Msgf("%-50s %-20s  %s\n", e.RelPath, "("+e.ProfileID+")", desc)
 			} else {
-				options.Logger.Silent().Msgf("%-50s %-20s\n", e.RelPath, "("+e.ProfileID+")")
+				options.Logger.Print().Msgf("%-50s %-20s\n", e.RelPath, "("+e.ProfileID+")")
 			}
 		}
 		os.Exit(0)

--- a/pkg/profile/profile.go
+++ b/pkg/profile/profile.go
@@ -95,6 +95,9 @@ func Parse(data []byte, path string) (*Profile, error) {
 	if err := yaml.Unmarshal(data, &raw); err != nil {
 		return nil, fmt.Errorf("could not parse profile %q: %w", path, err)
 	}
+	if len(raw) == 0 {
+		return nil, fmt.Errorf("profile %q is empty", path)
+	}
 
 	p := &Profile{}
 

--- a/pkg/profile/profile.go
+++ b/pkg/profile/profile.go
@@ -116,8 +116,14 @@ func Parse(data []byte, path string) (*Profile, error) {
 	}
 
 	// Extract inline target list.
-	if v, ok := rawString(raw, "list"); ok {
-		p.InlineTargets = v
+	// Reject non-string values (e.g. YAML sequences) so targets do not
+	// silently disappear when the profile is misformatted.
+	if v, ok := raw["list"]; ok {
+		s, ok := v.(string)
+		if !ok {
+			return nil, fmt.Errorf("profile field %q must be a string (got %T); use a YAML block scalar (|) for multi-line targets", "list", v)
+		}
+		p.InlineTargets = s
 	}
 
 	// Extract inline secrets block (preserve as-is for re-serialization).
@@ -284,7 +290,12 @@ func ListProfiles(profilesDir, templatesRootDir string) ([]ListEntry, error) {
 	var entries []ListEntry
 	err := filepath.WalkDir(profilesDir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
-			return nil // skip unreadable entries
+			if path == profilesDir {
+				// Root directory is missing or unreadable — surface the error so
+				// callers can distinguish "no profiles" from "bad profiles path".
+				return err
+			}
+			return nil // skip individual unreadable sub-entries
 		}
 		if d.IsDir() {
 			return nil

--- a/pkg/profile/profile.go
+++ b/pkg/profile/profile.go
@@ -1,0 +1,324 @@
+// Package profile implements template profile loading, validation, and materialization
+// for nuclei's template-profile feature (issue #5567).
+//
+// A template profile is a YAML file that bundles nuclei flags together with optional
+// metadata fields (id, name, purpose, description) and inline targets/secrets that
+// would otherwise require separate files.
+//
+// Example profile:
+//
+//	id: my-scan
+//	name: My Scan Profile
+//	purpose: Daily vuln scan of example.com
+//	description: Runs CVE templates against example.com
+//
+//	# Inline target list (materialized to a temp file)
+//	list: |
+//	  example.com
+//	  api.example.com
+//
+//	tags: cve
+//	exclude-tags: dos,fuzz
+//
+//	# Inline secrets block (materialized to a temp file)
+//	secrets:
+//	  static:
+//	    - type: header
+//	      domains:
+//	        - api.example.com
+//	      headers:
+//	        - key: X-API-Key
+//	          value: secret-here
+package profile
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Metadata holds informational fields that are stripped before passing the
+// profile to goflags.MergeConfigFile.  These fields are intentionally ignored
+// by the flag-merge step so users can annotate profiles freely.
+type Metadata struct {
+	ID          string `yaml:"id"`
+	Name        string `yaml:"name"`
+	Purpose     string `yaml:"purpose"`
+	Description string `yaml:"description"`
+}
+
+// Profile represents the parsed content of a template-profile YAML file.
+// It separates the nuclei-flag section from the metadata, inline-target list,
+// and inline-secrets block so each piece can be handled appropriately.
+type Profile struct {
+	Metadata
+
+	// InlineTargets is the content of the "list" key.  If non-empty it will
+	// be materialized into a temporary file and added to the input list.
+	InlineTargets string `yaml:"list"`
+
+	// InlineSecrets is the raw YAML value of the "secrets" key.  When present
+	// it is written to a temp file and appended to options.SecretsFile.
+	InlineSecrets interface{} `yaml:"secrets"`
+
+	// FlagOverrides holds every OTHER key in the profile so we can re-serialise
+	// a "clean" version without the metadata/list/secrets keys for goflags.
+	FlagOverrides map[string]interface{} `yaml:"-"`
+
+	// tempFiles tracks temp files created during materialization so callers
+	// can clean them up on exit.
+	tempFiles []string
+}
+
+// Load reads a profile YAML file, validates it, and returns a Profile.
+func Load(path string) (*Profile, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("could not read profile %q: %w", path, err)
+	}
+	return Parse(data, path)
+}
+
+// Parse decodes raw YAML profile bytes.  path is used only for error messages.
+func Parse(data []byte, path string) (*Profile, error) {
+	if len(data) == 0 {
+		return nil, fmt.Errorf("profile %q is empty", path)
+	}
+
+	// First pass: decode into a generic map so we can extract metadata and
+	// special keys without strict schema enforcement (extra fields are fine).
+	var raw map[string]interface{}
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("could not parse profile %q: %w", path, err)
+	}
+
+	p := &Profile{}
+
+	// Extract metadata fields (silently ignored by goflags merge).
+	if v, ok := rawString(raw, "id"); ok {
+		p.ID = v
+	}
+	if v, ok := rawString(raw, "name"); ok {
+		p.Name = v
+	}
+	if v, ok := rawString(raw, "purpose"); ok {
+		p.Purpose = v
+	}
+	if v, ok := rawString(raw, "description"); ok {
+		p.Description = v
+	}
+
+	// Extract inline target list.
+	if v, ok := rawString(raw, "list"); ok {
+		p.InlineTargets = v
+	}
+
+	// Extract inline secrets block (preserve as-is for re-serialization).
+	if v, ok := raw["secrets"]; ok {
+		p.InlineSecrets = v
+	}
+
+	// Build flag-overrides map: everything except our reserved keys.
+	reserved := map[string]bool{
+		"id": true, "name": true, "purpose": true, "description": true,
+		"list": true, "secrets": true,
+	}
+	p.FlagOverrides = make(map[string]interface{}, len(raw))
+	for k, v := range raw {
+		if !reserved[k] {
+			p.FlagOverrides[k] = v
+		}
+	}
+
+	return p, nil
+}
+
+// Validate checks that the profile is well-formed.  It returns a descriptive
+// error listing all problems found so users can fix them in one go.
+func (p *Profile) Validate() error {
+	var errs []string
+
+	if p.ID != "" && strings.ContainsAny(p.ID, " /\\") {
+		errs = append(errs, "id must not contain spaces or path separators")
+	}
+
+	// If there are inline secrets, make sure they look like a map (not a scalar).
+	if p.InlineSecrets != nil {
+		if _, ok := p.InlineSecrets.(map[string]interface{}); !ok {
+			errs = append(errs, "secrets must be a YAML mapping (expected static/dynamic keys)")
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("invalid profile: %s", strings.Join(errs, "; "))
+	}
+	return nil
+}
+
+// MaterializeTargets writes inline targets to a temporary file and returns its
+// path.  Returns ("", nil) if there are no inline targets.  The temp file is
+// registered for cleanup via TempFiles().
+func (p *Profile) MaterializeTargets(dir string) (string, error) {
+	if p.InlineTargets == "" {
+		return "", nil
+	}
+
+	f, err := os.CreateTemp(dir, "nuclei-profile-targets-*.txt")
+	if err != nil {
+		return "", fmt.Errorf("could not create targets temp file: %w", err)
+	}
+	defer f.Close()
+
+	// Write one target per non-empty line, trimming whitespace.
+	for _, line := range strings.Split(p.InlineTargets, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if _, err := fmt.Fprintln(f, line); err != nil {
+			return "", fmt.Errorf("could not write targets temp file: %w", err)
+		}
+	}
+
+	p.tempFiles = append(p.tempFiles, f.Name())
+	return f.Name(), nil
+}
+
+// MaterializeSecrets writes the inline secrets block to a temporary YAML file
+// and returns its path.  Returns ("", nil) if there are no inline secrets.
+func (p *Profile) MaterializeSecrets(dir string) (string, error) {
+	if p.InlineSecrets == nil {
+		return "", nil
+	}
+
+	secretsYAML, err := yaml.Marshal(p.InlineSecrets)
+	if err != nil {
+		return "", fmt.Errorf("could not serialize inline secrets: %w", err)
+	}
+
+	f, err := os.CreateTemp(dir, "nuclei-profile-secrets-*.yaml")
+	if err != nil {
+		return "", fmt.Errorf("could not create secrets temp file: %w", err)
+	}
+	defer f.Close()
+
+	if _, err := f.Write(secretsYAML); err != nil {
+		return "", fmt.Errorf("could not write secrets temp file: %w", err)
+	}
+
+	p.tempFiles = append(p.tempFiles, f.Name())
+	return f.Name(), nil
+}
+
+// WriteFlagsFile serializes the FlagOverrides (the nuclei flags portion of the
+// profile, stripped of metadata/list/secrets) to a temporary YAML file so it
+// can be passed to goflags.MergeConfigFile.  This avoids parse errors that
+// goflags would emit when encountering the extra metadata keys.
+//
+// Returns the path of the temp file, or ("", nil) if FlagOverrides is empty.
+func (p *Profile) WriteFlagsFile(dir string) (string, error) {
+	if len(p.FlagOverrides) == 0 {
+		return "", nil
+	}
+
+	flagsYAML, err := yaml.Marshal(p.FlagOverrides)
+	if err != nil {
+		return "", fmt.Errorf("could not serialize profile flags: %w", err)
+	}
+
+	f, err := os.CreateTemp(dir, "nuclei-profile-flags-*.yaml")
+	if err != nil {
+		return "", fmt.Errorf("could not create profile flags temp file: %w", err)
+	}
+	defer f.Close()
+
+	if _, err := f.Write(flagsYAML); err != nil {
+		return "", fmt.Errorf("could not write profile flags temp file: %w", err)
+	}
+
+	p.tempFiles = append(p.tempFiles, f.Name())
+	return f.Name(), nil
+}
+
+// TempFiles returns the paths of all temporary files created during
+// materialization.  Callers should remove these on exit.
+func (p *Profile) TempFiles() []string {
+	return p.tempFiles
+}
+
+// Summary returns a human-readable one-liner describing the profile.
+func (p *Profile) Summary() string {
+	var parts []string
+	if p.Name != "" {
+		parts = append(parts, p.Name)
+	} else if p.ID != "" {
+		parts = append(parts, p.ID)
+	}
+	if p.Purpose != "" {
+		parts = append(parts, "("+p.Purpose+")")
+	}
+	if len(parts) == 0 {
+		return "(unnamed profile)"
+	}
+	return strings.Join(parts, " ")
+}
+
+// ListProfiles walks profilesDir and returns one entry per YAML profile found.
+// Each entry is a ListEntry with the relative path from templatesRootDir and
+// the derived profile ID (filename without extension).
+type ListEntry struct {
+	RelPath   string
+	ProfileID string
+	Metadata  Metadata
+}
+
+// ListProfiles walks profilesDir and returns metadata for every YAML profile.
+func ListProfiles(profilesDir, templatesRootDir string) ([]ListEntry, error) {
+	var entries []ListEntry
+	err := filepath.WalkDir(profilesDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil // skip unreadable entries
+		}
+		if d.IsDir() {
+			return nil
+		}
+		ext := strings.ToLower(filepath.Ext(path))
+		if ext != ".yml" && ext != ".yaml" {
+			return nil
+		}
+
+		relPath, _ := filepath.Rel(templatesRootDir, path)
+		profileID := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+
+		entry := ListEntry{
+			RelPath:   relPath,
+			ProfileID: profileID,
+		}
+
+		// Best-effort metadata load — if parse fails just omit metadata.
+		if p, loadErr := Load(path); loadErr == nil {
+			entry.Metadata = p.Metadata
+			if entry.Metadata.ID == "" {
+				entry.Metadata.ID = profileID
+			}
+		}
+
+		entries = append(entries, entry)
+		return nil
+	})
+	return entries, err
+}
+
+// rawString is a helper that returns a string value from a raw map.
+func rawString(m map[string]interface{}, key string) (string, bool) {
+	v, ok := m[key]
+	if !ok {
+		return "", false
+	}
+	s, ok := v.(string)
+	return s, ok
+}

--- a/pkg/profile/profile_test.go
+++ b/pkg/profile/profile_test.go
@@ -1,0 +1,303 @@
+package profile
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// --- Parse / metadata tests ---
+
+func TestParseMetadata(t *testing.T) {
+	yaml := `
+id: my-scan
+name: My Scan
+purpose: Daily scan
+description: Scans example.com daily
+tags: cve
+exclude-tags: dos,fuzz
+`
+	p, err := Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.ID != "my-scan" {
+		t.Errorf("ID: got %q, want %q", p.ID, "my-scan")
+	}
+	if p.Name != "My Scan" {
+		t.Errorf("Name: got %q, want %q", p.Name, "My Scan")
+	}
+	if p.Purpose != "Daily scan" {
+		t.Errorf("Purpose: got %q, want %q", p.Purpose, "Daily scan")
+	}
+	if p.Description != "Scans example.com daily" {
+		t.Errorf("Description: got %q, want %q", p.Description, "Scans example.com daily")
+	}
+
+	// metadata keys must NOT appear in FlagOverrides (they'd confuse goflags)
+	for _, reserved := range []string{"id", "name", "purpose", "description"} {
+		if _, ok := p.FlagOverrides[reserved]; ok {
+			t.Errorf("reserved key %q leaked into FlagOverrides", reserved)
+		}
+	}
+
+	// nuclei-flag keys MUST appear in FlagOverrides
+	if _, ok := p.FlagOverrides["tags"]; !ok {
+		t.Error("expected 'tags' in FlagOverrides")
+	}
+	if _, ok := p.FlagOverrides["exclude-tags"]; !ok {
+		t.Error("expected 'exclude-tags' in FlagOverrides")
+	}
+}
+
+func TestParseExtraFieldsIgnored(t *testing.T) {
+	// Fields that are not nuclei flags and not our reserved keys should still be
+	// carried through to FlagOverrides without causing a parse error.
+	yaml := `
+id: test
+some-unknown-field: value
+another-custom-key: 123
+tags: cve
+`
+	p, err := Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("Parse should not fail on extra fields: %v", err)
+	}
+	if _, ok := p.FlagOverrides["some-unknown-field"]; !ok {
+		t.Error("extra field 'some-unknown-field' should be in FlagOverrides (goflags will ignore unknowns)")
+	}
+}
+
+func TestParseEmpty(t *testing.T) {
+	_, err := Parse([]byte{}, "empty.yml")
+	if err == nil {
+		t.Error("expected error for empty profile")
+	}
+}
+
+func TestParseInvalidYAML(t *testing.T) {
+	_, err := Parse([]byte(":\tinvalid: yaml: ["), "bad.yml")
+	if err == nil {
+		t.Error("expected error for invalid YAML")
+	}
+}
+
+// --- Validate tests ---
+
+func TestValidateOK(t *testing.T) {
+	p := &Profile{Metadata: Metadata{ID: "valid-id"}}
+	if err := p.Validate(); err != nil {
+		t.Errorf("unexpected validation error: %v", err)
+	}
+}
+
+func TestValidateIDWithSpaces(t *testing.T) {
+	p := &Profile{Metadata: Metadata{ID: "has space"}}
+	if err := p.Validate(); err == nil {
+		t.Error("expected validation error for ID with spaces")
+	}
+}
+
+func TestValidateSecretsNotAMap(t *testing.T) {
+	p := &Profile{InlineSecrets: "just a string, not a map"}
+	if err := p.Validate(); err == nil {
+		t.Error("expected validation error when secrets is not a mapping")
+	}
+}
+
+// --- MaterializeTargets tests ---
+
+func TestMaterializeTargets(t *testing.T) {
+	p := &Profile{
+		InlineTargets: `
+  example.com
+  api.example.com
+  # this is a comment
+  
+  chaos.projectdiscovery.io
+`,
+	}
+
+	tmpDir := t.TempDir()
+	path, err := p.MaterializeTargets(tmpDir)
+	if err != nil {
+		t.Fatalf("MaterializeTargets: %v", err)
+	}
+	if path == "" {
+		t.Fatal("expected non-empty path")
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	content := string(data)
+	for _, expected := range []string{"example.com", "api.example.com", "chaos.projectdiscovery.io"} {
+		if !strings.Contains(content, expected) {
+			t.Errorf("expected %q in target file content", expected)
+		}
+	}
+	// Comments should be stripped.
+	if strings.Contains(content, "this is a comment") {
+		t.Error("comments should be stripped from target file")
+	}
+	// File should be registered as a temp file.
+	if len(p.TempFiles()) != 1 || p.TempFiles()[0] != path {
+		t.Error("temp file not registered")
+	}
+}
+
+func TestMaterializeTargetsEmpty(t *testing.T) {
+	p := &Profile{}
+	path, err := p.MaterializeTargets(t.TempDir())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if path != "" {
+		t.Errorf("expected empty path for empty InlineTargets, got %q", path)
+	}
+}
+
+// --- MaterializeSecrets tests ---
+
+func TestMaterializeSecrets(t *testing.T) {
+	yamlInput := `
+id: test
+secrets:
+  static:
+    - type: header
+      domains:
+        - example.com
+      headers:
+        - key: X-API-Key
+          value: secret123
+`
+	p, err := Parse([]byte(yamlInput), "test.yml")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if p.InlineSecrets == nil {
+		t.Fatal("expected InlineSecrets to be non-nil")
+	}
+
+	tmpDir := t.TempDir()
+	path, err := p.MaterializeSecrets(tmpDir)
+	if err != nil {
+		t.Fatalf("MaterializeSecrets: %v", err)
+	}
+	if path == "" {
+		t.Fatal("expected non-empty path for inline secrets")
+	}
+
+	data, _ := os.ReadFile(path)
+	content := string(data)
+	if !strings.Contains(content, "X-API-Key") {
+		t.Errorf("expected secret header key in materialized secrets file, got: %s", content)
+	}
+}
+
+func TestMaterializeSecretsNil(t *testing.T) {
+	p := &Profile{}
+	path, err := p.MaterializeSecrets(t.TempDir())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if path != "" {
+		t.Errorf("expected empty path when no inline secrets, got %q", path)
+	}
+}
+
+// --- WriteFlagsFile tests ---
+
+func TestWriteFlagsFile(t *testing.T) {
+	yaml := `
+tags: cve
+exclude-tags: dos,fuzz
+template-concurrency: 5
+`
+	p, err := Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	tmpDir := t.TempDir()
+	path, err := p.WriteFlagsFile(tmpDir)
+	if err != nil {
+		t.Fatalf("WriteFlagsFile: %v", err)
+	}
+	if path == "" {
+		t.Fatal("expected non-empty path")
+	}
+
+	data, _ := os.ReadFile(path)
+	content := string(data)
+	if !strings.Contains(content, "tags") {
+		t.Error("flags file should contain 'tags'")
+	}
+	// Metadata keys must not appear in the flags file.
+	for _, key := range []string{"id:", "name:", "purpose:", "description:", "list:", "secrets:"} {
+		if strings.Contains(content, key) {
+			t.Errorf("flags file should not contain reserved key %q", key)
+		}
+	}
+}
+
+// --- Summary tests ---
+
+func TestSummary(t *testing.T) {
+	cases := []struct {
+		p    Profile
+		want string
+	}{
+		{Profile{Metadata: Metadata{Name: "My Scan", Purpose: "daily"}}, "My Scan (daily)"},
+		{Profile{Metadata: Metadata{ID: "vuln-scan"}}, "vuln-scan"},
+		{Profile{}, "(unnamed profile)"},
+	}
+	for _, tc := range cases {
+		got := tc.p.Summary()
+		if got != tc.want {
+			t.Errorf("Summary() = %q, want %q", got, tc.want)
+		}
+	}
+}
+
+// --- ListProfiles tests ---
+
+func TestListProfiles(t *testing.T) {
+	root := t.TempDir()
+	profilesDir := filepath.Join(root, "profiles")
+	if err := os.MkdirAll(profilesDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write two profile files.
+	profile1 := `id: cloud\nname: Cloud Scan\ntags: cloud`
+	profile2 := `id: cve-scan\ntags: cve`
+	if err := os.WriteFile(filepath.Join(profilesDir, "cloud.yml"), []byte(profile1), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(profilesDir, "cve.yaml"), []byte(profile2), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Write a non-YAML file that should be ignored.
+	if err := os.WriteFile(filepath.Join(profilesDir, "README.txt"), []byte("ignore me"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	entries, err := ListProfiles(profilesDir, root)
+	if err != nil {
+		t.Fatalf("ListProfiles: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Errorf("expected 2 entries, got %d", len(entries))
+	}
+
+	ids := make(map[string]bool)
+	for _, e := range entries {
+		ids[e.ProfileID] = true
+	}
+	if !ids["cloud"] || !ids["cve"] {
+		t.Errorf("expected profile IDs 'cloud' and 'cve', got %v", ids)
+	}
+}

--- a/pkg/profile/profile_test.go
+++ b/pkg/profile/profile_test.go
@@ -272,8 +272,13 @@ func TestListProfiles(t *testing.T) {
 	}
 
 	// Write two profile files.
-	profile1 := `id: cloud\nname: Cloud Scan\ntags: cloud`
-	profile2 := `id: cve-scan\ntags: cve`
+	profile1 := `id: cloud
+name: Cloud Scan
+tags: cloud
+`
+	profile2 := `id: cve-scan
+tags: cve
+`
 	if err := os.WriteFile(filepath.Join(profilesDir, "cloud.yml"), []byte(profile1), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -296,6 +301,9 @@ func TestListProfiles(t *testing.T) {
 	ids := make(map[string]bool)
 	for _, e := range entries {
 		ids[e.ProfileID] = true
+		if e.ProfileID == "cloud" && e.Metadata.Name != "Cloud Scan" {
+			t.Errorf("expected metadata name 'Cloud Scan' for cloud profile, got %q", e.Metadata.Name)
+		}
 	}
 	if !ids["cloud"] || !ids["cve"] {
 		t.Errorf("expected profile IDs 'cloud' and 'cve', got %v", ids)


### PR DESCRIPTION
## Summary

Implements improvements to nuclei's template profile system as requested in #5567.

## Changes

### New: `pkg/profile` package
A dedicated package separating profile concerns from the CLI entry point:
- `Parse()` / `Load()` — decode profile YAML with full tolerance for extra fields
- `Validate()` — check profile well-formedness with actionable error messages
- `MaterializeTargets()` — write inline `list:` block to a temp file
- `MaterializeSecrets()` — write inline `secrets:` block to a temp YAML file for the auth-provider pipeline
- `WriteFlagsFile()` — produce a clean flags-only YAML (stripped of metadata/list/secrets) for goflags
- `ListProfiles()` — enumerate profiles with metadata for `-tpl` output
- `Summary()` — human-readable profile description for log output

### Feature A: Ignore extra/metadata fields
Profile YAML may now include `id`, `name`, `purpose`, and `description` for documentation without causing a parse error. These are stripped before flags are merged.

### Feature B: Inline targets (`list:` key)
```yaml
list: |
  example.com
  api.example.com
  chaos.projectdiscovery.io
```
Materialized to a temp file and appended to `options.Targets`.

### Feature C: Inline secrets (`secrets:` key)
```yaml
secrets:
  static:
    - type: header
      domains: [api.example.com]
      headers:
        - key: X-API-Key
          value: secret-here
```
Serialized to a temp YAML file and appended to `options.SecretsFile`, flowing into the existing auth-provider pipeline.

### Improved error messages
Profile-not-found and invalid-YAML errors now suggest corrective actions.

### Improved `-tpl` output
Profiles with `name`/`purpose` metadata show them in formatted columns.

## Tests
14 unit tests in `pkg/profile/profile_test.go`. All pass.

Closes #5567

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Profile-based configuration with merged flags, profile summaries, and inline profile materialization for targets and secrets.

* **Bug Fixes**
  * More descriptive, actionable profile error messages; improved profile listing with metadata and ensured cleanup of temporary profile artifacts.

* **Tests**
  * Extensive tests covering profile parsing, validation, materialization, flag serialization, summaries, and listing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->