### PR TITLE
fix(fuzz): fix non-deterministic numeric path fuzzing and pointer mutation

### DIFF
--- a/pkg/fuzz/component/path.go
+++ b/pkg/fuzz/component/path.go
@@ -19,7 +19,7 @@ type Path struct {
 
 var _ Component = &Path{}
 
-// NewPath creates a new URL component
+// NewPath creates a new Path component
 func NewPath() *Path {
 	return &Path{}
 }
@@ -37,8 +37,7 @@ func (q *Path) Parse(req *retryablehttp.Request) (bool, error) {
 
 	splitted := strings.Split(req.Path, "/")
 	values := make(map[string]interface{})
-	
-	// Create a stable map
+
 	count := 1
 	for i, segment := range splitted {
 		if segment == "" && i == 0 {
@@ -55,32 +54,22 @@ func (q *Path) Parse(req *retryablehttp.Request) (bool, error) {
 	return true, nil
 }
 
-// Iterate iterates through the component
+// Iterate iterates over the component
 func (q *Path) Iterate(callback func(key string, value interface{}) error) (err error) {
-	q.value.parsed.Iterate(func(key string, value any) bool {
-		if errx := callback(key, value); errx != nil {
-			err = errx
-			return false
-		}
-		return true
-	})
-	return
+	return q.value.Iterate(callback)
 }
 
 // SetValue sets a value in the component
 func (q *Path) SetValue(key string, value string) error {
 	escaped := urlutil.PathEncode(value)
 	if !q.value.SetParsedValue(key, escaped) {
-		return ErrSetValue
+		return ErrKeyNotFound
 	}
 	return nil
 }
 
 // Delete deletes a key from the component
 func (q *Path) Delete(key string) error {
-	if !q.value.Delete(key) {
-		return ErrKeyNotFound
-	}
 	return nil
 }
 
@@ -94,7 +83,12 @@ func (q *Path) Rebuild() (*retryablehttp.Request, error) {
 	}
 
 	segmentIndex := 1
-	for i := 1; i < len(originalSplitted); i++ {
+	start := 0
+	if len(originalSplitted) > 0 && originalSplitted[0] == "" {
+		start = 1
+	}
+
+	for i := start; i < len(originalSplitted); i++ {
 		originalSegment := originalSplitted[i]
 		if originalSegment == "" {
 			continue
@@ -122,7 +116,7 @@ func (q *Path) Rebuild() (*retryablehttp.Request, error) {
 	return cloned, nil
 }
 
-// Clones current state to a new component
+// Clone clones the current state to a new component
 func (q *Path) Clone() Component {
 	return &Path{
 		value:        q.value.Clone(),

--- a/pkg/fuzz/component/path.go
+++ b/pkg/fuzz/component/path.go
@@ -91,12 +91,18 @@ func (q *Path) Rebuild() (*retryablehttp.Request, error) {
 	for i := start; i < len(originalSplitted); i++ {
 		originalSegment := originalSplitted[i]
 		if originalSegment == "" {
+			// Preserve empty segments (e.g., // or trailing /)
+			rebuiltSegments = append(rebuiltSegments, "")
 			continue
 		}
 
 		key := strconv.Itoa(segmentIndex)
 		if val, exists := q.value.parsed.Map.Get(key); exists && val != "" {
-			rebuiltSegments = append(rebuiltSegments, val.(string))
+			if s, ok := val.(string); ok {
+				rebuiltSegments = append(rebuiltSegments, s)
+			} else {
+				rebuiltSegments = append(rebuiltSegments, originalSegment)
+			}
 		} else {
 			rebuiltSegments = append(rebuiltSegments, originalSegment)
 		}

--- a/pkg/fuzz/component/path.go
+++ b/pkg/fuzz/component/path.go
@@ -12,9 +12,9 @@ import (
 
 // Path is a component for a request Path
 type Path struct {
-	value *Value
-
-	req *retryablehttp.Request
+	value        *Value
+	req          *retryablehttp.Request
+	originalPath string // Snapshot of original path
 }
 
 var _ Component = &Path{}
@@ -29,26 +29,27 @@ func (q *Path) Name() string {
 	return RequestPathComponent
 }
 
-// Parse parses the component and returns the
-// parsed component
+// Parse parses the component
 func (q *Path) Parse(req *retryablehttp.Request) (bool, error) {
 	q.req = req
+	q.originalPath = req.Path
 	q.value = NewValue("")
 
 	splitted := strings.Split(req.Path, "/")
 	values := make(map[string]interface{})
+	
+	// Create a stable map
+	count := 1
 	for i, segment := range splitted {
 		if segment == "" && i == 0 {
-			// Skip the first empty segment from leading "/"
 			continue
 		}
 		if segment == "" {
-			// Skip any other empty segments
 			continue
 		}
-		// Use 1-based indexing and store individual segments
-		key := strconv.Itoa(len(values) + 1)
+		key := strconv.Itoa(count)
 		values[key] = segment
+		count++
 	}
 	q.value.SetParsed(dataformat.KVMap(values), "")
 	return true, nil
@@ -67,7 +68,6 @@ func (q *Path) Iterate(callback func(key string, value interface{}) error) (err 
 }
 
 // SetValue sets a value in the component
-// for a key
 func (q *Path) SetValue(key string, value string) error {
 	escaped := urlutil.PathEncode(value)
 	if !q.value.SetParsedValue(key, escaped) {
@@ -84,53 +84,37 @@ func (q *Path) Delete(key string) error {
 	return nil
 }
 
-// Rebuild returns a new request with the
-// component rebuilt
+// Rebuild returns a new request with the component rebuilt
 func (q *Path) Rebuild() (*retryablehttp.Request, error) {
-	// Get the original path segments
-	originalSplitted := strings.Split(q.req.Path, "/")
-
-	// Create a new slice to hold the rebuilt segments
+	originalSplitted := strings.Split(q.originalPath, "/")
 	rebuiltSegments := make([]string, 0, len(originalSplitted))
 
-	// Add the first empty segment (from leading "/")
 	if len(originalSplitted) > 0 && originalSplitted[0] == "" {
 		rebuiltSegments = append(rebuiltSegments, "")
 	}
 
-	// Process each segment
-	segmentIndex := 1 // 1-based indexing for our stored values
+	segmentIndex := 1
 	for i := 1; i < len(originalSplitted); i++ {
 		originalSegment := originalSplitted[i]
 		if originalSegment == "" {
-			// Skip empty segments
 			continue
 		}
 
-		// Check if we have a replacement for this segment
 		key := strconv.Itoa(segmentIndex)
-		if newValue, exists := q.value.parsed.Map.GetOrDefault(key, "").(string); exists && newValue != "" {
-			rebuiltSegments = append(rebuiltSegments, newValue)
+		if val, exists := q.value.parsed.Map.Get(key); exists && val != "" {
+			rebuiltSegments = append(rebuiltSegments, val.(string))
 		} else {
 			rebuiltSegments = append(rebuiltSegments, originalSegment)
 		}
 		segmentIndex++
 	}
 
-	// Join the segments back into a path
 	rebuiltPath := strings.Join(rebuiltSegments, "/")
 
 	if unescaped, err := urlutil.PathDecode(rebuiltPath); err == nil {
-		// this is handle the case where anyportion of path has url encoded data
-		// by default the http/request official library will escape/encode special characters in path
-		// to avoid double encoding we unescape/decode already encoded value
-		//
-		// if there is a invalid url encoded value like %99 then it will still be encoded as %2599 and not %99
-		// the only way to make sure it stays as %99 is to implement raw request and unsafe for fuzzing as well
 		rebuiltPath = unescaped
 	}
 
-	// Clone the request and update the path
 	cloned := q.req.Clone(context.Background())
 	if err := cloned.UpdateRelPath(rebuiltPath, true); err != nil {
 		cloned.RawPath = rebuiltPath
@@ -141,7 +125,8 @@ func (q *Path) Rebuild() (*retryablehttp.Request, error) {
 // Clones current state to a new component
 func (q *Path) Clone() Component {
 	return &Path{
-		value: q.value.Clone(),
-		req:   q.req.Clone(context.Background()),
+		value:        q.value.Clone(),
+		req:          q.req.Clone(context.Background()),
+		originalPath: q.originalPath,
 	}
 }

--- a/pkg/fuzz/component/path.go
+++ b/pkg/fuzz/component/path.go
@@ -14,7 +14,7 @@ import (
 type Path struct {
 	value        *Value
 	req          *retryablehttp.Request
-	originalPath string // Snapshot of original path
+	originalPath string // Snapshot of original path for deterministic rebuilds
 }
 
 var _ Component = &Path{}
@@ -29,7 +29,7 @@ func (q *Path) Name() string {
 	return RequestPathComponent
 }
 
-// Parse parses the component
+// Parse parses the component and extracts path segments as keys
 func (q *Path) Parse(req *retryablehttp.Request) (bool, error) {
 	q.req = req
 	q.originalPath = req.Path
@@ -40,9 +40,11 @@ func (q *Path) Parse(req *retryablehttp.Request) (bool, error) {
 
 	count := 1
 	for i, segment := range splitted {
+		// Skip leading empty segment from "/"
 		if segment == "" && i == 0 {
 			continue
 		}
+		// Skip other empty segments for parsing keys, but they'll be preserved in Rebuild
 		if segment == "" {
 			continue
 		}
@@ -59,25 +61,29 @@ func (q *Path) Iterate(callback func(key string, value interface{}) error) (err 
 	return q.value.Iterate(callback)
 }
 
-// SetValue sets a value in the component
+// SetValue sets a value in the component for a key
 func (q *Path) SetValue(key string, value string) error {
 	escaped := urlutil.PathEncode(value)
 	if !q.value.SetParsedValue(key, escaped) {
-		return ErrKeyNotFound
+		return ErrSetValue
 	}
 	return nil
 }
 
 // Delete deletes a key from the component
 func (q *Path) Delete(key string) error {
+	if !q.value.Delete(key) {
+		return ErrKeyNotFound
+	}
 	return nil
 }
 
-// Rebuild returns a new request with the component rebuilt
+// Rebuild returns a new request with the component rebuilt, preserving original structure
 func (q *Path) Rebuild() (*retryablehttp.Request, error) {
 	originalSplitted := strings.Split(q.originalPath, "/")
 	rebuiltSegments := make([]string, 0, len(originalSplitted))
 
+	// Handle leading slash preservation
 	if len(originalSplitted) > 0 && originalSplitted[0] == "" {
 		rebuiltSegments = append(rebuiltSegments, "")
 	}
@@ -91,14 +97,17 @@ func (q *Path) Rebuild() (*retryablehttp.Request, error) {
 	for i := start; i < len(originalSplitted); i++ {
 		originalSegment := originalSplitted[i]
 		if originalSegment == "" {
-			// Preserve empty segments (e.g., // or trailing /)
+			// Preserve empty segments (e.g., // or trailing /) to maintain request semantics
 			rebuiltSegments = append(rebuiltSegments, "")
 			continue
 		}
 
 		key := strconv.Itoa(segmentIndex)
-		if val, exists := q.value.parsed.Map.Get(key); exists && val != "" {
-			if s, ok := val.(string); ok {
+		// Check for replacement or deletion
+		if val, exists := q.value.parsed.Map.Get(key); exists {
+			if val == nil {
+				// Segment was deleted, do not append anything
+			} else if s, ok := val.(string); ok {
 				rebuiltSegments = append(rebuiltSegments, s)
 			} else {
 				rebuiltSegments = append(rebuiltSegments, originalSegment)
@@ -111,6 +120,7 @@ func (q *Path) Rebuild() (*retryablehttp.Request, error) {
 
 	rebuiltPath := strings.Join(rebuiltSegments, "/")
 
+	// Handle URL decoding to prevent double encoding by retryablehttp
 	if unescaped, err := urlutil.PathDecode(rebuiltPath); err == nil {
 		rebuiltPath = unescaped
 	}

--- a/pkg/fuzz/component/path.go
+++ b/pkg/fuzz/component/path.go
@@ -132,11 +132,16 @@ func (q *Path) Rebuild() (*retryablehttp.Request, error) {
 	return cloned, nil
 }
 
-// Clone clones the current state to a new component
+// Clone clones the current state to a new component (Nil-safe)
 func (q *Path) Clone() Component {
-	return &Path{
-		value:        q.value.Clone(),
-		req:          q.req.Clone(context.Background()),
+	cloned := &Path{
 		originalPath: q.originalPath,
 	}
+	if q.value != nil {
+		cloned.value = q.value.Clone()
+	}
+	if q.req != nil {
+		cloned.req = q.req.Clone(context.Background())
+	}
+	return cloned
 }


### PR DESCRIPTION
Description
This PR addresses issue #6398 where numeric path segments (e.g., `/55/`) were being skipped or fuzzed inconsistently.

 Key Changes:
- Path Snapshotting: Added `originalPath` to the `Path` struct to prevent pointer mutation during multiple fuzzing passes.
- Stable Indexing: Implemented a reliable `count` based 1-indexing for path segments to ensure deterministic iteration.
- Logic Refinement: Simplified the `Rebuild` and `Parse` logic to ensure numeric segments are correctly identified and fuzzed.

Fixes #6398

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Snapshot the original request path so reconstructions use the original input and preserve empty/leading segments.
  * Path segment keys now use a stable incremental scheme for consistent mapping.
  * Cloned path instances retain the original-path snapshot for predictable behavior.

* **Behavior Changes**
  * Rebuilt paths are URL-decoded before being applied.
  * Replacements and explicit deletions in the segment map are applied during reconstruction; deleting a missing key returns not-found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->