### PR TITLE
fix: prevent symlink following in file protocol scanning

### DIFF
--- a/pkg/protocols/file/find.go
+++ b/pkg/protocols/file/find.go
@@ -53,6 +53,14 @@ func (request *Request) findGlobPathMatches(absPath string, processed map[string
 		return errors.Errorf("wildcard found, but unable to glob: %s\n", err)
 	}
 	for _, match := range matches {
+		// Skip symlinks to prevent traversal outside scan scope
+		info, err := os.Lstat(match)
+		if err != nil {
+			continue
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			continue
+		}
 		if !request.validatePath(absPath, match, false) {
 			continue
 		}

--- a/pkg/protocols/file/find.go
+++ b/pkg/protocols/file/find.go
@@ -67,9 +67,13 @@ func (request *Request) findGlobPathMatches(absPath string, processed map[string
 // findFileMatches finds if a path is an absolute file. If the path
 // is a file, it returns true otherwise false with no errors.
 func (request *Request) findFileMatches(absPath string, processed map[string]struct{}, callback func(string)) (bool, error) {
-	info, err := os.Stat(absPath)
+	info, err := os.Lstat(absPath)
 	if err != nil {
 		return false, err
+	}
+	// Skip symlinks to prevent traversal outside scan scope
+	if info.Mode()&os.ModeSymlink != 0 {
+		return false, nil
 	}
 	if !info.Mode().IsRegular() {
 		return false, nil
@@ -94,6 +98,10 @@ func (request *Request) findDirectoryMatches(absPath string, processed map[strin
 				return nil
 			}
 			if d.IsDir() {
+				return nil
+			}
+			// Skip symlinks to prevent traversal outside scan scope
+			if d.Type()&os.ModeSymlink != 0 {
 				return nil
 			}
 			if !request.validatePath(absPath, path, false) {


### PR DESCRIPTION
## Proposed Changes

The file protocol scanner follows symlinks when enumerating files, allowing information disclosure of files outside the intended scan scope (CWE-59: Improper Link Resolution Before File Access).

### Root Cause

In `pkg/protocols/file/find.go`, the `findFileMatches` function uses `os.Stat()` (line 70) which transparently follows symlinks. When a user scans a directory like `/var/www/`, an attacker who can write to that directory can place symlinks pointing to sensitive files:

```bash
# Attacker creates symlinks in a web directory being scanned
ln -s /etc/shadow /var/www/uploads/shadow
ln -s /home/user/.ssh/id_rsa /var/www/uploads/key
ln -s /etc/ /var/www/uploads/etc_link  # symlink to entire directory
```

When nuclei scans `/var/www/` with the file protocol, `os.Stat()` follows these symlinks and nuclei processes the target files as if they were inside the scan directory.

### Attack Scenarios

**Scenario 1: Shared hosting environment**
- Nuclei is used to scan web roots for sensitive file patterns (e.g., `.env`, `credentials.json`)
- Attacker creates symlinks in their web root pointing to other tenants' sensitive files
- Nuclei follows the symlinks and reports/extracts content from files outside the scan scope

**Scenario 2: CI/CD pipeline scanning**
- Repository contains symlinks created by an attacker (via PR)
- CI pipeline runs nuclei file protocol templates against the checked-out repo
- Symlinks point to CI secrets, environment files, or host filesystem paths
- Nuclei follows them and the extracted data appears in scan results

### The Fix

**`findFileMatches`** — Changed `os.Stat()` to `os.Lstat()` which does NOT follow symlinks, and added an explicit check for `os.ModeSymlink` to skip symlinked files:

```go
info, err := os.Lstat(absPath)  // Lstat: does not follow symlinks
if err != nil {
    return false, err
}
if info.Mode()&os.ModeSymlink != 0 {
    return false, nil  // Skip symlinks
}
```

**`findDirectoryMatches`** — Added `d.Type()&os.ModeSymlink` check in the `filepath.WalkDir` callback to skip symlinked entries during recursive directory traversal:

```go
if d.Type()&os.ModeSymlink != 0 {
    return nil  // Skip symlinks
}
```

Note: `filepath.WalkDir` already uses `os.Lstat` internally (per Go docs), so `d.Type()` correctly reports symlinks. The explicit check ensures they are skipped rather than processed.

### Files Changed

- `pkg/protocols/file/find.go` — `os.Stat` → `os.Lstat` in `findFileMatches`, symlink skip checks in both `findFileMatches` and `findDirectoryMatches`

### Security Impact

- **CWE-59**: Improper Link Resolution Before File Access
- **CWE-61**: UNIX Symbolic Link Following
- **Severity**: Medium-High
- **Attack Vector**: Attacker places symlinks in a directory scanned by nuclei's file protocol → sensitive files outside scan scope are read and reported
- **Impact**: Information disclosure of arbitrary files readable by the nuclei process

## Proof

- `os.Lstat` is the standard Go approach for symlink-safe file operations — it returns symlink info without resolving the target
- `os.ModeSymlink` bit check is the idiomatic Go pattern for detecting symlinks
- `filepath.WalkDir` already provides symlink information via `d.Type()`, so the check has zero performance overhead

## Checklist

- [x] PR created against `dev` branch
- [x] All checks passed (lint, unit/integration/regression tests)
- [x] Minimal, focused change — only file discovery functions modified
- [x] No behavioral change for regular files — only symlinks are now skipped
- [x] Consistent with Go standard library symlink handling patterns

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened file-scanning to detect and ignore symbolic links during globbing, file checks, and directory traversal, preventing traversal outside the intended scan scope and improving safety.
  * Preserves existing path validation and public interfaces while excluding symlink targets early in the processing flow.
  * Manifest updated to reflect these changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->