### PR TITLE
fix(authx): block concurrent dynamic secret fetch until completion

### DIFF
--- a/pkg/authprovider/authx/dynamic.go
+++ b/pkg/authprovider/authx/dynamic.go
@@ -3,6 +3,7 @@ package authx
 import (
 	"fmt"
 	"strings"
+	"sync"
 	"sync/atomic"
 
 	"github.com/projectdiscovery/gologger"
@@ -31,7 +32,7 @@ type Dynamic struct {
 	Extracted     map[string]interface{} `json:"-" yaml:"-"`         // extracted values from the dynamic secret
 	fetchCallback LazyFetchSecret        `json:"-" yaml:"-"`
 	fetched       *atomic.Bool           `json:"-" yaml:"-"` // atomic flag to check if the secret has been fetched
-	fetching      *atomic.Bool           `json:"-" yaml:"-"` // atomic flag to prevent recursive fetch calls
+	fetchOnce     sync.Once              `json:"-" yaml:"-"` // ensures all callers block until fetch completes
 	error         error                  `json:"-" yaml:"-"` // error if any
 }
 
@@ -71,7 +72,7 @@ func (d *Dynamic) UnmarshalJSON(data []byte) error {
 // Validate validates the dynamic secret
 func (d *Dynamic) Validate() error {
 	d.fetched = &atomic.Bool{}
-	d.fetching = &atomic.Bool{}
+	d.fetchOnce = sync.Once{}
 	if d.TemplatePath == "" {
 		return errkit.New(" template-path is required for dynamic secret")
 	}
@@ -183,16 +184,7 @@ func (d *Dynamic) applyValuesToSecret(secret *Secret) error {
 
 // GetStrategy returns the auth strategies for the dynamic secret
 func (d *Dynamic) GetStrategies() []AuthStrategy {
-	if d.fetched.Load() {
-		if d.error != nil {
-			return nil
-		}
-	} else {
-		// Try to fetch if not already fetched
-		_ = d.Fetch(true)
-	}
-
-	if d.error != nil {
+	if err := d.Fetch(true); err != nil {
 		return nil
 	}
 	var strategies []AuthStrategy
@@ -207,23 +199,12 @@ func (d *Dynamic) GetStrategies() []AuthStrategy {
 
 // Fetch fetches the dynamic secret
 // if isFatal is true, it will stop the execution if the secret could not be fetched
+// All concurrent callers block until the single fetch attempt completes.
 func (d *Dynamic) Fetch(isFatal bool) error {
-	if d.fetched.Load() {
-		return d.error
-	}
-
-	// Try to set fetching flag atomically
-	if !d.fetching.CompareAndSwap(false, true) {
-		// Already fetching, return current error
-		return d.error
-	}
-
-	// We're the only one fetching, call the callback
-	d.error = d.fetchCallback(d)
-
-	// Mark as fetched and clear fetching flag
-	d.fetched.Store(true)
-	d.fetching.Store(false)
+	d.fetchOnce.Do(func() {
+		d.error = d.fetchCallback(d)
+		d.fetched.Store(true)
+	})
 
 	if d.error != nil && isFatal {
 		gologger.Fatal().Msgf("Could not fetch dynamic secret: %s\n", d.error)

--- a/pkg/authprovider/authx/dynamic.go
+++ b/pkg/authprovider/authx/dynamic.go
@@ -72,7 +72,6 @@ func (d *Dynamic) UnmarshalJSON(data []byte) error {
 // Validate validates the dynamic secret
 func (d *Dynamic) Validate() error {
 	d.fetched = &atomic.Bool{}
-	d.fetchOnce = sync.Once{}
 	if d.TemplatePath == "" {
 		return errkit.New(" template-path is required for dynamic secret")
 	}


### PR DESCRIPTION
/claim #6592
Closes #6592

## Summary

This fixes a race condition in dynamic secret fetching for authenticated scans.

Previously, concurrent callers to `Dynamic.Fetch()` could return before the first fetch completed, allowing strategy construction to proceed with empty auth state and causing unauthenticated requests to be sent.

## Root Cause

The previous implementation used an atomic `fetching` flag that did not block concurrent callers. If a second goroutine entered `Fetch()` while a fetch was in progress, it would return the current `d.error`, which could still be `nil`, leading to execution with incomplete secrets.

## Fix

- Replaced `fetching *atomic.Bool` with `sync.Once`
- Ensured all concurrent callers block until the first fetch completes
- Updated `GetStrategies()` to stop discarding `Fetch(true)` errors

## Result

Authenticated requests no longer proceed with partially initialized dynamic secrets, preventing unauthenticated outbound requests during secret-file authentication.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified internal concurrency for dynamic secret fetching to make fetch behavior more predictable and consistent.
* **Bug Fixes**
  * Prevented duplicate simultaneous fetches and ensured concurrent callers reliably wait for a single fetch to complete, improving stability when loading secrets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->