### PR TITLE
Fix(clientpool): remove global variable from clientpool in favour for local variable

### DIFF
--- a/pkg/protocols/common/protocolinit/init.go
+++ b/pkg/protocols/common/protocolinit/init.go
@@ -4,7 +4,6 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/js/compiler"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/dns/dnsclientpool"
-	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/http/httpclientpool"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/http/signerpool"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/network/networkclientpool"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/whois/rdapclientpool"
@@ -18,9 +17,6 @@ func Init(options *types.Options) error {
 		return err
 	}
 	if err := dnsclientpool.Init(options); err != nil {
-		return err
-	}
-	if err := httpclientpool.Init(options); err != nil {
 		return err
 	}
 	if err := signerpool.Init(options); err != nil {

--- a/pkg/protocols/http/httpclientpool/clientpool.go
+++ b/pkg/protocols/http/httpclientpool/clientpool.go
@@ -28,16 +28,8 @@ import (
 	urlutil "github.com/projectdiscovery/utils/url"
 )
 
-var (
-	forceMaxRedirects int
-)
-
 // Init initializes the clientpool implementation
 func Init(options *types.Options) error {
-	if options.ShouldFollowHTTPRedirects() {
-		forceMaxRedirects = options.MaxRedirects
-	}
-
 	return nil
 }
 
@@ -221,7 +213,7 @@ func wrappedGet(options *types.Options, configuration *Configuration) (*retryabl
 	redirectFlow := configuration.RedirectFlow
 	maxRedirects := configuration.MaxRedirects
 
-	if forceMaxRedirects > 0 {
+	if options.ShouldFollowHTTPRedirects() {
 		// by default we enable general redirects following
 		switch {
 		case options.FollowHostRedirects:
@@ -229,7 +221,7 @@ func wrappedGet(options *types.Options, configuration *Configuration) (*retryabl
 		default:
 			redirectFlow = FollowAllRedirect
 		}
-		maxRedirects = forceMaxRedirects
+		maxRedirects = options.MaxRedirects
 	}
 	if options.DisableRedirects {
 		options.FollowRedirects = false

--- a/pkg/protocols/http/httpclientpool/clientpool.go
+++ b/pkg/protocols/http/httpclientpool/clientpool.go
@@ -221,7 +221,9 @@ func wrappedGet(options *types.Options, configuration *Configuration) (*retryabl
 		default:
 			redirectFlow = FollowAllRedirect
 		}
-		maxRedirects = options.MaxRedirects
+		if options.MaxRedirects > 0 {
+			maxRedirects = options.MaxRedirects
+		}
 	}
 	if options.DisableRedirects {
 		options.FollowRedirects = false

--- a/pkg/protocols/http/httpclientpool/clientpool.go
+++ b/pkg/protocols/http/httpclientpool/clientpool.go
@@ -28,11 +28,6 @@ import (
 	urlutil "github.com/projectdiscovery/utils/url"
 )
 
-// Init initializes the clientpool implementation
-func Init(options *types.Options) error {
-	return nil
-}
-
 // ConnectionConfiguration contains the custom configuration options for a connection
 type ConnectionConfiguration struct {
 	// DisableKeepAlive of the connection


### PR DESCRIPTION
## Proposed changes

When multiple instances of nuclei SDK are initialized, the `clientpool.Init()` function is called multiple times, leading to unexpected/overwrite behavior in the `wrapperGet` function.

Since the `wrapperGet` function already has access to the options, there is little reason to initialize this variable globally, and it can just be done in the `wrapperGet` func.

## Flow changes

Based on this change, the flow also is slightly changed, before hand, it would only follow redirects if the option `options.MaxRedirects` > 0 (and thus ignore the `FollowHostRedirects` and `FollowRedirects` options if it was == 0. 

Now if `max(options.MaxRedirects, configuration.MaxRedirects) > 0` it will follow redirects (aka honoring the options).


### Proof

```
  WARNING: DATA RACE
  Read at 0x00000ad7dbd8 by goroutine 863:
    github.com/projectdiscovery/nuclei/v3/pkg/protocols/http/httpclientpool.wrappedGet()
        /home/runner/_work/<omitted>/<omitted>/vendor/github.com/projectdiscovery/nuclei/v3/pkg/protocols/http/httpclientpool/clientpool.go:224 +0x3e4
    github.com/projectdiscovery/nuclei/v3/pkg/protocols/http/httpclientpool.Get()
        /home/runner/_work/<omitted>/<omitted>/vendor/github.com/projectdiscovery/nuclei/v3/pkg/protocols/http/httpclientpool/clientpool.go:180 +0x246
    github.com/projectdiscovery/nuclei/v3/pkg/protocols/http.(*Request).Compile()
        /home/runner/_work/<omitted>/<omitted>/vendor/github.com/projectdiscovery/nuclei/v3/pkg/protocols/http/http.go:348 +0xc28
  
  Previous write at 0x00000ad7dbd8 by goroutine 846:
    github.com/projectdiscovery/nuclei/v3/pkg/protocols/http/httpclientpool.Init()
        /home/runner/_work/<omitted>/<omitted>/vendor/github.com/projectdiscovery/nuclei/v3/pkg/protocols/http/httpclientpool/clientpool.go:38 +0xb3
    github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolinit.Init()
        /home/runner/_work/<omitted>/<omitted>/vendor/github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolinit/init.go:23 +0x5b
    fmt.Sscanf()
        /opt/hostedtoolcache/go/1.25.0/x64/src/fmt/scan.go:114 +0x264
    github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
        /home/runner/_work/<omitted>/<omitted>/vendor/github.com/syndtr/goleveldb/leveldb/storage/file_storage.go:657 +0x18e
```

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved HTTP redirect handling: per-request redirect settings are now respected (including disabling redirects and per-request max redirects), removing shared mutable global state.
  * Removed the global initializer for the HTTP client pool from startup flow so the pool no longer requires a separate package-level init step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->