### PR TITLE
fix(js): watchdog + propagates context to all JS library network calls

### DIFF
--- a/cmd/memogen/function.tpl
+++ b/cmd/memogen/function.tpl
@@ -11,7 +11,7 @@ import (
 
 {{range .Functions}}
     {{ .SignatureWithPrefix "memoized" }} {
-        hash := "{{ .Name }}" {{range .Params}}{{if ne .Type "context.Context"}} + ":" + fmt.Sprint({{.Name}}){{end}}{{end}}
+        hash := "{{ .Name }}" {{range .Params}}{{if ne .Type "&{context Context}"}} + ":" + fmt.Sprint({{.Name}}){{end}}{{end}}
 
         v, err, _ := protocolstate.Memoizer.Do(hash, func() (interface{}, error) {
             return {{.Name}}({{.ParamsNames}})

--- a/cmd/memogen/function.tpl
+++ b/cmd/memogen/function.tpl
@@ -11,7 +11,7 @@ import (
 
 {{range .Functions}}
     {{ .SignatureWithPrefix "memoized" }} {
-        hash := "{{ .Name }}" {{range .Params}} + ":" + fmt.Sprint({{.Name}}) {{end}}
+        hash := "{{ .Name }}" {{range .Params}}{{if ne .Type "context.Context"}} + ":" + fmt.Sprint({{.Name}}){{end}}{{end}}
 
         v, err, _ := protocolstate.Memoizer.Do(hash, func() (interface{}, error) {
             return {{.Name}}({{.ParamsNames}})

--- a/pkg/js/compiler/compiler.go
+++ b/pkg/js/compiler/compiler.go
@@ -135,6 +135,11 @@ func (c *Compiler) ExecuteWithOptions(program *goja.Program, args *ExecuteArgs, 
 			}
 		}()
 
+		// Propagate the deadline context so that ExecuteProgram (and both
+		// the pooled and non-pooled paths) can use it for slot acquisition
+		// and watchdog goroutines. Without this, opts.Context carries no
+		// deadline and pool slots are held indefinitely by zombie goroutines.
+		opts.Context = ctx
 		return ExecuteProgram(program, args, opts)
 	})
 	if err != nil {

--- a/pkg/js/compiler/non-pool.go
+++ b/pkg/js/compiler/non-pool.go
@@ -2,6 +2,7 @@ package compiler
 
 import (
 	"sync"
+	"sync/atomic"
 
 	"github.com/Mzack9999/goja"
 	syncutil "github.com/projectdiscovery/utils/sync"
@@ -16,8 +17,32 @@ var (
 
 func executeWithoutPooling(p *goja.Program, args *ExecuteArgs, opts *ExecuteOptions) (result goja.Value, err error) {
 	lazyFixedSgInit()
-	ephemeraljsc.Add()
-	defer ephemeraljsc.Done()
+	// Acquire a pool slot, respecting the execution deadline. Returns
+	// immediately if the context has already expired.
+	if err := ephemeraljsc.AddWithContext(opts.Context); err != nil {
+		return nil, err
+	}
+	// Watchdog: release the pool slot if the deadline expires while the
+	// goroutine is still running (zombie). See executeWithPoolingProgram
+	// for the full explanation. The atomic.Bool guarantees exactly one
+	// Done() call between the watchdog and the normal defer path.
+	var slotReleased atomic.Bool
+	done := make(chan struct{})
+	go func() {
+		select {
+		case <-opts.Context.Done():
+			if slotReleased.CompareAndSwap(false, true) {
+				ephemeraljsc.Done()
+			}
+		case <-done:
+		}
+	}()
+	defer func() {
+		close(done)
+		if slotReleased.CompareAndSwap(false, true) {
+			ephemeraljsc.Done()
+		}
+	}()
 	runtime := createNewRuntime()
 	return executeWithRuntime(runtime, p, args, opts)
 }

--- a/pkg/js/compiler/pool.go
+++ b/pkg/js/compiler/pool.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"reflect"
 	"sync"
+	"sync/atomic"
 
 	"github.com/Mzack9999/goja"
 	"github.com/Mzack9999/goja_nodejs/console"
@@ -85,6 +86,7 @@ func executeWithRuntime(runtime *goja.Runtime, p *goja.Program, args *ExecuteArg
 			opts.Cleanup(runtime)
 		}
 		runtime.RemoveContextValue("executionId")
+		runtime.RemoveContextValue("ctx")
 	}()
 
 	// TODO(dwisiswant0): remove this once we get the RCA.
@@ -113,6 +115,7 @@ func executeWithRuntime(runtime *goja.Runtime, p *goja.Program, args *ExecuteArg
 
 	// inject execution id and context
 	runtime.SetContextValue("executionId", opts.ExecutionId)
+	runtime.SetContextValue("ctx", opts.Context)
 
 	// execute the script
 	return runtime.RunProgram(p)
@@ -139,8 +142,34 @@ func executeWithPoolingProgram(p *goja.Program, args *ExecuteArgs, opts *Execute
 	lazySgInit()
 	sgResizeCheck(opts.Context)
 
-	pooljsc.Add()
-	defer pooljsc.Done()
+	// Acquire a pool slot, respecting the execution deadline. Returns
+	// immediately if the context has already expired.
+	if err := pooljsc.AddWithContext(opts.Context); err != nil {
+		return nil, err
+	}
+	// Watchdog: release the pool slot if the deadline expires while the
+	// goroutine is still running (zombie). ExecFuncWithTwoReturns abandons
+	// the caller on timeout, but the goroutine keeps running and holds its
+	// slot via defer. The watchdog ensures the slot is freed at the deadline
+	// so the pool doesn't starve. The atomic.Bool guarantees exactly one
+	// Done() call between the watchdog and the normal defer path.
+	var slotReleased atomic.Bool
+	done := make(chan struct{})
+	go func() {
+		select {
+		case <-opts.Context.Done():
+			if slotReleased.CompareAndSwap(false, true) {
+				pooljsc.Done()
+			}
+		case <-done:
+		}
+	}()
+	defer func() {
+		close(done)
+		if slotReleased.CompareAndSwap(false, true) {
+			pooljsc.Done()
+		}
+	}()
 	runtime := gojapool.Get().(*goja.Runtime)
 	defer gojapool.Put(runtime)
 	var buff bytes.Buffer

--- a/pkg/js/compiler/pool_starvation_test.go
+++ b/pkg/js/compiler/pool_starvation_test.go
@@ -1,0 +1,122 @@
+package compiler
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	syncutil "github.com/projectdiscovery/utils/sync"
+)
+
+// TestPoolSlotStarvation reproduces the core bug from issue #6894:
+// zombie goroutines from timed-out JS executions hold pool slots
+// indefinitely, causing subsequent executions to fail.
+//
+// The flow:
+//  1. ExecFuncWithTwoReturns wraps ExecuteProgram in a goroutine with a deadline.
+//  2. Inside ExecuteProgram, pool.Add() acquires a slot, defer pool.Done() is set.
+//  3. The JS script makes a network call using context.TODO() (no deadline).
+//  4. The deadline fires and ExecFuncWithTwoReturns returns the deadline error.
+//  5. The goroutine is STILL running (zombie), holding the pool slot via defer.
+//  6. With enough zombies, all slots are consumed and new executions time out
+//     waiting for a slot that will never be released.
+func TestPoolSlotStarvation(t *testing.T) {
+	const poolSize = 3
+	pool, err := syncutil.New(syncutil.WithSize(poolSize))
+	require.NoError(t, err)
+
+	// Simulate zombies: goroutines that acquire a slot, then block for a
+	// long time (as if stuck on a network call with context.TODO()).
+	// The caller "abandons" them via a short deadline.
+	var zombieWg sync.WaitGroup
+	for i := range poolSize {
+		zombieWg.Add(1)
+		go func(idx int) {
+			defer zombieWg.Done()
+			// This is what happens inside executeWithoutPooling/executeWithPoolingProgram:
+			pool.Add()
+			defer pool.Done()
+			// Simulate a stuck network call (15s in the original report).
+			time.Sleep(10 * time.Second)
+		}(i)
+	}
+
+	// Give zombies time to acquire their slots.
+	time.Sleep(100 * time.Millisecond)
+
+	// All slots are held by zombies. Try to acquire a new slot with a
+	// deadline - this should fail because no slots are available and
+	// zombies won't release them for ~10s.
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	err = pool.AddWithContext(ctx)
+	elapsed := time.Since(start)
+
+	// This demonstrates the starvation: the pool is fully exhausted by zombies,
+	// and the new acquisition times out.
+	require.Error(t, err, "should fail, all slots held by zombie goroutines")
+	require.Less(t, elapsed, 2*time.Second, "should fail fast at deadline, not block forever")
+	t.Logf("Pool starvation confirmed: new slot acquisition failed after %v (pool exhausted by %d zombies)", elapsed, poolSize)
+}
+
+// TestWatchdogPreventsStarvation demonstrates the fix: a watchdog goroutine
+// releases pool slots when the deadline expires, even if the zombie is still
+// running. This is the core of the fix in PR #6896.
+func TestWatchdogPreventsStarvation(t *testing.T) {
+	const poolSize = 3
+	pool, err := syncutil.New(syncutil.WithSize(poolSize))
+	require.NoError(t, err)
+
+	// Fill all slots with "zombies" that have a 100ms deadline but block for
+	// 10s. The watchdog pattern releases each slot when the deadline fires.
+	for i := range poolSize {
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+
+		require.NoError(t, pool.AddWithContext(ctx), "initial acquisition %d", i)
+
+		watchdogDone := make(chan struct{})
+		var once sync.Once
+
+		releaseSlot := func() {
+			once.Do(func() { pool.Done() })
+		}
+
+		// Watchdog: free the slot when deadline expires.
+		go func() {
+			select {
+			case <-ctx.Done():
+				releaseSlot()
+			case <-watchdogDone:
+			}
+		}()
+
+		// Zombie worker: blocks for 10s but the watchdog will free its slot.
+		go func() {
+			defer func() {
+				close(watchdogDone)
+				releaseSlot()
+			}()
+			time.Sleep(10 * time.Second)
+		}()
+	}
+
+	// Wait for all deadlines to fire and watchdogs to release slots.
+	time.Sleep(200 * time.Millisecond)
+
+	// All slots should be free now, so new acquisitions should work.
+	for i := range poolSize {
+		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		defer cancel()
+		require.NoError(t, pool.AddWithContext(ctx),
+			"post-recovery acquisition %d/%d (pool should no longer be starved)", i+1, poolSize)
+		pool.Done()
+	}
+
+	t.Log("Watchdog fix confirmed: all slots recovered after zombie deadline expiry")
+}

--- a/pkg/js/compiler/pool_test.go
+++ b/pkg/js/compiler/pool_test.go
@@ -1,0 +1,141 @@
+package compiler
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	syncutil "github.com/projectdiscovery/utils/sync"
+)
+
+// TestAddWithContextRespectsDeadline verifies that AddWithContext returns an
+// error when the context deadline expires while waiting for a pool slot.
+// Before the fix, Add() used context.Background() and would block indefinitely.
+func TestAddWithContextRespectsDeadline(t *testing.T) {
+	pool, err := syncutil.New(syncutil.WithSize(1))
+	require.NoError(t, err)
+
+	// Fill the only slot.
+	pool.Add()
+	defer pool.Done()
+
+	// Try to acquire with a short deadline — should fail fast, not hang.
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	err = pool.AddWithContext(ctx)
+	elapsed := time.Since(start)
+
+	require.Error(t, err, "AddWithContext should fail when pool is full and deadline expires")
+	require.Less(t, elapsed, 200*time.Millisecond, "AddWithContext should fail fast after deadline")
+}
+
+// TestWatchdogReleasesSlotOnDeadline verifies that the watchdog goroutine
+// releases a pool slot when the execution deadline expires, even if the
+// worker goroutine is still running (zombie). This is the core fix for
+// pool slot starvation: without the watchdog, a zombie goroutine holds its
+// slot via defer Done() until its network call eventually times out (or never).
+func TestWatchdogReleasesSlotOnDeadline(t *testing.T) {
+	pool, err := syncutil.New(syncutil.WithSize(1))
+	require.NoError(t, err)
+
+	// Acquire the only slot (simulates a JS execution starting).
+	pool.Add()
+
+	// Set up the watchdog pattern (same as our fix in pool.go / non-pool.go).
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	var slotReleased atomic.Bool
+	watchdogDone := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			if slotReleased.CompareAndSwap(false, true) {
+				pool.Done()
+			}
+		case <-watchdogDone:
+		}
+	}()
+	defer func() {
+		close(watchdogDone)
+		if slotReleased.CompareAndSwap(false, true) {
+			pool.Done()
+		}
+	}()
+
+	// Wait for the deadline to fire and the watchdog to release the slot.
+	<-ctx.Done()
+	time.Sleep(20 * time.Millisecond)
+
+	// A new execution should be able to acquire the slot, even though the
+	// "zombie" never called Done() itself.
+	freshCtx, freshCancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer freshCancel()
+	require.NoError(t, pool.AddWithContext(freshCtx),
+		"slot acquisition should succeed after watchdog release")
+	pool.Done()
+}
+
+// TestPoolExhaustionRecovery demonstrates the complete starvation/recovery
+// cycle. All pool slots are filled with zombie goroutines that block well
+// beyond their deadline. The watchdog pattern frees the slots when the
+// deadlines expire, allowing subsequent executions to proceed.
+//
+// Without the fix, the pool stays permanently exhausted and every subsequent
+// AddWithContext call fails (or Add() blocks forever).
+func TestPoolExhaustionRecovery(t *testing.T) {
+	const poolSize = 3
+	pool, err := syncutil.New(syncutil.WithSize(poolSize))
+	require.NoError(t, err)
+
+	// Fill every slot with a "zombie" that blocks for 10s but has a 100ms
+	// deadline. The watchdog should free each slot after ~100ms.
+	for i := range poolSize {
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+
+		require.NoError(t, pool.AddWithContext(ctx), "initial slot acquisition %d", i)
+
+		var released atomic.Bool
+		done := make(chan struct{})
+
+		// Watchdog: release slot when deadline expires.
+		go func() {
+			select {
+			case <-ctx.Done():
+				if released.CompareAndSwap(false, true) {
+					pool.Done()
+				}
+			case <-done:
+			}
+		}()
+
+		// Zombie worker: blocks for 10s simulating a hung network call.
+		go func() {
+			defer func() {
+				close(done)
+				if released.CompareAndSwap(false, true) {
+					pool.Done()
+				}
+			}()
+			time.Sleep(10 * time.Second)
+		}()
+	}
+
+	// Pool is fully saturated. Wait for all deadlines to expire.
+	time.Sleep(200 * time.Millisecond)
+
+	// All slots should now be free. Acquire and release each one.
+	for i := range poolSize {
+		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		defer cancel()
+		require.NoError(t, pool.AddWithContext(ctx),
+			"post-recovery slot acquisition %d/%d (pool still starved)", i+1, poolSize)
+		pool.Done()
+	}
+}

--- a/pkg/js/compiler/pool_test.go
+++ b/pkg/js/compiler/pool_test.go
@@ -22,7 +22,7 @@ func TestAddWithContextRespectsDeadline(t *testing.T) {
 	pool.Add()
 	defer pool.Done()
 
-	// Try to acquire with a short deadline — should fail fast, not hang.
+	// Try to acquire with a short deadline, should fail fast and not hang.
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
 

--- a/pkg/js/libs/kerberos/sendtokdc.go
+++ b/pkg/js/libs/kerberos/sendtokdc.go
@@ -5,7 +5,6 @@ package kerberos
 // it is copied here because the library does not export "SendToKDC()"
 
 import (
-	"context"
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
@@ -74,6 +73,7 @@ func sendToKDCTcp(kclient *Client, msg string) ([]byte, error) {
 		return nil, fmt.Errorf("dialers not initialized for %s", executionId)
 	}
 
+	dialCtx := kclient.nj.Context()
 	var errs []string
 	for i := 1; i <= len(kdcs); i++ {
 		host, port, err := net.SplitHostPort(kdcs[i])
@@ -81,7 +81,7 @@ func sendToKDCTcp(kclient *Client, msg string) ([]byte, error) {
 			// use that ip address instead of realm/domain for resolving
 			host = kclient.config.ip
 		}
-		tcpConn, err := dialers.Fastdialer.Dial(context.TODO(), "tcp", net.JoinHostPort(host, port))
+		tcpConn, err := dialers.Fastdialer.Dial(dialCtx, "tcp", net.JoinHostPort(host, port))
 		if err != nil {
 			errs = append(errs, fmt.Sprintf("error establishing connection to %s: %v", kdcs[i], err))
 			continue
@@ -114,6 +114,7 @@ func sendToKDCUdp(kclient *Client, msg string) ([]byte, error) {
 	if dialers == nil {
 		return nil, fmt.Errorf("dialers not initialized for %s", executionId)
 	}
+	dialCtx := kclient.nj.Context()
 	var errs []string
 	for i := 1; i <= len(kdcs); i++ {
 		host, port, err := net.SplitHostPort(kdcs[i])
@@ -121,7 +122,7 @@ func sendToKDCUdp(kclient *Client, msg string) ([]byte, error) {
 			// use that ip address instead of realm/domain for resolving
 			host = kclient.config.ip
 		}
-		udpConn, err := dialers.Fastdialer.Dial(context.TODO(), "udp", net.JoinHostPort(host, port))
+		udpConn, err := dialers.Fastdialer.Dial(dialCtx, "udp", net.JoinHostPort(host, port))
 		if err != nil {
 			errs = append(errs, fmt.Sprintf("error establishing connection to %s: %v", kdcs[i], err))
 			continue

--- a/pkg/js/libs/ldap/ldap.go
+++ b/pkg/js/libs/ldap/ldap.go
@@ -1,7 +1,6 @@
 package ldap
 
 import (
-	"context"
 	"crypto/tls"
 	"fmt"
 	"net"
@@ -92,12 +91,13 @@ func NewClient(call goja.ConstructorCall, runtime *goja.Runtime) *goja.Object {
 		panic("dialers with executionId " + executionId + " not found")
 	}
 
+	dialCtx := c.nj.Context()
 	var conn net.Conn
 	if u.Scheme == "ldapi" {
 		if u.Path == "" || u.Path == "/" {
 			u.Path = "/var/run/slapd/ldapi"
 		}
-		conn, err = dialers.Fastdialer.Dial(context.TODO(), "unix", u.Path)
+		conn, err = dialers.Fastdialer.Dial(dialCtx, "unix", u.Path)
 		c.nj.HandleError(err, "failed to connect to ldap server")
 	} else {
 		host, port, err := net.SplitHostPort(u.Host)
@@ -116,12 +116,12 @@ func NewClient(call goja.ConstructorCall, runtime *goja.Runtime) *goja.Object {
 			if port == "" {
 				port = ldap.DefaultLdapPort
 			}
-			conn, err = dialers.Fastdialer.Dial(context.TODO(), "udp", net.JoinHostPort(host, port))
+			conn, err = dialers.Fastdialer.Dial(dialCtx, "udp", net.JoinHostPort(host, port))
 		case "ldap":
 			if port == "" {
 				port = ldap.DefaultLdapPort
 			}
-			conn, err = dialers.Fastdialer.Dial(context.TODO(), "tcp", net.JoinHostPort(host, port))
+			conn, err = dialers.Fastdialer.Dial(dialCtx, "tcp", net.JoinHostPort(host, port))
 		case "ldaps":
 			if port == "" {
 				port = ldap.DefaultLdapsPort
@@ -130,7 +130,7 @@ func NewClient(call goja.ConstructorCall, runtime *goja.Runtime) *goja.Object {
 			if c.cfg.ServerName != "" {
 				serverName = c.cfg.ServerName
 			}
-			conn, err = dialers.Fastdialer.DialTLSWithConfig(context.TODO(), "tcp", net.JoinHostPort(host, port),
+			conn, err = dialers.Fastdialer.DialTLSWithConfig(dialCtx, "tcp", net.JoinHostPort(host, port),
 				&tls.Config{InsecureSkipVerify: true, MinVersion: tls.VersionTLS10, ServerName: serverName})
 		default:
 			err = fmt.Errorf("unsupported ldap url schema %v", u.Scheme)

--- a/pkg/js/libs/mssql/memo.mssql.go
+++ b/pkg/js/libs/mssql/memo.mssql.go
@@ -2,7 +2,9 @@
 package mssql
 
 import (
+	"context"
 	"errors"
+
 	"fmt"
 
 	_ "github.com/microsoft/go-mssqldb"
@@ -10,11 +12,11 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
 )
 
-func memoizedconnect(executionId string, host string, port int, username string, password string, dbName string) (bool, error) {
+func memoizedconnect(ctx context.Context, executionId string, host string, port int, username string, password string, dbName string) (bool, error) {
 	hash := "connect" + ":" + fmt.Sprint(executionId) + ":" + fmt.Sprint(host) + ":" + fmt.Sprint(port) + ":" + fmt.Sprint(username) + ":" + fmt.Sprint(password) + ":" + fmt.Sprint(dbName)
 
 	v, err, _ := protocolstate.Memoizer.Do(hash, func() (interface{}, error) {
-		return connect(executionId, host, port, username, password, dbName)
+		return connect(ctx, executionId, host, port, username, password, dbName)
 	})
 	if err != nil {
 		return false, err
@@ -26,11 +28,11 @@ func memoizedconnect(executionId string, host string, port int, username string,
 	return false, errors.New("could not convert cached result")
 }
 
-func memoizedisMssql(executionId string, host string, port int) (bool, error) {
+func memoizedisMssql(ctx context.Context, executionId string, host string, port int) (bool, error) {
 	hash := "isMssql" + ":" + fmt.Sprint(executionId) + ":" + fmt.Sprint(host) + ":" + fmt.Sprint(port)
 
 	v, err, _ := protocolstate.Memoizer.Do(hash, func() (interface{}, error) {
-		return isMssql(executionId, host, port)
+		return isMssql(ctx, executionId, host, port)
 	})
 	if err != nil {
 		return false, err

--- a/pkg/js/libs/mssql/mssql.go
+++ b/pkg/js/libs/mssql/mssql.go
@@ -82,7 +82,7 @@ func connect(ctx context.Context, executionId string, host string, port int, use
 		_ = db.Close()
 	}()
 
-	_, err = db.Exec("select 1")
+	_, err = db.ExecContext(ctx, "select 1")
 	if err != nil {
 		switch {
 		case strings.Contains(err.Error(), "connect: connection refused"):
@@ -192,7 +192,7 @@ func (c *MSSQLClient) ExecuteQuery(ctx context.Context, host string, port int, u
 	db.SetMaxOpenConns(1)
 	db.SetMaxIdleConns(0)
 
-	rows, err := db.Query(query)
+	rows, err := db.QueryContext(ctx, query)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/js/libs/mssql/mssql.go
+++ b/pkg/js/libs/mssql/mssql.go
@@ -38,7 +38,7 @@ type (
 // ```
 func (c *MSSQLClient) Connect(ctx context.Context, host string, port int, username, password string) (bool, error) {
 	executionId := ctx.Value("executionId").(string)
-	return memoizedconnect(executionId, host, port, username, password, "master")
+	return memoizedconnect(ctx, executionId, host, port, username, password, "master")
 }
 
 // ConnectWithDB connects to MS SQL database using given credentials and database name.
@@ -53,11 +53,11 @@ func (c *MSSQLClient) Connect(ctx context.Context, host string, port int, userna
 // ```
 func (c *MSSQLClient) ConnectWithDB(ctx context.Context, host string, port int, username, password, dbName string) (bool, error) {
 	executionId := ctx.Value("executionId").(string)
-	return memoizedconnect(executionId, host, port, username, password, dbName)
+	return memoizedconnect(ctx, executionId, host, port, username, password, dbName)
 }
 
 // @memo
-func connect(executionId string, host string, port int, username string, password string, dbName string) (bool, error) {
+func connect(ctx context.Context, executionId string, host string, port int, username string, password string, dbName string) (bool, error) {
 	if host == "" || port <= 0 {
 		return false, fmt.Errorf("invalid host or port")
 	}
@@ -111,11 +111,11 @@ func connect(executionId string, host string, port int, username string, passwor
 // ```
 func (c *MSSQLClient) IsMssql(ctx context.Context, host string, port int) (bool, error) {
 	executionId := ctx.Value("executionId").(string)
-	return memoizedisMssql(executionId, host, port)
+	return memoizedisMssql(ctx, executionId, host, port)
 }
 
 // @memo
-func isMssql(executionId string, host string, port int) (bool, error) {
+func isMssql(ctx context.Context, executionId string, host string, port int) (bool, error) {
 	if !protocolstate.IsHostAllowed(executionId, host) {
 		// host is not valid according to network policy
 		return false, protocolstate.ErrHostDenied.Msgf(host)
@@ -126,7 +126,7 @@ func isMssql(executionId string, host string, port int) (bool, error) {
 		return false, fmt.Errorf("dialers not initialized for %s", executionId)
 	}
 
-	conn, err := dialer.Fastdialer.Dial(context.TODO(), "tcp", net.JoinHostPort(host, fmt.Sprintf("%d", port)))
+	conn, err := dialer.Fastdialer.Dial(ctx, "tcp", net.JoinHostPort(host, fmt.Sprintf("%d", port)))
 	if err != nil {
 		return false, err
 	}

--- a/pkg/js/libs/mysql/memo.mysql.go
+++ b/pkg/js/libs/mysql/memo.mysql.go
@@ -2,17 +2,19 @@
 package mysql
 
 import (
+	"context"
 	"errors"
+
 	"fmt"
 
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
 )
 
-func memoizedisMySQL(executionId string, host string, port int) (bool, error) {
+func memoizedisMySQL(ctx context.Context, executionId string, host string, port int) (bool, error) {
 	hash := "isMySQL" + ":" + fmt.Sprint(executionId) + ":" + fmt.Sprint(host) + ":" + fmt.Sprint(port)
 
 	v, err, _ := protocolstate.Memoizer.Do(hash, func() (interface{}, error) {
-		return isMySQL(executionId, host, port)
+		return isMySQL(ctx, executionId, host, port)
 	})
 	if err != nil {
 		return false, err
@@ -24,11 +26,11 @@ func memoizedisMySQL(executionId string, host string, port int) (bool, error) {
 	return false, errors.New("could not convert cached result")
 }
 
-func memoizedfingerprintMySQL(executionId string, host string, port int) (MySQLInfo, error) {
+func memoizedfingerprintMySQL(ctx context.Context, executionId string, host string, port int) (MySQLInfo, error) {
 	hash := "fingerprintMySQL" + ":" + fmt.Sprint(executionId) + ":" + fmt.Sprint(host) + ":" + fmt.Sprint(port)
 
 	v, err, _ := protocolstate.Memoizer.Do(hash, func() (interface{}, error) {
-		return fingerprintMySQL(executionId, host, port)
+		return fingerprintMySQL(ctx, executionId, host, port)
 	})
 	if err != nil {
 		return MySQLInfo{}, err

--- a/pkg/js/libs/mysql/memo.mysql_private.go
+++ b/pkg/js/libs/mysql/memo.mysql_private.go
@@ -2,17 +2,19 @@
 package mysql
 
 import (
+	"context"
 	"errors"
+
 	"fmt"
 
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
 )
 
-func memoizedconnectWithDSN(executionId string, dsn string) (bool, error) {
+func memoizedconnectWithDSN(ctx context.Context, executionId string, dsn string) (bool, error) {
 	hash := "connectWithDSN" + ":" + fmt.Sprint(executionId) + ":" + fmt.Sprint(dsn)
 
 	v, err, _ := protocolstate.Memoizer.Do(hash, func() (interface{}, error) {
-		return connectWithDSN(executionId, dsn)
+		return connectWithDSN(ctx, executionId, dsn)
 	})
 	if err != nil {
 		return false, err

--- a/pkg/js/libs/mysql/mysql.go
+++ b/pkg/js/libs/mysql/mysql.go
@@ -237,7 +237,7 @@ func (c *MySQLClient) ExecuteQueryWithOpts(ctx context.Context, opts MySQLOption
 	db.SetMaxOpenConns(1)
 	db.SetMaxIdleConns(0)
 
-	rows, err := db.Query(query)
+	rows, err := db.QueryContext(ctx, query)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/js/libs/mysql/mysql.go
+++ b/pkg/js/libs/mysql/mysql.go
@@ -38,11 +38,11 @@ type (
 func (c *MySQLClient) IsMySQL(ctx context.Context, host string, port int) (bool, error) {
 	executionId := ctx.Value("executionId").(string)
 	// todo: why this is exposed? Service fingerprint should be automatic
-	return memoizedisMySQL(executionId, host, port)
+	return memoizedisMySQL(ctx, executionId, host, port)
 }
 
 // @memo
-func isMySQL(executionId string, host string, port int) (bool, error) {
+func isMySQL(ctx context.Context, executionId string, host string, port int) (bool, error) {
 	if !protocolstate.IsHostAllowed(executionId, host) {
 		// host is not valid according to network policy
 		return false, protocolstate.ErrHostDenied.Msgf(host)
@@ -52,7 +52,7 @@ func isMySQL(executionId string, host string, port int) (bool, error) {
 		return false, fmt.Errorf("dialers not initialized for %s", executionId)
 	}
 
-	conn, err := dialer.Fastdialer.Dial(context.TODO(), "tcp", net.JoinHostPort(host, fmt.Sprintf("%d", port)))
+	conn, err := dialer.Fastdialer.Dial(ctx, "tcp", net.JoinHostPort(host, fmt.Sprintf("%d", port)))
 	if err != nil {
 		return false, err
 	}
@@ -108,7 +108,7 @@ func (c *MySQLClient) Connect(ctx context.Context, host string, port int, userna
 	if err != nil {
 		return false, err
 	}
-	return connectWithDSN(executionId, dsn)
+	return memoizedconnectWithDSN(ctx, executionId, dsn)
 }
 
 type (
@@ -136,11 +136,11 @@ type (
 // ```
 func (c *MySQLClient) FingerprintMySQL(ctx context.Context, host string, port int) (MySQLInfo, error) {
 	executionId := ctx.Value("executionId").(string)
-	return memoizedfingerprintMySQL(executionId, host, port)
+	return memoizedfingerprintMySQL(ctx, executionId, host, port)
 }
 
 // @memo
-func fingerprintMySQL(executionId string, host string, port int) (MySQLInfo, error) {
+func fingerprintMySQL(ctx context.Context, executionId string, host string, port int) (MySQLInfo, error) {
 	info := MySQLInfo{}
 	if !protocolstate.IsHostAllowed(executionId, host) {
 		// host is not valid according to network policy
@@ -151,7 +151,7 @@ func fingerprintMySQL(executionId string, host string, port int) (MySQLInfo, err
 		return MySQLInfo{}, fmt.Errorf("dialers not initialized for %s", executionId)
 	}
 
-	conn, err := dialer.Fastdialer.Dial(context.TODO(), "tcp", net.JoinHostPort(host, fmt.Sprintf("%d", port)))
+	conn, err := dialer.Fastdialer.Dial(ctx, "tcp", net.JoinHostPort(host, fmt.Sprintf("%d", port)))
 	if err != nil {
 		return info, err
 	}
@@ -192,7 +192,7 @@ func fingerprintMySQL(executionId string, host string, port int) (MySQLInfo, err
 // ```
 func (c *MySQLClient) ConnectWithDSN(ctx context.Context, dsn string) (bool, error) {
 	executionId := ctx.Value("executionId").(string)
-	return memoizedconnectWithDSN(executionId, dsn)
+	return memoizedconnectWithDSN(ctx, executionId, dsn)
 }
 
 // ExecuteQueryWithOpts connects to Mysql database using given credentials

--- a/pkg/js/libs/mysql/mysql_private.go
+++ b/pkg/js/libs/mysql/mysql_private.go
@@ -73,7 +73,7 @@ func BuildDSN(opts MySQLOptions) (string, error) {
 }
 
 // @memo
-func connectWithDSN(executionId string, dsn string) (bool, error) {
+func connectWithDSN(ctx context.Context, executionId string, dsn string) (bool, error) {
 	db, err := sql.Open("mysql", dsn)
 	if err != nil {
 		return false, err
@@ -84,8 +84,8 @@ func connectWithDSN(executionId string, dsn string) (bool, error) {
 	db.SetMaxOpenConns(1)
 	db.SetMaxIdleConns(0)
 
-	ctx := context.WithValue(context.Background(), "executionId", executionId) // nolint: staticcheck
-	err = db.PingContext(ctx)
+	pingCtx := context.WithValue(ctx, "executionId", executionId) // nolint: staticcheck
+	err = db.PingContext(pingCtx)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/js/libs/oracle/memo.oracle.go
+++ b/pkg/js/libs/oracle/memo.oracle.go
@@ -2,17 +2,19 @@
 package oracle
 
 import (
+	"context"
 	"errors"
+
 	"fmt"
 
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
 )
 
-func memoizedisOracle(executionId string, host string, port int) (IsOracleResponse, error) {
+func memoizedisOracle(ctx context.Context, executionId string, host string, port int) (IsOracleResponse, error) {
 	hash := "isOracle" + ":" + fmt.Sprint(executionId) + ":" + fmt.Sprint(host) + ":" + fmt.Sprint(port)
 
 	v, err, _ := protocolstate.Memoizer.Do(hash, func() (interface{}, error) {
-		return isOracle(executionId, host, port)
+		return isOracle(ctx, executionId, host, port)
 	})
 	if err != nil {
 		return IsOracleResponse{}, err

--- a/pkg/js/libs/oracle/oracle.go
+++ b/pkg/js/libs/oracle/oracle.go
@@ -48,11 +48,11 @@ type (
 // ```
 func (c *OracleClient) IsOracle(ctx context.Context, host string, port int) (IsOracleResponse, error) {
 	executionId := ctx.Value("executionId").(string)
-	return memoizedisOracle(executionId, host, port)
+	return memoizedisOracle(ctx, executionId, host, port)
 }
 
 // @memo
-func isOracle(executionId string, host string, port int) (IsOracleResponse, error) {
+func isOracle(ctx context.Context, executionId string, host string, port int) (IsOracleResponse, error) {
 	resp := IsOracleResponse{}
 
 	dialer := protocolstate.GetDialersWithId(executionId)
@@ -61,7 +61,7 @@ func isOracle(executionId string, host string, port int) (IsOracleResponse, erro
 	}
 
 	timeout := 5 * time.Second
-	conn, err := dialer.Fastdialer.Dial(context.TODO(), "tcp", net.JoinHostPort(host, strconv.Itoa(port)))
+	conn, err := dialer.Fastdialer.Dial(ctx, "tcp", net.JoinHostPort(host, strconv.Itoa(port)))
 	if err != nil {
 		return resp, err
 	}

--- a/pkg/js/libs/oracle/oracle.go
+++ b/pkg/js/libs/oracle/oracle.go
@@ -83,27 +83,21 @@ func isOracle(ctx context.Context, executionId string, host string, port int) (I
 	return resp, nil
 }
 
-func (c *OracleClient) oracleDbInstance(connStr string, executionId string) (*goora.OracleConnector, error) {
-	if c.connector != nil {
-		return c.connector, nil
+func (c *OracleClient) oracleDbInstance(ctx context.Context, connStr string, executionId string) (*goora.OracleConnector, error) {
+	if c.connector == nil {
+		connector := goora.NewConnector(connStr)
+		oraConnector, ok := connector.(*goora.OracleConnector)
+		if !ok {
+			return nil, fmt.Errorf("failed to cast connector to OracleConnector")
+		}
+		c.connector = oraConnector
 	}
 
-	connector := goora.NewConnector(connStr)
-	oraConnector, ok := connector.(*goora.OracleConnector)
-	if !ok {
-		return nil, fmt.Errorf("failed to cast connector to OracleConnector")
-	}
+	// Refresh the dialer on every call so the connector uses the current
+	// execution context instead of a stale or already-canceled one.
+	c.connector.Dialer(&oracleCustomDialer{executionId: executionId, ctx: ctx})
 
-	// Create custom dialer wrapper
-	customDialer := &oracleCustomDialer{
-		executionId: executionId,
-	}
-
-	oraConnector.Dialer(customDialer)
-
-	c.connector = oraConnector
-
-	return oraConnector, nil
+	return c.connector, nil
 }
 
 // Connect connects to an Oracle database
@@ -122,7 +116,7 @@ func (c *OracleClient) Connect(ctx context.Context, host string, port int, servi
 func (c *OracleClient) ConnectWithDSN(ctx context.Context, dsn string) (bool, error) {
 	executionId := ctx.Value("executionId").(string)
 
-	connector, err := c.oracleDbInstance(dsn, executionId)
+	connector, err := c.oracleDbInstance(ctx, dsn, executionId)
 	if err != nil {
 		return false, err
 	}
@@ -136,7 +130,7 @@ func (c *OracleClient) ConnectWithDSN(ctx context.Context, dsn string) (bool, er
 	db.SetMaxIdleConns(0)
 
 	// Test the connection
-	err = db.Ping()
+	err = db.PingContext(ctx)
 	if err != nil {
 		return false, err
 	}
@@ -182,7 +176,7 @@ func (c *OracleClient) ExecuteQuery(ctx context.Context, host string, port int, 
 func (c *OracleClient) ExecuteQueryWithDSN(ctx context.Context, dsn string, query string) (*utils.SQLResult, error) {
 	executionId := ctx.Value("executionId").(string)
 
-	connector, err := c.oracleDbInstance(dsn, executionId)
+	connector, err := c.oracleDbInstance(ctx, dsn, executionId)
 	if err != nil {
 		return nil, err
 	}
@@ -194,7 +188,7 @@ func (c *OracleClient) ExecuteQueryWithDSN(ctx context.Context, dsn string, quer
 	db.SetMaxOpenConns(1)
 	db.SetMaxIdleConns(0)
 
-	rows, err := db.Query(query)
+	rows, err := db.QueryContext(ctx, query)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/js/libs/oracle/oracledialer.go
+++ b/pkg/js/libs/oracle/oracledialer.go
@@ -12,9 +12,16 @@ import (
 // oracleCustomDialer implements the dialer interface expected by go-ora
 type oracleCustomDialer struct {
 	executionId string
+	ctx         context.Context
 }
 
 func (o *oracleCustomDialer) dialWithCtx(ctx context.Context, network, address string) (net.Conn, error) {
+	if ctx == nil {
+		ctx = o.ctx
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	dialers := protocolstate.GetDialersWithId(o.executionId)
 	if dialers == nil {
 		return nil, fmt.Errorf("dialers not initialized for %s", o.executionId)
@@ -27,11 +34,15 @@ func (o *oracleCustomDialer) dialWithCtx(ctx context.Context, network, address s
 }
 
 func (o *oracleCustomDialer) Dial(network, address string) (net.Conn, error) {
-	return o.dialWithCtx(context.Background(), network, address)
+	return o.dialWithCtx(o.ctx, network, address)
 }
 
 func (o *oracleCustomDialer) DialTimeout(network, address string, timeout time.Duration) (net.Conn, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	baseCtx := o.ctx
+	if baseCtx == nil {
+		baseCtx = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(baseCtx, timeout)
 	defer cancel()
 
 	return o.dialWithCtx(ctx, network, address)

--- a/pkg/js/libs/oracle/oracledialer.go
+++ b/pkg/js/libs/oracle/oracledialer.go
@@ -27,7 +27,7 @@ func (o *oracleCustomDialer) dialWithCtx(ctx context.Context, network, address s
 }
 
 func (o *oracleCustomDialer) Dial(network, address string) (net.Conn, error) {
-	return o.dialWithCtx(context.TODO(), network, address)
+	return o.dialWithCtx(context.Background(), network, address)
 }
 
 func (o *oracleCustomDialer) DialTimeout(network, address string, timeout time.Duration) (net.Conn, error) {

--- a/pkg/js/libs/pop3/memo.pop3.go
+++ b/pkg/js/libs/pop3/memo.pop3.go
@@ -2,17 +2,19 @@
 package pop3
 
 import (
+	"context"
 	"errors"
+
 	"fmt"
 
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
 )
 
-func memoizedisPoP3(executionId string, host string, port int) (IsPOP3Response, error) {
+func memoizedisPoP3(ctx context.Context, executionId string, host string, port int) (IsPOP3Response, error) {
 	hash := "isPoP3" + ":" + fmt.Sprint(executionId) + ":" + fmt.Sprint(host) + ":" + fmt.Sprint(port)
 
 	v, err, _ := protocolstate.Memoizer.Do(hash, func() (interface{}, error) {
-		return isPoP3(executionId, host, port)
+		return isPoP3(ctx, executionId, host, port)
 	})
 	if err != nil {
 		return IsPOP3Response{}, err

--- a/pkg/js/libs/pop3/pop3.go
+++ b/pkg/js/libs/pop3/pop3.go
@@ -36,11 +36,11 @@ type (
 // ```
 func IsPOP3(ctx context.Context, host string, port int) (IsPOP3Response, error) {
 	executionId := ctx.Value("executionId").(string)
-	return memoizedisPoP3(executionId, host, port)
+	return memoizedisPoP3(ctx, executionId, host, port)
 }
 
 // @memo
-func isPoP3(executionId string, host string, port int) (IsPOP3Response, error) {
+func isPoP3(ctx context.Context, executionId string, host string, port int) (IsPOP3Response, error) {
 	resp := IsPOP3Response{}
 
 	dialer := protocolstate.GetDialersWithId(executionId)
@@ -49,7 +49,7 @@ func isPoP3(executionId string, host string, port int) (IsPOP3Response, error) {
 	}
 
 	timeout := 5 * time.Second
-	conn, err := dialer.Fastdialer.Dial(context.TODO(), "tcp", net.JoinHostPort(host, strconv.Itoa(port)))
+	conn, err := dialer.Fastdialer.Dial(ctx, "tcp", net.JoinHostPort(host, strconv.Itoa(port)))
 	if err != nil {
 		return resp, err
 	}

--- a/pkg/js/libs/postgres/memo.postgres.go
+++ b/pkg/js/libs/postgres/memo.postgres.go
@@ -9,8 +9,6 @@ import (
 
 	utils "github.com/projectdiscovery/nuclei/v3/pkg/js/utils"
 
-	_ "github.com/projectdiscovery/nuclei/v3/pkg/js/utils/pgwrap"
-
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
 )
 

--- a/pkg/js/libs/postgres/memo.postgres.go
+++ b/pkg/js/libs/postgres/memo.postgres.go
@@ -2,7 +2,9 @@
 package postgres
 
 import (
+	"context"
 	"errors"
+
 	"fmt"
 
 	utils "github.com/projectdiscovery/nuclei/v3/pkg/js/utils"
@@ -12,11 +14,11 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
 )
 
-func memoizedisPostgres(executionId string, host string, port int) (bool, error) {
+func memoizedisPostgres(ctx context.Context, executionId string, host string, port int) (bool, error) {
 	hash := "isPostgres" + ":" + fmt.Sprint(executionId) + ":" + fmt.Sprint(host) + ":" + fmt.Sprint(port)
 
 	v, err, _ := protocolstate.Memoizer.Do(hash, func() (interface{}, error) {
-		return isPostgres(executionId, host, port)
+		return isPostgres(ctx, executionId, host, port)
 	})
 	if err != nil {
 		return false, err
@@ -28,11 +30,11 @@ func memoizedisPostgres(executionId string, host string, port int) (bool, error)
 	return false, errors.New("could not convert cached result")
 }
 
-func memoizedexecuteQuery(executionId string, host string, port int, username string, password string, dbName string, query string) (*utils.SQLResult, error) {
+func memoizedexecuteQuery(ctx context.Context, executionId string, host string, port int, username string, password string, dbName string, query string) (*utils.SQLResult, error) {
 	hash := "executeQuery" + ":" + fmt.Sprint(executionId) + ":" + fmt.Sprint(host) + ":" + fmt.Sprint(port) + ":" + fmt.Sprint(username) + ":" + fmt.Sprint(password) + ":" + fmt.Sprint(dbName) + ":" + fmt.Sprint(query)
 
 	v, err, _ := protocolstate.Memoizer.Do(hash, func() (interface{}, error) {
-		return executeQuery(executionId, host, port, username, password, dbName, query)
+		return executeQuery(ctx, executionId, host, port, username, password, dbName, query)
 	})
 	if err != nil {
 		return nil, err
@@ -44,11 +46,11 @@ func memoizedexecuteQuery(executionId string, host string, port int, username st
 	return nil, errors.New("could not convert cached result")
 }
 
-func memoizedconnect(executionId string, host string, port int, username string, password string, dbName string) (bool, error) {
+func memoizedconnect(ctx context.Context, executionId string, host string, port int, username string, password string, dbName string) (bool, error) {
 	hash := "connect" + ":" + fmt.Sprint(executionId) + ":" + fmt.Sprint(host) + ":" + fmt.Sprint(port) + ":" + fmt.Sprint(username) + ":" + fmt.Sprint(password) + ":" + fmt.Sprint(dbName)
 
 	v, err, _ := protocolstate.Memoizer.Do(hash, func() (interface{}, error) {
-		return connect(executionId, host, port, username, password, dbName)
+		return connect(ctx, executionId, host, port, username, password, dbName)
 	})
 	if err != nil {
 		return false, err

--- a/pkg/js/libs/postgres/postgres.go
+++ b/pkg/js/libs/postgres/postgres.go
@@ -2,7 +2,6 @@ package postgres
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"net"
 	"strings"
@@ -12,8 +11,7 @@ import (
 	"github.com/praetorian-inc/fingerprintx/pkg/plugins"
 	postgres "github.com/praetorian-inc/fingerprintx/pkg/plugins/services/postgresql"
 	utils "github.com/projectdiscovery/nuclei/v3/pkg/js/utils"
-	"github.com/projectdiscovery/nuclei/v3/pkg/js/utils/pgwrap"   //nolint:staticcheck // need to call init
-	_ "github.com/projectdiscovery/nuclei/v3/pkg/js/utils/pgwrap" //nolint:staticcheck
+	"github.com/projectdiscovery/nuclei/v3/pkg/js/utils/pgwrap"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
 )
 
@@ -128,7 +126,7 @@ func executeQuery(ctx context.Context, executionId string, host string, port int
 	target := net.JoinHostPort(host, fmt.Sprintf("%d", port))
 
 	connStr := fmt.Sprintf("postgres://%s:%s@%s/%s?sslmode=disable&executionId=%s", username, password, target, dbName, executionId)
-	db, err := sql.Open(pgwrap.PGWrapDriver, connStr)
+	db, err := pgwrap.OpenDB(ctx, executionId, connStr)
 	if err != nil {
 		return nil, err
 	}
@@ -136,7 +134,7 @@ func executeQuery(ctx context.Context, executionId string, host string, port int
 		_ = db.Close()
 	}()
 
-	rows, err := db.Query(query)
+	rows, err := db.QueryContext(ctx, query)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/js/libs/postgres/postgres.go
+++ b/pkg/js/libs/postgres/postgres.go
@@ -39,11 +39,11 @@ type (
 func (c *PGClient) IsPostgres(ctx context.Context, host string, port int) (bool, error) {
 	executionId := ctx.Value("executionId").(string)
 	// todo: why this is exposed? Service fingerprint should be automatic
-	return memoizedisPostgres(executionId, host, port)
+	return memoizedisPostgres(ctx, executionId, host, port)
 }
 
 // @memo
-func isPostgres(executionId string, host string, port int) (bool, error) {
+func isPostgres(ctx context.Context, executionId string, host string, port int) (bool, error) {
 	timeout := 10 * time.Second
 
 	dialer := protocolstate.GetDialersWithId(executionId)
@@ -51,7 +51,7 @@ func isPostgres(executionId string, host string, port int) (bool, error) {
 		return false, fmt.Errorf("dialers not initialized for %s", executionId)
 	}
 
-	conn, err := dialer.Fastdialer.Dial(context.TODO(), "tcp", fmt.Sprintf("%s:%d", host, port))
+	conn, err := dialer.Fastdialer.Dial(ctx, "tcp", fmt.Sprintf("%s:%d", host, port))
 	if err != nil {
 		return false, err
 	}
@@ -91,7 +91,7 @@ func (c *PGClient) Connect(ctx context.Context, host string, port int, username 
 		return false, fmt.Errorf("not a postgres service")
 	}
 	executionId := ctx.Value("executionId").(string)
-	return memoizedconnect(executionId, host, port, username, password, "postgres")
+	return memoizedconnect(ctx, executionId, host, port, username, password, "postgres")
 }
 
 // ExecuteQuery connects to Postgres database using given credentials and database name.
@@ -115,11 +115,11 @@ func (c *PGClient) ExecuteQuery(ctx context.Context, host string, port int, user
 
 	executionId := ctx.Value("executionId").(string)
 
-	return memoizedexecuteQuery(executionId, host, port, username, password, dbName, query)
+	return memoizedexecuteQuery(ctx, executionId, host, port, username, password, dbName, query)
 }
 
 // @memo
-func executeQuery(executionId string, host string, port int, username string, password string, dbName string, query string) (*utils.SQLResult, error) {
+func executeQuery(ctx context.Context, executionId string, host string, port int, username string, password string, dbName string, query string) (*utils.SQLResult, error) {
 	if !protocolstate.IsHostAllowed(executionId, host) {
 		// host is not valid according to network policy
 		return nil, protocolstate.ErrHostDenied.Msgf(host)
@@ -168,11 +168,11 @@ func (c *PGClient) ConnectWithDB(ctx context.Context, host string, port int, use
 
 	executionId := ctx.Value("executionId").(string)
 
-	return memoizedconnect(executionId, host, port, username, password, dbName)
+	return memoizedconnect(ctx, executionId, host, port, username, password, dbName)
 }
 
 // @memo
-func connect(executionId string, host string, port int, username string, password string, dbName string) (bool, error) {
+func connect(ctx context.Context, executionId string, host string, port int, username string, password string, dbName string) (bool, error) {
 	if host == "" || port <= 0 {
 		return false, fmt.Errorf("invalid host or port")
 	}
@@ -184,7 +184,7 @@ func connect(executionId string, host string, port int, username string, passwor
 
 	target := net.JoinHostPort(host, fmt.Sprintf("%d", port))
 
-	ctx, cancel := context.WithCancel(context.Background())
+	execCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	dialer := protocolstate.GetDialersWithId(executionId)
@@ -207,7 +207,7 @@ func connect(executionId string, host string, port int, username string, passwor
 		_ = db.Close()
 	}()
 
-	_, err := db.ExecContext(ctx, "select 1")
+	_, err := db.ExecContext(execCtx, "select 1")
 	if err != nil {
 		switch true {
 		case strings.Contains(err.Error(), "connect: connection refused"):

--- a/pkg/js/libs/rdp/memo.rdp.go
+++ b/pkg/js/libs/rdp/memo.rdp.go
@@ -2,17 +2,19 @@
 package rdp
 
 import (
+	"context"
 	"errors"
+
 	"fmt"
 
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
 )
 
-func memoizedisRDP(executionId string, host string, port int) (IsRDPResponse, error) {
+func memoizedisRDP(ctx context.Context, executionId string, host string, port int) (IsRDPResponse, error) {
 	hash := "isRDP" + ":" + fmt.Sprint(executionId) + ":" + fmt.Sprint(host) + ":" + fmt.Sprint(port)
 
 	v, err, _ := protocolstate.Memoizer.Do(hash, func() (interface{}, error) {
-		return isRDP(executionId, host, port)
+		return isRDP(ctx, executionId, host, port)
 	})
 	if err != nil {
 		return IsRDPResponse{}, err
@@ -24,11 +26,11 @@ func memoizedisRDP(executionId string, host string, port int) (IsRDPResponse, er
 	return IsRDPResponse{}, errors.New("could not convert cached result")
 }
 
-func memoizedcheckRDPAuth(executionId string, host string, port int) (CheckRDPAuthResponse, error) {
+func memoizedcheckRDPAuth(ctx context.Context, executionId string, host string, port int) (CheckRDPAuthResponse, error) {
 	hash := "checkRDPAuth" + ":" + fmt.Sprint(executionId) + ":" + fmt.Sprint(host) + ":" + fmt.Sprint(port)
 
 	v, err, _ := protocolstate.Memoizer.Do(hash, func() (interface{}, error) {
-		return checkRDPAuth(executionId, host, port)
+		return checkRDPAuth(ctx, executionId, host, port)
 	})
 	if err != nil {
 		return CheckRDPAuthResponse{}, err
@@ -40,11 +42,11 @@ func memoizedcheckRDPAuth(executionId string, host string, port int) (CheckRDPAu
 	return CheckRDPAuthResponse{}, errors.New("could not convert cached result")
 }
 
-func memoizedcheckRDPEncryption(executionId string, host string, port int) (RDPEncryptionResponse, error) {
+func memoizedcheckRDPEncryption(ctx context.Context, executionId string, host string, port int) (RDPEncryptionResponse, error) {
 	hash := "checkRDPEncryption" + ":" + fmt.Sprint(executionId) + ":" + fmt.Sprint(host) + ":" + fmt.Sprint(port)
 
 	v, err, _ := protocolstate.Memoizer.Do(hash, func() (interface{}, error) {
-		return checkRDPEncryption(executionId, host, port)
+		return checkRDPEncryption(ctx, executionId, host, port)
 	})
 	if err != nil {
 		return RDPEncryptionResponse{}, err

--- a/pkg/js/libs/rdp/rdp.go
+++ b/pkg/js/libs/rdp/rdp.go
@@ -211,17 +211,21 @@ func checkRDPEncryption(ctx context.Context, executionId string, host string, po
 
 	for name, value := range protocols {
 		dialCtx, cancel := context.WithTimeout(ctx, defaultTimeout)
-		defer cancel()
 		conn, err := dialer.Fastdialer.Dial(dialCtx, "tcp", net.JoinHostPort(host, strconv.Itoa(port)))
 		if err != nil {
+			cancel()
 			continue
 		}
-		defer func() {
+		if err := setConnDeadlineFromContext(conn, dialCtx); err != nil {
 			_ = conn.Close()
-		}()
+			cancel()
+			continue
+		}
 
 		// Test protocol
 		isRDP, err := testRDPProtocol(conn, value)
+		_ = conn.Close()
+		cancel()
 		if err == nil && isRDP {
 			switch SecurityLayer(name) {
 			case SecurityLayerNativeRDP:
@@ -248,17 +252,21 @@ func checkRDPEncryption(ctx context.Context, executionId string, host string, po
 
 	for encryptionLevel, value := range ciphers {
 		dialCtx, cancel := context.WithTimeout(ctx, defaultTimeout)
-		defer cancel()
 		conn, err := dialer.Fastdialer.Dial(dialCtx, "tcp", net.JoinHostPort(host, strconv.Itoa(port)))
 		if err != nil {
+			cancel()
 			continue
 		}
-		defer func() {
+		if err := setConnDeadlineFromContext(conn, dialCtx); err != nil {
 			_ = conn.Close()
-		}()
+			cancel()
+			continue
+		}
 
 		// Test cipher
 		isRDP, err := testRDPCipher(conn, value)
+		_ = conn.Close()
+		cancel()
 		if err == nil && isRDP {
 			switch encryptionLevel {
 			case EncryptionLevelRC4_40bit:
@@ -274,6 +282,14 @@ func checkRDPEncryption(ctx context.Context, executionId string, host string, po
 	}
 
 	return resp, nil
+}
+
+func setConnDeadlineFromContext(conn net.Conn, ctx context.Context) error {
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return nil
+	}
+	return conn.SetDeadline(deadline)
 }
 
 // testRDPProtocol tests RDP with a specific security protocol

--- a/pkg/js/libs/rdp/rdp.go
+++ b/pkg/js/libs/rdp/rdp.go
@@ -39,11 +39,11 @@ type (
 // ```
 func IsRDP(ctx context.Context, host string, port int) (IsRDPResponse, error) {
 	executionId := ctx.Value("executionId").(string)
-	return memoizedisRDP(executionId, host, port)
+	return memoizedisRDP(ctx, executionId, host, port)
 }
 
 // @memo
-func isRDP(executionId string, host string, port int) (IsRDPResponse, error) {
+func isRDP(ctx context.Context, executionId string, host string, port int) (IsRDPResponse, error) {
 	resp := IsRDPResponse{}
 
 	dialer := protocolstate.GetDialersWithId(executionId)
@@ -52,7 +52,7 @@ func isRDP(executionId string, host string, port int) (IsRDPResponse, error) {
 	}
 
 	timeout := 5 * time.Second
-	conn, err := dialer.Fastdialer.Dial(context.TODO(), "tcp", fmt.Sprintf("%s:%d", host, port))
+	conn, err := dialer.Fastdialer.Dial(ctx, "tcp", fmt.Sprintf("%s:%d", host, port))
 	if err != nil {
 		return resp, err
 	}
@@ -98,11 +98,11 @@ type (
 // ```
 func CheckRDPAuth(ctx context.Context, host string, port int) (CheckRDPAuthResponse, error) {
 	executionId := ctx.Value("executionId").(string)
-	return memoizedcheckRDPAuth(executionId, host, port)
+	return memoizedcheckRDPAuth(ctx, executionId, host, port)
 }
 
 // @memo
-func checkRDPAuth(executionId string, host string, port int) (CheckRDPAuthResponse, error) {
+func checkRDPAuth(ctx context.Context, executionId string, host string, port int) (CheckRDPAuthResponse, error) {
 	resp := CheckRDPAuthResponse{}
 
 	dialer := protocolstate.GetDialersWithId(executionId)
@@ -110,7 +110,7 @@ func checkRDPAuth(executionId string, host string, port int) (CheckRDPAuthRespon
 		return CheckRDPAuthResponse{}, fmt.Errorf("dialers not initialized for %s", executionId)
 	}
 	timeout := 5 * time.Second
-	conn, err := dialer.Fastdialer.Dial(context.TODO(), "tcp", fmt.Sprintf("%s:%d", host, port))
+	conn, err := dialer.Fastdialer.Dial(ctx, "tcp", fmt.Sprintf("%s:%d", host, port))
 	if err != nil {
 		return resp, err
 	}
@@ -188,11 +188,11 @@ type (
 // ```
 func CheckRDPEncryption(ctx context.Context, host string, port int) (RDPEncryptionResponse, error) {
 	executionId := ctx.Value("executionId").(string)
-	return memoizedcheckRDPEncryption(executionId, host, port)
+	return memoizedcheckRDPEncryption(ctx, executionId, host, port)
 }
 
 // @memo
-func checkRDPEncryption(executionId string, host string, port int) (RDPEncryptionResponse, error) {
+func checkRDPEncryption(ctx context.Context, executionId string, host string, port int) (RDPEncryptionResponse, error) {
 	dialer := protocolstate.GetDialersWithId(executionId)
 	if dialer == nil {
 		return RDPEncryptionResponse{}, fmt.Errorf("dialers not initialized for %s", executionId)
@@ -210,9 +210,9 @@ func checkRDPEncryption(executionId string, host string, port int) (RDPEncryptio
 	}
 
 	for name, value := range protocols {
-		ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+		dialCtx, cancel := context.WithTimeout(ctx, defaultTimeout)
 		defer cancel()
-		conn, err := dialer.Fastdialer.Dial(ctx, "tcp", net.JoinHostPort(host, strconv.Itoa(port)))
+		conn, err := dialer.Fastdialer.Dial(dialCtx, "tcp", net.JoinHostPort(host, strconv.Itoa(port)))
 		if err != nil {
 			continue
 		}
@@ -247,9 +247,9 @@ func checkRDPEncryption(executionId string, host string, port int) (RDPEncryptio
 	}
 
 	for encryptionLevel, value := range ciphers {
-		ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+		dialCtx, cancel := context.WithTimeout(ctx, defaultTimeout)
 		defer cancel()
-		conn, err := dialer.Fastdialer.Dial(ctx, "tcp", net.JoinHostPort(host, strconv.Itoa(port)))
+		conn, err := dialer.Fastdialer.Dial(dialCtx, "tcp", net.JoinHostPort(host, strconv.Itoa(port)))
 		if err != nil {
 			continue
 		}

--- a/pkg/js/libs/redis/memo.redis.go
+++ b/pkg/js/libs/redis/memo.redis.go
@@ -2,17 +2,19 @@
 package redis
 
 import (
+	"context"
 	"errors"
+
 	"fmt"
 
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
 )
 
-func memoizedgetServerInfo(executionId string, host string, port int) (string, error) {
+func memoizedgetServerInfo(ctx context.Context, executionId string, host string, port int) (string, error) {
 	hash := "getServerInfo" + ":" + fmt.Sprint(executionId) + ":" + fmt.Sprint(host) + ":" + fmt.Sprint(port)
 
 	v, err, _ := protocolstate.Memoizer.Do(hash, func() (interface{}, error) {
-		return getServerInfo(executionId, host, port)
+		return getServerInfo(ctx, executionId, host, port)
 	})
 	if err != nil {
 		return "", err
@@ -24,11 +26,11 @@ func memoizedgetServerInfo(executionId string, host string, port int) (string, e
 	return "", errors.New("could not convert cached result")
 }
 
-func memoizedconnect(executionId string, host string, port int, password string) (bool, error) {
+func memoizedconnect(ctx context.Context, executionId string, host string, port int, password string) (bool, error) {
 	hash := "connect" + ":" + fmt.Sprint(executionId) + ":" + fmt.Sprint(host) + ":" + fmt.Sprint(port) + ":" + fmt.Sprint(password)
 
 	v, err, _ := protocolstate.Memoizer.Do(hash, func() (interface{}, error) {
-		return connect(executionId, host, port, password)
+		return connect(ctx, executionId, host, port, password)
 	})
 	if err != nil {
 		return false, err
@@ -40,11 +42,11 @@ func memoizedconnect(executionId string, host string, port int, password string)
 	return false, errors.New("could not convert cached result")
 }
 
-func memoizedgetServerInfoAuth(executionId string, host string, port int, password string) (string, error) {
+func memoizedgetServerInfoAuth(ctx context.Context, executionId string, host string, port int, password string) (string, error) {
 	hash := "getServerInfoAuth" + ":" + fmt.Sprint(executionId) + ":" + fmt.Sprint(host) + ":" + fmt.Sprint(port) + ":" + fmt.Sprint(password)
 
 	v, err, _ := protocolstate.Memoizer.Do(hash, func() (interface{}, error) {
-		return getServerInfoAuth(executionId, host, port, password)
+		return getServerInfoAuth(ctx, executionId, host, port, password)
 	})
 	if err != nil {
 		return "", err
@@ -56,11 +58,11 @@ func memoizedgetServerInfoAuth(executionId string, host string, port int, passwo
 	return "", errors.New("could not convert cached result")
 }
 
-func memoizedisAuthenticated(executionId string, host string, port int) (bool, error) {
+func memoizedisAuthenticated(ctx context.Context, executionId string, host string, port int) (bool, error) {
 	hash := "isAuthenticated" + ":" + fmt.Sprint(executionId) + ":" + fmt.Sprint(host) + ":" + fmt.Sprint(port)
 
 	v, err, _ := protocolstate.Memoizer.Do(hash, func() (interface{}, error) {
-		return isAuthenticated(executionId, host, port)
+		return isAuthenticated(ctx, executionId, host, port)
 	})
 	if err != nil {
 		return false, err

--- a/pkg/js/libs/redis/redis.go
+++ b/pkg/js/libs/redis/redis.go
@@ -20,11 +20,11 @@ import (
 // ```
 func GetServerInfo(ctx context.Context, host string, port int) (string, error) {
 	executionId := ctx.Value("executionId").(string)
-	return memoizedgetServerInfo(executionId, host, port)
+	return memoizedgetServerInfo(ctx, executionId, host, port)
 }
 
 // @memo
-func getServerInfo(executionId string, host string, port int) (string, error) {
+func getServerInfo(ctx context.Context, executionId string, host string, port int) (string, error) {
 	if !protocolstate.IsHostAllowed(executionId, host) {
 		// host is not valid according to network policy
 		return "", protocolstate.ErrHostDenied.Msgf(host)
@@ -40,13 +40,13 @@ func getServerInfo(executionId string, host string, port int) (string, error) {
 	}()
 
 	// Ping the Redis server
-	_, err := client.Ping(context.TODO()).Result()
+	_, err := client.Ping(ctx).Result()
 	if err != nil {
 		return "", err
 	}
 
 	// Get Redis server info
-	infoCmd := client.Info(context.TODO())
+	infoCmd := client.Info(ctx)
 	if infoCmd.Err() != nil {
 		return "", infoCmd.Err()
 	}
@@ -62,11 +62,11 @@ func getServerInfo(executionId string, host string, port int) (string, error) {
 // ```
 func Connect(ctx context.Context, host string, port int, password string) (bool, error) {
 	executionId := ctx.Value("executionId").(string)
-	return memoizedconnect(executionId, host, port, password)
+	return memoizedconnect(ctx, executionId, host, port, password)
 }
 
 // @memo
-func connect(executionId string, host string, port int, password string) (bool, error) {
+func connect(ctx context.Context, executionId string, host string, port int, password string) (bool, error) {
 	if !protocolstate.IsHostAllowed(executionId, host) {
 		// host is not valid according to network policy
 		return false, protocolstate.ErrHostDenied.Msgf(host)
@@ -81,12 +81,12 @@ func connect(executionId string, host string, port int, password string) (bool, 
 		_ = client.Close()
 	}()
 
-	_, err := client.Ping(context.TODO()).Result()
+	_, err := client.Ping(ctx).Result()
 	if err != nil {
 		return false, err
 	}
 	// Get Redis server info
-	infoCmd := client.Info(context.TODO())
+	infoCmd := client.Info(ctx)
 	if infoCmd.Err() != nil {
 		return false, infoCmd.Err()
 	}
@@ -102,11 +102,11 @@ func connect(executionId string, host string, port int, password string) (bool, 
 // ```
 func GetServerInfoAuth(ctx context.Context, host string, port int, password string) (string, error) {
 	executionId := ctx.Value("executionId").(string)
-	return memoizedgetServerInfoAuth(executionId, host, port, password)
+	return memoizedgetServerInfoAuth(ctx, executionId, host, port, password)
 }
 
 // @memo
-func getServerInfoAuth(executionId string, host string, port int, password string) (string, error) {
+func getServerInfoAuth(ctx context.Context, executionId string, host string, port int, password string) (string, error) {
 	if !protocolstate.IsHostAllowed(executionId, host) {
 		// host is not valid according to network policy
 		return "", protocolstate.ErrHostDenied.Msgf(host)
@@ -122,13 +122,13 @@ func getServerInfoAuth(executionId string, host string, port int, password strin
 	}()
 
 	// Ping the Redis server
-	_, err := client.Ping(context.TODO()).Result()
+	_, err := client.Ping(ctx).Result()
 	if err != nil {
 		return "", err
 	}
 
 	// Get Redis server info
-	infoCmd := client.Info(context.TODO())
+	infoCmd := client.Info(ctx)
 	if infoCmd.Err() != nil {
 		return "", infoCmd.Err()
 	}
@@ -144,11 +144,11 @@ func getServerInfoAuth(executionId string, host string, port int, password strin
 // ```
 func IsAuthenticated(ctx context.Context, host string, port int) (bool, error) {
 	executionId := ctx.Value("executionId").(string)
-	return memoizedisAuthenticated(executionId, host, port)
+	return memoizedisAuthenticated(ctx, executionId, host, port)
 }
 
 // @memo
-func isAuthenticated(executionId string, host string, port int) (bool, error) {
+func isAuthenticated(ctx context.Context, executionId string, host string, port int) (bool, error) {
 	plugin := pluginsredis.REDISPlugin{}
 	timeout := 5 * time.Second
 	dialer := protocolstate.GetDialersWithId(executionId)
@@ -156,7 +156,7 @@ func isAuthenticated(executionId string, host string, port int) (bool, error) {
 		return false, fmt.Errorf("dialers not initialized for %s", executionId)
 	}
 
-	conn, err := dialer.Fastdialer.Dial(context.TODO(), "tcp", fmt.Sprintf("%s:%d", host, port))
+	conn, err := dialer.Fastdialer.Dial(ctx, "tcp", fmt.Sprintf("%s:%d", host, port))
 	if err != nil {
 		return false, err
 	}
@@ -194,13 +194,13 @@ func RunLuaScript(ctx context.Context, host string, port int, password string, s
 	}()
 
 	// Ping the Redis server
-	_, err := client.Ping(context.TODO()).Result()
+	_, err := client.Ping(ctx).Result()
 	if err != nil {
 		return "", err
 	}
 
 	// Get Redis server info
-	infoCmd := client.Eval(context.Background(), script, []string{})
+	infoCmd := client.Eval(ctx, script, []string{})
 
 	if infoCmd.Err() != nil {
 		return "", infoCmd.Err()

--- a/pkg/js/libs/rsync/memo.rsync.go
+++ b/pkg/js/libs/rsync/memo.rsync.go
@@ -2,17 +2,19 @@
 package rsync
 
 import (
+	"context"
 	"errors"
+
 	"fmt"
 
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
 )
 
-func memoizedisRsync(executionId string, host string, port int) (IsRsyncResponse, error) {
+func memoizedisRsync(ctx context.Context, executionId string, host string, port int) (IsRsyncResponse, error) {
 	hash := "isRsync" + ":" + fmt.Sprint(executionId) + ":" + fmt.Sprint(host) + ":" + fmt.Sprint(port)
 
 	v, err, _ := protocolstate.Memoizer.Do(hash, func() (interface{}, error) {
-		return isRsync(executionId, host, port)
+		return isRsync(ctx, executionId, host, port)
 	})
 	if err != nil {
 		return IsRsyncResponse{}, err

--- a/pkg/js/libs/rsync/rsync.go
+++ b/pkg/js/libs/rsync/rsync.go
@@ -54,12 +54,12 @@ type (
 	}
 )
 
-func connectWithFastDialer(executionId string, host string, port int) (net.Conn, error) {
+func connectWithFastDialer(ctx context.Context, executionId string, host string, port int) (net.Conn, error) {
 	dialer := protocolstate.GetDialersWithId(executionId)
 	if dialer == nil {
 		return nil, fmt.Errorf("dialers not initialized for %s", executionId)
 	}
-	return dialer.Fastdialer.Dial(context.Background(), "tcp", net.JoinHostPort(host, strconv.Itoa(port)))
+	return dialer.Fastdialer.Dial(ctx, "tcp", net.JoinHostPort(host, strconv.Itoa(port)))
 }
 
 // IsRsync checks if a host is running a Rsync server.
@@ -71,15 +71,15 @@ func connectWithFastDialer(executionId string, host string, port int) (net.Conn,
 // ```
 func IsRsync(ctx context.Context, host string, port int) (IsRsyncResponse, error) {
 	executionId := ctx.Value("executionId").(string)
-	return memoizedisRsync(executionId, host, port)
+	return memoizedisRsync(ctx, executionId, host, port)
 }
 
 // @memo
-func isRsync(executionId string, host string, port int) (IsRsyncResponse, error) {
+func isRsync(ctx context.Context, executionId string, host string, port int) (IsRsyncResponse, error) {
 	resp := IsRsyncResponse{}
 
 	timeout := 5 * time.Second
-	conn, err := connectWithFastDialer(executionId, host, port)
+	conn, err := connectWithFastDialer(ctx, executionId, host, port)
 	if err != nil {
 		return resp, err
 	}

--- a/pkg/js/libs/smb/memo.smb.go
+++ b/pkg/js/libs/smb/memo.smb.go
@@ -2,7 +2,9 @@
 package smb
 
 import (
+	"context"
 	"errors"
+
 	"fmt"
 
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
@@ -10,11 +12,11 @@ import (
 	"github.com/zmap/zgrab2/lib/smb/smb"
 )
 
-func memoizedconnectSMBInfoMode(executionId string, host string, port int) (*smb.SMBLog, error) {
+func memoizedconnectSMBInfoMode(ctx context.Context, executionId string, host string, port int) (*smb.SMBLog, error) {
 	hash := "connectSMBInfoMode" + ":" + fmt.Sprint(executionId) + ":" + fmt.Sprint(host) + ":" + fmt.Sprint(port)
 
 	v, err, _ := protocolstate.Memoizer.Do(hash, func() (interface{}, error) {
-		return connectSMBInfoMode(executionId, host, port)
+		return connectSMBInfoMode(ctx, executionId, host, port)
 	})
 	if err != nil {
 		return nil, err
@@ -26,11 +28,11 @@ func memoizedconnectSMBInfoMode(executionId string, host string, port int) (*smb
 	return nil, errors.New("could not convert cached result")
 }
 
-func memoizedlistShares(executionId string, host string, port int, user string, password string) ([]string, error) {
+func memoizedlistShares(ctx context.Context, executionId string, host string, port int, user string, password string) ([]string, error) {
 	hash := "listShares" + ":" + fmt.Sprint(executionId) + ":" + fmt.Sprint(host) + ":" + fmt.Sprint(port) + ":" + fmt.Sprint(user) + ":" + fmt.Sprint(password)
 
 	v, err, _ := protocolstate.Memoizer.Do(hash, func() (interface{}, error) {
-		return listShares(executionId, host, port, user, password)
+		return listShares(ctx, executionId, host, port, user, password)
 	})
 	if err != nil {
 		return []string{}, err

--- a/pkg/js/libs/smb/memo.smb_private.go
+++ b/pkg/js/libs/smb/memo.smb_private.go
@@ -2,7 +2,9 @@
 package smb
 
 import (
+	"context"
 	"errors"
+
 	"fmt"
 
 	"time"
@@ -12,11 +14,11 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
 )
 
-func memoizedcollectSMBv2Metadata(executionId string, host string, port int, timeout time.Duration) (*plugins.ServiceSMB, error) {
+func memoizedcollectSMBv2Metadata(ctx context.Context, executionId string, host string, port int, timeout time.Duration) (*plugins.ServiceSMB, error) {
 	hash := "collectSMBv2Metadata" + ":" + fmt.Sprint(executionId) + ":" + fmt.Sprint(host) + ":" + fmt.Sprint(port) + ":" + fmt.Sprint(timeout)
 
 	v, err, _ := protocolstate.Memoizer.Do(hash, func() (interface{}, error) {
-		return collectSMBv2Metadata(executionId, host, port, timeout)
+		return collectSMBv2Metadata(ctx, executionId, host, port, timeout)
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/js/libs/smb/memo.smbghost.go
+++ b/pkg/js/libs/smb/memo.smbghost.go
@@ -2,6 +2,8 @@
 package smb
 
 import (
+	"context"
+
 	"errors"
 
 	"fmt"
@@ -9,11 +11,11 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
 )
 
-func memoizeddetectSMBGhost(executionId string, host string, port int) (bool, error) {
+func memoizeddetectSMBGhost(ctx context.Context, executionId string, host string, port int) (bool, error) {
 	hash := "detectSMBGhost" + ":" + fmt.Sprint(executionId) + ":" + fmt.Sprint(host) + ":" + fmt.Sprint(port)
 
 	v, err, _ := protocolstate.Memoizer.Do(hash, func() (interface{}, error) {
-		return detectSMBGhost(executionId, host, port)
+		return detectSMBGhost(ctx, executionId, host, port)
 	})
 	if err != nil {
 		return false, err

--- a/pkg/js/libs/smb/smb.go
+++ b/pkg/js/libs/smb/smb.go
@@ -36,11 +36,11 @@ type (
 // ```
 func (c *SMBClient) ConnectSMBInfoMode(ctx context.Context, host string, port int) (*smb.SMBLog, error) {
 	executionId := ctx.Value("executionId").(string)
-	return memoizedconnectSMBInfoMode(executionId, host, port)
+	return memoizedconnectSMBInfoMode(ctx, executionId, host, port)
 }
 
 // @memo
-func connectSMBInfoMode(executionId string, host string, port int) (*smb.SMBLog, error) {
+func connectSMBInfoMode(ctx context.Context, executionId string, host string, port int) (*smb.SMBLog, error) {
 	if !protocolstate.IsHostAllowed(executionId, host) {
 		// host is not valid according to network policy
 		return nil, protocolstate.ErrHostDenied.Msgf(host)
@@ -49,7 +49,7 @@ func connectSMBInfoMode(executionId string, host string, port int) (*smb.SMBLog,
 	if dialer == nil {
 		return nil, fmt.Errorf("dialers not initialized for %s", executionId)
 	}
-	conn, err := dialer.Fastdialer.Dial(context.TODO(), "tcp", fmt.Sprintf("%s:%d", host, port))
+	conn, err := dialer.Fastdialer.Dial(ctx, "tcp", fmt.Sprintf("%s:%d", host, port))
 	if err != nil {
 		return nil, err
 	}
@@ -61,7 +61,7 @@ func connectSMBInfoMode(executionId string, host string, port int) (*smb.SMBLog,
 	}
 
 	// try to negotiate SMBv1
-	conn, err = dialer.Fastdialer.Dial(context.TODO(), "tcp", fmt.Sprintf("%s:%d", host, port))
+	conn, err = dialer.Fastdialer.Dial(ctx, "tcp", fmt.Sprintf("%s:%d", host, port))
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +92,7 @@ func (c *SMBClient) ListSMBv2Metadata(ctx context.Context, host string, port int
 		// host is not valid according to network policy
 		return nil, protocolstate.ErrHostDenied.Msgf(host)
 	}
-	return memoizedcollectSMBv2Metadata(executionId, host, port, 5*time.Second)
+	return memoizedcollectSMBv2Metadata(ctx, executionId, host, port, 5*time.Second)
 }
 
 // ListShares tries to connect to provided host and port
@@ -112,11 +112,11 @@ func (c *SMBClient) ListSMBv2Metadata(ctx context.Context, host string, port int
 // ```
 func (c *SMBClient) ListShares(ctx context.Context, host string, port int, user, password string) ([]string, error) {
 	executionId := ctx.Value("executionId").(string)
-	return memoizedlistShares(executionId, host, port, user, password)
+	return memoizedlistShares(ctx, executionId, host, port, user, password)
 }
 
 // @memo
-func listShares(executionId string, host string, port int, user string, password string) ([]string, error) {
+func listShares(ctx context.Context, executionId string, host string, port int, user string, password string) ([]string, error) {
 	if !protocolstate.IsHostAllowed(executionId, host) {
 		// host is not valid according to network policy
 		return nil, protocolstate.ErrHostDenied.Msgf(host)
@@ -126,7 +126,7 @@ func listShares(executionId string, host string, port int, user string, password
 		return nil, fmt.Errorf("dialers not initialized for %s", executionId)
 	}
 
-	conn, err := dialer.Fastdialer.Dial(context.TODO(), "tcp", fmt.Sprintf("%s:%d", host, port))
+	conn, err := dialer.Fastdialer.Dial(ctx, "tcp", fmt.Sprintf("%s:%d", host, port))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/js/libs/smb/smb_private.go
+++ b/pkg/js/libs/smb/smb_private.go
@@ -16,7 +16,7 @@ import (
 
 // collectSMBv2Metadata collects metadata for SMBv2 services.
 // @memo
-func collectSMBv2Metadata(executionId string, host string, port int, timeout time.Duration) (*plugins.ServiceSMB, error) {
+func collectSMBv2Metadata(ctx context.Context, executionId string, host string, port int, timeout time.Duration) (*plugins.ServiceSMB, error) {
 	if timeout == 0 {
 		timeout = 5 * time.Second
 	}
@@ -25,7 +25,7 @@ func collectSMBv2Metadata(executionId string, host string, port int, timeout tim
 		return nil, fmt.Errorf("dialers not initialized for %s", executionId)
 	}
 
-	conn, err := dialer.Fastdialer.Dial(context.TODO(), "tcp", net.JoinHostPort(host, fmt.Sprintf("%d", port)))
+	conn, err := dialer.Fastdialer.Dial(ctx, "tcp", net.JoinHostPort(host, fmt.Sprintf("%d", port)))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/js/libs/smb/smbghost.go
+++ b/pkg/js/libs/smb/smbghost.go
@@ -28,11 +28,11 @@ const (
 // ```
 func (c *SMBClient) DetectSMBGhost(ctx context.Context, host string, port int) (bool, error) {
 	executionId := ctx.Value("executionId").(string)
-	return memoizeddetectSMBGhost(executionId, host, port)
+	return memoizeddetectSMBGhost(ctx, executionId, host, port)
 }
 
 // @memo
-func detectSMBGhost(executionId string, host string, port int) (bool, error) {
+func detectSMBGhost(ctx context.Context, executionId string, host string, port int) (bool, error) {
 	if !protocolstate.IsHostAllowed(executionId, host) {
 		// host is not valid according to network policy
 		return false, protocolstate.ErrHostDenied.Msgf(host)
@@ -42,7 +42,7 @@ func detectSMBGhost(executionId string, host string, port int) (bool, error) {
 	if dialer == nil {
 		return false, fmt.Errorf("dialers not initialized for %s", executionId)
 	}
-	conn, err := dialer.Fastdialer.Dial(context.TODO(), "tcp", addr)
+	conn, err := dialer.Fastdialer.Dial(ctx, "tcp", addr)
 	if err != nil {
 		return false, err
 

--- a/pkg/js/libs/smtp/smtp.go
+++ b/pkg/js/libs/smtp/smtp.go
@@ -1,7 +1,6 @@
 package smtp
 
 import (
-	"context"
 	"fmt"
 	"net"
 	"net/smtp"
@@ -95,7 +94,7 @@ func (c *Client) IsSMTP() (SMTPResponse, error) {
 		return SMTPResponse{}, fmt.Errorf("dialers not initialized for %s", executionId)
 	}
 
-	conn, err := dialer.Fastdialer.Dial(context.TODO(), "tcp", net.JoinHostPort(c.host, c.port))
+	conn, err := dialer.Fastdialer.Dial(c.nj.Context(), "tcp", net.JoinHostPort(c.host, c.port))
 	if err != nil {
 		return resp, err
 	}
@@ -139,7 +138,7 @@ func (c *Client) IsOpenRelay(msg *SMTPMessage) (bool, error) {
 	}
 
 	addr := net.JoinHostPort(c.host, c.port)
-	conn, err := dialer.Fastdialer.Dial(context.TODO(), "tcp", addr)
+	conn, err := dialer.Fastdialer.Dial(c.nj.Context(), "tcp", addr)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/js/libs/telnet/memo.telnet.go
+++ b/pkg/js/libs/telnet/memo.telnet.go
@@ -2,17 +2,19 @@
 package telnet
 
 import (
+	"context"
 	"errors"
+
 	"fmt"
 
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
 )
 
-func memoizedisTelnet(executionId string, host string, port int) (IsTelnetResponse, error) {
+func memoizedisTelnet(ctx context.Context, executionId string, host string, port int) (IsTelnetResponse, error) {
 	hash := "isTelnet" + ":" + fmt.Sprint(executionId) + ":" + fmt.Sprint(host) + ":" + fmt.Sprint(port)
 
 	v, err, _ := protocolstate.Memoizer.Do(hash, func() (interface{}, error) {
-		return isTelnet(executionId, host, port)
+		return isTelnet(ctx, executionId, host, port)
 	})
 	if err != nil {
 		return IsTelnetResponse{}, err

--- a/pkg/js/libs/telnet/telnet.go
+++ b/pkg/js/libs/telnet/telnet.go
@@ -75,11 +75,11 @@ type (
 // ```
 func IsTelnet(ctx context.Context, host string, port int) (IsTelnetResponse, error) {
 	executionId := ctx.Value("executionId").(string)
-	return memoizedisTelnet(executionId, host, port)
+	return memoizedisTelnet(ctx, executionId, host, port)
 }
 
 // @memo
-func isTelnet(executionId string, host string, port int) (IsTelnetResponse, error) {
+func isTelnet(ctx context.Context, executionId string, host string, port int) (IsTelnetResponse, error) {
 	resp := IsTelnetResponse{}
 
 	timeout := 5 * time.Second
@@ -88,7 +88,7 @@ func isTelnet(executionId string, host string, port int) (IsTelnetResponse, erro
 		return IsTelnetResponse{}, fmt.Errorf("dialers not initialized for %s", executionId)
 	}
 
-	conn, err := dialer.Fastdialer.Dial(context.TODO(), "tcp", net.JoinHostPort(host, strconv.Itoa(port)))
+	conn, err := dialer.Fastdialer.Dial(ctx, "tcp", net.JoinHostPort(host, strconv.Itoa(port)))
 	if err != nil {
 		return resp, err
 	}
@@ -132,7 +132,7 @@ func (c *TelnetClient) Connect(ctx context.Context, host string, port int, usern
 	}
 
 	// Create TCP connection
-	conn, err := dialer.Fastdialer.Dial(context.TODO(), "tcp", net.JoinHostPort(host, strconv.Itoa(port)))
+	conn, err := dialer.Fastdialer.Dial(ctx, "tcp", net.JoinHostPort(host, strconv.Itoa(port)))
 	if err != nil {
 		return false, err
 	}
@@ -180,7 +180,7 @@ func (c *TelnetClient) Info(ctx context.Context, host string, port int) (TelnetI
 		return TelnetInfoResponse{}, fmt.Errorf("dialers not initialized for %s", executionId)
 	}
 
-	conn, err := dialer.Fastdialer.Dial(context.TODO(), "tcp", net.JoinHostPort(host, strconv.Itoa(port)))
+	conn, err := dialer.Fastdialer.Dial(ctx, "tcp", net.JoinHostPort(host, strconv.Itoa(port)))
 	if err != nil {
 		return TelnetInfoResponse{}, err
 	}
@@ -226,7 +226,7 @@ func (c *TelnetClient) GetTelnetNTLMInfo(ctx context.Context, host string, port 
 	}
 
 	// Create TCP connection
-	conn, err := dialer.Fastdialer.Dial(context.TODO(), "tcp", net.JoinHostPort(host, strconv.Itoa(port)))
+	conn, err := dialer.Fastdialer.Dial(ctx, "tcp", net.JoinHostPort(host, strconv.Itoa(port)))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/js/libs/vnc/memo.vnc.go
+++ b/pkg/js/libs/vnc/memo.vnc.go
@@ -2,17 +2,19 @@
 package vnc
 
 import (
+	"context"
 	"errors"
+
 	"fmt"
 
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
 )
 
-func memoizedisVNC(executionId string, host string, port int) (IsVNCResponse, error) {
+func memoizedisVNC(ctx context.Context, executionId string, host string, port int) (IsVNCResponse, error) {
 	hash := "isVNC" + ":" + fmt.Sprint(executionId) + ":" + fmt.Sprint(host) + ":" + fmt.Sprint(port)
 
 	v, err, _ := protocolstate.Memoizer.Do(hash, func() (interface{}, error) {
-		return isVNC(executionId, host, port)
+		return isVNC(ctx, executionId, host, port)
 	})
 	if err != nil {
 		return IsVNCResponse{}, err

--- a/pkg/js/libs/vnc/vnc.go
+++ b/pkg/js/libs/vnc/vnc.go
@@ -50,11 +50,11 @@ type (
 // ```
 func (c *VNCClient) Connect(ctx context.Context, host string, port int, password string) (bool, error) {
 	executionId := ctx.Value("executionId").(string)
-	return connect(executionId, host, port, password)
+	return connect(ctx, executionId, host, port, password)
 }
 
 // connect attempts to authenticate with a VNC server using the given password
-func connect(executionId string, host string, port int, password string) (bool, error) {
+func connect(ctx context.Context, executionId string, host string, port int, password string) (bool, error) {
 	if host == "" || port <= 0 {
 		return false, fmt.Errorf("invalid host or port")
 	}
@@ -68,7 +68,7 @@ func connect(executionId string, host string, port int, password string) (bool, 
 		return false, fmt.Errorf("dialers not initialized for %s", executionId)
 	}
 
-	conn, err := dialer.Fastdialer.Dial(context.TODO(), "tcp", net.JoinHostPort(host, strconv.Itoa(port)))
+	conn, err := dialer.Fastdialer.Dial(ctx, "tcp", net.JoinHostPort(host, strconv.Itoa(port)))
 	if err != nil {
 		return false, err
 	}
@@ -83,7 +83,7 @@ func connect(executionId string, host string, port int, password string) (bool, 
 	vncConfig := vnclib.NewClientConfig(password)
 
 	// Attempt to connect and authenticate
-	c, err := vnclib.Connect(context.TODO(), conn, vncConfig)
+	c, err := vnclib.Connect(ctx, conn, vncConfig)
 	if err != nil {
 		// Check for specific authentication errors
 		if isAuthError(err) {
@@ -120,11 +120,11 @@ func isAuthError(err error) bool {
 // ```
 func IsVNC(ctx context.Context, host string, port int) (IsVNCResponse, error) {
 	executionId := ctx.Value("executionId").(string)
-	return memoizedisVNC(executionId, host, port)
+	return memoizedisVNC(ctx, executionId, host, port)
 }
 
 // @memo
-func isVNC(executionId string, host string, port int) (IsVNCResponse, error) {
+func isVNC(ctx context.Context, executionId string, host string, port int) (IsVNCResponse, error) {
 	resp := IsVNCResponse{}
 
 	timeout := 5 * time.Second
@@ -132,7 +132,7 @@ func isVNC(executionId string, host string, port int) (IsVNCResponse, error) {
 	if dialer == nil {
 		return IsVNCResponse{}, fmt.Errorf("dialers not initialized for %s", executionId)
 	}
-	conn, err := dialer.Fastdialer.Dial(context.TODO(), "tcp", net.JoinHostPort(host, strconv.Itoa(port)))
+	conn, err := dialer.Fastdialer.Dial(ctx, "tcp", net.JoinHostPort(host, strconv.Itoa(port)))
 	if err != nil {
 		return resp, err
 	}

--- a/pkg/js/utils/nucleijs.go
+++ b/pkg/js/utils/nucleijs.go
@@ -51,18 +51,18 @@ func (j *NucleiJS) ExecutionId() string {
 	return executionId.(string)
 }
 
-// Context returns the deadline context from the goja runtime, or
-// context.TODO() if none is set.
+// Context returns the execution context from the goja runtime, or
+// context.Background() if none is set.
 func (j *NucleiJS) Context() context.Context {
 	if j == nil || j.vm == nil {
-		return context.TODO()
+		return context.Background()
 	}
 	if ctx, ok := j.vm.GetContextValue("ctx"); ok {
 		if c, valid := ctx.(context.Context); valid {
 			return c
 		}
 	}
-	return context.TODO()
+	return context.Background()
 }
 
 // see: https://arc.net/l/quote/wpenftpc for throwing docs

--- a/pkg/js/utils/nucleijs.go
+++ b/pkg/js/utils/nucleijs.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"strings"
@@ -48,6 +49,20 @@ func (j *NucleiJS) ExecutionId() string {
 		return ""
 	}
 	return executionId.(string)
+}
+
+// Context returns the deadline context from the goja runtime, or
+// context.TODO() if none is set.
+func (j *NucleiJS) Context() context.Context {
+	if j == nil || j.vm == nil {
+		return context.TODO()
+	}
+	if ctx, ok := j.vm.GetContextValue("ctx"); ok {
+		if c, valid := ctx.(context.Context); valid {
+			return c
+		}
+	}
+	return context.TODO()
 }
 
 // see: https://arc.net/l/quote/wpenftpc for throwing docs

--- a/pkg/js/utils/nucleijs_test.go
+++ b/pkg/js/utils/nucleijs_test.go
@@ -1,0 +1,40 @@
+package utils
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Mzack9999/goja"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNucleiJSContextFallback(t *testing.T) {
+	t.Run("nil receiver", func(t *testing.T) {
+		ctx := (*NucleiJS)(nil).Context()
+		require.NotNil(t, ctx)
+		require.NoError(t, ctx.Err())
+	})
+
+	t.Run("missing runtime context", func(t *testing.T) {
+		ctx := NewNucleiJS(goja.New()).Context()
+		require.NotNil(t, ctx)
+		require.NoError(t, ctx.Err())
+	})
+}
+
+func TestNucleiJSContextUsesRuntimeValue(t *testing.T) {
+	runtime := goja.New()
+	expected, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	runtime.SetContextValue("ctx", expected)
+
+	ctx := NewNucleiJS(runtime).Context()
+	require.Same(t, expected, ctx)
+
+	deadline, ok := ctx.Deadline()
+	require.True(t, ok)
+	expectedDeadline, _ := expected.Deadline()
+	require.Equal(t, expectedDeadline, deadline)
+}

--- a/pkg/js/utils/pgwrap/pgwrap.go
+++ b/pkg/js/utils/pgwrap/pgwrap.go
@@ -20,6 +20,7 @@ const (
 
 type pgDial struct {
 	executionId string
+	ctx         context.Context
 }
 
 func (p *pgDial) Dial(network, address string) (net.Conn, error) {
@@ -27,7 +28,11 @@ func (p *pgDial) Dial(network, address string) (net.Conn, error) {
 	if dialers == nil {
 		return nil, fmt.Errorf("dialers not initialized for %s", p.executionId)
 	}
-	return dialers.Fastdialer.Dial(context.Background(), network, address)
+	ctx := p.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return dialers.Fastdialer.Dial(ctx, network, address)
 }
 
 func (p *pgDial) DialTimeout(network, address string, timeout time.Duration) (net.Conn, error) {
@@ -35,17 +40,36 @@ func (p *pgDial) DialTimeout(network, address string, timeout time.Duration) (ne
 	if dialers == nil {
 		return nil, fmt.Errorf("dialers not initialized for %s", p.executionId)
 	}
-	ctx, cancel := context.WithTimeoutCause(context.Background(), timeout, fastdialer.ErrDialTimeout)
+	baseCtx := p.ctx
+	if baseCtx == nil {
+		baseCtx = context.Background()
+	}
+	ctx, cancel := context.WithTimeoutCause(baseCtx, timeout, fastdialer.ErrDialTimeout)
 	defer cancel()
 	return dialers.Fastdialer.Dial(ctx, network, address)
 }
 
 func (p *pgDial) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	if ctx == nil {
+		ctx = p.ctx
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	dialers := protocolstate.GetDialersWithId(p.executionId)
 	if dialers == nil {
 		return nil, fmt.Errorf("dialers not initialized for %s", p.executionId)
 	}
 	return dialers.Fastdialer.Dial(ctx, network, address)
+}
+
+func OpenDB(ctx context.Context, executionId string, dsn string) (*sql.DB, error) {
+	connector, err := pq.NewConnector(dsn)
+	if err != nil {
+		return nil, err
+	}
+	connector.Dialer(&pgDial{executionId: executionId, ctx: ctx})
+	return sql.OpenDB(connector), nil
 }
 
 // Unfortunately lib/pq does not provide easy to customize or

--- a/pkg/js/utils/pgwrap/pgwrap.go
+++ b/pkg/js/utils/pgwrap/pgwrap.go
@@ -27,7 +27,7 @@ func (p *pgDial) Dial(network, address string) (net.Conn, error) {
 	if dialers == nil {
 		return nil, fmt.Errorf("dialers not initialized for %s", p.executionId)
 	}
-	return dialers.Fastdialer.Dial(context.TODO(), network, address)
+	return dialers.Fastdialer.Dial(context.Background(), network, address)
 }
 
 func (p *pgDial) DialTimeout(network, address string, timeout time.Duration) (net.Conn, error) {


### PR DESCRIPTION
Fixes #6894

Replaces #6896 - created a new branch since maintainer push wasn't enabled on the original PR.

Includes the pool slot starvation fix from @AuditeMarlow (watchdog goroutine + `AddWithContext`) plus context propagation to all JS library network calls so zombies actually get killed when the deadline fires.

Changes:
- Watchdog goroutine releases pool slots on deadline expiry even if the worker is still stuck
- `AddWithContext` replaces `Add` so slot acquisition respects the deadline too
- Propagated the execution context to all JS protocol libraries (redis, smb, vnc, telnet, rdp, ldap, mysql, mssql, pop3, postgres, oracle, kerberos, smtp) replacing `context.TODO()` in network calls
- Added `NucleiJS.Context()` helper to retrieve the deadline context from the goja runtime
- Updated memogen template to exclude `context.Context` params from cache hash by type
- Added unit tests for pool starvation and watchdog recovery

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Execution paths and network/database probes now honor caller contexts and deadlines end-to-end.
  * Watchdog-based deadline handling added to promptly recover pooled resources when deadlines expire.
  * Runtime context retrieval available so embedded scripts can surface their execution context.
  * Memoization now omits the runtime context value from cache keys to reduce unnecessary cache churn.

* **Tests**
  * Added tests covering deadline handling, watchdog recovery, and pool starvation/recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->