### PR TITLE
fix: stabilize path fuzz rebuilds

### DIFF
--- a/pkg/fuzz/component/path.go
+++ b/pkg/fuzz/component/path.go
@@ -15,6 +15,8 @@ type Path struct {
 	value *Value
 
 	req *retryablehttp.Request
+
+	originalPath string
 }
 
 var _ Component = &Path{}
@@ -33,6 +35,7 @@ func (q *Path) Name() string {
 // parsed component
 func (q *Path) Parse(req *retryablehttp.Request) (bool, error) {
 	q.req = req
+	q.originalPath = req.Path
 	q.value = NewValue("")
 
 	splitted := strings.Split(req.Path, "/")
@@ -88,7 +91,7 @@ func (q *Path) Delete(key string) error {
 // component rebuilt
 func (q *Path) Rebuild() (*retryablehttp.Request, error) {
 	// Get the original path segments
-	originalSplitted := strings.Split(q.req.Path, "/")
+	originalSplitted := strings.Split(q.originalPath, "/")
 
 	// Create a new slice to hold the rebuilt segments
 	rebuiltSegments := make([]string, 0, len(originalSplitted))
@@ -132,6 +135,8 @@ func (q *Path) Rebuild() (*retryablehttp.Request, error) {
 
 	// Clone the request and update the path
 	cloned := q.req.Clone(context.Background())
+	cloned.URL = cloned.URL.Clone()
+	cloned.Request.URL = cloned.URL.URL
 	if err := cloned.UpdateRelPath(rebuiltPath, true); err != nil {
 		cloned.RawPath = rebuiltPath
 	}
@@ -140,8 +145,13 @@ func (q *Path) Rebuild() (*retryablehttp.Request, error) {
 
 // Clones current state to a new component
 func (q *Path) Clone() Component {
+	clonedReq := q.req.Clone(context.Background())
+	clonedReq.URL = clonedReq.URL.Clone()
+	clonedReq.Request.URL = clonedReq.URL.URL
+
 	return &Path{
-		value: q.value.Clone(),
-		req:   q.req.Clone(context.Background()),
+		value:        q.value.Clone(),
+		req:          clonedReq,
+		originalPath: q.originalPath,
 	}
 }

--- a/pkg/fuzz/component/path_test.go
+++ b/pkg/fuzz/component/path_test.go
@@ -127,3 +127,45 @@ func TestPathComponent_SQLInjection(t *testing.T) {
 	// Let's also test what the actual URL looks like
 	t.Logf("Full URL: %s", newReq.String())
 }
+
+func TestPathComponent_RebuildDoesNotMutateOriginalRequest(t *testing.T) {
+	path := NewPath()
+	req, err := retryablehttp.NewRequest(http.MethodGet, "https://example.com/user/55/profile", nil)
+	require.NoError(t, err)
+
+	found, err := path.Parse(req)
+	require.NoError(t, err)
+	require.True(t, found)
+
+	require.NoError(t, path.SetValue("1", "user OR True"))
+
+	rebuilt, err := path.Rebuild()
+	require.NoError(t, err)
+	require.Equal(t, "/user OR True/55/profile", rebuilt.Path)
+
+	require.Equal(t, "/user/55/profile", req.Path)
+	require.Equal(t, "/user/55/profile", path.originalPath)
+}
+
+func TestPathComponent_RebuildUsesOriginalPathAcrossMultipleMutations(t *testing.T) {
+	path := NewPath()
+	req, err := retryablehttp.NewRequest(http.MethodGet, "https://example.com/user/55/profile", nil)
+	require.NoError(t, err)
+
+	found, err := path.Parse(req)
+	require.NoError(t, err)
+	require.True(t, found)
+
+	require.NoError(t, path.SetValue("3", "profile OR True"))
+
+	rebuiltLast, err := path.Rebuild()
+	require.NoError(t, err)
+	require.Equal(t, "/user/55/profile OR True", rebuiltLast.Path)
+
+	require.NoError(t, path.SetValue("3", "profile"))
+	require.NoError(t, path.SetValue("2", "55 OR True"))
+
+	rebuiltNumeric, err := path.Rebuild()
+	require.NoError(t, err)
+	require.Equal(t, "/user/55 OR True/profile", rebuiltNumeric.Path)
+}


### PR DESCRIPTION
/claim #6398

## Proposed changes

This keeps the fix scoped to `pkg/fuzz/component/path.go`.

- snapshot the original path during `Parse()` and rebuild from that immutable value instead of `q.req.Path`
- deep-clone the embedded `retryablehttp` URL before calling `UpdateRelPath()` so one fuzz iteration cannot leak state into the next one
- add focused regression tests covering both source-request mutation and repeated path mutations across numeric segments

The practical effect is that path fuzzing no longer depends on a previously mutated request path when generating later iterations.

### Proof

Targeted regression tests:

```bash
go test ./pkg/fuzz/component -run 'Test(PathComponent|URLComponent)' -count=1 -v
```

Scoped fuzz package validation:

```bash
go test ./pkg/fuzz/... -count=1
```

Both commands pass locally with this patch.

## Checklist

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes & Improvements**
  * Improved path reconstruction to correctly preserve original request path data.
  * Path mutations are now properly isolated and don't affect the original request.
  * Clone operations now create fully independent copies.

* **Tests**
  * Added comprehensive tests validating path reconstruction behavior and mutation isolation across sequential operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->