### PR TITLE
fix: add nil check for opts in executeWithRuntime (#7248)

### DIFF
--- a/pkg/js/compiler/pool.go
+++ b/pkg/js/compiler/pool.go
@@ -112,7 +112,9 @@ func executeWithRuntime(runtime *goja.Runtime, p *goja.Program, args *ExecuteArg
 	}
 
 	// inject execution id and context
-	runtime.SetContextValue("executionId", opts.ExecutionId)
+	if opts != nil {
+		runtime.SetContextValue("executionId", opts.ExecutionId)
+	}
 
 	// execute the script
 	return runtime.RunProgram(p)


### PR DESCRIPTION
## Summary

Adds a nil check before accessing `opts.ExecutionId` in `executeWithRuntime` in `pkg/js/compiler/pool.go`.

## Problem

Line 115 accesses `opts.ExecutionId` without checking if `opts` is nil first:

```go
runtime.SetContextValue("executionId", opts.ExecutionId)
```

However, other accesses to `opts` in the same function already perform nil checks:
- Line 86: `if opts != nil && opts.Cleanup != nil`
- Line 109: `if opts != nil && opts.Callback != nil`

This inconsistency means calling `executeWithRuntime` with a nil `opts` will panic.

## Fix

Wrap the `runtime.SetContextValue` call in an `if opts != nil` guard, consistent with the existing nil checks in the function.

## Changes

- `pkg/js/compiler/pool.go`: Added nil check before `opts.ExecutionId` access

Closes #7248

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a potential runtime error that could occur when processing execution requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->