### PR TITLE
feat: add xss_context analyzer for context-aware XSS detection

### DIFF
--- a/pkg/fuzz/analyzers/analyzers.go
+++ b/pkg/fuzz/analyzers/analyzers.go
@@ -65,6 +65,8 @@ type Options struct {
 	ResponseBody string
 	// ResponseHeaders is the response headers from the already-executed request
 	ResponseHeaders string
+	// ResponseStatusCode is the HTTP status code from the already-executed request
+	ResponseStatusCode int
 }
 
 var (

--- a/pkg/fuzz/analyzers/analyzers.go
+++ b/pkg/fuzz/analyzers/analyzers.go
@@ -61,6 +61,10 @@ type Options struct {
 	HttpClient         *retryablehttp.Client
 	ResponseTimeDelay  time.Duration
 	AnalyzerParameters map[string]interface{}
+	// ResponseBody is the response body from the already-executed request
+	ResponseBody string
+	// ResponseHeaders is the response headers from the already-executed request
+	ResponseHeaders string
 }
 
 var (

--- a/pkg/fuzz/analyzers/xss/analyzer.go
+++ b/pkg/fuzz/analyzers/xss/analyzer.go
@@ -1,0 +1,102 @@
+// Package xss implements an XSS context analyzer for the nuclei fuzzer.
+//
+// It detects reflected payloads in HTTP responses and classifies the HTML
+// context of each reflection to determine exploitability. This enables
+// context-aware XSS fuzzing with fewer false positives.
+package xss
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/projectdiscovery/gologger"
+	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz/analyzers"
+)
+
+const maxResponseBodySize = 10 * 1024 * 1024 // 10 MB
+
+// Analyzer is an XSS context analyzer for the fuzzer
+type Analyzer struct{}
+
+var _ analyzers.Analyzer = &Analyzer{}
+
+func init() {
+	analyzers.RegisterAnalyzer("xss_context", &Analyzer{})
+}
+
+func (a *Analyzer) Name() string {
+	return "xss_context"
+}
+
+// ApplyInitialTransformation replaces [XSS_CANARY] with a canary string
+// containing HTML/JS-significant probe characters, then applies standard
+// payload transformations ([RANDNUM], [RANDSTR]).
+func (a *Analyzer) ApplyInitialTransformation(data string, params map[string]interface{}) string {
+	prefix := "xss"
+	if len(params) > 0 {
+		if v, ok := params["canary_prefix"]; ok {
+			if s, ok := v.(string); ok && s != "" {
+				prefix = s
+			}
+		}
+	}
+	canary := buildCanary(prefix)
+	data = strings.ReplaceAll(data, "[XSS_CANARY]", canary)
+	data = analyzers.ApplyPayloadTransformations(data)
+	return data
+}
+
+// buildCanary creates a canary string with HTML/JS-significant probe chars.
+func buildCanary(prefix string) string {
+	randStr := fmt.Sprintf("%d", analyzers.GetRandomInteger())
+	return prefix + randStr + "<>'\"`"
+}
+
+// Analyze checks for reflected XSS by looking for the canary in the response
+// body and classifying the injection context.
+func (a *Analyzer) Analyze(options *analyzers.Options) (bool, string, error) {
+	gr := options.FuzzGenerated
+	payload := a.ApplyInitialTransformation(gr.OriginalPayload, options.AnalyzerParameters)
+	if payload == "" {
+		return false, "", nil
+	}
+
+	body := options.ResponseBody
+	// If response body not provided in options, re-issue the request
+	if body == "" {
+		if err := gr.Component.SetValue(gr.Key, payload); err != nil {
+			return false, "", errors.Wrap(err, "could not set value in component")
+		}
+		defer func() {
+			// Restore original value
+			_ = gr.Component.SetValue(gr.Key, gr.Value)
+		}()
+
+		rebuilt, err := gr.Component.Rebuild()
+		if err != nil {
+			return false, "", errors.Wrap(err, "could not rebuild request")
+		}
+		gologger.Verbose().Msgf("[%s] Sending request for: %s", a.Name(), rebuilt.String())
+
+		resp, err := options.HttpClient.Do(rebuilt)
+		if err != nil {
+			return false, "", errors.Wrap(err, "could not do request")
+		}
+		defer resp.Body.Close()
+
+		bodyBytes, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBodySize))
+		if err != nil {
+			return false, "", errors.Wrap(err, "could not read response body")
+		}
+		body = string(bodyBytes)
+	}
+
+	findings := classifyReflections(body, payload)
+	if len(findings) == 0 {
+		return false, "", nil
+	}
+
+	return true, formatFindings(findings), nil
+}

--- a/pkg/fuzz/analyzers/xss/analyzer.go
+++ b/pkg/fuzz/analyzers/xss/analyzer.go
@@ -49,9 +49,10 @@ func (a *Analyzer) ApplyInitialTransformation(data string, params map[string]int
 }
 
 // buildCanary creates a canary string with HTML/JS-significant probe chars.
+// Includes : for javascript: protocol detection and - for --> comment breakout.
 func buildCanary(prefix string) string {
 	randStr := fmt.Sprintf("%d", analyzers.GetRandomInteger())
-	return prefix + randStr + "<>'\"`"
+	return prefix + randStr + "<>'\"`:-"
 }
 
 // Analyze checks for reflected XSS by looking for the canary in the response
@@ -69,9 +70,10 @@ func (a *Analyzer) Analyze(options *analyzers.Options) (bool, string, error) {
 	}
 
 	body := options.ResponseBody
-	// If response body not provided in options AND status suggests a body
-	// should exist, re-issue the request with a fresh canary.
-	if body == "" && options.ResponseStatusCode > 0 {
+	// If no response was received (status code 0), re-issue the request
+	// with a fresh canary. When ResponseStatusCode > 0, the body was
+	// already captured by the caller (even if legitimately empty).
+	if options.ResponseStatusCode == 0 {
 		freshPayload := a.ApplyInitialTransformation(gr.OriginalPayload, options.AnalyzerParameters)
 		if freshPayload == "" {
 			return false, "", nil

--- a/pkg/fuzz/analyzers/xss/analyzer.go
+++ b/pkg/fuzz/analyzers/xss/analyzer.go
@@ -58,19 +58,28 @@ func buildCanary(prefix string) string {
 // body and classifying the injection context.
 func (a *Analyzer) Analyze(options *analyzers.Options) (bool, string, error) {
 	gr := options.FuzzGenerated
-	payload := a.ApplyInitialTransformation(gr.OriginalPayload, options.AnalyzerParameters)
+
+	// Use gr.Value (the actual payload sent) as the reflection marker.
+	// ApplyInitialTransformation generates a new random canary each call,
+	// so re-transforming gr.OriginalPayload would produce a different string
+	// than what was actually sent and reflected.
+	payload := gr.Value
 	if payload == "" {
 		return false, "", nil
 	}
 
 	body := options.ResponseBody
-	// If response body not provided in options, re-issue the request
-	if body == "" {
-		if err := gr.Component.SetValue(gr.Key, payload); err != nil {
+	// If response body not provided in options AND status suggests a body
+	// should exist, re-issue the request with a fresh canary.
+	if body == "" && options.ResponseStatusCode > 0 {
+		freshPayload := a.ApplyInitialTransformation(gr.OriginalPayload, options.AnalyzerParameters)
+		if freshPayload == "" {
+			return false, "", nil
+		}
+		if err := gr.Component.SetValue(gr.Key, freshPayload); err != nil {
 			return false, "", errors.Wrap(err, "could not set value in component")
 		}
 		defer func() {
-			// Restore original value
 			_ = gr.Component.SetValue(gr.Key, gr.Value)
 		}()
 
@@ -91,6 +100,7 @@ func (a *Analyzer) Analyze(options *analyzers.Options) (bool, string, error) {
 			return false, "", errors.Wrap(err, "could not read response body")
 		}
 		body = string(bodyBytes)
+		payload = freshPayload
 	}
 
 	findings := classifyReflections(body, payload)

--- a/pkg/fuzz/analyzers/xss/context.go
+++ b/pkg/fuzz/analyzers/xss/context.go
@@ -1,0 +1,294 @@
+package xss
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Context represents the HTML context where a reflection was found
+type Context int
+
+const (
+	ContextHTMLBody Context = iota
+	ContextHTMLAttrDoubleQuoted
+	ContextHTMLAttrSingleQuoted
+	ContextHTMLAttrUnquoted
+	ContextScriptBlock
+	ContextScriptStringDouble
+	ContextScriptStringSingle
+	ContextScriptTemplateLiteral
+	ContextHTMLComment
+	ContextStyleBlock
+	ContextURLAttribute
+)
+
+var contextNames = map[Context]string{
+	ContextHTMLBody:              "html-body",
+	ContextHTMLAttrDoubleQuoted:  "html-attr-double-quoted",
+	ContextHTMLAttrSingleQuoted:  "html-attr-single-quoted",
+	ContextHTMLAttrUnquoted:      "html-attr-unquoted",
+	ContextScriptBlock:           "script-block",
+	ContextScriptStringDouble:    "script-string-double",
+	ContextScriptStringSingle:    "script-string-single",
+	ContextScriptTemplateLiteral: "script-template",
+	ContextHTMLComment:           "html-comment",
+	ContextStyleBlock:            "style-block",
+	ContextURLAttribute:          "url-attribute",
+}
+
+func (c Context) String() string {
+	if name, ok := contextNames[c]; ok {
+		return name
+	}
+	return "unknown"
+}
+
+// contextSeverity ranks contexts by exploitability (higher = more dangerous)
+var contextSeverity = map[Context]int{
+	ContextHTMLBody:              5,
+	ContextHTMLAttrDoubleQuoted:  6,
+	ContextHTMLAttrSingleQuoted:  6,
+	ContextHTMLAttrUnquoted:      7,
+	ContextScriptBlock:           9,
+	ContextScriptStringDouble:    8,
+	ContextScriptStringSingle:    8,
+	ContextScriptTemplateLiteral: 8,
+	ContextHTMLComment:           3,
+	ContextStyleBlock:            4,
+	ContextURLAttribute:          7,
+}
+
+// Reflection represents a single reflected payload finding
+type Reflection struct {
+	Context      Context
+	Exploitable  bool
+	BreakoutChar string
+}
+
+// classifyReflections finds all occurrences of the canary in body and
+// classifies each one's HTML context. Uses heuristic quote-tracking rather
+// than html.Tokenizer because the canary itself contains HTML-breaking
+// characters (<>'") that would cause a tokenizer to misparse the document.
+func classifyReflections(body, canary string) []Reflection {
+	if canary == "" || body == "" {
+		return nil
+	}
+
+	lowerBody := strings.ToLower(body)
+	lowerCanary := strings.ToLower(canary)
+
+	var findings []Reflection
+	offset := 0
+	for {
+		idx := strings.Index(lowerBody[offset:], lowerCanary)
+		if idx < 0 {
+			break
+		}
+		absIdx := offset + idx
+		before := body[:absIdx]
+		ctx := classifyContext(before)
+		exploitable, breakoutChar := isExploitable(ctx, body, absIdx, canary)
+		findings = append(findings, Reflection{
+			Context:      ctx,
+			Exploitable:  exploitable,
+			BreakoutChar: breakoutChar,
+		})
+		offset = absIdx + len(canary)
+	}
+	return findings
+}
+
+// classifyContext determines the HTML context based on content before the
+// reflection point using heuristic analysis.
+func classifyContext(before string) Context {
+	lowerBefore := strings.ToLower(before)
+
+	// Check comment context: <!-- without closing -->
+	lastCommentOpen := strings.LastIndex(lowerBefore, "<!--")
+	lastCommentClose := strings.LastIndex(lowerBefore, "-->")
+	if lastCommentOpen > lastCommentClose {
+		return ContextHTMLComment
+	}
+
+	// Check style context
+	lastStyleOpen := strings.LastIndex(lowerBefore, "<style")
+	lastStyleClose := strings.LastIndex(lowerBefore, "</style")
+	if lastStyleOpen > lastStyleClose && lastStyleOpen > strings.LastIndex(lowerBefore, ">") {
+		// Still inside the <style> opening tag
+	} else if lastStyleOpen > lastStyleClose {
+		return ContextStyleBlock
+	}
+
+	// Check script context
+	lastScriptOpen := strings.LastIndex(lowerBefore, "<script")
+	lastScriptClose := strings.LastIndex(lowerBefore, "</script")
+	if lastScriptOpen > lastScriptClose {
+		return classifyScriptContext(before[lastScriptOpen:])
+	}
+
+	// Check if inside an HTML tag (attribute context)
+	lastLt := strings.LastIndex(before, "<")
+	lastGt := strings.LastIndex(before, ">")
+	if lastLt > lastGt {
+		return classifyAttributeContext(before[lastLt:])
+	}
+
+	return ContextHTMLBody
+}
+
+// classifyScriptContext determines the specific JS context within a <script> block
+func classifyScriptContext(scriptContent string) Context {
+	// Find the end of the <script> opening tag
+	gtIdx := strings.Index(scriptContent, ">")
+	if gtIdx < 0 {
+		// Still in the <script> opening tag attributes
+		return classifyAttributeContext(scriptContent)
+	}
+	jsContent := scriptContent[gtIdx+1:]
+
+	// Track quote state to determine JS string context
+	inDouble := false
+	inSingle := false
+	inTemplate := false
+	escaped := false
+
+	for _, ch := range jsContent {
+		if escaped {
+			escaped = false
+			continue
+		}
+		if ch == '\\' {
+			escaped = true
+			continue
+		}
+
+		switch {
+		case !inDouble && !inSingle && !inTemplate && ch == '"':
+			inDouble = true
+		case inDouble && ch == '"':
+			inDouble = false
+		case !inDouble && !inSingle && !inTemplate && ch == '\'':
+			inSingle = true
+		case inSingle && ch == '\'':
+			inSingle = false
+		case !inDouble && !inSingle && !inTemplate && ch == '`':
+			inTemplate = true
+		case inTemplate && ch == '`':
+			inTemplate = false
+		}
+	}
+
+	if inDouble {
+		return ContextScriptStringDouble
+	}
+	if inSingle {
+		return ContextScriptStringSingle
+	}
+	if inTemplate {
+		return ContextScriptTemplateLiteral
+	}
+	return ContextScriptBlock
+}
+
+// classifyAttributeContext determines the attribute quote context
+func classifyAttributeContext(tagContent string) Context {
+	// Check for URL attributes
+	lowerTag := strings.ToLower(tagContent)
+	urlAttrs := []string{"href=", "src=", "action=", "formaction=", "data=", "poster="}
+	for _, attr := range urlAttrs {
+		if strings.Contains(lowerTag, attr) {
+			return ContextURLAttribute
+		}
+	}
+
+	// Determine quote context by tracking quotes after the last '='
+	lastEq := strings.LastIndex(tagContent, "=")
+	if lastEq < 0 {
+		return ContextHTMLAttrUnquoted
+	}
+
+	afterEq := strings.TrimLeft(tagContent[lastEq+1:], " \t\n\r")
+	if len(afterEq) == 0 {
+		return ContextHTMLAttrUnquoted
+	}
+
+	switch afterEq[0] {
+	case '"':
+		return ContextHTMLAttrDoubleQuoted
+	case '\'':
+		return ContextHTMLAttrSingleQuoted
+	default:
+		return ContextHTMLAttrUnquoted
+	}
+}
+
+// isExploitable checks whether the context-specific breakout characters survived encoding
+func isExploitable(ctx Context, body string, reflectionIdx int, canary string) (bool, string) {
+	reflected := body[reflectionIdx : reflectionIdx+len(canary)]
+
+	switch ctx {
+	case ContextHTMLBody:
+		if strings.Contains(reflected, "<") && strings.Contains(reflected, ">") {
+			return true, "<>"
+		}
+	case ContextHTMLAttrDoubleQuoted:
+		if strings.Contains(reflected, "\"") {
+			return true, "\""
+		}
+	case ContextHTMLAttrSingleQuoted:
+		if strings.Contains(reflected, "'") {
+			return true, "'"
+		}
+	case ContextHTMLAttrUnquoted:
+		if strings.Contains(reflected, ">") || strings.Contains(reflected, " ") {
+			return true, "> or space"
+		}
+	case ContextScriptBlock:
+		if strings.Contains(reflected, "<") || strings.Contains(reflected, "'") || strings.Contains(reflected, "\"") {
+			return true, "</script> or quotes"
+		}
+	case ContextScriptStringDouble:
+		if strings.Contains(reflected, "\"") {
+			return true, "\""
+		}
+	case ContextScriptStringSingle:
+		if strings.Contains(reflected, "'") {
+			return true, "'"
+		}
+	case ContextScriptTemplateLiteral:
+		if strings.Contains(reflected, "`") {
+			return true, "`"
+		}
+	case ContextHTMLComment:
+		if strings.Contains(reflected, ">") && strings.Contains(reflected, "-") {
+			return true, "-->"
+		}
+	case ContextStyleBlock:
+		if strings.Contains(reflected, "<") {
+			return true, "</style>"
+		}
+	case ContextURLAttribute:
+		// javascript: protocol injection
+		return true, "javascript:"
+	}
+
+	return false, ""
+}
+
+// formatFindings formats the reflection findings into a human-readable string
+func formatFindings(findings []Reflection) string {
+	if len(findings) == 0 {
+		return ""
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("[xss_context] found %d reflection(s):", len(findings)))
+	for i, f := range findings {
+		exploitability := "not exploitable"
+		if f.Exploitable {
+			exploitability = fmt.Sprintf("exploitable (breakout: %s)", f.BreakoutChar)
+		}
+		sb.WriteString(fmt.Sprintf("\n  %d. context: %s, %s", i+1, f.Context, exploitability))
+	}
+	return sb.String()
+}

--- a/pkg/fuzz/analyzers/xss/context.go
+++ b/pkg/fuzz/analyzers/xss/context.go
@@ -5,6 +5,10 @@ import (
 	"strings"
 )
 
+// maxReflections limits the number of reflections processed per response
+// to prevent memory exhaustion from adversarial inputs.
+const maxReflections = 50
+
 // Context represents the HTML context where a reflection was found
 type Context int
 
@@ -78,6 +82,9 @@ func classifyReflections(body, canary string) []Reflection {
 	var findings []Reflection
 	offset := 0
 	for offset+canaryLen <= len(body) {
+		if len(findings) >= maxReflections {
+			break
+		}
 		idx := indexFold(body[offset:], canary)
 		if idx < 0 {
 			break

--- a/pkg/fuzz/analyzers/xss/context.go
+++ b/pkg/fuzz/analyzers/xss/context.go
@@ -74,13 +74,11 @@ func classifyReflections(body, canary string) []Reflection {
 		return nil
 	}
 
-	lowerBody := strings.ToLower(body)
-	lowerCanary := strings.ToLower(canary)
-
+	canaryLen := len(canary)
 	var findings []Reflection
 	offset := 0
-	for {
-		idx := strings.Index(lowerBody[offset:], lowerCanary)
+	for offset+canaryLen <= len(body) {
+		idx := indexFold(body[offset:], canary)
 		if idx < 0 {
 			break
 		}
@@ -93,9 +91,28 @@ func classifyReflections(body, canary string) []Reflection {
 			Exploitable:  exploitable,
 			BreakoutChar: breakoutChar,
 		})
-		offset = absIdx + len(canary)
+		offset = absIdx + canaryLen
 	}
 	return findings
+}
+
+// indexFold finds the first case-insensitive occurrence of needle in haystack,
+// returning the byte index in haystack. Uses EqualFold window scanning to
+// avoid byte-length shifts that strings.ToLower can introduce for non-ASCII.
+func indexFold(haystack, needle string) int {
+	n := len(needle)
+	if n == 0 {
+		return 0
+	}
+	if n > len(haystack) {
+		return -1
+	}
+	for i := 0; i <= len(haystack)-n; i++ {
+		if strings.EqualFold(haystack[i:i+n], needle) {
+			return i
+		}
+	}
+	return -1
 }
 
 // classifyContext determines the HTML context based on content before the
@@ -192,19 +209,16 @@ func classifyScriptContext(scriptContent string) Context {
 
 // classifyAttributeContext determines the attribute quote context
 func classifyAttributeContext(tagContent string) Context {
-	// Check for URL attributes
-	lowerTag := strings.ToLower(tagContent)
-	urlAttrs := []string{"href=", "src=", "action=", "formaction=", "data=", "poster="}
-	for _, attr := range urlAttrs {
-		if strings.Contains(lowerTag, attr) {
-			return ContextURLAttribute
-		}
-	}
-
 	// Determine quote context by tracking quotes after the last '='
 	lastEq := strings.LastIndex(tagContent, "=")
 	if lastEq < 0 {
 		return ContextHTMLAttrUnquoted
+	}
+
+	// Check if the attribute containing the reflection is a URL attribute
+	// by parsing backwards from the '=' to find the attribute name.
+	if isURLAttribute(tagContent, lastEq) {
+		return ContextURLAttribute
 	}
 
 	afterEq := strings.TrimLeft(tagContent[lastEq+1:], " \t\n\r")
@@ -220,6 +234,27 @@ func classifyAttributeContext(tagContent string) Context {
 	default:
 		return ContextHTMLAttrUnquoted
 	}
+}
+
+// isURLAttribute checks whether the attribute at the given '=' position
+// is a URL-type attribute (href, src, action, formaction, data, poster).
+func isURLAttribute(tagContent string, eqIdx int) bool {
+	// Walk backwards from eqIdx to find the attribute name start
+	nameEnd := eqIdx
+	nameStart := nameEnd
+	for nameStart > 0 && tagContent[nameStart-1] != ' ' && tagContent[nameStart-1] != '\t' &&
+		tagContent[nameStart-1] != '\n' && tagContent[nameStart-1] != '\r' &&
+		tagContent[nameStart-1] != '<' {
+		nameStart--
+	}
+	attrName := strings.ToLower(tagContent[nameStart:nameEnd])
+	urlAttrs := []string{"href", "src", "action", "formaction", "data", "poster"}
+	for _, ua := range urlAttrs {
+		if attrName == ua {
+			return true
+		}
+	}
+	return false
 }
 
 // isExploitable checks whether the context-specific breakout characters survived encoding
@@ -268,8 +303,11 @@ func isExploitable(ctx Context, body string, reflectionIdx int, canary string) (
 			return true, "</style>"
 		}
 	case ContextURLAttribute:
-		// javascript: protocol injection
-		return true, "javascript:"
+		// Only exploitable if the reflected value contains an unencoded colon,
+		// which is required for javascript: protocol injection.
+		if strings.Contains(reflected, ":") {
+			return true, "javascript:"
+		}
 	}
 
 	return false, ""

--- a/pkg/fuzz/analyzers/xss/context_test.go
+++ b/pkg/fuzz/analyzers/xss/context_test.go
@@ -1,0 +1,315 @@
+package xss
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestClassifyReflections_HTMLBody(t *testing.T) {
+	canary := "xss1234<>'\"`"
+	body := `<html><body><div>` + canary + `</div></body></html>`
+	findings := classifyReflections(body, canary)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+	if findings[0].Context != ContextHTMLBody {
+		t.Fatalf("expected html-body context, got %s", findings[0].Context)
+	}
+	if !findings[0].Exploitable {
+		t.Fatal("expected exploitable (< and > present)")
+	}
+}
+
+func TestClassifyReflections_AttrDoubleQuoted(t *testing.T) {
+	canary := "xss5678<>'\"`"
+	body := `<html><input type="text" value="` + canary + `"></html>`
+	findings := classifyReflections(body, canary)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+	if findings[0].Context != ContextHTMLAttrDoubleQuoted {
+		t.Fatalf("expected html-attr-double-quoted, got %s", findings[0].Context)
+	}
+	if !findings[0].Exploitable {
+		t.Fatal("expected exploitable (double quote present)")
+	}
+}
+
+func TestClassifyReflections_AttrSingleQuoted(t *testing.T) {
+	canary := "xss9012<>'\"`"
+	body := `<html><input type='text' value='` + canary + `'></html>`
+	findings := classifyReflections(body, canary)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+	if findings[0].Context != ContextHTMLAttrSingleQuoted {
+		t.Fatalf("expected html-attr-single-quoted, got %s", findings[0].Context)
+	}
+	if !findings[0].Exploitable {
+		t.Fatal("expected exploitable (single quote present)")
+	}
+}
+
+func TestClassifyReflections_AttrUnquoted(t *testing.T) {
+	canary := "xss3456<>'\"`"
+	body := `<html><input type=text value=` + canary + `></html>`
+	findings := classifyReflections(body, canary)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+	if findings[0].Context != ContextHTMLAttrUnquoted {
+		t.Fatalf("expected html-attr-unquoted, got %s", findings[0].Context)
+	}
+}
+
+func TestClassifyReflections_ScriptBlock(t *testing.T) {
+	canary := "xss7890<>'\"`"
+	body := `<html><script>var x = ` + canary + `;</script></html>`
+	findings := classifyReflections(body, canary)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+	if findings[0].Context != ContextScriptBlock {
+		t.Fatalf("expected script-block, got %s", findings[0].Context)
+	}
+	if !findings[0].Exploitable {
+		t.Fatal("expected exploitable")
+	}
+}
+
+func TestClassifyReflections_ScriptStringDouble(t *testing.T) {
+	canary := "xss1111<>'\"`"
+	body := `<html><script>var x = "` + canary + `</script></html>`
+	findings := classifyReflections(body, canary)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+	if findings[0].Context != ContextScriptStringDouble {
+		t.Fatalf("expected script-string-double, got %s", findings[0].Context)
+	}
+}
+
+func TestClassifyReflections_ScriptStringSingle(t *testing.T) {
+	canary := "xss2222<>'\"`"
+	body := `<html><script>var x = '` + canary + `</script></html>`
+	findings := classifyReflections(body, canary)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+	if findings[0].Context != ContextScriptStringSingle {
+		t.Fatalf("expected script-string-single, got %s", findings[0].Context)
+	}
+}
+
+func TestClassifyReflections_ScriptTemplateLiteral(t *testing.T) {
+	canary := "xss3333<>'\"`"
+	body := "<html><script>var x = `" + canary + "</script></html>"
+	findings := classifyReflections(body, canary)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+	if findings[0].Context != ContextScriptTemplateLiteral {
+		t.Fatalf("expected script-template, got %s", findings[0].Context)
+	}
+}
+
+func TestClassifyReflections_HTMLComment(t *testing.T) {
+	canary := "xss4444<>'\"`"
+	body := `<html><!-- ` + canary + ` --></html>`
+	findings := classifyReflections(body, canary)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+	if findings[0].Context != ContextHTMLComment {
+		t.Fatalf("expected html-comment, got %s", findings[0].Context)
+	}
+}
+
+func TestClassifyReflections_StyleBlock(t *testing.T) {
+	canary := "xss5555<>'\"`"
+	body := `<html><style>body { color: ` + canary + `; }</style></html>`
+	findings := classifyReflections(body, canary)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+	if findings[0].Context != ContextStyleBlock {
+		t.Fatalf("expected style-block, got %s", findings[0].Context)
+	}
+}
+
+func TestClassifyReflections_URLAttribute(t *testing.T) {
+	canary := "xss6666<>'\"`"
+	body := `<html><a href="` + canary + `">link</a></html>`
+	findings := classifyReflections(body, canary)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+	if findings[0].Context != ContextURLAttribute {
+		t.Fatalf("expected url-attribute, got %s", findings[0].Context)
+	}
+}
+
+func TestClassifyReflections_MultipleReflections(t *testing.T) {
+	canary := "xss7777<>'\"`"
+	body := `<html><div>` + canary + `</div><script>var x = "` + canary + `";</script></html>`
+	findings := classifyReflections(body, canary)
+	if len(findings) != 2 {
+		t.Fatalf("expected 2 findings, got %d", len(findings))
+	}
+	if findings[0].Context != ContextHTMLBody {
+		t.Fatalf("expected first finding html-body, got %s", findings[0].Context)
+	}
+	if findings[1].Context != ContextScriptStringDouble {
+		t.Fatalf("expected second finding script-string-double, got %s", findings[1].Context)
+	}
+}
+
+func TestClassifyReflections_NoReflection(t *testing.T) {
+	canary := "xss8888<>'\"`"
+	body := `<html><body>nothing here</body></html>`
+	findings := classifyReflections(body, canary)
+	if len(findings) != 0 {
+		t.Fatalf("expected 0 findings, got %d", len(findings))
+	}
+}
+
+func TestClassifyReflections_EmptyInputs(t *testing.T) {
+	if findings := classifyReflections("", "canary"); findings != nil {
+		t.Fatal("expected nil for empty body")
+	}
+	if findings := classifyReflections("body", ""); findings != nil {
+		t.Fatal("expected nil for empty canary")
+	}
+}
+
+func TestClassifyReflections_CaseInsensitive(t *testing.T) {
+	canary := "XSS9999<>'\"`"
+	body := `<html><body>` + "xss9999<>'\"`" + `</body></html>`
+	findings := classifyReflections(body, canary)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding (case-insensitive), got %d", len(findings))
+	}
+}
+
+func TestIsExploitable_HTMLBody(t *testing.T) {
+	canary := "xss1234<>'\"`"
+	body := `<div>` + canary + `</div>`
+	exploitable, breakout := isExploitable(ContextHTMLBody, body, 5, canary)
+	if !exploitable {
+		t.Fatal("expected exploitable for html-body with < and >")
+	}
+	if breakout != "<>" {
+		t.Fatalf("expected breakout '<>', got '%s'", breakout)
+	}
+}
+
+func TestIsExploitable_HTMLBodyEncoded(t *testing.T) {
+	canary := "xss1234&lt;&gt;'\"`"
+	body := `<div>` + canary + `</div>`
+	exploitable, _ := isExploitable(ContextHTMLBody, body, 5, canary)
+	if exploitable {
+		t.Fatal("should not be exploitable when < > are encoded")
+	}
+}
+
+func TestIsExploitable_AttrDoubleQuoted(t *testing.T) {
+	canary := "xss5678<>'\"`"
+	body := `<input value="` + canary + `">`
+	exploitable, _ := isExploitable(ContextHTMLAttrDoubleQuoted, body, 14, canary)
+	if !exploitable {
+		t.Fatal("expected exploitable for double-quoted attr with double quote")
+	}
+}
+
+func TestIsExploitable_ScriptBlock(t *testing.T) {
+	canary := "xss7890<>'\"`"
+	body := `<script>var x = ` + canary + `;</script>`
+	exploitable, _ := isExploitable(ContextScriptBlock, body, 16, canary)
+	if !exploitable {
+		t.Fatal("expected exploitable for script block")
+	}
+}
+
+func TestBuildCanary(t *testing.T) {
+	canary := buildCanary("test")
+	if !strings.HasPrefix(canary, "test") {
+		t.Fatal("canary should start with prefix")
+	}
+	for _, ch := range []string{"<", ">", "'", "\"", "`"} {
+		if !strings.Contains(canary, ch) {
+			t.Fatalf("canary missing probe char: %s", ch)
+		}
+	}
+}
+
+func TestBuildCanary_CustomPrefix(t *testing.T) {
+	canary := buildCanary("custom")
+	if !strings.HasPrefix(canary, "custom") {
+		t.Fatal("canary should start with custom prefix")
+	}
+}
+
+func TestContextString(t *testing.T) {
+	tests := map[Context]string{
+		ContextHTMLBody:              "html-body",
+		ContextScriptBlock:           "script-block",
+		ContextHTMLComment:           "html-comment",
+		ContextHTMLAttrDoubleQuoted:  "html-attr-double-quoted",
+		ContextScriptTemplateLiteral: "script-template",
+	}
+	for ctx, expected := range tests {
+		if ctx.String() != expected {
+			t.Fatalf("context %d: expected %s, got %s", ctx, expected, ctx.String())
+		}
+	}
+}
+
+func TestClassifyJSContext(t *testing.T) {
+	tests := []struct {
+		name     string
+		script   string
+		expected Context
+	}{
+		{"bare code", `<script>var x = VALUE;`, ContextScriptBlock},
+		{"double string", `<script>var x = "VALUE`, ContextScriptStringDouble},
+		{"single string", `<script>var x = 'VALUE`, ContextScriptStringSingle},
+		{"template literal", "<script>var x = `VALUE", ContextScriptTemplateLiteral},
+		{"escaped quote", `<script>var x = "hello \"VALUE`, ContextScriptStringDouble},
+		{"closed string", `<script>var x = "hello";VALUE`, ContextScriptBlock},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := classifyScriptContext(tt.script)
+			if result != tt.expected {
+				t.Fatalf("expected %s, got %s", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestFormatFindings(t *testing.T) {
+	findings := []Reflection{
+		{Context: ContextHTMLBody, Exploitable: true, BreakoutChar: "<>"},
+		{Context: ContextScriptBlock, Exploitable: false},
+	}
+	result := formatFindings(findings)
+	if !strings.Contains(result, "2 reflection(s)") {
+		t.Fatal("should mention 2 reflections")
+	}
+	if !strings.Contains(result, "html-body") {
+		t.Fatal("should mention html-body context")
+	}
+	if !strings.Contains(result, "script-block") {
+		t.Fatal("should mention script-block context")
+	}
+	if !strings.Contains(result, "exploitable") {
+		t.Fatal("should mention exploitability")
+	}
+}
+
+func TestFormatFindings_Empty(t *testing.T) {
+	result := formatFindings(nil)
+	if result != "" {
+		t.Fatal("expected empty string for no findings")
+	}
+}

--- a/pkg/fuzz/analyzers/xss/context_test.go
+++ b/pkg/fuzz/analyzers/xss/context_test.go
@@ -313,3 +313,74 @@ func TestFormatFindings_Empty(t *testing.T) {
 		t.Fatal("expected empty string for no findings")
 	}
 }
+
+func TestURLAttribute_OnlyExploitableWithColon(t *testing.T) {
+	// Canary with colon should be exploitable
+	canaryWithColon := "javascript:alert(1)"
+	body := `<a href="` + canaryWithColon + `">link</a>`
+	findings := classifyReflections(body, canaryWithColon)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+	if findings[0].Context != ContextURLAttribute {
+		t.Fatalf("expected url-attribute, got %s", findings[0].Context)
+	}
+	if !findings[0].Exploitable {
+		t.Fatal("expected exploitable when colon present")
+	}
+
+	// Canary without colon should NOT be exploitable
+	canaryNoColon := "xss1234noproto"
+	body2 := `<a href="` + canaryNoColon + `">link</a>`
+	findings2 := classifyReflections(body2, canaryNoColon)
+	if len(findings2) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings2))
+	}
+	if findings2[0].Context != ContextURLAttribute {
+		t.Fatalf("expected url-attribute, got %s", findings2[0].Context)
+	}
+	if findings2[0].Exploitable {
+		t.Fatal("should not be exploitable without colon")
+	}
+}
+
+func TestURLAttribute_NarrowDetection(t *testing.T) {
+	// Reflection in a non-URL attribute of a tag that also has href
+	// should NOT be classified as url-attribute
+	canary := "xss4321test"
+	body := `<a href="safe" class="` + canary + `">link</a>`
+	findings := classifyReflections(body, canary)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+	if findings[0].Context == ContextURLAttribute {
+		t.Fatal("should not be url-attribute when reflection is in class, not href")
+	}
+	if findings[0].Context != ContextHTMLAttrDoubleQuoted {
+		t.Fatalf("expected html-attr-double-quoted, got %s", findings[0].Context)
+	}
+}
+
+func TestIndexFold(t *testing.T) {
+	tests := []struct {
+		name     string
+		haystack string
+		needle   string
+		expected int
+	}{
+		{"exact match", "hello world", "world", 6},
+		{"case insensitive", "Hello WORLD", "world", 6},
+		{"no match", "hello world", "xyz", -1},
+		{"empty needle", "hello", "", 0},
+		{"needle longer", "hi", "hello", -1},
+		{"non-ascii", "Stra\u00dfe", "stra\u00dfe", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := indexFold(tt.haystack, tt.needle)
+			if got != tt.expected {
+				t.Fatalf("indexFold(%q, %q) = %d, want %d", tt.haystack, tt.needle, got, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/fuzz/analyzers/xss/context_test.go
+++ b/pkg/fuzz/analyzers/xss/context_test.go
@@ -235,7 +235,7 @@ func TestBuildCanary(t *testing.T) {
 	if !strings.HasPrefix(canary, "test") {
 		t.Fatal("canary should start with prefix")
 	}
-	for _, ch := range []string{"<", ">", "'", "\"", "`"} {
+	for _, ch := range []string{"<", ">", "'", "\"", "`", ":", "-"} {
 		if !strings.Contains(canary, ch) {
 			t.Fatalf("canary missing probe char: %s", ch)
 		}
@@ -358,6 +358,18 @@ func TestURLAttribute_NarrowDetection(t *testing.T) {
 	}
 	if findings[0].Context != ContextHTMLAttrDoubleQuoted {
 		t.Fatalf("expected html-attr-double-quoted, got %s", findings[0].Context)
+	}
+}
+
+func TestClassifyReflections_MaxReflectionsLimit(t *testing.T) {
+	canary := "xssLIMIT"
+	body := strings.Repeat(canary+" ", maxReflections+20)
+	findings := classifyReflections(body, canary)
+	if len(findings) > maxReflections {
+		t.Fatalf("expected at most %d reflections, got %d", maxReflections, len(findings))
+	}
+	if len(findings) != maxReflections {
+		t.Fatalf("expected exactly %d reflections (capped), got %d", maxReflections, len(findings))
 	}
 }
 

--- a/pkg/protocols/http/http.go
+++ b/pkg/protocols/http/http.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/projectdiscovery/fastdialer/fastdialer"
 	_ "github.com/projectdiscovery/nuclei/v3/pkg/fuzz/analyzers/time"
+	_ "github.com/projectdiscovery/nuclei/v3/pkg/fuzz/analyzers/xss"
 
 	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz"
 	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz/analyzers"

--- a/pkg/protocols/http/request.go
+++ b/pkg/protocols/http/request.go
@@ -1017,6 +1017,8 @@ func (request *Request) executeRequest(input *contextargs.Context, generatedRequ
 				HttpClient:         request.httpClient,
 				ResponseTimeDelay:  duration,
 				AnalyzerParameters: request.Analyzer.Parameters,
+				ResponseBody:       bodyStr,
+				ResponseHeaders:    headersStr,
 			})
 			if err != nil {
 				gologger.Warning().Msgf("Could not analyze response: %v\n", err)

--- a/pkg/protocols/http/request.go
+++ b/pkg/protocols/http/request.go
@@ -1019,6 +1019,7 @@ func (request *Request) executeRequest(input *contextargs.Context, generatedRequ
 				AnalyzerParameters: request.Analyzer.Parameters,
 				ResponseBody:       bodyStr,
 				ResponseHeaders:    headersStr,
+				ResponseStatusCode: respChain.Response().StatusCode,
 			})
 			if err != nil {
 				gologger.Warning().Msgf("Could not analyze response: %v\n", err)


### PR DESCRIPTION
## Proposed changes

Implements a new `xss_context` analyzer for the fuzzing engine that classifies reflected XSS injection points by their HTML context and determines exploitability. Closes #5838.

### How it works

1. **Canary injection**: Replaces `[XSS_CANARY]` in payloads with a canary string containing HTML/JS-significant probe characters: `<>'"\``
2. **Reflection detection**: Finds all occurrences of the canary in the HTTP response body (case-insensitive)
3. **Context classification**: Classifies each reflection into one of 11 context types:
   - `html-body` — between HTML tags (`<div>VALUE</div>`)
   - `html-attr-double-quoted` — inside `"..."` attribute
   - `html-attr-single-quoted` — inside `'...'` attribute
   - `html-attr-unquoted` — unquoted attribute value
   - `script-block` — inside `<script>` outside strings
   - `script-string-double` — inside JS `"..."` string
   - `script-string-single` — inside JS `'...'` string
   - `script-template` — inside JS template literal
   - `html-comment` — inside `<!-- ... -->`
   - `style-block` — inside `<style>` tag
   - `url-attribute` — in href/src/action attributes
4. **Exploitability check**: Verifies whether context-specific breakout characters survive encoding (e.g., `<>` for html-body, `"` for double-quoted attributes)

### Architecture

- New package `pkg/fuzz/analyzers/xss/` with three files:
  - `analyzer.go` — implements `analyzers.Analyzer` interface, registered as `xss_context`
  - `context.go` — HTML context classification engine using heuristic quote-tracking
  - `context_test.go` — 25 comprehensive tests
- Modified `pkg/fuzz/analyzers/analyzers.go` — added `ResponseBody` and `ResponseHeaders` to `Options`
- Modified `pkg/protocols/http/request.go` — passes response body/headers to analyzer
- Modified `pkg/protocols/http/http.go` — blank import for auto-registration

### Design decisions

- Uses **heuristic quote-tracking** instead of Go's `html.Tokenizer` for context classification because the canary itself contains HTML-breaking characters (`<>'\"`) that would cause a standard tokenizer to misparse the document
- Follows the same registration pattern as the existing `time_delay` analyzer
- Reuses the response body already available in the request execution path (no extra HTTP requests needed when `ResponseBody` is provided via Options)
- Falls back to issuing its own request when `ResponseBody` is not available
- Applies `io.LimitReader` (10 MB cap) to prevent memory exhaustion from large response bodies
- Restores component state after mutation via defer

### Example template usage

```yaml
http:
  - method: GET
    path:
      - "{{BaseURL}}/search?q=[XSS_CANARY]"
    fuzzing:
      - type: query
        part: value
        mode: single
        fuzz:
          - "[XSS_CANARY]"
    analyzer:
      name: xss_context
```

### Proof

All 25 tests pass with `go vet` clean:

```
$ go vet ./pkg/fuzz/analyzers/xss/...
$ go test ./pkg/fuzz/analyzers/xss/... -v -count=1
=== RUN   TestClassifyReflections_HTMLBody
--- PASS: TestClassifyReflections_HTMLBody (0.00s)
=== RUN   TestClassifyReflections_AttrDoubleQuoted
--- PASS: TestClassifyReflections_AttrDoubleQuoted (0.00s)
=== RUN   TestClassifyReflections_AttrSingleQuoted
--- PASS: TestClassifyReflections_AttrSingleQuoted (0.00s)
=== RUN   TestClassifyReflections_AttrUnquoted
--- PASS: TestClassifyReflections_AttrUnquoted (0.00s)
=== RUN   TestClassifyReflections_ScriptBlock
--- PASS: TestClassifyReflections_ScriptBlock (0.00s)
=== RUN   TestClassifyReflections_ScriptStringDouble
--- PASS: TestClassifyReflections_ScriptStringDouble (0.00s)
=== RUN   TestClassifyReflections_ScriptStringSingle
--- PASS: TestClassifyReflections_ScriptStringSingle (0.00s)
=== RUN   TestClassifyReflections_ScriptTemplateLiteral
--- PASS: TestClassifyReflections_ScriptTemplateLiteral (0.00s)
=== RUN   TestClassifyReflections_HTMLComment
--- PASS: TestClassifyReflections_HTMLComment (0.00s)
=== RUN   TestClassifyReflections_StyleBlock
--- PASS: TestClassifyReflections_StyleBlock (0.00s)
=== RUN   TestClassifyReflections_URLAttribute
--- PASS: TestClassifyReflections_URLAttribute (0.00s)
=== RUN   TestClassifyReflections_MultipleReflections
--- PASS: TestClassifyReflections_MultipleReflections (0.00s)
=== RUN   TestClassifyReflections_NoReflection
--- PASS: TestClassifyReflections_NoReflection (0.00s)
=== RUN   TestClassifyReflections_EmptyInputs
--- PASS: TestClassifyReflections_EmptyInputs (0.00s)
=== RUN   TestClassifyReflections_CaseInsensitive
--- PASS: TestClassifyReflections_CaseInsensitive (0.00s)
=== RUN   TestIsExploitable_HTMLBody
--- PASS: TestIsExploitable_HTMLBody (0.00s)
=== RUN   TestIsExploitable_HTMLBodyEncoded
--- PASS: TestIsExploitable_HTMLBodyEncoded (0.00s)
=== RUN   TestIsExploitable_AttrDoubleQuoted
--- PASS: TestIsExploitable_AttrDoubleQuoted (0.00s)
=== RUN   TestIsExploitable_ScriptBlock
--- PASS: TestIsExploitable_ScriptBlock (0.00s)
=== RUN   TestBuildCanary
--- PASS: TestBuildCanary (0.00s)
=== RUN   TestBuildCanary_CustomPrefix
--- PASS: TestBuildCanary_CustomPrefix (0.00s)
=== RUN   TestContextString
--- PASS: TestContextString (0.00s)
=== RUN   TestClassifyJSContext
--- PASS: TestClassifyJSContext (0.00s)
=== RUN   TestFormatFindings
--- PASS: TestFormatFindings (0.00s)
=== RUN   TestFormatFindings_Empty
--- PASS: TestFormatFindings_Empty (0.00s)
PASS
ok      github.com/projectdiscovery/nuclei/v3/pkg/fuzz/analyzers/xss    0.990s
```

## Checklist

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

/claim #5838

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an XSS Context Analyzer that detects payload reflections, classifies HTML/JS contexts (body, attributes, script, style, URL, etc.), and reports exploitability with breakout hints.
  * Analyzer now receives full response content (body, headers, status code) via new response fields to enable deeper analysis.

* **Tests**
  * Comprehensive unit tests covering context classification, exploitability detection, canary handling, and report formatting.

* **Chores**
  * Integrated the new analyzer into the HTTP pipeline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->