### PR TITLE
[BOUNTY #6398] Fix: Use OrderedMap in Path.Parse() for deterministic fuzzing iteration

### DIFF
--- a/pkg/fuzz/component/path.go
+++ b/pkg/fuzz/component/path.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz/dataformat"
 	"github.com/projectdiscovery/retryablehttp-go"
+	mapsutil "github.com/projectdiscovery/utils/maps"
 	urlutil "github.com/projectdiscovery/utils/url"
 )
 
@@ -36,7 +37,7 @@ func (q *Path) Parse(req *retryablehttp.Request) (bool, error) {
 	q.value = NewValue("")
 
 	split := strings.Split(req.Path, "/")
-	values := make(map[string]interface{})
+	orderedValues := mapsutil.NewOrderedMap[string, any]()
 	for i, segment := range split {
 		if segment == "" && i == 0 {
 			// Skip the first empty segment from leading "/"
@@ -46,11 +47,11 @@ func (q *Path) Parse(req *retryablehttp.Request) (bool, error) {
 			// Skip any other empty segments
 			continue
 		}
-		// Use 1-based indexing and store individual segments
-		key := strconv.Itoa(len(values) + 1)
-		values[key] = segment
+		// Use 1-based indexing and store individual segments in order
+		key := strconv.Itoa(orderedValues.Size() + 1)
+		orderedValues.Set(key, segment)
 	}
-	q.value.SetParsed(dataformat.KVMap(values), "")
+	q.value.SetParsed(dataformat.KVOrderedMap(&orderedValues), "")
 	return true, nil
 }
 


### PR DESCRIPTION
## Problem

Path fuzzing randomly skips segments due to non-deterministic map iteration order in Go.

`/user/55/profile` - sometimes fuzzes `55`, sometimes skips it.

## Root Cause

`Path.Parse()` uses a plain `map[string]interface{}` which has random iteration order in Go. When the fuzz frequency tracker uses the key as parameter name for filtering, the non-deterministic order causes unpredictable behavior.

## Fix

Replace `map[string]interface{}` with `mapsutil.OrderedMap` (matching the Cookie component pattern).

## Changes

`pkg/fuzz/component/path.go`:
- Import `mapsutil`
- Use `mapsutil.NewOrderedMap[string, any]()` instead of `map[string]interface{}`
- Use `.Size()` and `.Set()` instead of map operations
- Pass `dataformat.KVOrderedMap` instead of `dataformat.KVMap`

## Testing

Existing tests in `path_test.go` continue to pass (ordered iteration is a superset of unordered).

Closes #6398

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Path fuzzing operations now preserve segment ordering, ensuring consistent and accurate test case generation during path component analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->