### PR TITLE
fix(auth): prefetch secrets when secret files are provided

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -688,7 +688,7 @@ func (r *Runner) RunEnumeration() error {
 	r.displayExecutionInfo(store)
 
 	// prefetch secrets if enabled
-	if executorOpts.AuthProvider != nil && r.options.PreFetchSecrets {
+	if executorOpts.AuthProvider != nil && (r.options.PreFetchSecrets || len(r.options.SecretsFile) > 0) {
 		r.Logger.Info().Msgf("Pre-fetching secrets from authprovider[s]")
 		if err := executorOpts.AuthProvider.PreFetchSecrets(); err != nil {
 			return errors.Wrap(err, "could not pre-fetch secrets")

--- a/lib/sdk_private.go
+++ b/lib/sdk_private.go
@@ -229,7 +229,7 @@ func (e *NucleiEngine) init(ctx context.Context) error {
 	}
 
 	// prefetch secrets
-	if e.executerOpts.AuthProvider != nil && e.opts.PreFetchSecrets {
+	if e.executerOpts.AuthProvider != nil && (e.opts.PreFetchSecrets || len(e.opts.SecretsFile) > 0) {
 		if err := e.executerOpts.AuthProvider.PreFetchSecrets(); err != nil {
 			return errors.Wrap(err, "could not prefetch secrets")
 		}


### PR DESCRIPTION
Fixes #6592

## Summary
When `--secret-file` is provided, authenticated scan secrets should be prefetched before scan execution begins.

Previously, `PreFetchSecrets()` only ran when the `--prefetch-secrets` flag was enabled. This change also triggers prefetch when one or more secret files are configured.

## Changes
- updated prefetch condition in `internal/runner/runner.go`
- updated prefetch condition in `lib/sdk_private.go`

## Result
This ensures authenticated secrets are loaded earlier for secret-file based scans, reducing the chance that normal scan requests begin before auth setup is ready.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved secrets handling: secrets configured via configuration files are now automatically pre-fetched, ensuring consistent behavior without requiring additional settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->