### PR TITLE
fix: use crypto/rand instead of math/rand in JS global functions

### DIFF
--- a/pkg/js/global/scripts.go
+++ b/pkg/js/global/scripts.go
@@ -3,8 +3,9 @@ package global
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
 	"embed"
-	"math/rand"
+	"math/big"
 	"net"
 	"reflect"
 	"time"
@@ -49,8 +50,8 @@ func initBuiltInFunc(runtime *goja.Runtime) {
 		Description: "Rand returns a random byte slice of length n",
 		FuncDecl: func(n int) []byte {
 			b := make([]byte, n)
-			for i := range b {
-				b[i] = byte(rand.Intn(255))
+			if _, err := rand.Read(b); err != nil {
+				return nil
 			}
 			return b
 		},
@@ -61,7 +62,11 @@ func initBuiltInFunc(runtime *goja.Runtime) {
 		Signatures:  []string{"RandInt() int"},
 		Description: "RandInt returns a random int",
 		FuncDecl: func() int64 {
-			return rand.Int63()
+			n, err := rand.Int(rand.Reader, new(big.Int).SetInt64(1<<63-1))
+			if err != nil {
+				return 0
+			}
+			return n.Int64()
 		},
 	})
 


### PR DESCRIPTION
## Proposed Changes

The `Rand()` and `RandInt()` JavaScript helper functions in `pkg/js/global/scripts.go` currently use Go's `math/rand` package, which is a **pseudorandom number generator (PRNG)** that is deterministic and predictable. This is a security concern because these functions are exposed to nuclei template authors, who may use them for generating security-sensitive values such as:

- Authentication tokens or session identifiers
- Cryptographic nonces
- Random padding in protocol fuzzing
- Any value where unpredictability is a security requirement

### The Problem

`math/rand` uses a deterministic algorithm seeded by a predictable value. An attacker who can observe or guess the seed can predict all future outputs. Go's own documentation explicitly warns:

> *"Top-level functions such as Float64 and Int should not be used for security-sensitive work. Use the crypto/rand package instead."*

### The Fix

This PR replaces `math/rand` with `crypto/rand` in both functions:

| Function | Before (insecure) | After (secure) |
|---|---|---|
| `Rand(n)` | `rand.Intn(255)` loop | `crypto/rand.Read(b)` — fills byte slice with cryptographically secure random bytes |
| `RandInt()` | `rand.Int63()` | `crypto/rand.Int(rand.Reader, max)` — returns cryptographically secure random int64 |

Both functions now gracefully handle the (extremely rare) case where the OS entropy source fails, returning zero-values instead of panicking.

### Files Changed

- `pkg/js/global/scripts.go` — replaced `math/rand` import with `crypto/rand` + `math/big`, updated `Rand()` and `RandInt()` implementations

### Security Impact

- **CWE-338**: Use of Cryptographically Weak Pseudo-Random Number Generator
- **Severity**: Medium-High (depends on template usage context)
- **Attack vector**: An attacker observing scanner traffic could predict "random" values if templates use these functions for security-sensitive operations

## Proof

- The change is a direct API substitution — `crypto/rand.Read` and `crypto/rand.Int` are drop-in replacements with the same semantics
- `crypto/rand` uses `/dev/urandom` on Unix and `CryptGenRandom` on Windows — both are OS-provided CSPRNGs
- No behavioral change for template authors — functions have identical signatures and return types

## Checklist

- [x] PR created against `dev` branch
- [x] All checks passed (lint, unit/integration/regression tests)
- [x] Minimal, focused change — only the two affected functions are modified
- [x] No breaking changes to the JavaScript template API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced the random number generation implementation for improved stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->