### PR TITLE
fix: headless http client better err catch

### DIFF
--- a/pkg/protocols/headless/engine/http_client.go
+++ b/pkg/protocols/headless/engine/http_client.go
@@ -65,8 +65,8 @@ func newHttpClient(options *types.Options) (*http.Client, error) {
 			transport.Proxy = http.ProxyURL(proxyURL)
 		}
 	} else if options.AliveSocksProxy != "" {
-		socksURL, proxyErr := url.Parse(options.AliveSocksProxy)
-		if proxyErr != nil {
+		socksURL, err := url.Parse(options.AliveSocksProxy)
+		if err != nil {
 			return nil, err
 		}
 		dialer, err := proxy.FromURL(socksURL, proxy.Direct)


### PR DESCRIPTION
## Proposed changes

For now func returns (nil,nil) at proxy error, instead (nil, err)

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SOCKS proxy error handling to ensure URL parsing failures and proxy initialization issues are properly caught and reported, preventing silent failures in proxy configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->