### PR TITLE
fix(xss): strip all C0 control chars from URI schemes per WHATWG spec

### DIFF
--- a/pkg/fuzz/analyzers/xss/analyzer.go
+++ b/pkg/fuzz/analyzers/xss/analyzer.go
@@ -387,7 +387,7 @@ func classifyAttributeContext(attrName, attrValue, tagName string) XSSContext {
 	}
 
 	if _, ok := urlAttrs[attrName]; ok {
-		trimmed := strings.TrimSpace(strings.ToLower(attrValue))
+		trimmed := stripC0Controls(strings.TrimSpace(strings.ToLower(attrValue)))
 		if strings.HasPrefix(trimmed, "javascript:") ||
 			strings.HasPrefix(trimmed, "vbscript:") ||
 			strings.HasPrefix(trimmed, "data:text/html") ||
@@ -406,6 +406,20 @@ func classifyAttributeContext(attrName, attrValue, tagName string) XSSContext {
 	}
 
 	return ContextHTMLAttribute
+}
+
+// stripC0Controls removes all C0 control characters (0x00-0x1F) and DEL (0x7F)
+// from the string. Per the WHATWG URL spec, browsers silently strip these
+// characters from URI schemes before interpretation, so an attacker can bypass
+// naive prefix checks by inserting them (e.g. "java\x00script:" is treated as
+// "javascript:" by browsers).
+func stripC0Controls(s string) string {
+	return strings.Map(func(r rune) rune {
+		if r <= 0x1F || r == 0x7F {
+			return -1 // drop the character
+		}
+		return r
+	}, s)
 }
 
 // containsMarker does a case-insensitive substring check.

--- a/pkg/fuzz/analyzers/xss/analyzer_test.go
+++ b/pkg/fuzz/analyzers/xss/analyzer_test.go
@@ -277,6 +277,24 @@ func TestAnalyzeReflectionContext(t *testing.T) {
 			marker:   marker,
 			expected: ContextScript,
 		},
+		{
+			name:     "tab (0x09) mid-scheme in javascript: URI",
+			body:     "<a href=\"java\x09script:alert('FUZZ1337MARKER')\">xss</a>",
+			marker:   marker,
+			expected: ContextScript,
+		},
+		{
+			name:     "LF (0x0A) mid-scheme in javascript: URI",
+			body:     "<a href=\"java\x0ascript:alert('FUZZ1337MARKER')\">xss</a>",
+			marker:   marker,
+			expected: ContextScript,
+		},
+		{
+			name:     "CR (0x0D) mid-scheme in javascript: URI",
+			body:     "<a href=\"java\x0dscript:alert('FUZZ1337MARKER')\">xss</a>",
+			marker:   marker,
+			expected: ContextScript,
+		},
 
 		// === ScriptData Context (non-executable script) ===
 		{

--- a/pkg/fuzz/analyzers/xss/analyzer_test.go
+++ b/pkg/fuzz/analyzers/xss/analyzer_test.go
@@ -222,6 +222,62 @@ func TestAnalyzeReflectionContext(t *testing.T) {
 			expected: ContextHTMLAttributeURL,
 		},
 
+		// === C0 control character bypass in javascript: URI ===
+		{
+			name:     "NULL byte in javascript: URI scheme",
+			body:     "<a href=\"java\x00script:alert('FUZZ1337MARKER')\">xss</a>",
+			marker:   marker,
+			expected: ContextScript,
+		},
+		{
+			name:     "form feed (0x0C) in javascript: URI scheme",
+			body:     "<a href=\"java\x0cscript:alert('FUZZ1337MARKER')\">xss</a>",
+			marker:   marker,
+			expected: ContextScript,
+		},
+		{
+			name:     "vertical tab (0x0B) in javascript: URI scheme",
+			body:     "<a href=\"java\x0bscript:alert('FUZZ1337MARKER')\">xss</a>",
+			marker:   marker,
+			expected: ContextScript,
+		},
+		{
+			name:     "bell (0x07) in javascript: URI scheme",
+			body:     "<a href=\"\x07javascript:alert('FUZZ1337MARKER')\">xss</a>",
+			marker:   marker,
+			expected: ContextScript,
+		},
+		{
+			name:     "backspace (0x08) in javascript: URI scheme",
+			body:     "<a href=\"java\x08script:alert('FUZZ1337MARKER')\">xss</a>",
+			marker:   marker,
+			expected: ContextScript,
+		},
+		{
+			name:     "DEL (0x7F) in javascript: URI scheme",
+			body:     "<a href=\"java\x7fscript:alert('FUZZ1337MARKER')\">xss</a>",
+			marker:   marker,
+			expected: ContextScript,
+		},
+		{
+			name:     "multiple mixed C0 control chars in javascript: URI",
+			body:     "<a href=\"\x01j\x02a\x03v\x04a\x05s\x06c\x07r\x08i\x0ep\x0ft:alert('FUZZ1337MARKER')\">xss</a>",
+			marker:   marker,
+			expected: ContextScript,
+		},
+		{
+			name:     "C0 chars in vbscript: URI in href",
+			body:     "<a href=\"\x00vb\x0bscript:msgbox(FUZZ1337MARKER)\">click</a>",
+			marker:   marker,
+			expected: ContextScript,
+		},
+		{
+			name:     "C0 chars in data:text/html URI in iframe src",
+			body:     "<iframe src=\"\x0cdata:text/html,<h1>FUZZ1337MARKER</h1>\">",
+			marker:   marker,
+			expected: ContextScript,
+		},
+
 		// === ScriptData Context (non-executable script) ===
 		{
 			name:     "reflection in script type=application/json",


### PR DESCRIPTION
## Summary

- Fixes a bypass in the XSS context analyzer's dangerous URI scheme detection where only tab (0x09), LF (0x0A), and CR (0x0D) were stripped from scheme prefixes before comparison
- Per the [WHATWG URL spec](https://url.spec.whatwg.org/#url-parsing), browsers silently strip **all** C0 control characters (0x00-0x1F) and DEL (0x7F) from URI schemes, meaning attackers could bypass detection with payloads like `java\x00script:`, `java\x0Cscript:`, `\x07javascript:`, etc.
- Adds `stripC0Controls()` using `strings.Map` to remove the full C0 range (0x00-0x1F) plus DEL (0x7F) before scheme prefix matching
- Adds 9 new test cases covering NULL byte, form feed, vertical tab, bell, backspace, DEL, multiple mixed C0 chars, vbscript with C0, and data: URI with C0

## Context

This is a v2 of #7279 which was closed because the Neo security bot correctly identified that the original fix only handled tab/LF/CR and missed the broader C0 control character range.

Fixes #7086

## Test plan

- [x] All 69 existing + new tests pass (`go test ./pkg/fuzz/analyzers/xss/...`)
- [x] New tests specifically cover: NULL (0x00), vertical tab (0x0B), form feed (0x0C), bell (0x07), backspace (0x08), DEL (0x7F), multiple mixed C0 chars, vbscript with C0, data:text/html with C0
- [ ] Verify no regressions in broader test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved XSS detection for URL-like attributes by normalizing and filtering control characters so dangerous URI schemes are consistently recognized.
* **Tests**
  * Expanded test coverage with cases asserting correct classification when control characters are embedded in URI-like values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->