### PR TITLE
fix: prevent path traversal in S3 custom template downloads

### DIFF
--- a/pkg/external/customtemplates/s3.go
+++ b/pkg/external/customtemplates/s3.go
@@ -87,7 +87,9 @@ func downloadToFile(downloader *manager.Downloader, targetDirectory, bucket, key
 	// Create the directories in the path
 	file := filepath.Clean(filepath.Join(targetDirectory, key))
 	// Prevent path traversal - ensure the file stays within targetDirectory
-	if !strings.HasPrefix(file, filepath.Clean(targetDirectory)) {
+	// Append separator to prevent sibling directory bypass (e.g., /templates-evil matching /templates)
+	cleanTarget := filepath.Clean(targetDirectory) + string(filepath.Separator)
+	if !strings.HasPrefix(file, cleanTarget) {
 		return fmt.Errorf("path traversal detected in S3 object key: %s", key)
 	}
 	// If empty dir in s3

--- a/pkg/external/customtemplates/s3.go
+++ b/pkg/external/customtemplates/s3.go
@@ -2,6 +2,7 @@ package customtemplates
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -84,12 +85,16 @@ func NewS3Providers(options *types.Options) ([]*customTemplateS3Bucket, error) {
 
 func downloadToFile(downloader *manager.Downloader, targetDirectory, bucket, key string) error {
 	// Create the directories in the path
-	file := filepath.Join(targetDirectory, key)
+	file := filepath.Clean(filepath.Join(targetDirectory, key))
+	// Prevent path traversal - ensure the file stays within targetDirectory
+	if !strings.HasPrefix(file, filepath.Clean(targetDirectory)) {
+		return fmt.Errorf("path traversal detected in S3 object key: %s", key)
+	}
 	// If empty dir in s3
 	if stringsutil.HasSuffixI(key, "/") {
-		return os.MkdirAll(file, 0775)
+		return os.MkdirAll(file, 0750)
 	}
-	if err := os.MkdirAll(filepath.Dir(file), 0775); err != nil {
+	if err := os.MkdirAll(filepath.Dir(file), 0750); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Proposed Changes

The S3 custom template download function is vulnerable to **path traversal** (CWE-22), similar to the well-known "Zip Slip" vulnerability class. S3 object keys are attacker-controlled and were used directly in `filepath.Join()` without validation, allowing template files to be written outside the intended download directory.

Additionally, directories were created with **overly permissive `0775` permissions**, allowing other local users to modify downloaded templates.

### Root Cause

In `pkg/external/customtemplates/s3.go`, the `downloadToFile` function constructs the output path by directly joining the target directory with the S3 object key:

```go
func downloadToFile(downloader *manager.Downloader, targetDirectory, bucket, key string) error {
    file := filepath.Join(targetDirectory, key)  // key is attacker-controlled
    // ...
    fd, err := os.Create(file)  // arbitrary file write
}
```

S3 object keys can contain path separators and traversal sequences. An attacker who controls the contents of an S3 bucket (or compromises one) can create objects with keys like:
- `../../../etc/cron.d/malicious-job`
- `../../.ssh/authorized_keys`
- `../../../home/user/.bashrc`

### Exploitation Scenario

1. User configures nuclei to download custom templates from an S3 bucket: `-aws-bucket-name my-templates`
2. Attacker has write access to the bucket (compromised credentials, misconfigured bucket policy, or social engineering)
3. Attacker uploads an S3 object with key `../../../home/user/.bashrc`
4. When nuclei downloads templates, `filepath.Join(downloadPath, "../../../home/user/.bashrc")` resolves outside `downloadPath`
5. The malicious file overwrites the user's `.bashrc` → **arbitrary code execution** on next shell login

### The Fix

**Path Validation** — The output path is now cleaned with `filepath.Clean()` and validated with `strings.HasPrefix()` to ensure it stays within `targetDirectory`:

```go
file := filepath.Clean(filepath.Join(targetDirectory, key))
if !strings.HasPrefix(file, filepath.Clean(targetDirectory)) {
    return fmt.Errorf("path traversal detected in S3 object key: %s", key)
}
```

**Tightened Permissions** — Directory permissions changed from `0775` to `0750`, preventing other local users from modifying downloaded template files.

### Files Changed

- `pkg/external/customtemplates/s3.go` — added path traversal validation in `downloadToFile`, tightened directory permissions from `0775` to `0750`

### Security Impact

- **CWE-22**: Path Traversal via S3 object keys (Zip Slip variant)
- **CWE-732**: Incorrect Permission Assignment for Critical Resource
- **Severity**: High
- **Attack Vector**: Malicious S3 object keys → arbitrary file write on the machine running nuclei
- **Impact**: Arbitrary file overwrite, potential code execution via overwritten config/script files

## Proof

This follows the same validated pattern already used in `pkg/installer/template.go` for zip extraction path traversal prevention. The fix is a standard defense against Zip Slip-style attacks as recommended by [Snyk's research](https://security.snyk.io/research/zip-slip-vulnerability).

## Checklist

- [x] PR created against `dev` branch
- [x] All checks passed (lint, unit/integration/regression tests)
- [x] Minimal, focused change — only S3 download function modified
- [x] Follows existing codebase patterns for path traversal prevention
- [x] Permissions tightened to principle of least privilege

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added path traversal protection for downloads to prevent unauthorized file access.
  * Tightened directory creation permissions to improve access control.
  * Improved error handling and control flow around path validation and directory operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->