### PR TITLE
fix(expressions): only eval template-authored expressions

### DIFF
--- a/cmd/integration-test/http.go
+++ b/cmd/integration-test/http.go
@@ -88,6 +88,7 @@ var httpTestcases = []TestCaseInfo{
 	{Path: "protocols/http/multi-request.yaml", TestCase: &httpMultiRequest{}},
 	{Path: "protocols/http/http-matcher-extractor-dy-extractor.yaml", TestCase: &httpMatcherExtractorDynamicExtractor{}},
 	{Path: "protocols/http/multi-http-var-sharing.yaml", TestCase: &httpMultiVarSharing{}},
+	{Path: "protocols/http/response-data-literal-reuse.yaml", TestCase: &httpResponseDataLiteralReuse{}},
 	{Path: "protocols/http/raw-path-single-slash.yaml", TestCase: &httpRawPathSingleSlash{}},
 	{Path: "protocols/http/raw-unsafe-path-single-slash.yaml", TestCase: &httpRawUnsafePathSingleSlash{}},
 }
@@ -99,6 +100,31 @@ func (h *httpMultiVarSharing) Execute(filePath string) error {
 	if err != nil {
 		return err
 	}
+	return expectResultsCount(results, 1)
+}
+
+type httpResponseDataLiteralReuse struct{}
+
+func (h *httpResponseDataLiteralReuse) Execute(filePath string) error {
+	router := httprouter.New()
+	router.GET("/", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+		_, _ = fmt.Fprint(w, `{{md5("Hello")}}`)
+	})
+	router.GET("/echo", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+		if r.URL.Query().Get("x") != `{{md5("Hello")}}` {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+
+	results, err := testutils.RunNucleiTemplateAndGetResults(filePath, ts.URL, debug)
+	if err != nil {
+		return err
+	}
+
 	return expectResultsCount(results, 1)
 }
 

--- a/integration_tests/protocols/http/response-data-literal-reuse.yaml
+++ b/integration_tests/protocols/http/response-data-literal-reuse.yaml
@@ -1,0 +1,34 @@
+id: response-data-literal-reuse
+
+info:
+  name: Response data literal reuse
+  author: dwisiswant0
+  severity: info
+  description: |
+    Make sure response-derived {{...}} content stays literal when reused in a
+    later request.
+  tags: test,http
+
+http:
+  - raw:
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+
+    extractors:
+      - type: regex
+        name: extracted_body
+        part: body
+        regex:
+          - '(?s)(.*)'
+        internal: true
+
+  - raw:
+      - |
+        GET /echo?x={{extracted_body}} HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers:
+      - type: status
+        status:
+          - 200

--- a/pkg/protocols/common/expressions/expressions.go
+++ b/pkg/protocols/common/expressions/expressions.go
@@ -43,6 +43,8 @@ func EvaluateByte(data []byte, base map[string]interface{}) ([]byte, error) {
 }
 
 func evaluate(data string, base map[string]interface{}) (string, error) {
+	expressions := FindExpressions(data, marker.ParenthesisOpen, marker.ParenthesisClose, base)
+
 	// replace simple placeholders (key => value) MarkerOpen + key + MarkerClose and General + key + General to value
 	data = replacer.Replace(data, base)
 
@@ -50,7 +52,6 @@ func evaluate(data string, base map[string]interface{}) (string, error) {
 	// - simple: containing base values keys (variables)
 	// - complex: containing helper functions [ + variables]
 	// literals like {{2+2}} are not considered expressions
-	expressions := FindExpressions(data, marker.ParenthesisOpen, marker.ParenthesisClose, base)
 	for _, expression := range expressions {
 		// replace variable placeholders with base values
 		expression = replacer.Replace(expression, base)

--- a/pkg/protocols/common/expressions/expressions_test.go
+++ b/pkg/protocols/common/expressions/expressions_test.go
@@ -62,3 +62,46 @@ func TestEval(t *testing.T) {
 		require.Equal(t, item.expected, value, "could not get correct expression")
 	}
 }
+
+func TestEvaluateDoesNotReinterpretResolvedValues(t *testing.T) {
+	items := []struct {
+		name     string
+		input    string
+		expected string
+		extra    map[string]interface{}
+	}{
+		{
+			name:     "helper syntax in resolved values stays literal",
+			input:    "/?x={{body}}",
+			expected: `/?x={{md5("Hello")}}-by-Adelle`,
+			extra: map[string]interface{}{
+				"body": `{{md5("Hello")}}-by-Adelle`,
+			},
+		},
+		{
+			name:     "resolved values cannot access other variables",
+			input:    "Authorization: {{body}}",
+			expected: "Authorization: {{secret_token}}",
+			extra: map[string]interface{}{
+				"body":         "{{secret_token}}",
+				"secret_token": "top-secret-cia-mi6-kgb-mossad-classified",
+			},
+		},
+		{
+			name:     "template-authored placeholders inside helper expressions still resolve",
+			input:    "{{base64('{{Host}}')}}",
+			expected: "MTI3LjAuMC4x",
+			extra: map[string]interface{}{
+				"Host": "127.0.0.1",
+			},
+		},
+	}
+
+	for _, item := range items {
+		t.Run(item.name, func(t *testing.T) {
+			value, err := Evaluate(item.input, item.extra)
+			require.NoError(t, err)
+			require.Equal(t, item.expected, value)
+		})
+	}
+}


### PR DESCRIPTION
## Proposed changes

`expressions.Evaluate()` currently replaces
placeholders first and then scans the substituted
output for expressions which allows
response-derived values, including extractor
output, to be reinterpreted as DSL/helper syntax
on a second pass, which then becomes more serious
when env-backed variables are enabled.

So making this by collecting expressions from the
original template text before placeholder
substitution and then evaluating only those
original expressions after normal replacement to
keep trusted template-authored helpers working,
including placeholders nested inside helper
arguments while treating substituted response data
as literal text.

Fixes #7210

### Proof

```console
$ go test -v -count 1 -run ^TestEvaluateDoesNotReinterpretResolvedValues$ ./pkg/protocols/common/expressions
=== RUN   TestEvaluateDoesNotReinterpretResolvedValues
=== RUN   TestEvaluateDoesNotReinterpretResolvedValues/helper_syntax_in_resolved_values_stays_literal
=== RUN   TestEvaluateDoesNotReinterpretResolvedValues/resolved_values_cannot_access_other_variables
=== RUN   TestEvaluateDoesNotReinterpretResolvedValues/template-authored_placeholders_inside_helper_expressions_still_resolve
--- PASS: TestEvaluateDoesNotReinterpretResolvedValues (0.00s)
    --- PASS: TestEvaluateDoesNotReinterpretResolvedValues/helper_syntax_in_resolved_values_stays_literal (0.00s)
    --- PASS: TestEvaluateDoesNotReinterpretResolvedValues/resolved_values_cannot_access_other_variables (0.00s)
    --- PASS: TestEvaluateDoesNotReinterpretResolvedValues/template-authored_placeholders_inside_helper_expressions_still_resolve (0.00s)
PASS
ok  	github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/expressions	0.084s
```

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Expression detection now runs before data replacement, preventing helper syntax and resolved values from being re-interpreted while preserving correct placeholder resolution.

* **Tests**
  * Added unit tests verifying resolved values remain literal and isolated from other variables.
  * Added an integration test validating literal reuse of response data in HTTP scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->