### PR TITLE
fix(fuzz): harden XSS context analyzer edge cases (#7086)

### DIFF
--- a/pkg/fuzz/analyzers/xss/analyzer.go
+++ b/pkg/fuzz/analyzers/xss/analyzer.go
@@ -387,7 +387,11 @@ func classifyAttributeContext(attrName, attrValue, tagName string) XSSContext {
 	}
 
 	if _, ok := urlAttrs[attrName]; ok {
-		trimmed := strings.TrimSpace(strings.ToLower(attrValue))
+		// WHATWG URL spec: browsers strip ASCII tab (0x09), newline (0x0A),
+		// and carriage return (0x0D) from URL scheme before parsing. This means
+		// "java\tscript:" or "java\nscript:" are equivalent to "javascript:" in
+		// navigable contexts. We normalize these characters out before checking.
+		trimmed := normalizeURIScheme(attrValue)
 		if strings.HasPrefix(trimmed, "javascript:") ||
 			strings.HasPrefix(trimmed, "vbscript:") ||
 			strings.HasPrefix(trimmed, "data:text/html") ||
@@ -406,6 +410,24 @@ func classifyAttributeContext(attrName, attrValue, tagName string) XSSContext {
 	}
 
 	return ContextHTMLAttribute
+}
+
+// normalizeURIScheme strips leading whitespace plus ASCII tab, newline, and
+// carriage-return characters that browsers silently remove from URL schemes
+// per the WHATWG URL spec, then lowercases the result for prefix comparison.
+// This ensures that obfuscated URIs like "java\tscript:" or "java\nscript:"
+// are correctly identified as dangerous schemes.
+func normalizeURIScheme(val string) string {
+	var b strings.Builder
+	b.Grow(len(val))
+	for _, c := range val {
+		// Strip ASCII tab (0x09), LF (0x0A), CR (0x0D)
+		if c == '\t' || c == '\n' || c == '\r' {
+			continue
+		}
+		b.WriteRune(c)
+	}
+	return strings.TrimSpace(strings.ToLower(b.String()))
 }
 
 // containsMarker does a case-insensitive substring check.

--- a/pkg/fuzz/analyzers/xss/analyzer_test.go
+++ b/pkg/fuzz/analyzers/xss/analyzer_test.go
@@ -422,6 +422,137 @@ func TestAnalyzeReflectionContext(t *testing.T) {
 			marker:   marker,
 			expected: ContextHTMLBody,
 		},
+
+		// ================================================================
+		// Regression tests for issue #7086:
+		// XSS Context Analyzer misclassifies javascript: URIs and JSON
+		// script blocks.
+		// ================================================================
+
+		// --- #7086 Edge Case 1: javascript: URI classification ---
+		// javascript: URIs in executable sinks must be ContextScript.
+		{
+			name:     "#7086: javascript: URI with tab in scheme (WHATWG normalization)",
+			body:     "<a href=\"java\tscript:alert('FUZZ1337MARKER')\">xss</a>",
+			marker:   marker,
+			expected: ContextScript,
+		},
+		{
+			name:     "#7086: javascript: URI with newline in scheme",
+			body:     "<a href=\"java\nscript:alert('FUZZ1337MARKER')\">xss</a>",
+			marker:   marker,
+			expected: ContextScript,
+		},
+		{
+			name:     "#7086: javascript: URI with CR in scheme",
+			body:     "<a href=\"java\rscript:alert('FUZZ1337MARKER')\">xss</a>",
+			marker:   marker,
+			expected: ContextScript,
+		},
+		{
+			name:     "#7086: javascript: URI with mixed whitespace in scheme",
+			body:     "<a href=\"j\ta\nv\ra\tscript:alert('FUZZ1337MARKER')\">xss</a>",
+			marker:   marker,
+			expected: ContextScript,
+		},
+		{
+			name:     "#7086: javascript: URI in formaction on button",
+			body:     `<button formaction="javascript:void(FUZZ1337MARKER)">Go</button>`,
+			marker:   marker,
+			expected: ContextScript,
+		},
+		{
+			name:     "#7086: javascript: URI in iframe src",
+			body:     `<iframe src="javascript:alert('FUZZ1337MARKER')"></iframe>`,
+			marker:   marker,
+			expected: ContextScript,
+		},
+		{
+			name:     "#7086: javascript: URI in object data attr",
+			body:     `<object data="javascript:alert('FUZZ1337MARKER')"></object>`,
+			marker:   marker,
+			expected: ContextScript,
+		},
+
+		// --- #7086 Edge Case 2: JSON script blocks ---
+		// <script type="application/json"> is non-executable data context.
+		{
+			name:     "#7086: script type=application/json is ScriptData",
+			body:     `<script type="application/json">{"key": "FUZZ1337MARKER"}</script>`,
+			marker:   marker,
+			expected: ContextScriptData,
+		},
+		{
+			name:     "#7086: script type=application/ld+json is ScriptData",
+			body:     `<script type="application/ld+json">{"name": "FUZZ1337MARKER"}</script>`,
+			marker:   marker,
+			expected: ContextScriptData,
+		},
+		{
+			name:     "#7086: script type=application/json with charset param is ScriptData",
+			body:     `<script type="application/json; charset=utf-8">{"v": "FUZZ1337MARKER"}</script>`,
+			marker:   marker,
+			expected: ContextScriptData,
+		},
+		{
+			name:     "#7086: mixed JSON and executable script blocks",
+			body:     `<script type="application/json">{"safe": "data"}</script><script>var x = "FUZZ1337MARKER";</script>`,
+			marker:   marker,
+			expected: ContextScript,
+		},
+		{
+			name:     "#7086: script type empty string is executable",
+			body:     `<script type="">var x = "FUZZ1337MARKER";</script>`,
+			marker:   marker,
+			expected: ContextScript,
+		},
+
+		// --- #7086 Edge Case 3: Case-insensitive reflection detection ---
+		{
+			name:     "#7086: marker fully uppercased in body still detected",
+			body:     `<p>FUZZ1337MARKER appears here</p>`,
+			marker:   "fuzz1337marker",
+			expected: ContextHTMLBody,
+		},
+		{
+			name:     "#7086: marker with random casing in script",
+			body:     `<script>var x = "Fuzz1337Marker";</script>`,
+			marker:   "FUZZ1337MARKER",
+			expected: ContextScript,
+		},
+		{
+			name:     "#7086: marker case-insensitive in attribute value",
+			body:     `<input value="fUzZ1337mArKeR">`,
+			marker:   "FUZZ1337MARKER",
+			expected: ContextHTMLAttribute,
+		},
+		{
+			name:     "#7086: marker case-insensitive in comment",
+			body:     `<!-- fuzz1337marker -->`,
+			marker:   "FUZZ1337MARKER",
+			expected: ContextComment,
+		},
+
+		// --- #7086 Edge Case 4: srcdoc attribute context ---
+		// srcdoc contains nested HTML that the browser parses independently.
+		{
+			name:     "#7086: srcdoc on iframe is HTMLBody context",
+			body:     `<iframe srcdoc="<b>FUZZ1337MARKER</b>"></iframe>`,
+			marker:   marker,
+			expected: ContextHTMLBody,
+		},
+		{
+			name:     "#7086: srcdoc with script injection is HTMLBody",
+			body:     `<iframe srcdoc="<script>alert(FUZZ1337MARKER)</script>"></iframe>`,
+			marker:   marker,
+			expected: ContextHTMLBody,
+		},
+		{
+			name:     "#7086: srcdoc with complex nested HTML",
+			body:     `<iframe srcdoc="<html><body><img src=x onerror=alert(FUZZ1337MARKER)></body></html>"></iframe>`,
+			marker:   marker,
+			expected: ContextHTMLBody,
+		},
 	}
 
 	for _, tc := range tests {
@@ -465,6 +596,34 @@ func TestAnalyzeReflectionContext_NoPanic(t *testing.T) {
 			}()
 			_, _ = AnalyzeReflectionContext(input, "FUZZ1337MARKER")
 		}()
+	}
+}
+
+func TestNormalizeURIScheme(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"plain javascript:", "javascript:alert(1)", "javascript:alert(1)"},
+		{"tab in scheme", "java\tscript:alert(1)", "javascript:alert(1)"},
+		{"newline in scheme", "java\nscript:alert(1)", "javascript:alert(1)"},
+		{"CR in scheme", "java\rscript:alert(1)", "javascript:alert(1)"},
+		{"mixed whitespace in scheme", "j\ta\nv\ra\tscript:x", "javascript:x"},
+		{"leading spaces preserved by TrimSpace", "  javascript:x", "javascript:x"},
+		{"mixed case", "JavaScript:alert(1)", "javascript:alert(1)"},
+		{"data URI", "data:text/html,<h1>hi</h1>", "data:text/html,<h1>hi</h1>"},
+		{"normal URL unchanged", "https://example.com", "https://example.com"},
+		{"empty string", "", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := normalizeURIScheme(tc.input)
+			if got != tc.expected {
+				t.Errorf("normalizeURIScheme(%q) = %q, want %q", tc.input, got, tc.expected)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #7086 — XSS Context Analyzer misclassifies javascript: URIs and JSON script blocks.

/claim #7086

> **Note:** PR #7208 and other previous attempts were closed. This is a fresh, minimal implementation that builds on the existing tokenizer-based analyzer already on `dev`.

### Changes

**1. WHATWG-compliant URI scheme normalization** (`normalizeURIScheme`)

Per the [WHATWG URL spec](https://url.spec.whatwg.org/#url-parsing), browsers strip ASCII tab (0x09), newline (0x0A), and carriage return (0x0D) from URL schemes before parsing. This means URIs like `java\tscript:alert(1)` execute identically to `javascript:alert(1)` in navigable contexts (`<a href>`, `<iframe src>`, etc.).

The existing code used `strings.TrimSpace` + `strings.ToLower` which correctly handles leading whitespace and case, but did not strip embedded control characters. The new `normalizeURIScheme` function handles this per spec.

**2. Regression tests for all 4 edge cases from #7086**

Added 19 new test cases explicitly labeled with `#7086:` prefix:

| Edge case | Tests added |
|---|---|
| javascript: URI classification | 7 tests — tab/newline/CR in scheme, formaction, iframe src, object data |
| JSON script blocks (non-executable) | 5 tests — application/json, ld+json, charset params, mixed blocks, empty type |
| Case-insensitive reflection detection | 4 tests — body, script, attribute, comment contexts |
| srcdoc attribute context | 3 tests — basic, script injection, complex nested HTML |

Plus a unit test for `normalizeURIScheme` with 10 cases.

### Files changed

- `pkg/fuzz/analyzers/xss/analyzer.go` — Added `normalizeURIScheme()` + use it in `classifyAttributeContext`
- `pkg/fuzz/analyzers/xss/analyzer_test.go` — 19 regression tests for #7086 + 10 unit tests for URI normalization

### Proof

All 73 tests pass (54 existing + 19 new):

```
$ go test ./pkg/fuzz/analyzers/xss/... -v -count=1
--- PASS: TestAnalyzeReflectionContext (0.00s)
    --- PASS: #7086:_javascript:_URI_with_tab_in_scheme_(WHATWG_normalization) (0.00s)
    --- PASS: #7086:_javascript:_URI_with_newline_in_scheme (0.00s)
    --- PASS: #7086:_javascript:_URI_with_CR_in_scheme (0.00s)
    --- PASS: #7086:_javascript:_URI_with_mixed_whitespace_in_scheme (0.00s)
    --- PASS: #7086:_javascript:_URI_in_formaction_on_button (0.00s)
    --- PASS: #7086:_javascript:_URI_in_iframe_src (0.00s)
    --- PASS: #7086:_javascript:_URI_in_object_data_attr (0.00s)
    --- PASS: #7086:_script_type=application/json_is_ScriptData (0.00s)
    --- PASS: #7086:_script_type=application/ld+json_is_ScriptData (0.00s)
    --- PASS: #7086:_script_type=application/json_with_charset_param_is_ScriptData (0.00s)
    --- PASS: #7086:_mixed_JSON_and_executable_script_blocks (0.00s)
    --- PASS: #7086:_script_type_empty_string_is_executable (0.00s)
    --- PASS: #7086:_marker_fully_uppercased_in_body_still_detected (0.00s)
    --- PASS: #7086:_marker_with_random_casing_in_script (0.00s)
    --- PASS: #7086:_marker_case-insensitive_in_attribute_value (0.00s)
    --- PASS: #7086:_marker_case-insensitive_in_comment (0.00s)
    --- PASS: #7086:_srcdoc_on_iframe_is_HTMLBody_context (0.00s)
    --- PASS: #7086:_srcdoc_with_script_injection_is_HTMLBody (0.00s)
    --- PASS: #7086:_srcdoc_with_complex_nested_HTML (0.00s)
--- PASS: TestNormalizeURIScheme (0.00s)
PASS
ok  github.com/projectdiscovery/nuclei/v3/pkg/fuzz/analyzers/xss  0.818s
```

### Checklist

- [x] PR created against `dev` branch
- [x] All existing tests still pass
- [x] Tests added that prove the fix is effective
- [x] `go vet` passes cleanly
- [x] Minimal diff — only touches the 2 XSS analyzer files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced XSS analyzer to detect obfuscated JavaScript URIs with embedded whitespace characters (tabs, newlines, carriage returns), providing improved protection against evasion-based XSS attacks.

* **Tests**
  * Significantly expanded test coverage for obfuscated scheme detection patterns, non-executable script MIME types, and case-insensitive marker detection across various contexts to ensure comprehensive validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->