### PR TITLE
fix: prevent path traversal in markdown exporter

### DIFF
--- a/pkg/reporting/exporters/markdown/markdown.go
+++ b/pkg/reporting/exporters/markdown/markdown.go
@@ -2,6 +2,7 @@ package markdown
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -86,6 +87,12 @@ func (exporter *Exporter) Export(event *output.ResultEvent) error {
 		// Sanitize the subdirectory name to remove any characters that are not allowed in a directory name
 		subdirectory = sanitizeFilename(subdirectory)
 
+		// Validate the resolved path stays within the export directory
+		resolvedDir := filepath.Clean(filepath.Join(exporter.directory, subdirectory))
+		if !strings.HasPrefix(resolvedDir, filepath.Clean(exporter.directory)) {
+			return fmt.Errorf("path traversal detected in subdirectory: %s", subdirectory)
+		}
+
 		// Prepend the subdirectory name to the filename for the fileUrl
 		fileUrl = filepath.Join(subdirectory, filename)
 
@@ -111,7 +118,11 @@ func (exporter *Exporter) Export(event *output.ResultEvent) error {
 	dataBuilder.WriteString(format.CreateReportDescription(event, util.MarkdownFormatter{}, exporter.options.OmitRaw))
 	data := dataBuilder.Bytes()
 
-	return os.WriteFile(filepath.Join(exporter.directory, subdirectory, filename), data, 0644)
+	finalPath := filepath.Clean(filepath.Join(exporter.directory, subdirectory, filename))
+	if !strings.HasPrefix(finalPath, filepath.Clean(exporter.directory)) {
+		return fmt.Errorf("path traversal detected in output path: %s", finalPath)
+	}
+	return os.WriteFile(finalPath, data, 0644)
 }
 
 func createFileName(event *output.ResultEvent) string {
@@ -145,5 +156,7 @@ func sanitizeFilename(filename string) string {
 	if len(filename) > 256 {
 		filename = filename[0:255]
 	}
+	// Replace directory traversal sequences before other sanitization
+	filename = strings.ReplaceAll(filename, "..", "_")
 	return stringsutil.ReplaceAll(filename, "_", "?", "/", ">", "|", ":", ";", "*", "<", "\"", "'", " ")
 }

--- a/pkg/reporting/exporters/markdown/markdown.go
+++ b/pkg/reporting/exporters/markdown/markdown.go
@@ -88,8 +88,10 @@ func (exporter *Exporter) Export(event *output.ResultEvent) error {
 		subdirectory = sanitizeFilename(subdirectory)
 
 		// Validate the resolved path stays within the export directory
+		// Append separator to prevent sibling directory bypass (e.g., /reports-evil matching /reports)
+		cleanBase := filepath.Clean(exporter.directory) + string(filepath.Separator)
 		resolvedDir := filepath.Clean(filepath.Join(exporter.directory, subdirectory))
-		if !strings.HasPrefix(resolvedDir, filepath.Clean(exporter.directory)) {
+		if !strings.HasPrefix(resolvedDir, cleanBase) {
 			return fmt.Errorf("path traversal detected in subdirectory: %s", subdirectory)
 		}
 
@@ -118,8 +120,9 @@ func (exporter *Exporter) Export(event *output.ResultEvent) error {
 	dataBuilder.WriteString(format.CreateReportDescription(event, util.MarkdownFormatter{}, exporter.options.OmitRaw))
 	data := dataBuilder.Bytes()
 
+	cleanBase := filepath.Clean(exporter.directory) + string(filepath.Separator)
 	finalPath := filepath.Clean(filepath.Join(exporter.directory, subdirectory, filename))
-	if !strings.HasPrefix(finalPath, filepath.Clean(exporter.directory)) {
+	if !strings.HasPrefix(finalPath, cleanBase) {
 		return fmt.Errorf("path traversal detected in output path: %s", finalPath)
 	}
 	return os.WriteFile(finalPath, data, 0644)


### PR DESCRIPTION
## Proposed Changes

The markdown report exporter is vulnerable to **path traversal** (CWE-22) when the sort mode is set to `host` or `template`. An attacker-controlled `Host` header or crafted `TemplateID` containing `..` sequences can cause report files to be written outside the intended export directory.

### Root Cause

The `sanitizeFilename()` function in `pkg/reporting/exporters/markdown/markdown.go` replaces dangerous characters (`/`, `?`, `*`, etc.) with `_`, but **does not handle `..` (dot-dot) directory traversal sequences**.

When sort mode is `host`, the `event.Host` value is used as a subdirectory:

```go
case "host":
    subdirectory = event.Host  // attacker-controlled via HTTP Host header
```

After sanitization, `..` passes through unchanged. Then `filepath.Join(exporter.directory, "..")` resolves to the parent of the export directory, enabling arbitrary file writes.

### Exploitation Scenario

1. Attacker controls a web server that nuclei scans
2. The server returns a crafted `Host` header value: `../../../tmp/malicious`
3. The `/` characters are replaced with `_` by sanitizeFilename → `_.._.._.._tmp_malicious`
4. **But if the host is simply `..`** — it passes through completely unchanged
5. `filepath.Join("/reports", "..", "evil.md")` → `/evil.md` — file written outside reports directory

### The Fix (Defense in Depth — Two Layers)

**Layer 1: Sanitization** — `sanitizeFilename()` now replaces `..` with `_` before other character replacements:

```go
func sanitizeFilename(filename string) string {
    if len(filename) > 256 {
        filename = filename[0:255]
    }
    // Replace directory traversal sequences before other sanitization
    filename = strings.ReplaceAll(filename, "..", "_")
    return stringsutil.ReplaceAll(filename, "_", "?", "/", ">", "|", ":", ";", "*", "<", "\"", "'", " ")
}
```

**Layer 2: Path Validation** — Added `filepath.Clean()` + `strings.HasPrefix()` checks before both directory creation and file writing, ensuring the resolved path always stays within `exporter.directory`. This is the same validated pattern used in `pkg/installer/template.go` (the zip extraction path traversal guard).

### Files Changed

- `pkg/reporting/exporters/markdown/markdown.go` — added `..` replacement in sanitizeFilename, added path prefix validation before directory creation and file write

### Security Impact

- **CWE-22**: Improper Limitation of a Pathname to a Restricted Directory (Path Traversal)
- **Severity**: High
- **Attack Vector**: Malicious target server returns crafted Host header → nuclei writes markdown report files to arbitrary filesystem locations
- **Impact**: Arbitrary file write on the machine running nuclei

## Proof

The fix follows the exact same defensive pattern already established in the codebase:

```go
// pkg/installer/template.go lines 278-282 (existing protection)
newPath := filepath.Clean(filepath.Join(templateDir, relPath))
if !strings.HasPrefix(newPath, templateDir) {
    return ""  // reject path traversal
}
```

## Checklist

- [x] PR created against `dev` branch
- [x] All checks passed (lint, unit/integration/regression tests)
- [x] Minimal, focused change — only the markdown exporter is modified
- [x] Defense in depth — both sanitization and validation layers added
- [x] Follows existing codebase patterns for path traversal prevention

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened path validation throughout the export process to block directory traversal and ensure exported files stay inside the intended output folder.
  * Added pre-sanitization of filenames to neutralize traversal patterns and improved error reporting when invalid paths are detected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->