### PR TITLE
feat: add config.yaml support for nuclei scans

### DIFF
--- a/cmd/nuclei/config_extras.go
+++ b/cmd/nuclei/config_extras.go
@@ -118,15 +118,17 @@ func applyInlineList(raw map[string]interface{}, opts *types.Options) error {
 	if err != nil {
 		return fmt.Errorf("could not create temp targets file: %w", err)
 	}
+	// Register immediately so cleanupInternalTempFiles removes it even if a
+	// subsequent write or close fails.
+	internalTempFiles = append(internalTempFiles, tmpFile.Name())
+	opts.TargetsFilePath = tmpFile.Name()
+
 	for _, t := range targets {
 		fmt.Fprintln(tmpFile, t)
 	}
 	if err := tmpFile.Close(); err != nil {
 		return fmt.Errorf("could not write temp targets file: %w", err)
 	}
-
-	internalTempFiles = append(internalTempFiles, tmpFile.Name())
-	opts.TargetsFilePath = tmpFile.Name()
 	return nil
 }
 
@@ -173,6 +175,10 @@ func applyInlineSecrets(raw map[string]interface{}, opts *types.Options) error {
 	if err != nil {
 		return fmt.Errorf("could not create temp secrets file: %w", err)
 	}
+	// Register immediately so cleanupInternalTempFiles removes it even if a
+	// subsequent write or close fails.
+	internalTempFiles = append(internalTempFiles, tmpFile.Name())
+
 	if _, err := tmpFile.Write(secretsData); err != nil {
 		_ = tmpFile.Close()
 		return fmt.Errorf("could not write temp secrets file: %w", err)
@@ -180,8 +186,6 @@ func applyInlineSecrets(raw map[string]interface{}, opts *types.Options) error {
 	if err := tmpFile.Close(); err != nil {
 		return fmt.Errorf("could not close temp secrets file: %w", err)
 	}
-
-	internalTempFiles = append(internalTempFiles, tmpFile.Name())
 	opts.SecretsFile = append(opts.SecretsFile, tmpFile.Name())
 	return nil
 }

--- a/cmd/nuclei/config_extras.go
+++ b/cmd/nuclei/config_extras.go
@@ -1,0 +1,187 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v2"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/types"
+	fileutil "github.com/projectdiscovery/utils/file"
+)
+
+// internalTempFiles tracks temporary files created during config processing
+// so they can be cleaned up after the scan completes.
+var internalTempFiles []string
+
+// cleanupInternalTempFiles removes any temporary files created during config processing.
+func cleanupInternalTempFiles() {
+	for _, f := range internalTempFiles {
+		_ = os.Remove(f)
+	}
+}
+
+// processConfigExtras handles special YAML keys in config/profile files that require
+// custom processing beyond what goflags.MergeConfigFile provides:
+//
+//   - list: supports inline targets as a block scalar (multi-line string) or a YAML
+//     list of strings, in addition to the existing file-path string form.
+//
+//   - secrets: allows embedding auth config inline rather than pointing to a separate
+//     file. The section is written to a temporary file and appended to SecretsFile so
+//     the existing auth-provider machinery picks it up transparently.
+//
+// Unknown YAML keys (e.g. name, purpose, id, description) are silently ignored by
+// goflags.MergeConfigFile; this function does not change that behaviour.
+func processConfigExtras(filePath string, opts *types.Options) error {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return err
+	}
+
+	var raw map[string]interface{}
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		// Not a valid YAML file - goflags already handles the error; nothing to do.
+		return nil
+	}
+
+	if err := applyInlineList(raw, opts); err != nil {
+		return err
+	}
+
+	if err := applyInlineSecrets(raw, opts); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// applyInlineList handles the "list" key when it contains inline targets instead of
+// a file path. Supported forms:
+//
+//	list: |
+//	  target1.example.com
+//	  target2.example.com
+//
+//	list:
+//	  - target1.example.com
+//	  - target2.example.com
+//
+// If the current TargetsFilePath already points to an existing file (set via the
+// -l CLI flag), it is left unchanged so CLI flags keep their higher priority.
+func applyInlineList(raw map[string]interface{}, opts *types.Options) error {
+	listVal, ok := raw["list"]
+	if !ok {
+		return nil
+	}
+
+	var targets []string
+
+	switch v := listVal.(type) {
+	case string:
+		// A block scalar ("|") produces a string with embedded newlines.
+		// A plain single-line string is an existing file path; let goflags handle it.
+		lines := strings.Split(strings.TrimSpace(v), "\n")
+		if len(lines) <= 1 {
+			// Single value: treat as a file path (goflags already handled it).
+			return nil
+		}
+		for _, line := range lines {
+			if t := strings.TrimSpace(line); t != "" {
+				targets = append(targets, t)
+			}
+		}
+
+	case []interface{}:
+		// YAML sequence: each element is an inline target.
+		for _, item := range v {
+			if s, ok := item.(string); ok {
+				if t := strings.TrimSpace(s); t != "" {
+					targets = append(targets, t)
+				}
+			}
+		}
+	}
+
+	if len(targets) == 0 {
+		return nil
+	}
+
+	// Respect -l CLI flag: if TargetsFilePath already points to a real file,
+	// it was set by the user on the command line and takes priority.
+	if opts.TargetsFilePath != "" && fileutil.FileExists(opts.TargetsFilePath) {
+		return nil
+	}
+
+	tmpFile, err := os.CreateTemp("", "nuclei-targets-*.txt")
+	if err != nil {
+		return fmt.Errorf("could not create temp targets file: %w", err)
+	}
+	for _, t := range targets {
+		fmt.Fprintln(tmpFile, t)
+	}
+	if err := tmpFile.Close(); err != nil {
+		return fmt.Errorf("could not write temp targets file: %w", err)
+	}
+
+	internalTempFiles = append(internalTempFiles, tmpFile.Name())
+	opts.TargetsFilePath = tmpFile.Name()
+	return nil
+}
+
+// applyInlineSecrets handles the "secrets" key, which mirrors the format of a
+// standalone secrets file. The section is serialised back to YAML, written to a
+// temporary file, and that path is appended to opts.SecretsFile so the existing
+// FileAuthProvider picks it up without modification.
+//
+// Example config YAML section:
+//
+//	secrets:
+//	  static:
+//	    - type: header
+//	      domains:
+//	        - api.example.com
+//	      headers:
+//	        - key: X-Api-Key
+//	          value: my-secret-key
+//	  dynamic:
+//	    - template: custom-oauth-flow.yaml
+//	      variables:
+//	        - name: username
+//	          value: pdteam
+//	        - name: password
+//	          value: secret
+//	      type: cookie
+//	      domains:
+//	        - .*.example.com
+//	      headers:
+//	        - key: Authorization
+//	          value: Bearer {{token}}
+func applyInlineSecrets(raw map[string]interface{}, opts *types.Options) error {
+	secretsVal, ok := raw["secrets"]
+	if !ok {
+		return nil
+	}
+
+	secretsData, err := yaml.Marshal(secretsVal)
+	if err != nil {
+		return fmt.Errorf("could not serialise inline secrets: %w", err)
+	}
+
+	tmpFile, err := os.CreateTemp("", "nuclei-secrets-*.yaml")
+	if err != nil {
+		return fmt.Errorf("could not create temp secrets file: %w", err)
+	}
+	if _, err := tmpFile.Write(secretsData); err != nil {
+		_ = tmpFile.Close()
+		return fmt.Errorf("could not write temp secrets file: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		return fmt.Errorf("could not close temp secrets file: %w", err)
+	}
+
+	internalTempFiles = append(internalTempFiles, tmpFile.Name())
+	opts.SecretsFile = append(opts.SecretsFile, tmpFile.Name())
+	return nil
+}

--- a/cmd/nuclei/config_extras_test.go
+++ b/cmd/nuclei/config_extras_test.go
@@ -1,0 +1,238 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/types"
+	fileutil "github.com/projectdiscovery/utils/file"
+)
+
+func writeTemp(t *testing.T, content string) string {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "nuclei-test-*.yaml")
+	if err != nil {
+		t.Fatalf("could not create temp file: %v", err)
+	}
+	if _, err := f.WriteString(content); err != nil {
+		t.Fatalf("could not write temp file: %v", err)
+	}
+	_ = f.Close()
+	return f.Name()
+}
+
+// TestProcessConfigExtras_UnknownFieldsIgnored verifies that metadata fields
+// (name, purpose, id) in a config file do not cause errors.
+func TestProcessConfigExtras_UnknownFieldsIgnored(t *testing.T) {
+	cfg := writeTemp(t, `
+name: my-scan
+purpose: testing
+id: scan-001
+description: sanity check
+
+timeout: 30
+`)
+	opts := &types.Options{}
+	if err := processConfigExtras(cfg, opts); err != nil {
+		t.Fatalf("unexpected error for config with metadata fields: %v", err)
+	}
+	// no targets or secrets should have been set
+	if opts.TargetsFilePath != "" {
+		t.Errorf("expected TargetsFilePath to be empty, got %q", opts.TargetsFilePath)
+	}
+	if len(opts.SecretsFile) != 0 {
+		t.Errorf("expected no secrets files, got %v", []string(opts.SecretsFile))
+	}
+}
+
+// TestProcessConfigExtras_InlineListBlockScalar verifies that a block-scalar
+// "list" section creates a temp targets file.
+func TestProcessConfigExtras_InlineListBlockScalar(t *testing.T) {
+	cfg := writeTemp(t, `
+name: pd-scan
+list: |
+  cve.projectdiscovery.io
+  chaos.projectdiscovery.io
+  api.projectdiscovery.io
+`)
+	opts := &types.Options{}
+	if err := processConfigExtras(cfg, opts); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if opts.TargetsFilePath == "" {
+		t.Fatal("expected TargetsFilePath to be set")
+	}
+	internalTempFiles = nil // reset for other tests
+
+	content, err := os.ReadFile(opts.TargetsFilePath)
+	if err != nil {
+		t.Fatalf("could not read temp targets file: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(content)), "\n")
+	if len(lines) != 3 {
+		t.Errorf("expected 3 targets, got %d: %v", len(lines), lines)
+	}
+	_ = os.Remove(opts.TargetsFilePath)
+}
+
+// TestProcessConfigExtras_InlineListYAMLSequence verifies that a YAML-sequence
+// "list" section creates a temp targets file.
+func TestProcessConfigExtras_InlineListYAMLSequence(t *testing.T) {
+	cfg := writeTemp(t, `
+list:
+  - target1.example.com
+  - target2.example.com
+`)
+	opts := &types.Options{}
+	if err := processConfigExtras(cfg, opts); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if opts.TargetsFilePath == "" {
+		t.Fatal("expected TargetsFilePath to be set")
+	}
+	internalTempFiles = nil
+
+	content, err := os.ReadFile(opts.TargetsFilePath)
+	if err != nil {
+		t.Fatalf("could not read temp targets file: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(content)), "\n")
+	if len(lines) != 2 {
+		t.Errorf("expected 2 targets, got %d: %v", len(lines), lines)
+	}
+	_ = os.Remove(opts.TargetsFilePath)
+}
+
+// TestProcessConfigExtras_InlineListRespectsCLI verifies that when TargetsFilePath
+// already points to a real file (set via -l CLI flag), it is not overridden.
+func TestProcessConfigExtras_InlineListRespectsCLI(t *testing.T) {
+	// Create a real "CLI-set" targets file.
+	cliFile := writeTemp(t, "cli-target.example.com\n")
+
+	cfg := writeTemp(t, `
+list:
+  - config-target1.example.com
+  - config-target2.example.com
+`)
+	opts := &types.Options{TargetsFilePath: cliFile}
+	if err := processConfigExtras(cfg, opts); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// CLI file must win.
+	if opts.TargetsFilePath != cliFile {
+		t.Errorf("expected TargetsFilePath to remain %q, got %q", cliFile, opts.TargetsFilePath)
+	}
+}
+
+// TestProcessConfigExtras_InlineSecrets verifies that a "secrets" section is
+// written to a temp file and appended to SecretsFile.
+func TestProcessConfigExtras_InlineSecrets(t *testing.T) {
+	cfg := writeTemp(t, `
+name: pd-scan
+
+secrets:
+  static:
+    - type: header
+      domains:
+        - api.projectdiscovery.io
+      headers:
+        - key: x-pdcp-key
+          value: test-api-key-here
+`)
+	opts := &types.Options{}
+	if err := processConfigExtras(cfg, opts); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(opts.SecretsFile) != 1 {
+		t.Fatalf("expected 1 secrets file, got %d", len(opts.SecretsFile))
+	}
+	tmpSecretsPath := opts.SecretsFile[0]
+	internalTempFiles = nil
+
+	if !fileutil.FileExists(tmpSecretsPath) {
+		t.Fatalf("temp secrets file does not exist: %s", tmpSecretsPath)
+	}
+	content, err := os.ReadFile(tmpSecretsPath)
+	if err != nil {
+		t.Fatalf("could not read temp secrets file: %v", err)
+	}
+	if !strings.Contains(string(content), "x-pdcp-key") {
+		t.Errorf("secrets file missing expected key content, got:\n%s", string(content))
+	}
+	_ = os.Remove(tmpSecretsPath)
+}
+
+// TestProcessConfigExtras_InlineSecretsAndList verifies that both "secrets" and
+// "list" can be used together in a single config file.
+func TestProcessConfigExtras_InlineSecretsAndList(t *testing.T) {
+	cfg := writeTemp(t, `
+name: combined-scan
+purpose: test both features
+
+list:
+  - scanme.example.com
+
+secrets:
+  static:
+    - type: header
+      domains:
+        - scanme.example.com
+      headers:
+        - key: Authorization
+          value: Bearer test-token
+`)
+	opts := &types.Options{}
+	if err := processConfigExtras(cfg, opts); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if opts.TargetsFilePath == "" {
+		t.Error("expected TargetsFilePath to be set")
+	}
+	if len(opts.SecretsFile) != 1 {
+		t.Errorf("expected 1 secrets file, got %d", len(opts.SecretsFile))
+	}
+
+	// Cleanup
+	for _, f := range internalTempFiles {
+		_ = os.Remove(f)
+	}
+	internalTempFiles = nil
+}
+
+// TestProcessConfigExtras_FilePathList verifies that a single-line "list" value
+// (a file path) is left alone — goflags handles that case.
+func TestProcessConfigExtras_FilePathList(t *testing.T) {
+	cfg := writeTemp(t, `
+list: /tmp/my-targets.txt
+`)
+	opts := &types.Options{}
+	if err := processConfigExtras(cfg, opts); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Should not have created a temp file for a single-line list value.
+	if opts.TargetsFilePath != "" {
+		t.Errorf("expected TargetsFilePath to remain empty (goflags handles single-line list), got %q", opts.TargetsFilePath)
+	}
+}
+
+// TestCleanupInternalTempFiles verifies that cleanup removes the registered files.
+func TestCleanupInternalTempFiles(t *testing.T) {
+	f, err := os.CreateTemp("", "nuclei-cleanup-test-*")
+	if err != nil {
+		t.Fatalf("could not create temp file: %v", err)
+	}
+	_ = f.Close()
+	path := f.Name()
+
+	internalTempFiles = []string{path}
+	cleanupInternalTempFiles()
+	internalTempFiles = nil
+
+	if fileutil.FileExists(path) {
+		t.Errorf("expected temp file %q to be deleted after cleanup", path)
+	}
+}

--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -63,6 +63,7 @@ func main() {
 		options.Logger.Fatal().Msgf("Could not initialize options: %s\n", err)
 	}
 	_ = readConfig()
+	defer cleanupInternalTempFiles()
 
 	if options.ListDslSignatures {
 		options.Logger.Info().Msgf("The available custom DSL functions are:")
@@ -588,6 +589,10 @@ Additional documentation is available at: https://docs.nuclei.sh/getting-started
 		if err := flagSet.MergeConfigFile(cfgFile); err != nil {
 			options.Logger.Fatal().Msgf("Could not read config: %s\n", err)
 		}
+		// handle special keys (inline list, embedded secrets) not covered by goflags
+		if err := processConfigExtras(cfgFile, options); err != nil {
+			options.Logger.Warning().Msgf("Could not process config extras: %s\n", err)
+		}
 
 		if !options.Vars.IsEmpty() {
 			// Maybe we should add vars to the config file as well even if they are set via flags?
@@ -658,6 +663,10 @@ Additional documentation is available at: https://docs.nuclei.sh/getting-started
 		}
 		if err := flagSet.MergeConfigFile(templateProfile); err != nil {
 			options.Logger.Fatal().Msgf("Could not read template profile: %s\n", err)
+		}
+		// handle special keys (inline list, embedded secrets) not covered by goflags
+		if err := processConfigExtras(templateProfile, options); err != nil {
+			options.Logger.Warning().Msgf("Could not process profile extras: %s\n", err)
 		}
 	}
 


### PR DESCRIPTION
## Proposed Changes

Adds support for loading scan configuration via a YAML config file.

Users can now run:

nuclei -config config.yaml

The config file can include targets, template options, and other runtime flags.

CLI flags override config values to preserve existing behavior.

## Proof

Example config.yaml:

name: test-scan
list:
  - scanme.sh
timeout: 10

Command:

nuclei -config config.yaml

Targets and options are successfully loaded from the config file.

## Tests

Added tests in config_extras_test.go to validate config parsing and option merging.

/claim #5567
Fixes #5567
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Config files can include inline targets (block scalars or YAML lists) and inline secrets, removing the need for external files.
* **Behavior**
  * CLI-provided target file paths take precedence over inline targets; processing failures emit warnings but don't break startup.
* **Chores**
  * Temporary files created during config processing are automatically cleaned up on exit.
* **Tests**
  * Added tests covering inline lists, secrets, precedence, and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->