### PR TITLE
ci: integrate typos spell checker into CI workflow (#6532)

### DIFF
--- a/.github/workflows/typos.yaml
+++ b/.github/workflows/typos.yaml
@@ -1,0 +1,22 @@
+name: "🔤 Typos Check"
+
+on:
+  push:
+    branches: [dev]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  typos:
+    name: Spell Check
+    runs-on: ubuntu-latest
+    if: ${{ !endsWith(github.actor, '[bot]') }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: crate-ci/typos@v1
+        with:
+          config: ./_typos.toml

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,53 @@
+[files]
+extend-exclude = [
+    "**/testdata/**",
+    "integration_tests/**",
+    "pkg/js/generated/**",
+    "pkg/output/stats/waf/regexes.json",
+    "*.png",
+    "*.jpg",
+    "*.gif",
+    "*.exe",
+    "*.class",
+    "*.ser",
+    "dsl.md",
+    "SYNTAX-REFERENCE.md",
+    "nuclei-jsonschema.json",
+    "static/**",
+    "go.sum",
+    "README_*.md",
+    "bin/**",
+]
+
+[default.extend-words]
+oast = "oast"
+whois = "whois"
+memoize = "memoize"
+memogen = "memogen"
+projectdiscovery = "projectdiscovery"
+# CLI flag short names
+ot = "ot"
+hae = "hae"
+ue = "ue"
+# Part of JSONL(ine)/JSONL(ines) format notation
+ines = "ines"
+ine = "ine"
+# Go variable names / idioms
+typ = "typ"
+fo = "fo"
+# External library type (goflags.AllowdTypes)
+Allowd = "Allowd"
+# Test data content
+alo = "alo"
+Fo = "Fo"
+algoritmos = "algoritmos"
+# NooP in comment (matching NoopWriter struct)
+Noo = "Noo"
+# camelCase field name MisMatched
+Mis = "Mis"
+
+[default]
+extend-ignore-re = [
+    "[0-9a-fA-F]{32,}",
+    "[A-Za-z0-9+/]{40,}={0,2}",
+]


### PR DESCRIPTION
## Description

Integrates the [typos](https://github.com/crate-ci/typos) spell checker into CI to automatically catch typos in future PRs, as requested in #6532.

/claim #6532

## Changes

### `.github/workflows/typos.yaml`
- Standalone workflow following existing repo patterns
- Triggers on push to `dev`, pull requests, and manual dispatch
- Uses `actions/checkout@v6` (matching all other workflows)
- Pins `crate-ci/typos@v1` (versioned tag, not mutable branch ref)
- Skips bot commits with `!endsWith(github.actor, '[bot]')`
- Concurrency with `cancel-in-progress: true`

### `_typos.toml`
Comprehensive exclusion config to avoid false positives:
- **Test data**: `**/testdata/**`, `integration_tests/**`
- **Generated code**: `pkg/js/generated/**`
- **Binary/media files**: `*.png`, `*.jpg`, `*.gif`, `*.exe`, `*.class`, `*.ser`
- **Generated docs**: `dsl.md`, `SYNTAX-REFERENCE.md`, `nuclei-jsonschema.json`
- **WAF data**: `pkg/output/stats/waf/regexes.json`
- **Other**: `static/**`, `go.sum`, `README_*.md`, `bin/**`
- **Domain-specific terms**: CLI flag short names, protocol terms, Go idioms
- **Regex ignores**: hex strings, base64-encoded data

## Testing
Ran typos locally against the codebase — config suppresses all false positives while correctly catching real typos.

## Type of change
- [x] Maintenance (CI/tooling improvement)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced code quality checks with configuration for typo detection, including custom word definitions and file exclusion patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->