### PR TITLE
Fix #6674: Replace panic with error handling in template loader when d

### DIFF
--- a/pkg/input/provider/list/hmap.go
+++ b/pkg/input/provider/list/hmap.go
@@ -172,7 +172,8 @@ func (i *ListInputProvider) Set(executionId string, value string) {
 		// scan all ips
 		dialers := protocolstate.GetDialersWithId(executionId)
 		if dialers == nil {
-			panic("dialers with executionId " + executionId + " not found")
+			gologger.Error().Msgf("dialers with executionId %s not found", executionId)
+			return
 		}
 
 		dnsData, err := dialers.Fastdialer.GetDNSData(urlx.Hostname())
@@ -209,7 +210,8 @@ func (i *ListInputProvider) Set(executionId string, value string) {
 	if i.ipOptions.IPV6 {
 		dialers := protocolstate.GetDialersWithId(executionId)
 		if dialers == nil {
-			panic("dialers with executionId " + executionId + " not found")
+			gologger.Error().Msgf("dialers with executionId %s not found", executionId)
+			return
 		}
 
 		dnsData, err := dialers.Fastdialer.GetDNSData(urlx.Hostname())
@@ -419,7 +421,8 @@ func (i *ListInputProvider) Del(executionId string, value string) {
 		// scan all ips
 		dialers := protocolstate.GetDialersWithId(executionId)
 		if dialers == nil {
-			panic("dialers with executionId " + executionId + " not found")
+			gologger.Error().Msgf("dialers with executionId %s not found", executionId)
+			return
 		}
 
 		dnsData, err := dialers.Fastdialer.GetDNSData(urlx.Hostname())
@@ -456,7 +459,8 @@ func (i *ListInputProvider) Del(executionId string, value string) {
 	if i.ipOptions.IPV6 {
 		dialers := protocolstate.GetDialersWithId(executionId)
 		if dialers == nil {
-			panic("dialers with executionId " + executionId + " not found")
+			gologger.Error().Msgf("dialers with executionId %s not found", executionId)
+			return
 		}
 
 		dnsData, err := dialers.Fastdialer.GetDNSData(urlx.Hostname())

--- a/pkg/js/global/scripts.go
+++ b/pkg/js/global/scripts.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/rand"
 	"embed"
+	"fmt"
 	"math/big"
 	"net"
 	"reflect"
@@ -130,7 +131,7 @@ func initBuiltInFunc(runtime *goja.Runtime) {
 			executionId := ctx.Value("executionId").(string)
 			dialer := protocolstate.GetDialersWithId(executionId)
 			if dialer == nil {
-				panic("dialers with executionId " + executionId + " not found")
+				return false, fmt.Errorf("dialers with executionId %s not found", executionId)
 			}
 
 			conn, err := dialer.Fastdialer.Dial(ctx, "tcp", net.JoinHostPort(host, port))
@@ -161,7 +162,7 @@ func initBuiltInFunc(runtime *goja.Runtime) {
 			executionId := ctx.Value("executionId").(string)
 			dialer := protocolstate.GetDialersWithId(executionId)
 			if dialer == nil {
-				panic("dialers with executionId " + executionId + " not found")
+				return false, fmt.Errorf("dialers with executionId %s not found", executionId)
 			}
 
 			conn, err := dialer.Fastdialer.Dial(ctx, "udp", net.JoinHostPort(host, port))

--- a/pkg/js/libs/ldap/ldap.go
+++ b/pkg/js/libs/ldap/ldap.go
@@ -89,7 +89,8 @@ func NewClient(call goja.ConstructorCall, runtime *goja.Runtime) *goja.Object {
 	executionId := c.nj.ExecutionId()
 	dialers := protocolstate.GetDialersWithId(executionId)
 	if dialers == nil {
-		panic("dialers with executionId " + executionId + " not found")
+		c.nj.Throw("dialers with executionId %s not found", executionId)
+		return nil
 	}
 
 	var conn net.Conn

--- a/pkg/protocols/http/http.go
+++ b/pkg/protocols/http/http.go
@@ -378,7 +378,11 @@ func (request *Request) Compile(options *protocols.ExecutorOptions) error {
 				request.Raw[i] = strings.ReplaceAll(raw, "\n", "\r\n")
 			}
 		}
-		request.rawhttpClient = httpclientpool.GetRawHTTP(options)
+		rawClient, rawErr := httpclientpool.GetRawHTTP(options)
+		if rawErr != nil {
+			return errors.Wrap(rawErr, "could not get raw http client")
+		}
+		request.rawhttpClient = rawClient
 	}
 	if len(request.Matchers) > 0 || len(request.Extractors) > 0 {
 		compiled := &request.Operators

--- a/pkg/protocols/http/httpclientpool/clientpool.go
+++ b/pkg/protocols/http/httpclientpool/clientpool.go
@@ -139,11 +139,12 @@ func (c *Configuration) HasStandardOptions() bool {
 	return c.Threads == 0 && c.MaxRedirects == 0 && c.RedirectFlow == DontFollowRedirect && c.DisableCookie && c.Connection == nil && !c.NoTimeout && c.ResponseHeaderTimeout == 0
 }
 
-// GetRawHTTP returns the rawhttp request client
-func GetRawHTTP(options *protocols.ExecutorOptions) *rawhttp.Client {
+// GetRawHTTP returns the rawhttp request client.
+// Returns an error if dialers are not initialized for the given execution ID.
+func GetRawHTTP(options *protocols.ExecutorOptions) (*rawhttp.Client, error) {
 	dialers := protocolstate.GetDialersWithId(options.Options.ExecutionId)
 	if dialers == nil {
-		panic("dialers not initialized for execution id: " + options.Options.ExecutionId)
+		return nil, fmt.Errorf("dialers not initialized for execution id: %s", options.Options.ExecutionId)
 	}
 
 	// Lock the dialers to avoid a race when setting RawHTTPClient
@@ -151,7 +152,7 @@ func GetRawHTTP(options *protocols.ExecutorOptions) *rawhttp.Client {
 	defer dialers.Unlock()
 
 	if dialers.RawHTTPClient != nil {
-		return dialers.RawHTTPClient
+		return dialers.RawHTTPClient, nil
 	}
 
 	rawHttpOptionsCopy := *rawhttp.DefaultOptions
@@ -164,7 +165,7 @@ func GetRawHTTP(options *protocols.ExecutorOptions) *rawhttp.Client {
 	}
 	rawHttpOptionsCopy.Timeout = options.Options.GetTimeouts().HttpTimeout
 	dialers.RawHTTPClient = rawhttp.NewClient(&rawHttpOptionsCopy)
-	return dialers.RawHTTPClient
+	return dialers.RawHTTPClient, nil
 }
 
 // Get creates or gets a client for the protocol based on custom configuration

--- a/pkg/protocols/javascript/js.go
+++ b/pkg/protocols/javascript/js.go
@@ -401,7 +401,10 @@ func (request *Request) executeWithResults(port string, target *contextargs.Cont
 			results := map[string]interface{}(result)
 			results["error"] = outError.Error()
 			// generate and return failed event
-			data := request.generateEventData(input, results, hostPort)
+			data, dataErr := request.generateEventData(input, results, hostPort)
+			if dataErr != nil {
+				return dataErr
+			}
 			data = generators.MergeMaps(data, payloadValues)
 			event := eventcreator.CreateEventWithAdditionalOptions(request, data, request.options.Options.Debug || request.options.Options.DebugResponse, func(wrappedEvent *output.InternalWrappedEvent) {
 				allVars := argsCopy.Map()
@@ -586,7 +589,10 @@ func (request *Request) executeRequestWithPayloads(hostPort string, input *conte
 
 	values := mapsutil.Merge(payloadValues, results)
 	// generate event data
-	data := request.generateEventData(input, values, hostPort)
+	data, dataErr := request.generateEventData(input, values, hostPort)
+	if dataErr != nil {
+		return dataErr
+	}
 
 	// add and get values from templatectx
 	request.options.AddTemplateVars(input.MetaInput, request.Type(), request.GetID(), data)
@@ -633,11 +639,12 @@ func (request *Request) executeRequestWithPayloads(hostPort string, input *conte
 	return nil
 }
 
-// generateEventData generates event data for the request
-func (request *Request) generateEventData(input *contextargs.Context, values map[string]interface{}, matched string) map[string]interface{} {
+// generateEventData generates event data for the request.
+// Returns an error if dialers are not initialized for the given execution ID.
+func (request *Request) generateEventData(input *contextargs.Context, values map[string]interface{}, matched string) (map[string]interface{}, error) {
 	dialers := protocolstate.GetDialersWithId(request.options.Options.ExecutionId)
 	if dialers == nil {
-		panic(fmt.Sprintf("dialers not initialized for %s", request.options.Options.ExecutionId))
+		return nil, fmt.Errorf("dialers not initialized for %s", request.options.Options.ExecutionId)
 	}
 
 	data := make(map[string]interface{})
@@ -692,7 +699,7 @@ func (request *Request) generateEventData(input *contextargs.Context, values map
 			}
 		}
 	}
-	return data
+	return data, nil
 }
 
 func (request *Request) getArgsCopy(input *contextargs.Context, payloadValues map[string]interface{}, requestOptions *protocols.ExecutorOptions, ignoreErrors bool) (*compiler.ExecuteArgs, error) {


### PR DESCRIPTION
## Summary

Replaced all `panic()` calls triggered by missing dialers with proper error handling across the codebase. This prevents the application from crashing when dialers are unavailable, allowing callers to handle the situation gracefully instead.

## Changes

- **`pkg/input/provider/list/hmap.go`** — Replaced 4 `panic()` calls in `Set()` and `Del()` with `gologger.Error().Msgf()` + early return
- **`pkg/js/global/scripts.go`** — Replaced 2 `panic()` calls in `isPortOpen` and `isUDPPortOpen` with `return false, fmt.Errorf(...)`
- **`pkg/js/libs/ldap/ldap.go`** — Replaced `panic()` with `c.nj.Throw()` + `return nil`, matching the established pattern in other JS lib constructors
- **`pkg/protocols/http/httpclientpool/clientpool.go`** — Changed `GetRawHTTP()` to return `(*rawhttp.Client, error)` instead of panicking; added doc comment
- **`pkg/protocols/http/http.go`** — Updated caller of `GetRawHTTP()` to handle the new error return
- **`pkg/protocols/javascript/js.go`** — Changed `generateEventData()` to return `(map[string]interface{}, error)` and updated both callers

## Testing

All changes are mechanical replacements following established error-handling patterns in each package. Function signatures were updated and all callers were verified to handle the new error returns correctly.

---

/claim #6674

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling across HTTP client management, JavaScript execution, LDAP connections, and input processing modules. The application now gracefully manages initialization failures with proper error reporting and recovery instead of crashing, significantly improving stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->