### PR TITLE
fix(auth): prefetch secret-file auth and block concurrent fetch

### DIFF
--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -495,7 +495,7 @@ on extensive configurability, massive extensibility and ease of use.`)
 
 	flagSet.CreateGroup("Authentication", "Authentication",
 		flagSet.StringSliceVarP(&options.SecretsFile, "secret-file", "sf", nil, "path to config file containing secrets for nuclei authenticated scan", goflags.CommaSeparatedStringSliceOptions),
-		flagSet.BoolVarP(&options.PreFetchSecrets, "prefetch-secrets", "ps", false, "prefetch secrets from the secrets file"),
+		flagSet.BoolVarP(&options.PreFetchSecrets, "prefetch-secrets", "ps", false, "legacy compatibility flag; authenticated scans now prefetch secrets automatically"),
 	)
 
 	flagSet.SetCustomHelpText(`EXAMPLES:

--- a/internal/runner/lazy.go
+++ b/internal/runner/lazy.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/projectdiscovery/nuclei/v3/pkg/authprovider"
 	"github.com/projectdiscovery/nuclei/v3/pkg/authprovider/authx"
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog"
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/disk"
@@ -16,10 +17,28 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/helpers/writer"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/replacer"
 	"github.com/projectdiscovery/nuclei/v3/pkg/scan"
+	"github.com/projectdiscovery/nuclei/v3/pkg/templates"
 	"github.com/projectdiscovery/nuclei/v3/pkg/types"
 	"github.com/projectdiscovery/utils/env"
 	"github.com/projectdiscovery/utils/errkit"
 )
+
+// PreFetchAuthSecrets prefetches secrets when an auth provider is configured.
+func PreFetchAuthSecrets(provider authprovider.AuthProvider) error {
+	if provider == nil {
+		return nil
+	}
+	return provider.PreFetchSecrets()
+}
+
+func prepareAuthTemplate(tmpl *templates.Template) {
+	if tmpl == nil {
+		return
+	}
+	for _, request := range tmpl.RequestsHTTP {
+		request.SkipSecretFile = true
+	}
+}
 
 type AuthLazyFetchOptions struct {
 	TemplateStore *loader.Store
@@ -79,6 +98,7 @@ func GetLazyAuthFetchCallback(opts *AuthLazyFetchOptions) authx.LazyFetchSecret 
 		}
 		data := map[string]interface{}{}
 		tmpl := tmpls[0]
+		prepareAuthTemplate(tmpl)
 		// add args to tmpl here
 		vars := map[string]interface{}{}
 		mainCtx := context.Background()

--- a/internal/runner/lazy_test.go
+++ b/internal/runner/lazy_test.go
@@ -1,0 +1,81 @@
+package runner
+
+import (
+	"errors"
+	"net/url"
+	"testing"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/authprovider/authx"
+	httpProtocol "github.com/projectdiscovery/nuclei/v3/pkg/protocols/http"
+	"github.com/projectdiscovery/nuclei/v3/pkg/templates"
+	urlutil "github.com/projectdiscovery/utils/url"
+	"github.com/stretchr/testify/require"
+)
+
+type testAuthProvider struct {
+	calls int
+	err   error
+}
+
+func (t *testAuthProvider) LookupAddr(string) []authx.AuthStrategy {
+	return nil
+}
+
+func (t *testAuthProvider) LookupURL(*url.URL) []authx.AuthStrategy {
+	return nil
+}
+
+func (t *testAuthProvider) LookupURLX(*urlutil.URL) []authx.AuthStrategy {
+	return nil
+}
+
+func (t *testAuthProvider) GetTemplatePaths() []string {
+	return nil
+}
+
+func (t *testAuthProvider) PreFetchSecrets() error {
+	t.calls++
+	return t.err
+}
+
+func TestPreFetchAuthSecrets(t *testing.T) {
+	require.NoError(t, PreFetchAuthSecrets(nil))
+
+	provider := &testAuthProvider{}
+	require.NoError(t, PreFetchAuthSecrets(provider))
+	require.Equal(t, 1, provider.calls)
+}
+
+func TestPreFetchAuthSecretsReturnsProviderError(t *testing.T) {
+	expectedErr := errors.New("prefetch failed")
+	provider := &testAuthProvider{err: expectedErr}
+
+	require.ErrorIs(t, PreFetchAuthSecrets(provider), expectedErr)
+	require.Equal(t, 1, provider.calls)
+}
+
+func TestPrepareAuthTemplateSkipsSecretFile(t *testing.T) {
+	tmpl := &templates.Template{
+		RequestsHTTP: []*httpProtocol.Request{{}, {}},
+	}
+
+	prepareAuthTemplate(tmpl)
+
+	for _, request := range tmpl.RequestsHTTP {
+		require.True(t, request.SkipSecretFile)
+	}
+}
+
+func TestPrepareAuthTemplateSkipsSecretFileForEachInstance(t *testing.T) {
+	templatesToPrepare := []*templates.Template{
+		{RequestsHTTP: []*httpProtocol.Request{{}}},
+		{RequestsHTTP: []*httpProtocol.Request{{}}},
+	}
+
+	for _, tmpl := range templatesToPrepare {
+		prepareAuthTemplate(tmpl)
+		for _, request := range tmpl.RequestsHTTP {
+			require.True(t, request.SkipSecretFile)
+		}
+	}
+}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -687,10 +687,10 @@ func (r *Runner) RunEnumeration() error {
 	// display execution info like version , templates used etc
 	r.displayExecutionInfo(store)
 
-	// prefetch secrets if enabled
-	if executorOpts.AuthProvider != nil && r.options.PreFetchSecrets {
+	// prefetch secrets before normal template execution when auth is configured
+	if executorOpts.AuthProvider != nil {
 		r.Logger.Info().Msgf("Pre-fetching secrets from authprovider[s]")
-		if err := executorOpts.AuthProvider.PreFetchSecrets(); err != nil {
+		if err := PreFetchAuthSecrets(executorOpts.AuthProvider); err != nil {
 			return errors.Wrap(err, "could not pre-fetch secrets")
 		}
 	}

--- a/lib/config.go
+++ b/lib/config.go
@@ -485,7 +485,8 @@ func WithAuthProvider(provider authprovider.AuthProvider) NucleiSDKOptions {
 	}
 }
 
-// LoadSecretsFromFile allows loading secrets from file
+// LoadSecretsFromFile allows loading secrets from file.
+// Deprecated: the prefetch argument is retained for backward compatibility; authenticated scans prefetch automatically.
 func LoadSecretsFromFile(files []string, prefetch bool) NucleiSDKOptions {
 	return func(e *NucleiEngine) error {
 		e.opts.SecretsFile = goflags.StringSlice(files)

--- a/lib/sdk_private.go
+++ b/lib/sdk_private.go
@@ -207,6 +207,7 @@ func (e *NucleiEngine) init(ctx context.Context) error {
 	if e.opts.ShouldUseHostError() && e.hostErrCache != nil {
 		e.executerOpts.HostErrorsCache = e.hostErrCache
 	}
+	prefetchAuthProvider := false
 	if len(e.opts.SecretsFile) > 0 {
 		authTmplStore, err := runner.GetAuthTmplStore(e.opts, e.catalog, e.executerOpts)
 		if err != nil {
@@ -223,13 +224,15 @@ func (e *NucleiEngine) init(ctx context.Context) error {
 			return errors.Wrap(err, "could not create auth provider")
 		}
 		e.executerOpts.AuthProvider = provider
+		prefetchAuthProvider = true
 	}
 	if e.authprovider != nil {
 		e.executerOpts.AuthProvider = e.authprovider
+		prefetchAuthProvider = false
 	}
 
-	// prefetch secrets before normal template execution when auth is configured
-	if e.executerOpts.AuthProvider != nil {
+	// prefetch secrets before normal template execution only for providers created from secret files
+	if prefetchAuthProvider {
 		if err := runner.PreFetchAuthSecrets(e.executerOpts.AuthProvider); err != nil {
 			return errors.Wrap(err, "could not prefetch secrets")
 		}

--- a/lib/sdk_private.go
+++ b/lib/sdk_private.go
@@ -228,9 +228,9 @@ func (e *NucleiEngine) init(ctx context.Context) error {
 		e.executerOpts.AuthProvider = e.authprovider
 	}
 
-	// prefetch secrets
-	if e.executerOpts.AuthProvider != nil && e.opts.PreFetchSecrets {
-		if err := e.executerOpts.AuthProvider.PreFetchSecrets(); err != nil {
+	// prefetch secrets before normal template execution when auth is configured
+	if e.executerOpts.AuthProvider != nil {
+		if err := runner.PreFetchAuthSecrets(e.executerOpts.AuthProvider); err != nil {
 			return errors.Wrap(err, "could not prefetch secrets")
 		}
 	}

--- a/pkg/authprovider/authx/dynamic.go
+++ b/pkg/authprovider/authx/dynamic.go
@@ -3,6 +3,7 @@ package authx
 import (
 	"fmt"
 	"strings"
+	"sync"
 	"sync/atomic"
 
 	"github.com/projectdiscovery/gologger"
@@ -31,7 +32,7 @@ type Dynamic struct {
 	Extracted     map[string]interface{} `json:"-" yaml:"-"`         // extracted values from the dynamic secret
 	fetchCallback LazyFetchSecret        `json:"-" yaml:"-"`
 	fetched       *atomic.Bool           `json:"-" yaml:"-"` // atomic flag to check if the secret has been fetched
-	fetching      *atomic.Bool           `json:"-" yaml:"-"` // atomic flag to prevent recursive fetch calls
+	fetchOnce     *sync.Once             `json:"-" yaml:"-"` // shared state for a single blocking fetch
 	error         error                  `json:"-" yaml:"-"` // error if any
 }
 
@@ -71,7 +72,7 @@ func (d *Dynamic) UnmarshalJSON(data []byte) error {
 // Validate validates the dynamic secret
 func (d *Dynamic) Validate() error {
 	d.fetched = &atomic.Bool{}
-	d.fetching = &atomic.Bool{}
+	d.fetchOnce = &sync.Once{}
 	if d.TemplatePath == "" {
 		return errkit.New(" template-path is required for dynamic secret")
 	}
@@ -212,20 +213,14 @@ func (d *Dynamic) Fetch(isFatal bool) error {
 		return d.error
 	}
 
-	// Try to set fetching flag atomically
-	if !d.fetching.CompareAndSwap(false, true) {
-		// Already fetching, return current error
-		return d.error
-	}
+	shouldFatal := false
+	d.fetchOnce.Do(func() {
+		shouldFatal = isFatal
+		d.error = d.fetchCallback(d)
+		d.fetched.Store(true)
+	})
 
-	// We're the only one fetching, call the callback
-	d.error = d.fetchCallback(d)
-
-	// Mark as fetched and clear fetching flag
-	d.fetched.Store(true)
-	d.fetching.Store(false)
-
-	if d.error != nil && isFatal {
+	if d.error != nil && shouldFatal {
 		gologger.Fatal().Msgf("Could not fetch dynamic secret: %s\n", d.error)
 	}
 	return d.error

--- a/pkg/authprovider/authx/dynamic_test.go
+++ b/pkg/authprovider/authx/dynamic_test.go
@@ -1,7 +1,10 @@
 package authx
 
 import (
+	"errors"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -122,4 +125,105 @@ func TestDynamicUnmarshalJSON(t *testing.T) {
 		err := d.UnmarshalJSON(data)
 		require.NoError(t, err)
 	})
+}
+
+func newTestDynamic(t *testing.T, callback LazyFetchSecret) *Dynamic {
+	t.Helper()
+
+	dynamic := &Dynamic{
+		Secret: &Secret{
+			Type:    string(BearerTokenAuth),
+			Domains: []string{"example.com"},
+			Token:   "Bearer {{token}}",
+		},
+		TemplatePath: "auth-template.yaml",
+		Variables: []KV{{
+			Key:   "username",
+			Value: "tester",
+		}},
+	}
+	require.NoError(t, dynamic.Validate())
+	dynamic.SetLazyFetchCallback(callback)
+	return dynamic
+}
+
+func TestDynamicFetchBlocksConcurrentCallers(t *testing.T) {
+	var calls atomic.Int32
+	started := make(chan struct{})
+	release := make(chan struct{})
+	done := make(chan error, 2)
+
+	dynamic := newTestDynamic(t, func(d *Dynamic) error {
+		calls.Add(1)
+		close(started)
+		<-release
+		d.Extracted = map[string]interface{}{"token": "secret-token"}
+		return nil
+	})
+
+	go func() {
+		done <- dynamic.Fetch(false)
+	}()
+
+	<-started
+
+	go func() {
+		done <- dynamic.Fetch(false)
+	}()
+
+	select {
+	case err := <-done:
+		t.Fatalf("concurrent fetch returned before first fetch finished: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(release)
+	require.NoError(t, <-done)
+	require.NoError(t, <-done)
+	require.EqualValues(t, 1, calls.Load())
+	require.True(t, dynamic.fetched.Load())
+	require.Equal(t, "Bearer secret-token", dynamic.Secret.Token)
+}
+
+func TestDynamicGetStrategiesWaitsForFetchCompletion(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	done := make(chan []AuthStrategy, 1)
+
+	dynamic := newTestDynamic(t, func(d *Dynamic) error {
+		close(started)
+		<-release
+		d.Extracted = map[string]interface{}{"token": "secret-token"}
+		return nil
+	})
+
+	go func() {
+		done <- dynamic.GetStrategies()
+	}()
+
+	<-started
+
+	select {
+	case strategies := <-done:
+		t.Fatalf("strategies became available before fetch completed: %d", len(strategies))
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(release)
+	strategies := <-done
+	require.Len(t, strategies, 1)
+	require.Equal(t, "Bearer secret-token", dynamic.Secret.Token)
+	require.NoError(t, dynamic.Error())
+}
+
+func TestDynamicGetStrategiesReturnsNilOnFetchFailure(t *testing.T) {
+	expectedErr := errors.New("fetch failed")
+	dynamic := newTestDynamic(t, func(d *Dynamic) error {
+		return expectedErr
+	})
+
+	require.ErrorIs(t, dynamic.Fetch(false), expectedErr)
+	require.Nil(t, dynamic.GetStrategies())
+	require.ErrorIs(t, dynamic.Error(), expectedErr)
+	require.True(t, dynamic.fetched.Load())
 }

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -420,7 +420,7 @@ type Options struct {
 	JsConcurrency int
 	// SecretsFile is file containing secrets for nuclei
 	SecretsFile goflags.StringSlice
-	// PreFetchSecrets pre-fetches the secrets from the auth provider
+	// Deprecated: authenticated scans now pre-fetch secrets automatically whenever an auth provider is configured.
 	PreFetchSecrets bool
 	// FormatUseRequiredOnly only uses required fields when generating requests
 	FormatUseRequiredOnly bool


### PR DESCRIPTION
## Proposed changes

Fixes #6592
/claim #6592 


- restore authenticated scan startup ordering for `-secret-file`, so auth completes before normal scan traffic starts
- apply the same auth prefetch behavior in both runner and SDK paths when an auth provider is configured
- serialize the first dynamic auth fetch so concurrent callers wait for initialized auth state instead of racing ahead
- prevent auth bootstrap templates from re-applying secret-file auth while they establish the authenticated session
- add focused tests for auth prefetch/bootstrap behavior and dynamic auth fetch synchronization

### Proof

Automated coverage:

- added coverage for auth prefetch success/failure and auth-template bootstrap without secret-file re-entry
- added coverage for concurrent dynamic fetch waiting behavior and fetch failure handling

Tests run:

```sh
go test ./internal/runner -race -count=1
go test ./pkg/authprovider/authx -race -count=1
go test ./lib -run 'TestHeadlessOptionInitialization|TestContextCancelNucleiEngine' -count=1
```

<img width="1157" height="175" alt="tests" src="https://github.com/user-attachments/assets/0684a607-bbaf-4b7c-9282-02677393ced3" />

Output:
```
ok  	github.com/projectdiscovery/nuclei/v3/internal/runner	1.635s
ok  	github.com/projectdiscovery/nuclei/v3/pkg/authprovider/authx	2.655s
ok  	github.com/projectdiscovery/nuclei/v3/lib	26.000s
```

Manual reproduction on an affected build:

```sh
nuclei -secret-file docs_learn/django-login.yaml -target http://localhost:8000/ -v
```

In this local Django repro, a small request-logging middleware prints `AnonymousUser` for unauthenticated requests and `<authenticated-user>` for authenticated requests. The ordering of those labels is the regression signal.

Note: the initial `GET /accounts/login/` is expected to appear as unauthenticated because it is the bootstrap request that fetches the login page and CSRF token.

Before (`v3.7.1` from `PATH`):

### Screenshot 1: affected Django server log showing AnonymousUser on non-login requests before POST /accounts/login/ completes

<img width="1596" height="347" alt="before" src="https://github.com/user-attachments/assets/623cff6c-4d18-42a4-b2d5-86f53e8ad7c6" />



This reproduces #6592: normal scan requests reach the target before the login flow has established authenticated state.

Manual verification on this branch:

```sh
nuclei-patched -secret-file docs_learn/django-login.yaml -target http://localhost:8000/ -v
```

After (this branch):

### Screenshot 2: patched Django server log showing GET /accounts/login/, POST /accounts/login/, then the first normal scan requests as `engbot@example.com` (authenticated user)

<img width="1596" height="314" alt="after" src="https://github.com/user-attachments/assets/5daea502-33e2-4023-ae29-f3db0ad385b9" />



This shows the login flow completing before the first normal scan requests, and those requests are observed as authenticated.

## Checklist

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Authenticated scans now automatically prefetch secrets when an auth provider is configured.

* **Bug Fixes**
  * Improved concurrency and one-time execution behavior for lazy authentication secret fetching to avoid duplicate or racey fetches.

* **Deprecations**
  * The prefetch-secrets flag is now marked legacy; it's retained for compatibility but no longer required.

* **Tests**
  * Added tests covering lazy auth secret prefetching, error propagation, and concurrency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->