### PR TITLE
fix: prevent panic when dialers are not initialized in GetRawHTTP

### DIFF
--- a/pkg/protocols/http/http.go
+++ b/pkg/protocols/http/http.go
@@ -379,7 +379,10 @@ func (request *Request) Compile(options *protocols.ExecutorOptions) error {
 				request.Raw[i] = strings.ReplaceAll(raw, "\n", "\r\n")
 			}
 		}
-		request.rawhttpClient = httpclientpool.GetRawHTTP(options)
+		request.rawhttpClient, err = httpclientpool.GetRawHTTP(options)
+		if err != nil {
+			return errors.Wrap(err, "failed to get raw HTTP client")
+		}
 	}
 	if len(request.Matchers) > 0 || len(request.Extractors) > 0 {
 		compiled := &request.Operators

--- a/pkg/protocols/http/httpclientpool/clientpool.go
+++ b/pkg/protocols/http/httpclientpool/clientpool.go
@@ -140,10 +140,10 @@ func (c *Configuration) HasStandardOptions() bool {
 }
 
 // GetRawHTTP returns the rawhttp request client
-func GetRawHTTP(options *protocols.ExecutorOptions) *rawhttp.Client {
+func GetRawHTTP(options *protocols.ExecutorOptions) (*rawhttp.Client, error) {
 	dialers := protocolstate.GetDialersWithId(options.Options.ExecutionId)
 	if dialers == nil {
-		panic("dialers not initialized for execution id: " + options.Options.ExecutionId)
+		return nil, fmt.Errorf("dialers not initialized for execution id: %s", options.Options.ExecutionId)
 	}
 
 	// Lock the dialers to avoid a race when setting RawHTTPClient
@@ -151,9 +151,8 @@ func GetRawHTTP(options *protocols.ExecutorOptions) *rawhttp.Client {
 	defer dialers.Unlock()
 
 	if dialers.RawHTTPClient != nil {
-		return dialers.RawHTTPClient
+		return dialers.RawHTTPClient, nil
 	}
-
 	rawHttpOptionsCopy := *rawhttp.DefaultOptions
 	if options.Options.AliveHttpProxy != "" {
 		rawHttpOptionsCopy.Proxy = options.Options.AliveHttpProxy
@@ -164,7 +163,7 @@ func GetRawHTTP(options *protocols.ExecutorOptions) *rawhttp.Client {
 	}
 	rawHttpOptionsCopy.Timeout = options.Options.GetTimeouts().HttpTimeout
 	dialers.RawHTTPClient = rawhttp.NewClient(&rawHttpOptionsCopy)
-	return dialers.RawHTTPClient
+	return dialers.RawHTTPClient, nil
 }
 
 // Get creates or gets a client for the protocol based on custom configuration


### PR DESCRIPTION
Fixes #6674

/claim #6674

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Enhanced HTTP protocol stability with improved error handling for raw HTTP client acquisition. The application now returns descriptive error messages instead of crashing, enabling better troubleshooting of connection issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->