### PR TITLE
fix: prevent concurrent map writes in MultiPartForm.Decode

### DIFF
--- a/pkg/fuzz/dataformat/dataformat.go
+++ b/pkg/fuzz/dataformat/dataformat.go
@@ -74,7 +74,9 @@ type Decoded struct {
 	Data KV
 }
 
-// Decode decodes the data from a format
+// Decode decodes the data from a format.
+// Note: MultiPartForm.IsType() returns false, so the singleton is safe here.
+// If that changes, this loop should use Get() for fresh instances.
 func Decode(data string) (*Decoded, error) {
 	for _, dataformat := range dataformats {
 		if dataformat.IsType(data) {
@@ -92,13 +94,16 @@ func Decode(data string) (*Decoded, error) {
 	return nil, nil
 }
 
-// Encode encodes the data into a format
+// Encode encodes the data into a format.
+// Like Get(), MultiPartForm is instantiated fresh to avoid concurrent map writes
+// when multiple goroutines encode simultaneously (see #7028).
 func Encode(data KV, dataformat string) (string, error) {
 	if dataformat == "" {
 		return "", errors.New("dataformat is required")
 	}
-	if encoder, ok := dataformats[dataformat]; ok {
-		return encoder.Encode(data)
+	encoder := Get(dataformat)
+	if encoder == nil {
+		return "", fmt.Errorf("dataformat %s is not supported", dataformat)
 	}
-	return "", fmt.Errorf("dataformat %s is not supported", dataformat)
+	return encoder.Encode(data)
 }

--- a/pkg/fuzz/dataformat/dataformat.go
+++ b/pkg/fuzz/dataformat/dataformat.go
@@ -38,8 +38,14 @@ const (
 	MultiPartFormDataFormat = "multipart/form-data"
 )
 
-// Get returns the dataformat by name
+// Get returns the dataformat by name.
+// MultiPartForm holds mutable state (boundary, filesMetadata), so a fresh
+// instance is returned every call to avoid concurrent map writes when
+// multiple goroutines scan different targets simultaneously (see #7028).
 func Get(name string) DataFormat {
+	if name == MultiPartFormDataFormat {
+		return NewMultiPartForm()
+	}
 	return dataformats[name]
 }
 

--- a/pkg/fuzz/dataformat/multipart_test.go
+++ b/pkg/fuzz/dataformat/multipart_test.go
@@ -370,21 +370,62 @@ func TestMultiPartForm_GetFileMetadataWithNilMap(t *testing.T) {
 	assert.False(t, exists)
 }
 
-// TestMultiPartFormConcurrentDecode verifies that Get("multipart/form-data")
+// TestMultiPartFormConcurrentDecodeEncode verifies that Get("multipart/form-data")
 // returns independent instances so concurrent goroutines do not trigger a
 // fatal "concurrent map writes" panic (regression test for #7028).
-func TestMultiPartFormConcurrentDecode(t *testing.T) {
+// Each goroutine exercises ParseBoundary, Decode, and Encode to cover the
+// full mutable-state surface of MultiPartForm.
+func TestMultiPartFormConcurrentDecodeEncode(t *testing.T) {
+	const boundary = "----TestBoundary7028"
+	const contentType = "multipart/form-data; boundary=" + boundary
+
+	// Sample multipart body that Decode will parse.
+	body := "------TestBoundary7028\r\nContent-Disposition: form-data; name=\"field\"\r\n\r\nvalue\r\n------TestBoundary7028--\r\n"
+
 	var wg sync.WaitGroup
 	for i := 0; i < 100; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			format := Get(MultiPartFormDataFormat)
+
+			form := Get(MultiPartFormDataFormat)
+			mpForm, ok := form.(*MultiPartForm)
+			require.True(t, ok)
+
+			// ParseBoundary writes to boundary field.
+			err := mpForm.ParseBoundary(contentType)
+			require.NoError(t, err)
+
+			// Decode writes to filesMetadata.
+			decoded, err := mpForm.Decode(body)
+			require.NoError(t, err)
+			require.NotNil(t, decoded)
+
+			// Encode reads boundary and filesMetadata.
+			encoded, err := mpForm.Encode(decoded)
+			require.NoError(t, err)
+			require.NotEmpty(t, encoded)
+		}()
+	}
+	wg.Wait()
+}
+
+// TestMultiPartFormConcurrentPackageLevelEncode verifies that the package-level
+// Encode() function also returns fresh MultiPartForm instances (see #7028).
+func TestMultiPartFormConcurrentPackageLevelEncode(t *testing.T) {
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
 			kv := mapsutil.NewOrderedMap[string, any]()
 			kv.Set("key", "value")
-			// Encode writes to the instance's filesMetadata; running this
-			// concurrently across separate instances must not race.
-			_, _ = format.Encode(KVOrderedMap(&kv))
+			// Package-level Encode must use Get() internally so each call
+			// gets its own MultiPartForm instance.
+			_, err := Encode(KVOrderedMap(&kv), MultiPartFormDataFormat)
+			// Encode will fail (empty boundary) but must NOT panic from
+			// concurrent map writes -- that is the regression we guard against.
+			_ = err
 		}()
 	}
 	wg.Wait()

--- a/pkg/fuzz/dataformat/multipart_test.go
+++ b/pkg/fuzz/dataformat/multipart_test.go
@@ -1,6 +1,7 @@
 package dataformat
 
 import (
+	"sync"
 	"testing"
 
 	mapsutil "github.com/projectdiscovery/utils/maps"
@@ -367,4 +368,24 @@ func TestMultiPartForm_GetFileMetadataWithNilMap(t *testing.T) {
 	// GetFileMetadata should handle nil filesMetadata gracefully
 	_, exists := form.GetFileMetadata("anything")
 	assert.False(t, exists)
+}
+
+// TestMultiPartFormConcurrentDecode verifies that Get("multipart/form-data")
+// returns independent instances so concurrent goroutines do not trigger a
+// fatal "concurrent map writes" panic (regression test for #7028).
+func TestMultiPartFormConcurrentDecode(t *testing.T) {
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			format := Get(MultiPartFormDataFormat)
+			kv := mapsutil.NewOrderedMap[string, any]()
+			kv.Set("key", "value")
+			// Encode writes to the instance's filesMetadata; running this
+			// concurrently across separate instances must not race.
+			_, _ = format.Encode(KVOrderedMap(&kv))
+		}()
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
## Summary

`MultiPartForm` stores mutable state (`boundary` string and `filesMetadata` map) but was registered as a singleton in `dataformat.init()` and returned via `dataformat.Get()` to every goroutine. When scanning multiple targets concurrently, this caused `fatal error: concurrent map writes` — a Go runtime error that cannot be caught by `recover()`.

### Root Cause

```
dataformat.init() → RegisterDataFormat(NewMultiPartForm())  // singleton
dataformat.Get("multipart/form-data")                       // returns same instance to all goroutines
```

Multiple goroutines writing to `m.boundary` and `m.filesMetadata` simultaneously triggers the fatal error.

### Fix

Return a fresh `MultiPartForm` instance from `dataformat.Get()` when the requested format is `multipart/form-data`, since it's the only `DataFormat` implementation with mutable state. All other formats remain singletons (they are stateless).

```go
func Get(name string) DataFormat {
    if name == MultiPartFormDataFormat {
        return NewMultiPartForm()
    }
    return dataformats[name]
}
```

### Changes

- `pkg/fuzz/dataformat/dataformat.go`: Return fresh instance for multipart/form-data
- `pkg/fuzz/dataformat/multipart_test.go`: Add concurrent access regression test (100 goroutines)

## Test plan
- [x] `TestMultiPartFormConcurrentDecode` — 100 concurrent goroutines calling `Get()` + `Encode()` without panic
- [x] Existing multipart tests still pass
- [ ] `go test ./pkg/fuzz/dataformat/... -race` — verify no data races detected
- [ ] Manual test: scan multiple targets with multipart/form-data fuzzing template

Fixes #7028

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability for multipart form handling under concurrent requests by ensuring each operation uses an independent instance to prevent crashes.

* **Tests**
  * Added concurrency tests exercising multipart form encode/decode paths to validate stability under concurrent use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->