### PR TITLE
fix(js): propagate proxy, timeout, and custom headers to JS templates

### DIFF
--- a/pkg/js/compiler/compiler.go
+++ b/pkg/js/compiler/compiler.go
@@ -45,6 +45,11 @@ type ExecuteOptions struct {
 
 	TimeoutVariants *types.Timeouts
 
+	// ProxyURL is the HTTP proxy URL to use for network connections via
+	// HTTP CONNECT. SOCKS proxies are handled by the fastdialer layer
+	// and should not be passed here.
+	ProxyURL string
+
 	// Manually exported objects
 	exports map[string]interface{}
 }

--- a/pkg/js/compiler/compiler.go
+++ b/pkg/js/compiler/compiler.go
@@ -45,10 +45,14 @@ type ExecuteOptions struct {
 
 	TimeoutVariants *types.Timeouts
 
-	// ProxyURL is the HTTP proxy URL to use for network connections via
-	// HTTP CONNECT. SOCKS proxies are handled by the fastdialer layer
-	// and should not be passed here.
+	// ProxyURL is the HTTP(S) proxy URL for JS net dials via HTTP CONNECT.
+	// SOCKS proxies are handled by fastdialer and must not be set here.
 	ProxyURL string
+
+	// CustomHeaders contains global CLI headers for the nuclei/http module.
+	// Raw nuclei/net connections construct their own wire payloads and do not
+	// consume these headers.
+	CustomHeaders []string
 
 	// Manually exported objects
 	exports map[string]interface{}

--- a/pkg/js/compiler/pool.go
+++ b/pkg/js/compiler/pool.go
@@ -92,6 +92,8 @@ func executeWithRuntime(ctx context.Context, runtime *goja.Runtime, p *goja.Prog
 		}
 		runtime.RemoveContextValue("executionId")
 		runtime.RemoveContextValue("ctx")
+		runtime.RemoveContextValue("timeoutVariants")
+		runtime.RemoveContextValue("proxyURL")
 	}()
 
 	// set template ctx
@@ -103,6 +105,14 @@ func executeWithRuntime(ctx context.Context, runtime *goja.Runtime, p *goja.Prog
 
 	runtime.SetContextValue("executionId", opts.ExecutionId)
 	runtime.SetContextValue("ctx", ctx)
+	// inject timeout variants so JS libraries can use the user-specified timeout
+	if opts.TimeoutVariants != nil {
+		runtime.SetContextValue("timeoutVariants", opts.TimeoutVariants)
+	}
+	// inject proxy URL so JS libraries can route connections through the proxy
+	if opts.ProxyURL != "" {
+		runtime.SetContextValue("proxyURL", opts.ProxyURL)
+	}
 	enableRequire(runtime)
 
 	// register extra callbacks if any

--- a/pkg/js/compiler/session.go
+++ b/pkg/js/compiler/session.go
@@ -137,8 +137,22 @@ func (s *session) prepareCommon() {
 		_ = s.config.runtime.Set(k, v)
 	}
 
+	executionCtx := s.config.ctx
+	if s.config.opts.TimeoutVariants != nil {
+		s.config.runtime.SetContextValue("timeoutVariants", s.config.opts.TimeoutVariants)
+		executionCtx = context.WithValue(executionCtx, "timeoutVariants", s.config.opts.TimeoutVariants) //nolint:staticcheck
+	}
+	if s.config.opts.ProxyURL != "" {
+		s.config.runtime.SetContextValue("proxyURL", s.config.opts.ProxyURL)
+		executionCtx = context.WithValue(executionCtx, "proxyURL", s.config.opts.ProxyURL) //nolint:staticcheck
+	}
+	if len(s.config.opts.CustomHeaders) > 0 {
+		headers := append([]string(nil), s.config.opts.CustomHeaders...)
+		s.config.runtime.SetContextValue("customHeaders", headers)
+		executionCtx = context.WithValue(executionCtx, "customHeaders", headers) //nolint:staticcheck
+	}
 	s.config.runtime.SetContextValue("executionId", s.config.opts.ExecutionId)
-	s.config.runtime.SetContextValue("ctx", s.config.ctx)
+	s.config.runtime.SetContextValue("ctx", executionCtx)
 	enableRequire(s.config.runtime)
 }
 
@@ -207,6 +221,9 @@ func (s *session) cleanupCommon() {
 	}
 	s.config.runtime.RemoveContextValue("executionId")
 	s.config.runtime.RemoveContextValue("ctx")
+	s.config.runtime.RemoveContextValue("timeoutVariants")
+	s.config.runtime.RemoveContextValue("proxyURL")
+	s.config.runtime.RemoveContextValue("customHeaders")
 }
 
 func (s *session) cleanupPath() {

--- a/pkg/js/compiler/session_test.go
+++ b/pkg/js/compiler/session_test.go
@@ -1,0 +1,107 @@
+package compiler
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/projectdiscovery/goja"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
+	"github.com/projectdiscovery/nuclei/v3/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSessionInjectsProxyAndTimeoutContext(t *testing.T) {
+	runtime := goja.New()
+	program, err := goja.Compile("test.js", `
+		function run() {
+			return { success: true };
+		}
+		run();
+	`, false)
+	require.NoError(t, err)
+
+	var sawProxy string
+	var sawTimeout time.Duration
+	var sawHeaders []string
+	proxyURL := "http://127.0.0.1:8080"
+	customHeaders := []string{"X-Global: value"}
+	timeouts := &types.Timeouts{
+		TcpReadTimeout:             12 * time.Second,
+		JsCompilerExecutionTimeout: 5 * time.Second,
+	}
+
+	opts := &ExecuteOptions{
+		ExecutionId:     "session-proxy-test",
+		ProxyURL:        proxyURL,
+		CustomHeaders:   customHeaders,
+		TimeoutVariants: timeouts,
+		Callback: func(rt *goja.Runtime) error {
+			if v, ok := rt.GetContextValue("proxyURL"); ok {
+				sawProxy, _ = v.(string)
+			}
+			if v, ok := rt.GetContextValue("timeoutVariants"); ok {
+				if tv, ok := v.(*types.Timeouts); ok && tv != nil {
+					sawTimeout = tv.TcpReadTimeout
+				}
+			}
+			if v, ok := rt.GetContextValue("customHeaders"); ok {
+				sawHeaders, _ = v.([]string)
+			}
+			if v, ok := rt.GetContextValue("ctx"); ok {
+				executionCtx, _ := v.(context.Context)
+				require.Equal(t, proxyURL, executionCtx.Value("proxyURL"))
+				require.Equal(t, timeouts, executionCtx.Value("timeoutVariants"))
+				require.Equal(t, customHeaders, executionCtx.Value("customHeaders"))
+			}
+			return nil
+		},
+	}
+
+	_, err = executeWithRuntime(context.Background(), runtime, program, NewExecuteArgs(), opts, nil)
+	require.NoError(t, err)
+	require.Equal(t, "http://127.0.0.1:8080", sawProxy)
+	require.Equal(t, 12*time.Second, sawTimeout)
+	require.Equal(t, customHeaders, sawHeaders)
+
+	_, ok := runtime.GetContextValue("proxyURL")
+	require.False(t, ok, "proxyURL should be cleaned up after execution")
+	_, ok = runtime.GetContextValue("timeoutVariants")
+	require.False(t, ok, "timeoutVariants should be cleaned up after execution")
+	_, ok = runtime.GetContextValue("customHeaders")
+	require.False(t, ok, "customHeaders should be cleaned up after execution")
+}
+
+func TestSessionAppliesOptionsToJSHTTP(t *testing.T) {
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "example.com", r.Host)
+		_, _ = io.WriteString(w, r.Header.Get("X-Global"))
+	}))
+	t.Cleanup(proxy.Close)
+
+	executionID := "session-js-http"
+	require.NoError(t, protocolstate.Init(&types.Options{ExecutionId: executionID}))
+	t.Cleanup(func() { protocolstate.Close(executionID) })
+
+	source := `
+		const http = require("nuclei/http");
+		http.Get("http://example.com/through-proxy").Body;
+	`
+	program, err := goja.Compile("test.js", source, false)
+	require.NoError(t, err)
+
+	result, err := executeWithRuntime(t.Context(), createNewRuntime(), program, NewExecuteArgs(), &ExecuteOptions{
+		ExecutionId:   executionID,
+		ProxyURL:      proxy.URL,
+		CustomHeaders: []string{"X-Global: inherited"},
+		TimeoutVariants: &types.Timeouts{
+			HttpTimeout:                2 * time.Second,
+			JsCompilerExecutionTimeout: 5 * time.Second,
+		},
+	}, nil)
+	require.NoError(t, err)
+	require.Equal(t, "inherited", result.String())
+}

--- a/pkg/js/global/scripts.go
+++ b/pkg/js/global/scripts.go
@@ -14,6 +14,7 @@ import (
 	"github.com/logrusorgru/aurora/v4"
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/nuclei/v3/pkg/js/gojs"
+	jsnet "github.com/projectdiscovery/nuclei/v3/pkg/js/libs/net"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/utils/vardump"
 	"github.com/projectdiscovery/nuclei/v3/pkg/types"
@@ -127,13 +128,7 @@ func initBuiltInFunc(runtime *goja.Runtime) {
 				return false, errkit.New("isPortOpen: host or port is empty")
 			}
 
-			executionId := ctx.Value("executionId").(string)
-			dialer := protocolstate.GetDialersWithId(executionId)
-			if dialer == nil {
-				panic("dialers with executionId " + executionId + " not found")
-			}
-
-			conn, err := dialer.Fastdialer.Dial(ctx, "tcp", net.JoinHostPort(host, port))
+			conn, err := jsnet.Dial(ctx, "tcp", net.JoinHostPort(host, port))
 			if err != nil {
 				return false, err
 			}

--- a/pkg/js/libs/http/http.go
+++ b/pkg/js/libs/http/http.go
@@ -22,6 +22,7 @@ import (
 	"github.com/projectdiscovery/goja"
 	"github.com/projectdiscovery/nuclei/v3/pkg/js/utils"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
+	"github.com/projectdiscovery/nuclei/v3/pkg/types"
 	"golang.org/x/net/publicsuffix"
 )
 
@@ -87,9 +88,9 @@ func NewClient(call goja.ConstructorCall, runtime *goja.Runtime) *goja.Object {
 		nj:              utils.NewNucleiJS(runtime),
 		FollowRedirects: true,
 		MaxRedirects:    defaultMaxRedirects,
-		TimeoutSeconds:  defaultTimeoutSeconds,
+		TimeoutSeconds:  timeoutSecondsFromRuntime(runtime),
 		MaxBodyBytes:    defaultMaxBodyBytes,
-		headers:         make(http.Header),
+		headers:         customHeadersFromRuntime(runtime),
 	}
 	c.nj.ObjectSig = "Client(options?)"
 
@@ -230,7 +231,7 @@ func Post(ctx context.Context, rawURL, body string) (*Response, error) {
 // @example
 // ```javascript
 // const http = require('nuclei/http');
-// const resp = http.Request('OPTIONS', 'https://example.com', '');
+// const resp = http.Request("OPTIONS", "https://example.com", "");
 // ```
 func Request(ctx context.Context, method, rawURL, body string) (*Response, error) {
 	return defaultClient().Request(ctx, method, rawURL, body)
@@ -240,13 +241,14 @@ func defaultClient() *Client {
 	return &Client{
 		FollowRedirects: true,
 		MaxRedirects:    defaultMaxRedirects,
-		TimeoutSeconds:  defaultTimeoutSeconds,
+		TimeoutSeconds:  0,
 		MaxBodyBytes:    defaultMaxBodyBytes,
 		headers:         make(http.Header),
 	}
 }
 
 func (c *Client) do(ctx context.Context, method, rawURL, body string) (*Response, error) {
+	timeout := requestTimeout(ctx, c.TimeoutSeconds)
 	c.init()
 
 	executionID := executionIDFrom(ctx, c)
@@ -281,8 +283,12 @@ func (c *Client) do(ctx context.Context, method, rawURL, body string) (*Response
 		tlsConfig.ServerName = host
 	}
 
+	proxy, err := proxyFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
 	transport := &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
+		Proxy: proxy,
 		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
 			return dialers.Fastdialer.Dial(ctx, network, addr)
 		},
@@ -294,12 +300,13 @@ func (c *Client) do(ctx context.Context, method, rawURL, body string) (*Response
 		MaxIdleConns:          4,
 		MaxIdleConnsPerHost:   4,
 		IdleConnTimeout:       30 * time.Second,
-		ResponseHeaderTimeout: time.Duration(c.TimeoutSeconds) * time.Second,
+		ResponseHeaderTimeout: timeout,
 	}
+	defer transport.CloseIdleConnections()
 
 	httpClient := &http.Client{
 		Transport: transport,
-		Timeout:   time.Duration(c.TimeoutSeconds) * time.Second,
+		Timeout:   timeout,
 	}
 	if c.jar != nil {
 		httpClient.Jar = c.jar
@@ -330,9 +337,10 @@ func (c *Client) do(ctx context.Context, method, rawURL, body string) (*Response
 	if err != nil {
 		return nil, err
 	}
+	applyCustomHeaders(req.Header, customHeadersFromContext(ctx))
 	for k, vals := range c.headers {
 		for _, v := range vals {
-			req.Header.Add(k, v)
+			req.Header.Set(k, v)
 		}
 	}
 	if req.Header.Get("User-Agent") == "" {
@@ -364,6 +372,80 @@ func (c *Client) do(ctx context.Context, method, rawURL, body string) (*Response
 		header:     resp.Header.Clone(),
 	}
 	return out, nil
+}
+
+func timeoutSecondsFromRuntime(runtime *goja.Runtime) int {
+	if runtime != nil {
+		if value, ok := runtime.GetContextValue("timeoutVariants"); ok {
+			if timeouts, ok := value.(*types.Timeouts); ok && timeouts != nil && timeouts.HttpTimeout > 0 {
+				return int(timeouts.HttpTimeout / time.Second)
+			}
+		}
+	}
+	return defaultTimeoutSeconds
+}
+
+func requestTimeout(ctx context.Context, seconds int) time.Duration {
+	if seconds > 0 {
+		return time.Duration(seconds) * time.Second
+	}
+	if ctx != nil {
+		if timeouts, ok := ctx.Value("timeoutVariants").(*types.Timeouts); ok && timeouts != nil && timeouts.HttpTimeout > 0 {
+			return timeouts.HttpTimeout
+		}
+	}
+	return defaultTimeoutSeconds * time.Second
+}
+
+func proxyFromContext(ctx context.Context) (func(*http.Request) (*url.URL, error), error) {
+	if ctx == nil {
+		return http.ProxyFromEnvironment, nil
+	}
+	raw, _ := ctx.Value("proxyURL").(string)
+	if raw == "" {
+		return http.ProxyFromEnvironment, nil
+	}
+	proxyURL, err := url.Parse(raw)
+	if err != nil {
+		return nil, fmt.Errorf("http: invalid proxy URL: %w", err)
+	}
+	if proxyURL.Host == "" || (proxyURL.Scheme != "http" && proxyURL.Scheme != "https") {
+		return nil, fmt.Errorf("http: proxy URL must use http or https")
+	}
+	return http.ProxyURL(proxyURL), nil
+}
+
+func customHeadersFromRuntime(runtime *goja.Runtime) http.Header {
+	headers := make(http.Header)
+	if runtime == nil {
+		return headers
+	}
+	if value, ok := runtime.GetContextValue("customHeaders"); ok {
+		if raw, ok := value.([]string); ok {
+			applyCustomHeaders(headers, raw)
+		}
+	}
+	return headers
+}
+
+func customHeadersFromContext(ctx context.Context) []string {
+	if ctx == nil {
+		return nil
+	}
+	headers, _ := ctx.Value("customHeaders").([]string)
+	return headers
+}
+
+func applyCustomHeaders(headers http.Header, rawHeaders []string) {
+	for _, raw := range rawHeaders {
+		key, value, ok := strings.Cut(raw, ":")
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if !ok || key == "" || value == "" {
+			continue
+		}
+		headers.Set(key, value)
+	}
 }
 
 func executionIDFrom(ctx context.Context, c *Client) string {

--- a/pkg/js/libs/http/http_test.go
+++ b/pkg/js/libs/http/http_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/projectdiscovery/goja"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
@@ -190,6 +191,113 @@ func TestClientSetHeader(t *testing.T) {
 	resp, err := client.Get(ctx, srv.URL)
 	require.NoError(t, err)
 	require.Equal(t, "from-client", resp.Body)
+}
+
+func TestClientInheritsGlobalHeaders(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, r.Header.Get("X-Global")+"|"+r.Header.Get("X-Override"))
+	}))
+	t.Cleanup(srv.Close)
+
+	executionID := initExec(t, &types.Options{})
+	client := newRuntimeClient(t, executionID, Options{})
+	client.SetHeader("X-Override", "client")
+
+	ctx := withExec(executionID)
+	ctx = context.WithValue(ctx, "customHeaders", []string{ //nolint:staticcheck
+		"X-Global: from-cli",
+		"X-Override: global",
+		"invalid",
+	})
+	resp, err := client.Get(ctx, srv.URL)
+	require.NoError(t, err)
+	require.Equal(t, "from-cli|client", resp.Body)
+}
+
+func TestClientUsesConfiguredProxy(t *testing.T) {
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "example.com", r.Host)
+		require.Equal(t, "/through-proxy", r.URL.Path)
+		_, _ = io.WriteString(w, "proxied")
+	}))
+	t.Cleanup(proxy.Close)
+
+	executionID := initExec(t, &types.Options{})
+	client := newRuntimeClient(t, executionID, Options{})
+	ctx := withExec(executionID)
+	ctx = context.WithValue(ctx, "proxyURL", proxy.URL) //nolint:staticcheck
+
+	resp, err := client.Get(ctx, "http://example.com/through-proxy")
+	require.NoError(t, err)
+	require.Equal(t, "proxied", resp.Body)
+}
+
+func TestClientUsesConfiguredProxyForHTTPS(t *testing.T) {
+	target := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "secure-proxied")
+	}))
+	t.Cleanup(target.Close)
+
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodConnect, r.Method)
+		upstream, err := net.Dial("tcp", r.Host)
+		require.NoError(t, err)
+		defer func() { _ = upstream.Close() }()
+
+		hijacker, ok := w.(http.Hijacker)
+		require.True(t, ok)
+		client, rw, err := hijacker.Hijack()
+		require.NoError(t, err)
+		defer func() { _ = client.Close() }()
+
+		_, err = rw.WriteString("HTTP/1.1 200 Connection Established\r\n\r\n")
+		require.NoError(t, err)
+		require.NoError(t, rw.Flush())
+
+		done := make(chan struct{})
+		go func() {
+			_, _ = io.Copy(upstream, client)
+			close(done)
+		}()
+		_, _ = io.Copy(client, upstream)
+		<-done
+	}))
+	t.Cleanup(proxy.Close)
+
+	executionID := initExec(t, &types.Options{})
+	client := newRuntimeClient(t, executionID, Options{})
+	ctx := withExec(executionID)
+	ctx = context.WithValue(ctx, "proxyURL", proxy.URL) //nolint:staticcheck
+
+	resp, err := client.Get(ctx, target.URL)
+	require.NoError(t, err)
+	require.Equal(t, "secure-proxied", resp.Body)
+}
+
+func TestClientRejectsInvalidConfiguredProxy(t *testing.T) {
+	executionID := initExec(t, &types.Options{})
+	client := newRuntimeClient(t, executionID, Options{})
+	ctx := withExec(executionID)
+	ctx = context.WithValue(ctx, "proxyURL", "socks5://127.0.0.1:1080") //nolint:staticcheck
+
+	_, err := client.Get(ctx, "http://example.com/")
+	require.ErrorContains(t, err, "must use http or https")
+}
+
+func TestClientUsesConfiguredHTTPTimeout(t *testing.T) {
+	timeouts := &types.Timeouts{HttpTimeout: 7 * time.Second}
+	ctx := context.WithValue(context.Background(), "timeoutVariants", timeouts) //nolint:staticcheck
+	require.Equal(t, 7*time.Second, requestTimeout(ctx, 0))
+	require.Equal(t, 2*time.Second, requestTimeout(ctx, 2), "client option must override the global timeout")
+
+	runtime := goja.New()
+	runtime.SetContextValue("executionId", "timeout-test")
+	runtime.SetContextValue("timeoutVariants", timeouts)
+	obj, err := runtime.New(runtime.ToValue(NewClient))
+	require.NoError(t, err)
+	client, ok := obj.Export().(*Client)
+	require.True(t, ok)
+	require.Equal(t, 7, client.TimeoutSeconds)
 }
 
 func TestClientHead(t *testing.T) {

--- a/pkg/js/libs/net/net.go
+++ b/pkg/js/libs/net/net.go
@@ -61,7 +61,7 @@ func dialHTTPProxy(ctx context.Context, dial dialFunc, proxyURL string, address 
 		}
 		tlsConn := tls.Client(proxyConn, config)
 		if err := tlsConn.HandshakeContext(ctx); err != nil {
-			proxyConn.Close()
+			_ = proxyConn.Close()
 			return nil, fmt.Errorf("could not establish TLS connection to proxy %s: %w", proxyAddr, err)
 		}
 		proxyConn = tlsConn
@@ -79,20 +79,20 @@ func dialHTTPProxy(ctx context.Context, dial dialFunc, proxyURL string, address 
 
 	_ = proxyConn.SetDeadline(time.Now().Add(timeout))
 	if err := connectReq.Write(proxyConn); err != nil {
-		proxyConn.Close()
+		_ = proxyConn.Close()
 		return nil, fmt.Errorf("could not send CONNECT request: %w", err)
 	}
 
 	br := bufio.NewReader(proxyConn)
 	resp, err := http.ReadResponse(br, connectReq)
 	if err != nil {
-		proxyConn.Close()
+		_ = proxyConn.Close()
 		return nil, fmt.Errorf("could not read CONNECT response: %w", err)
 	}
 	_ = resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		proxyConn.Close()
+		_ = proxyConn.Close()
 		return nil, fmt.Errorf("proxy CONNECT returned status %d", resp.StatusCode)
 	}
 
@@ -206,7 +206,7 @@ func OpenTLS(ctx context.Context, protocol, address string) (*NetConn, error) {
 			}
 			tlsConn := tls.Client(conn, config)
 			if err := tlsConn.HandshakeContext(ctx); err != nil {
-				conn.Close()
+				_ = conn.Close()
 				return nil, fmt.Errorf("TLS handshake failed: %w", err)
 			}
 			return &NetConn{conn: tlsConn, timeout: timeout}, nil

--- a/pkg/js/libs/net/net.go
+++ b/pkg/js/libs/net/net.go
@@ -1,13 +1,18 @@
 package net
 
 import (
+	"bufio"
 	"context"
 	"crypto/tls"
+	"encoding/base64"
 	"encoding/hex"
 	"fmt"
 	"net"
+	"net/http"
+	"net/url"
 	"time"
 
+	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
 	"github.com/projectdiscovery/nuclei/v3/pkg/types"
 	"github.com/projectdiscovery/utils/errkit"
@@ -18,6 +23,91 @@ var (
 	defaultTimeout = time.Duration(5) * time.Second
 )
 
+// getTimeoutFromContext returns the configured TCP timeout or defaultTimeout.
+func getTimeoutFromContext(ctx context.Context) time.Duration {
+	if tv, ok := ctx.Value("timeoutVariants").(*types.Timeouts); ok && tv != nil {
+		if tv.TcpReadTimeout > 0 {
+			return tv.TcpReadTimeout
+		}
+	}
+	return defaultTimeout
+}
+
+type dialFunc func(ctx context.Context, network, address string) (net.Conn, error)
+
+// dialHTTPProxy establishes a TCP connection through an HTTP CONNECT proxy.
+func dialHTTPProxy(ctx context.Context, dial dialFunc, proxyURL string, address string, timeout time.Duration) (net.Conn, error) {
+	parsed, err := url.Parse(proxyURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid proxy URL: %w", err)
+	}
+	proxyAddr := parsed.Host
+	if _, _, splitErr := net.SplitHostPort(proxyAddr); splitErr != nil {
+		// no port specified, default to 8080
+		proxyAddr = proxyAddr + ":8080"
+	}
+
+	proxyConn, err := dial(ctx, "tcp", proxyAddr)
+	if err != nil {
+		return nil, fmt.Errorf("could not connect to proxy %s: %w", proxyAddr, err)
+	}
+
+	connectReq := &http.Request{
+		Method: http.MethodConnect,
+		URL:    &url.URL{Opaque: address},
+		Host:   address,
+		Header: make(http.Header),
+	}
+	if parsed.User != nil {
+		connectReq.Header.Set("Proxy-Authorization", "Basic "+basicAuth(parsed.User))
+	}
+
+	_ = proxyConn.SetDeadline(time.Now().Add(timeout))
+	if err := connectReq.Write(proxyConn); err != nil {
+		proxyConn.Close()
+		return nil, fmt.Errorf("could not send CONNECT request: %w", err)
+	}
+
+	br := bufio.NewReader(proxyConn)
+	resp, err := http.ReadResponse(br, connectReq)
+	if err != nil {
+		proxyConn.Close()
+		return nil, fmt.Errorf("could not read CONNECT response: %w", err)
+	}
+	_ = resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		proxyConn.Close()
+		return nil, fmt.Errorf("proxy CONNECT returned status %d", resp.StatusCode)
+	}
+
+	// reset deadline after successful CONNECT
+	_ = proxyConn.SetDeadline(time.Time{})
+
+	// preserve any bytes the buffered reader consumed past the CONNECT response
+	if br.Buffered() > 0 {
+		return &bufferedConn{Conn: proxyConn, reader: br}, nil
+	}
+	return proxyConn, nil
+}
+
+// basicAuth encodes proxy user credentials.
+func basicAuth(user *url.Userinfo) string {
+	username := user.Username()
+	password, _ := user.Password()
+	return base64.StdEncoding.EncodeToString([]byte(username + ":" + password))
+}
+
+// bufferedConn preserves bytes buffered during the CONNECT handshake.
+type bufferedConn struct {
+	net.Conn
+	reader *bufio.Reader
+}
+
+func (c *bufferedConn) Read(b []byte) (int, error) {
+	return c.reader.Read(b)
+}
+
 // Open opens a new connection to the address with a timeout.
 // supported protocols: tcp, udp
 // @example
@@ -26,19 +116,38 @@ var (
 // const conn = net.Open('tcp', 'acme.com:80');
 // ```
 func Open(ctx context.Context, protocol, address string) (*NetConn, error) {
+	timeout := getTimeoutFromContext(ctx)
 	executionId := ctx.Value("executionId").(string)
+
 	dialer := protocolstate.GetDialersWithId(executionId)
 	if dialer == nil {
 		return nil, fmt.Errorf("dialers not initialized for %s", executionId)
 	}
+
+	// check for HTTP proxy in context
+	if proxyURL, ok := ctx.Value("proxyURL").(string); ok && proxyURL != "" && protocol == "tcp" {
+		parsed, err := url.Parse(proxyURL)
+		if err != nil {
+			gologger.Warning().Msgf("Could not parse proxy URL '%s': %v, falling back to direct dial\n", proxyURL, err)
+		} else if parsed.Scheme == "http" || parsed.Scheme == "https" {
+			conn, err := dialHTTPProxy(ctx, dialer.Fastdialer.Dial, proxyURL, address, timeout)
+			if err != nil {
+				return nil, err
+			}
+			return &NetConn{conn: conn, timeout: timeout}, nil
+		} else {
+			gologger.Warning().Msgf("Unsupported proxy scheme '%s' in URL '%s', falling back to direct dial\n", parsed.Scheme, proxyURL)
+		}
+	}
+
 	conn, err := dialer.Fastdialer.Dial(ctx, protocol, address)
 	if err != nil {
 		return nil, err
 	}
-	return &NetConn{conn: conn, timeout: defaultTimeout}, nil
+	return &NetConn{conn: conn, timeout: timeout}, nil
 }
 
-// Open opens a new connection to the address with a timeout.
+// OpenTLS opens a new TLS connection to the address with a timeout.
 // supported protocols: tcp, udp
 // @example
 // ```javascript
@@ -46,6 +155,7 @@ func Open(ctx context.Context, protocol, address string) (*NetConn, error) {
 // const conn = net.OpenTLS('tcp', 'acme.com:443');
 // ```
 func OpenTLS(ctx context.Context, protocol, address string) (*NetConn, error) {
+	timeout := getTimeoutFromContext(ctx)
 	config := &tls.Config{InsecureSkipVerify: true, MinVersion: tls.VersionTLS10}
 	host, _, _ := net.SplitHostPort(address)
 	if host != "" {
@@ -53,17 +163,39 @@ func OpenTLS(ctx context.Context, protocol, address string) (*NetConn, error) {
 		c.ServerName = host
 		config = c
 	}
+
 	executionId := ctx.Value("executionId").(string)
 	dialer := protocolstate.GetDialersWithId(executionId)
 	if dialer == nil {
 		return nil, fmt.Errorf("dialers not initialized for %s", executionId)
 	}
 
+	// check for HTTP proxy in context
+	if proxyURL, ok := ctx.Value("proxyURL").(string); ok && proxyURL != "" && protocol == "tcp" {
+		parsed, err := url.Parse(proxyURL)
+		if err != nil {
+			gologger.Warning().Msgf("Could not parse proxy URL '%s': %v, falling back to direct dial\n", proxyURL, err)
+		} else if parsed.Scheme == "http" || parsed.Scheme == "https" {
+			conn, err := dialHTTPProxy(ctx, dialer.Fastdialer.Dial, proxyURL, address, timeout)
+			if err != nil {
+				return nil, err
+			}
+			tlsConn := tls.Client(conn, config)
+			if err := tlsConn.HandshakeContext(ctx); err != nil {
+				conn.Close()
+				return nil, fmt.Errorf("TLS handshake failed: %w", err)
+			}
+			return &NetConn{conn: tlsConn, timeout: timeout}, nil
+		} else {
+			gologger.Warning().Msgf("Unsupported proxy scheme '%s' in URL '%s', falling back to direct dial\n", parsed.Scheme, proxyURL)
+		}
+	}
+
 	conn, err := dialer.Fastdialer.DialTLSWithConfig(ctx, protocol, address, config)
 	if err != nil {
 		return nil, err
 	}
-	return &NetConn{conn: conn, timeout: defaultTimeout}, nil
+	return &NetConn{conn: conn, timeout: timeout}, nil
 }
 
 type (

--- a/pkg/js/libs/net/net.go
+++ b/pkg/js/libs/net/net.go
@@ -43,13 +43,28 @@ func dialHTTPProxy(ctx context.Context, dial dialFunc, proxyURL string, address 
 	}
 	proxyAddr := parsed.Host
 	if _, _, splitErr := net.SplitHostPort(proxyAddr); splitErr != nil {
-		// no port specified, default to 8080
-		proxyAddr = proxyAddr + ":8080"
+		defaultPort := "8080"
+		if parsed.Scheme == "https" {
+			defaultPort = "443"
+		}
+		proxyAddr = net.JoinHostPort(proxyAddr, defaultPort)
 	}
 
 	proxyConn, err := dial(ctx, "tcp", proxyAddr)
 	if err != nil {
 		return nil, fmt.Errorf("could not connect to proxy %s: %w", proxyAddr, err)
+	}
+	if parsed.Scheme == "https" {
+		config := &tls.Config{InsecureSkipVerify: true, MinVersion: tls.VersionTLS10}
+		if hostname := parsed.Hostname(); hostname != "" {
+			config.ServerName = hostname
+		}
+		tlsConn := tls.Client(proxyConn, config)
+		if err := tlsConn.HandshakeContext(ctx); err != nil {
+			proxyConn.Close()
+			return nil, fmt.Errorf("could not establish TLS connection to proxy %s: %w", proxyAddr, err)
+		}
+		proxyConn = tlsConn
 	}
 
 	connectReq := &http.Request{
@@ -98,6 +113,15 @@ func basicAuth(user *url.Userinfo) string {
 	return base64.StdEncoding.EncodeToString([]byte(username + ":" + password))
 }
 
+func redactProxyURL(proxyURL string) string {
+	parsed, err := url.Parse(proxyURL)
+	if err != nil {
+		return "<invalid proxy URL>"
+	}
+	parsed.User = nil
+	return parsed.String()
+}
+
 // bufferedConn preserves bytes buffered during the CONNECT handshake.
 type bufferedConn struct {
 	net.Conn
@@ -128,7 +152,7 @@ func Open(ctx context.Context, protocol, address string) (*NetConn, error) {
 	if proxyURL, ok := ctx.Value("proxyURL").(string); ok && proxyURL != "" && protocol == "tcp" {
 		parsed, err := url.Parse(proxyURL)
 		if err != nil {
-			gologger.Warning().Msgf("Could not parse proxy URL '%s': %v, falling back to direct dial\n", proxyURL, err)
+			gologger.Warning().Msgf("Could not parse proxy URL '%s': %v, falling back to direct dial\n", redactProxyURL(proxyURL), err)
 		} else if parsed.Scheme == "http" || parsed.Scheme == "https" {
 			conn, err := dialHTTPProxy(ctx, dialer.Fastdialer.Dial, proxyURL, address, timeout)
 			if err != nil {
@@ -136,7 +160,7 @@ func Open(ctx context.Context, protocol, address string) (*NetConn, error) {
 			}
 			return &NetConn{conn: conn, timeout: timeout}, nil
 		} else {
-			gologger.Warning().Msgf("Unsupported proxy scheme '%s' in URL '%s', falling back to direct dial\n", parsed.Scheme, proxyURL)
+			gologger.Warning().Msgf("Unsupported proxy scheme '%s' in URL '%s', falling back to direct dial\n", parsed.Scheme, redactProxyURL(proxyURL))
 		}
 	}
 
@@ -174,7 +198,7 @@ func OpenTLS(ctx context.Context, protocol, address string) (*NetConn, error) {
 	if proxyURL, ok := ctx.Value("proxyURL").(string); ok && proxyURL != "" && protocol == "tcp" {
 		parsed, err := url.Parse(proxyURL)
 		if err != nil {
-			gologger.Warning().Msgf("Could not parse proxy URL '%s': %v, falling back to direct dial\n", proxyURL, err)
+			gologger.Warning().Msgf("Could not parse proxy URL '%s': %v, falling back to direct dial\n", redactProxyURL(proxyURL), err)
 		} else if parsed.Scheme == "http" || parsed.Scheme == "https" {
 			conn, err := dialHTTPProxy(ctx, dialer.Fastdialer.Dial, proxyURL, address, timeout)
 			if err != nil {
@@ -187,7 +211,7 @@ func OpenTLS(ctx context.Context, protocol, address string) (*NetConn, error) {
 			}
 			return &NetConn{conn: tlsConn, timeout: timeout}, nil
 		} else {
-			gologger.Warning().Msgf("Unsupported proxy scheme '%s' in URL '%s', falling back to direct dial\n", parsed.Scheme, proxyURL)
+			gologger.Warning().Msgf("Unsupported proxy scheme '%s' in URL '%s', falling back to direct dial\n", parsed.Scheme, redactProxyURL(proxyURL))
 		}
 	}
 

--- a/pkg/js/libs/net/net.go
+++ b/pkg/js/libs/net/net.go
@@ -12,7 +12,6 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
 	"github.com/projectdiscovery/nuclei/v3/pkg/types"
 	"github.com/projectdiscovery/utils/errkit"
@@ -31,6 +30,21 @@ func getTimeoutFromContext(ctx context.Context) time.Duration {
 		}
 	}
 	return defaultTimeout
+}
+
+func proxyURLFromContext(ctx context.Context) string {
+	if proxyURL, ok := ctx.Value("proxyURL").(string); ok {
+		return proxyURL
+	}
+	return ""
+}
+
+func executionIDFromContext(ctx context.Context) (string, error) {
+	executionId, _ := ctx.Value("executionId").(string)
+	if executionId == "" {
+		return "", fmt.Errorf("executionId missing from context")
+	}
+	return executionId, nil
 }
 
 type dialFunc func(ctx context.Context, network, address string) (net.Conn, error)
@@ -132,6 +146,38 @@ func (c *bufferedConn) Read(b []byte) (int, error) {
 	return c.reader.Read(b)
 }
 
+// Dial opens a connection using the execution dialer.
+// When an HTTP(S) proxy is present in context, TCP dials use HTTP CONNECT.
+// Misconfigured proxies return an error instead of silently dialing direct.
+func Dial(ctx context.Context, protocol, address string) (net.Conn, error) {
+	executionId, err := executionIDFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	dialer := protocolstate.GetDialersWithId(executionId)
+	if dialer == nil {
+		return nil, fmt.Errorf("dialers not initialized for %s", executionId)
+	}
+
+	if proxyURL := proxyURLFromContext(ctx); proxyURL != "" {
+		if protocol != "tcp" {
+			return nil, fmt.Errorf("http proxy does not support protocol %q", protocol)
+		}
+		parsed, err := url.Parse(proxyURL)
+		if err != nil {
+			return nil, fmt.Errorf("invalid proxy URL %s: %w", redactProxyURL(proxyURL), err)
+		}
+		switch parsed.Scheme {
+		case "http", "https":
+			return dialHTTPProxy(ctx, dialer.Fastdialer.Dial, proxyURL, address, getTimeoutFromContext(ctx))
+		default:
+			return nil, fmt.Errorf("unsupported proxy scheme %q in %s (expected http or https)", parsed.Scheme, redactProxyURL(proxyURL))
+		}
+	}
+
+	return dialer.Fastdialer.Dial(ctx, protocol, address)
+}
+
 // Open opens a new connection to the address with a timeout.
 // supported protocols: tcp, udp
 // @example
@@ -141,30 +187,7 @@ func (c *bufferedConn) Read(b []byte) (int, error) {
 // ```
 func Open(ctx context.Context, protocol, address string) (*NetConn, error) {
 	timeout := getTimeoutFromContext(ctx)
-	executionId := ctx.Value("executionId").(string)
-
-	dialer := protocolstate.GetDialersWithId(executionId)
-	if dialer == nil {
-		return nil, fmt.Errorf("dialers not initialized for %s", executionId)
-	}
-
-	// check for HTTP proxy in context
-	if proxyURL, ok := ctx.Value("proxyURL").(string); ok && proxyURL != "" && protocol == "tcp" {
-		parsed, err := url.Parse(proxyURL)
-		if err != nil {
-			gologger.Warning().Msgf("Could not parse proxy URL '%s': %v, falling back to direct dial\n", redactProxyURL(proxyURL), err)
-		} else if parsed.Scheme == "http" || parsed.Scheme == "https" {
-			conn, err := dialHTTPProxy(ctx, dialer.Fastdialer.Dial, proxyURL, address, timeout)
-			if err != nil {
-				return nil, err
-			}
-			return &NetConn{conn: conn, timeout: timeout}, nil
-		} else {
-			gologger.Warning().Msgf("Unsupported proxy scheme '%s' in URL '%s', falling back to direct dial\n", parsed.Scheme, redactProxyURL(proxyURL))
-		}
-	}
-
-	conn, err := dialer.Fastdialer.Dial(ctx, protocol, address)
+	conn, err := Dial(ctx, protocol, address)
 	if err != nil {
 		return nil, err
 	}
@@ -188,33 +211,27 @@ func OpenTLS(ctx context.Context, protocol, address string) (*NetConn, error) {
 		config = c
 	}
 
-	executionId := ctx.Value("executionId").(string)
+	if proxyURLFromContext(ctx) != "" {
+		conn, err := Dial(ctx, protocol, address)
+		if err != nil {
+			return nil, err
+		}
+		tlsConn := tls.Client(conn, config)
+		if err := tlsConn.HandshakeContext(ctx); err != nil {
+			_ = conn.Close()
+			return nil, fmt.Errorf("TLS handshake failed: %w", err)
+		}
+		return &NetConn{conn: tlsConn, timeout: timeout}, nil
+	}
+
+	executionId, err := executionIDFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
 	dialer := protocolstate.GetDialersWithId(executionId)
 	if dialer == nil {
 		return nil, fmt.Errorf("dialers not initialized for %s", executionId)
 	}
-
-	// check for HTTP proxy in context
-	if proxyURL, ok := ctx.Value("proxyURL").(string); ok && proxyURL != "" && protocol == "tcp" {
-		parsed, err := url.Parse(proxyURL)
-		if err != nil {
-			gologger.Warning().Msgf("Could not parse proxy URL '%s': %v, falling back to direct dial\n", redactProxyURL(proxyURL), err)
-		} else if parsed.Scheme == "http" || parsed.Scheme == "https" {
-			conn, err := dialHTTPProxy(ctx, dialer.Fastdialer.Dial, proxyURL, address, timeout)
-			if err != nil {
-				return nil, err
-			}
-			tlsConn := tls.Client(conn, config)
-			if err := tlsConn.HandshakeContext(ctx); err != nil {
-				_ = conn.Close()
-				return nil, fmt.Errorf("TLS handshake failed: %w", err)
-			}
-			return &NetConn{conn: tlsConn, timeout: timeout}, nil
-		} else {
-			gologger.Warning().Msgf("Unsupported proxy scheme '%s' in URL '%s', falling back to direct dial\n", parsed.Scheme, redactProxyURL(proxyURL))
-		}
-	}
-
 	conn, err := dialer.Fastdialer.DialTLSWithConfig(ctx, protocol, address, config)
 	if err != nil {
 		return nil, err

--- a/pkg/js/libs/net/net_test.go
+++ b/pkg/js/libs/net/net_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -134,11 +135,52 @@ func TestDialHTTPProxy(t *testing.T) {
 		require.Error(t, err)
 	})
 
+	t.Run("successful HTTPS CONNECT tunnel", func(t *testing.T) {
+		targetPayload := "hello from secure proxy"
+		proxy := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodConnect {
+				http.Error(w, "expected CONNECT", http.StatusMethodNotAllowed)
+				return
+			}
+			hijacker, ok := w.(http.Hijacker)
+			if !ok {
+				http.Error(w, "hijacking not supported", http.StatusInternalServerError)
+				return
+			}
+			conn, rw, err := hijacker.Hijack()
+			if err != nil {
+				return
+			}
+			defer conn.Close()
+
+			_, _ = rw.WriteString("HTTP/1.1 200 Connection Established\r\n\r\n")
+			_, _ = rw.WriteString(targetPayload)
+			_ = rw.Flush()
+		}))
+		defer proxy.Close()
+
+		ctx := context.Background()
+		conn, err := dialHTTPProxy(ctx, directDial, proxy.URL, "example.com:443", 5*time.Second)
+		require.NoError(t, err)
+		defer conn.Close()
+
+		buf := make([]byte, 64)
+		n, err := conn.Read(buf)
+		require.NoError(t, err)
+		require.Equal(t, targetPayload, string(buf[:n]))
+	})
+
 	t.Run("unreachable proxy", func(t *testing.T) {
 		ctx := context.Background()
 		_, err := dialHTTPProxy(ctx, directDial, "http://127.0.0.1:1", "example.com:443", 1*time.Second)
 		require.Error(t, err)
 	})
+}
+
+func TestRedactProxyURL(t *testing.T) {
+	require.Equal(t, "http://proxy.example.com:8080", redactProxyURL("http://user:pass@proxy.example.com:8080"))
+	require.Equal(t, "http://proxy.example.com:8080", redactProxyURL("http://proxy.example.com:8080"))
+	require.Equal(t, "<invalid proxy URL>", redactProxyURL("://bad-url"))
 }
 
 // fakeConn is a minimal net.Conn for testing bufferedConn.

--- a/pkg/js/libs/net/net_test.go
+++ b/pkg/js/libs/net/net_test.go
@@ -1,0 +1,154 @@
+package net
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetTimeoutFromContext(t *testing.T) {
+	t.Run("default when missing", func(t *testing.T) {
+		require.Equal(t, defaultTimeout, getTimeoutFromContext(context.Background()))
+	})
+
+	t.Run("reads TcpReadTimeout", func(t *testing.T) {
+		expected := 15 * time.Second
+		tv := &types.Timeouts{TcpReadTimeout: expected}
+		ctx := context.WithValue(context.Background(), "timeoutVariants", tv)
+		require.Equal(t, expected, getTimeoutFromContext(ctx))
+	})
+}
+
+func TestBufferedConn(t *testing.T) {
+	t.Run("read drains buffered bytes first", func(t *testing.T) {
+		underlying := &bytes.Buffer{}
+		underlying.WriteString("hello world")
+
+		br := bufio.NewReader(underlying)
+		_, _ = br.Peek(5)
+
+		conn := &bufferedConn{
+			Conn:   &fakeConn{},
+			reader: br,
+		}
+
+		buf := make([]byte, 64)
+		n, err := conn.Read(buf)
+		require.NoError(t, err)
+		require.Equal(t, "hello world", string(buf[:n]))
+	})
+
+	t.Run("read returns EOF after buffer is drained", func(t *testing.T) {
+		underlying := bytes.NewBufferString("data")
+		br := bufio.NewReader(underlying)
+		conn := &bufferedConn{Conn: &fakeConn{}, reader: br}
+
+		buf := make([]byte, 64)
+		n, err := conn.Read(buf)
+		require.NoError(t, err)
+		require.Equal(t, "data", string(buf[:n]))
+
+		_, err = conn.Read(buf)
+		require.ErrorIs(t, err, io.EOF)
+	})
+}
+
+// directDial is a plain net.Dialer for tests (no fastdialer dependency).
+var directDial = (&net.Dialer{Timeout: 5 * time.Second}).DialContext
+
+func TestDialHTTPProxy(t *testing.T) {
+	t.Run("successful CONNECT tunnel", func(t *testing.T) {
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		defer ln.Close()
+
+		targetPayload := "hello from target"
+		go func() {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			defer conn.Close()
+
+			req, err := http.ReadRequest(bufio.NewReader(conn))
+			if err != nil {
+				return
+			}
+			_ = req.Body.Close()
+
+			_, _ = conn.Write([]byte("HTTP/1.1 200 Connection Established\r\n\r\n"))
+			_, _ = conn.Write([]byte(targetPayload))
+		}()
+
+		ctx := context.Background()
+		proxyURL := fmt.Sprintf("http://%s", ln.Addr().String())
+		conn, err := dialHTTPProxy(ctx, directDial, proxyURL, "example.com:443", 5*time.Second)
+		require.NoError(t, err)
+		defer conn.Close()
+
+		buf := make([]byte, 64)
+		n, err := conn.Read(buf)
+		require.NoError(t, err)
+		require.Equal(t, targetPayload, string(buf[:n]))
+	})
+
+	t.Run("proxy returns non-200 status", func(t *testing.T) {
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		defer ln.Close()
+
+		go func() {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			defer conn.Close()
+
+			req, err := http.ReadRequest(bufio.NewReader(conn))
+			if err != nil {
+				return
+			}
+			_ = req.Body.Close()
+			_, _ = conn.Write([]byte("HTTP/1.1 403 Forbidden\r\n\r\n"))
+		}()
+
+		ctx := context.Background()
+		proxyURL := fmt.Sprintf("http://%s", ln.Addr().String())
+		_, err = dialHTTPProxy(ctx, directDial, proxyURL, "example.com:443", 5*time.Second)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "403")
+	})
+
+	t.Run("invalid proxy URL", func(t *testing.T) {
+		ctx := context.Background()
+		_, err := dialHTTPProxy(ctx, directDial, "://bad-url", "example.com:443", 5*time.Second)
+		require.Error(t, err)
+	})
+
+	t.Run("unreachable proxy", func(t *testing.T) {
+		ctx := context.Background()
+		_, err := dialHTTPProxy(ctx, directDial, "http://127.0.0.1:1", "example.com:443", 1*time.Second)
+		require.Error(t, err)
+	})
+}
+
+// fakeConn is a minimal net.Conn for testing bufferedConn.
+type fakeConn struct{ net.Conn }
+
+func (f *fakeConn) Read([]byte) (int, error)         { return 0, io.EOF }
+func (f *fakeConn) Write([]byte) (int, error)        { return 0, nil }
+func (f *fakeConn) Close() error                     { return nil }
+func (f *fakeConn) LocalAddr() net.Addr              { return nil }
+func (f *fakeConn) RemoteAddr() net.Addr             { return nil }
+func (f *fakeConn) SetDeadline(time.Time) error      { return nil }
+func (f *fakeConn) SetReadDeadline(time.Time) error  { return nil }
+func (f *fakeConn) SetWriteDeadline(time.Time) error { return nil }

--- a/pkg/js/libs/net/net_test.go
+++ b/pkg/js/libs/net/net_test.go
@@ -24,7 +24,7 @@ func TestGetTimeoutFromContext(t *testing.T) {
 	t.Run("reads TcpReadTimeout", func(t *testing.T) {
 		expected := 15 * time.Second
 		tv := &types.Timeouts{TcpReadTimeout: expected}
-		ctx := context.WithValue(context.Background(), "timeoutVariants", tv)
+		ctx := context.WithValue(context.Background(), "timeoutVariants", tv) // nolint: staticcheck
 		require.Equal(t, expected, getTimeoutFromContext(ctx))
 	})
 }
@@ -70,7 +70,7 @@ func TestDialHTTPProxy(t *testing.T) {
 	t.Run("successful CONNECT tunnel", func(t *testing.T) {
 		ln, err := net.Listen("tcp", "127.0.0.1:0")
 		require.NoError(t, err)
-		defer ln.Close()
+		defer func() { _ = ln.Close() }()
 
 		targetPayload := "hello from target"
 		go func() {
@@ -78,7 +78,7 @@ func TestDialHTTPProxy(t *testing.T) {
 			if err != nil {
 				return
 			}
-			defer conn.Close()
+			defer func() { _ = conn.Close() }()
 
 			req, err := http.ReadRequest(bufio.NewReader(conn))
 			if err != nil {
@@ -94,7 +94,7 @@ func TestDialHTTPProxy(t *testing.T) {
 		proxyURL := fmt.Sprintf("http://%s", ln.Addr().String())
 		conn, err := dialHTTPProxy(ctx, directDial, proxyURL, "example.com:443", 5*time.Second)
 		require.NoError(t, err)
-		defer conn.Close()
+		defer func() { _ = conn.Close() }()
 
 		buf := make([]byte, 64)
 		n, err := conn.Read(buf)
@@ -105,14 +105,14 @@ func TestDialHTTPProxy(t *testing.T) {
 	t.Run("proxy returns non-200 status", func(t *testing.T) {
 		ln, err := net.Listen("tcp", "127.0.0.1:0")
 		require.NoError(t, err)
-		defer ln.Close()
+		defer func() { _ = ln.Close() }()
 
 		go func() {
 			conn, err := ln.Accept()
 			if err != nil {
 				return
 			}
-			defer conn.Close()
+			defer func() { _ = conn.Close() }()
 
 			req, err := http.ReadRequest(bufio.NewReader(conn))
 			if err != nil {
@@ -151,7 +151,7 @@ func TestDialHTTPProxy(t *testing.T) {
 			if err != nil {
 				return
 			}
-			defer conn.Close()
+			defer func() { _ = conn.Close() }()
 
 			_, _ = rw.WriteString("HTTP/1.1 200 Connection Established\r\n\r\n")
 			_, _ = rw.WriteString(targetPayload)
@@ -162,7 +162,7 @@ func TestDialHTTPProxy(t *testing.T) {
 		ctx := context.Background()
 		conn, err := dialHTTPProxy(ctx, directDial, proxy.URL, "example.com:443", 5*time.Second)
 		require.NoError(t, err)
-		defer conn.Close()
+		defer func() { _ = conn.Close() }()
 
 		buf := make([]byte, 64)
 		n, err := conn.Read(buf)

--- a/pkg/js/libs/net/net_test.go
+++ b/pkg/js/libs/net/net_test.go
@@ -9,9 +9,11 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
 	"github.com/projectdiscovery/nuclei/v3/pkg/types"
 	"github.com/stretchr/testify/require"
 )
@@ -174,6 +176,141 @@ func TestDialHTTPProxy(t *testing.T) {
 		ctx := context.Background()
 		_, err := dialHTTPProxy(ctx, directDial, "http://127.0.0.1:1", "example.com:443", 1*time.Second)
 		require.Error(t, err)
+	})
+
+	t.Run("proxy auth header", func(t *testing.T) {
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		defer func() { _ = ln.Close() }()
+
+		gotAuth := make(chan string, 1)
+		go func() {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			defer func() { _ = conn.Close() }()
+			req, err := http.ReadRequest(bufio.NewReader(conn))
+			if err != nil {
+				return
+			}
+			_ = req.Body.Close()
+			gotAuth <- req.Header.Get("Proxy-Authorization")
+			_, _ = conn.Write([]byte("HTTP/1.1 200 Connection Established\r\n\r\n"))
+		}()
+
+		proxyURL := fmt.Sprintf("http://user:secret@%s", ln.Addr().String())
+		conn, err := dialHTTPProxy(context.Background(), directDial, proxyURL, "example.com:443", 5*time.Second)
+		require.NoError(t, err)
+		defer func() { _ = conn.Close() }()
+
+		require.Equal(t, "Basic "+basicAuth(url.UserPassword("user", "secret")), <-gotAuth)
+	})
+}
+
+func TestDial(t *testing.T) {
+	t.Run("missing execution id", func(t *testing.T) {
+		_, err := Dial(context.Background(), "tcp", "127.0.0.1:1")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "executionId")
+	})
+
+	t.Run("unsupported proxy scheme fails hard", func(t *testing.T) {
+		opts := &types.Options{ExecutionId: "net-dial-scheme-" + t.Name()}
+		require.NoError(t, protocolstate.Init(opts))
+		t.Cleanup(func() { protocolstate.Close(opts.ExecutionId) })
+
+		ctx := context.WithValue(context.Background(), "executionId", opts.ExecutionId) // nolint: staticcheck
+		ctx = context.WithValue(ctx, "proxyURL", "socks5://127.0.0.1:1080")              // nolint: staticcheck
+		_, err := Dial(ctx, "tcp", "example.com:80")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unsupported proxy scheme")
+	})
+
+	t.Run("invalid proxy url fails hard", func(t *testing.T) {
+		opts := &types.Options{ExecutionId: "net-dial-invalid-" + t.Name()}
+		require.NoError(t, protocolstate.Init(opts))
+		t.Cleanup(func() { protocolstate.Close(opts.ExecutionId) })
+
+		ctx := context.WithValue(context.Background(), "executionId", opts.ExecutionId) // nolint: staticcheck
+		ctx = context.WithValue(ctx, "proxyURL", "://bad")                               // nolint: staticcheck
+		_, err := Dial(ctx, "tcp", "example.com:80")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid proxy URL")
+	})
+
+	t.Run("udp with http proxy fails hard", func(t *testing.T) {
+		opts := &types.Options{ExecutionId: "net-dial-udp-" + t.Name()}
+		require.NoError(t, protocolstate.Init(opts))
+		t.Cleanup(func() { protocolstate.Close(opts.ExecutionId) })
+
+		ctx := context.WithValue(context.Background(), "executionId", opts.ExecutionId) // nolint: staticcheck
+		ctx = context.WithValue(ctx, "proxyURL", "http://127.0.0.1:8080")                // nolint: staticcheck
+		_, err := Dial(ctx, "udp", "example.com:53")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "does not support protocol")
+	})
+
+	t.Run("open through local http proxy", func(t *testing.T) {
+		target, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		defer func() { _ = target.Close() }()
+
+		go func() {
+			conn, err := target.Accept()
+			if err != nil {
+				return
+			}
+			defer func() { _ = conn.Close() }()
+			_, _ = conn.Write([]byte("pong"))
+		}()
+
+		proxyLn, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		defer func() { _ = proxyLn.Close() }()
+
+		go func() {
+			conn, err := proxyLn.Accept()
+			if err != nil {
+				return
+			}
+			defer func() { _ = conn.Close() }()
+
+			req, err := http.ReadRequest(bufio.NewReader(conn))
+			if err != nil {
+				return
+			}
+			_ = req.Body.Close()
+			require.Equal(t, http.MethodConnect, req.Method)
+			require.Equal(t, target.Addr().String(), req.Host)
+
+			upstream, err := net.Dial("tcp", target.Addr().String())
+			if err != nil {
+				return
+			}
+			defer func() { _ = upstream.Close() }()
+
+			_, _ = conn.Write([]byte("HTTP/1.1 200 Connection Established\r\n\r\n"))
+			go func() { _, _ = io.Copy(upstream, conn) }()
+			_, _ = io.Copy(conn, upstream)
+		}()
+
+		opts := &types.Options{ExecutionId: "net-dial-proxy-" + t.Name()}
+		require.NoError(t, protocolstate.Init(opts))
+		t.Cleanup(func() { protocolstate.Close(opts.ExecutionId) })
+
+		ctx := context.WithValue(context.Background(), "executionId", opts.ExecutionId) // nolint: staticcheck
+		ctx = context.WithValue(ctx, "proxyURL", "http://"+proxyLn.Addr().String())     // nolint: staticcheck
+		ctx = context.WithValue(ctx, "timeoutVariants", &types.Timeouts{TcpReadTimeout: 5 * time.Second}) // nolint: staticcheck
+
+		nconn, err := Open(ctx, "tcp", target.Addr().String())
+		require.NoError(t, err)
+		defer func() { _ = nconn.Close() }()
+
+		buf := make([]byte, 16)
+		n, err := nconn.conn.Read(buf)
+		require.NoError(t, err)
+		require.Equal(t, "pong", string(buf[:n]))
 	})
 }
 

--- a/pkg/protocols/javascript/js.go
+++ b/pkg/protocols/javascript/js.go
@@ -157,6 +157,7 @@ func (request *Request) Compile(options *protocols.ExecutorOptions) error {
 		opts := &compiler.ExecuteOptions{
 			ExecutionId:     request.options.Options.ExecutionId,
 			TimeoutVariants: request.options.Options.GetTimeouts(),
+			ProxyURL:        request.options.Options.AliveHttpProxy,
 			Source:          &request.Init,
 		}
 		// register 'export' function to export variables from init code
@@ -332,6 +333,18 @@ func (request *Request) executeWithResults(port string, target *contextargs.Cont
 	payloadValues["Host"] = hostname
 	payloadValues["Port"] = port
 
+	// Expose custom headers from CLI flags (-H) as a map for JS templates.
+	if len(requestOptions.Options.CustomHeaders) > 0 {
+		headers := make(map[string]string)
+		for _, h := range requestOptions.Options.CustomHeaders {
+			parts := strings.SplitN(h, ":", 2)
+			if len(parts) == 2 {
+				headers[strings.TrimSpace(parts[0])] = strings.TrimSpace(parts[1])
+			}
+		}
+		payloadValues["custom_headers"] = headers
+	}
+
 	hostnameVariables := protocolutils.GenerateDNSVariables(hostname)
 	values := generators.MergeMaps(payloadValues, hostnameVariables, request.options.Constants, templateCtx.GetAll())
 	variablesMap := request.options.Variables.Evaluate(values)
@@ -380,7 +393,8 @@ func (request *Request) executeWithResults(port string, target *contextargs.Cont
 			&compiler.ExecuteOptions{
 				ExecutionId:     requestOptions.Options.ExecutionId,
 				TimeoutVariants: requestOptions.Options.GetTimeouts(),
-				Source: &request.PreCondition,
+				ProxyURL:        requestOptions.Options.AliveHttpProxy,
+				Source:          &request.PreCondition,
 			},
 		)
 		// if precondition was successful
@@ -564,6 +578,7 @@ func (request *Request) executeRequestWithPayloads(
 		&compiler.ExecuteOptions{
 			ExecutionId:     requestOptions.Options.ExecutionId,
 			TimeoutVariants: requestOptions.Options.GetTimeouts(),
+			ProxyURL:        requestOptions.Options.AliveHttpProxy,
 			Source:          &request.Code,
 		},
 	)

--- a/pkg/protocols/javascript/js.go
+++ b/pkg/protocols/javascript/js.go
@@ -170,6 +170,7 @@ func (request *Request) Compile(options *protocols.ExecutorOptions) error {
 			ExecutionId:     request.options.Options.ExecutionId,
 			TimeoutVariants: request.options.Options.GetTimeouts(),
 			ProxyURL:        request.options.Options.AliveHttpProxy,
+			CustomHeaders:   request.options.Options.CustomHeaders,
 			Source:          &request.Init,
 		}
 		// register 'export' function to export variables from init code
@@ -407,6 +408,7 @@ func (request *Request) executeWithResults(port string, target *contextargs.Cont
 				ExecutionId:     requestOptions.Options.ExecutionId,
 				TimeoutVariants: requestOptions.Options.GetTimeouts(),
 				ProxyURL:        requestOptions.Options.AliveHttpProxy,
+				CustomHeaders:   requestOptions.Options.CustomHeaders,
 				Source:          &request.PreCondition,
 			},
 		)
@@ -645,6 +647,7 @@ func (request *Request) executeRequestWithPayloads(
 			ExecutionId:     requestOptions.Options.ExecutionId,
 			TimeoutVariants: requestOptions.Options.GetTimeouts(),
 			ProxyURL:        requestOptions.Options.AliveHttpProxy,
+			CustomHeaders:   requestOptions.Options.CustomHeaders,
 			Source:          &request.Code,
 		},
 	)

--- a/pkg/protocols/javascript/js.go
+++ b/pkg/protocols/javascript/js.go
@@ -169,6 +169,7 @@ func (request *Request) Compile(options *protocols.ExecutorOptions) error {
 		opts := &compiler.ExecuteOptions{
 			ExecutionId:     request.options.Options.ExecutionId,
 			TimeoutVariants: request.options.Options.GetTimeouts(),
+			ProxyURL:        request.options.Options.AliveHttpProxy,
 			Source:          &request.Init,
 		}
 		// register 'export' function to export variables from init code
@@ -405,6 +406,7 @@ func (request *Request) executeWithResults(port string, target *contextargs.Cont
 			&compiler.ExecuteOptions{
 				ExecutionId:     requestOptions.Options.ExecutionId,
 				TimeoutVariants: requestOptions.Options.GetTimeouts(),
+				ProxyURL:        requestOptions.Options.AliveHttpProxy,
 				Source:          &request.PreCondition,
 			},
 		)
@@ -642,6 +644,7 @@ func (request *Request) executeRequestWithPayloads(
 		&compiler.ExecuteOptions{
 			ExecutionId:     requestOptions.Options.ExecutionId,
 			TimeoutVariants: requestOptions.Options.GetTimeouts(),
+			ProxyURL:        requestOptions.Options.AliveHttpProxy,
 			Source:          &request.Code,
 		},
 	)


### PR DESCRIPTION
## Proposed changes

Fixes #6645

JS protocol templates ignored --proxy, --timeout, and -H flags because these values were not forwarded to the JS execution context. This forwards them through ExecuteOptions into the JS runtime so net.Open/OpenTLS can route connections through an HTTP CONNECT proxy and respect the configured timeout. Custom headers are exposed as a template variable.

### Proof

```
$ go vet ./pkg/js/... ./pkg/protocols/javascript/...
$ go test -v -race ./pkg/js/libs/net/...
=== RUN   TestGetTimeoutFromContext
--- PASS: TestGetTimeoutFromContext (0.00s)
=== RUN   TestBufferedConn
--- PASS: TestBufferedConn (0.00s)
=== RUN   TestDialHTTPProxy
    --- PASS: TestDialHTTPProxy/successful_CONNECT_tunnel (0.00s)
    --- PASS: TestDialHTTPProxy/proxy_returns_non-200_status (0.00s)
    --- PASS: TestDialHTTPProxy/invalid_proxy_URL (0.00s)
    --- PASS: TestDialHTTPProxy/unreachable_proxy (0.00s)
--- PASS: TestDialHTTPProxy (0.00s)
PASS
```

## Checklist

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HTTP proxy support via HTTP CONNECT tunneling for applicable network requests
  * Connection timeouts now respect execution-context timeout variants
  * Exposes CLI custom headers to JavaScript templates
  * JS runtime receives per-execution proxy and timeout values to ensure correct behavior in pooled runtimes

* **Tests**
  * Added tests for proxy handling, timeout resolution, buffered-connection behavior, and CONNECT tunneling success/failure
<!-- end of auto-generated comment: release notes by coderabbit.ai -->