### PR TITLE
test(flow): add request condition tests for multi-raw-request templates

### DIFF
--- a/pkg/tmplexec/flow/flow_executor_test.go
+++ b/pkg/tmplexec/flow/flow_executor_test.go
@@ -191,15 +191,15 @@ func newThreeStepServer() *httptest.Server {
 	router := httprouter.New()
 	router.GET("/step1", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprint(w, "step1-ok")
+		_, _ = fmt.Fprint(w, "step1-ok")
 	})
 	router.GET("/step2", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprint(w, "step2-ok token=abc123secret")
+		_, _ = fmt.Fprint(w, "step2-ok token=abc123secret")
 	})
 	router.GET("/step3", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprint(w, "step3-ok")
+		_, _ = fmt.Fprint(w, "step3-ok")
 	})
 	return httptest.NewServer(router)
 }
@@ -208,19 +208,19 @@ func newThreeStepServerWithPayloads() *httptest.Server {
 	router := httprouter.New()
 	router.GET("/step1", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprint(w, "step1-ok")
+		_, _ = fmt.Fprint(w, "step1-ok")
 	})
 	router.POST("/login", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 		w.Header().Set("X-Auth-Token", "tok3nvalue99")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprint(w, "login-ok")
+		_, _ = fmt.Fprint(w, "login-ok")
 	})
 	router.GET("/admin", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 		w.WriteHeader(http.StatusOK)
 		if r.URL.Query().Get("token") == "tok3nvalue99" {
-			fmt.Fprint(w, "admin-ok")
+			_, _ = fmt.Fprint(w, "admin-ok")
 		} else {
-			fmt.Fprint(w, "admin-unauthorized")
+			_, _ = fmt.Fprint(w, "admin-unauthorized")
 		}
 	})
 	return httptest.NewServer(router)
@@ -269,13 +269,13 @@ func TestFlowRequestCondition(t *testing.T) {
 func newMultiPayloadServer() *httptest.Server {
 	router := httprouter.New()
 	router.GET("/step1", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
-		fmt.Fprint(w, "step1-ok")
+		_, _ = fmt.Fprint(w, "step1-ok")
 	})
 	router.POST("/login", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
-		fmt.Fprint(w, "login-ok")
+		_, _ = fmt.Fprint(w, "login-ok")
 	})
 	router.GET("/data", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
-		fmt.Fprint(w, "data-ok")
+		_, _ = fmt.Fprint(w, "data-ok")
 	})
 	return httptest.NewServer(router)
 }

--- a/pkg/tmplexec/flow/flow_executor_test.go
+++ b/pkg/tmplexec/flow/flow_executor_test.go
@@ -2,10 +2,14 @@ package flow_test
 
 import (
 	"context"
+	"fmt"
 	"log"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/julienschmidt/httprouter"
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/config"
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/disk"
 	"github.com/projectdiscovery/nuclei/v3/pkg/loader/workflow"
@@ -180,5 +184,155 @@ func TestFlowWithNoMatchers(t *testing.T) {
 		gotresults, err := Template.Executer.Execute(ctx)
 		require.Nil(t, err, "could not execute template")
 		require.True(t, gotresults)
+	})
+}
+
+func newThreeStepServer() *httptest.Server {
+	router := httprouter.New()
+	router.GET("/step1", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "step1-ok")
+	})
+	router.GET("/step2", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "step2-ok token=abc123secret")
+	})
+	router.GET("/step3", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "step3-ok")
+	})
+	return httptest.NewServer(router)
+}
+
+func newThreeStepServerWithPayloads() *httptest.Server {
+	router := httprouter.New()
+	router.GET("/step1", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "step1-ok")
+	})
+	router.POST("/login", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+		w.Header().Set("X-Auth-Token", "tok3nvalue99")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "login-ok")
+	})
+	router.GET("/admin", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+		w.WriteHeader(http.StatusOK)
+		if r.URL.Query().Get("token") == "tok3nvalue99" {
+			fmt.Fprint(w, "admin-ok")
+		} else {
+			fmt.Fprint(w, "admin-unauthorized")
+		}
+	})
+	return httptest.NewServer(router)
+}
+
+// TestFlowRequestCondition reproduces issue #5095:
+// with flow: http() and 3 raw requests, numbered variables like
+// body_1, body_2 from earlier requests should be accessible in matchers
+// that run on the 3rd request's event.
+func TestFlowRequestCondition(t *testing.T) {
+	setup()
+	ts := newThreeStepServer()
+	defer ts.Close()
+
+	t.Run("without flow (baseline)", func(t *testing.T) {
+		tmpl, err := templates.Parse("testcases/noflow-request-condition.yaml", nil, executerOpts)
+		require.Nil(t, err, "could not parse template")
+		require.Empty(t, tmpl.Flow, "should NOT be a flow template")
+
+		err = tmpl.Executer.Compile()
+		require.Nil(t, err, "could not compile template")
+
+		input := contextargs.NewWithInput(context.Background(), ts.URL)
+		ctx := scan.NewScanContext(context.Background(), input)
+		gotresults, err := tmpl.Executer.Execute(ctx)
+		require.Nil(t, err, "could not execute template")
+		require.True(t, gotresults, "expected match without flow")
+	})
+
+	t.Run("with flow", func(t *testing.T) {
+		tmpl, err := templates.Parse("testcases/flow-request-condition.yaml", nil, executerOpts)
+		require.Nil(t, err, "could not parse template")
+		require.NotEmpty(t, tmpl.Flow, "should be a flow template")
+
+		err = tmpl.Executer.Compile()
+		require.Nil(t, err, "could not compile template")
+
+		input := contextargs.NewWithInput(context.Background(), ts.URL)
+		ctx := scan.NewScanContext(context.Background(), input)
+		gotresults, err := tmpl.Executer.Execute(ctx)
+		require.Nil(t, err, "could not execute template")
+		require.True(t, gotresults, "expected match with flow (issue #5095)")
+	})
+}
+
+func newMultiPayloadServer() *httptest.Server {
+	router := httprouter.New()
+	router.GET("/step1", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+		fmt.Fprint(w, "step1-ok")
+	})
+	router.POST("/login", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+		fmt.Fprint(w, "login-ok")
+	})
+	router.GET("/data", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+		fmt.Fprint(w, "data-ok")
+	})
+	return httptest.NewServer(router)
+}
+
+// TestFlowMultiPayloadIteration tests that request condition variables
+// survive across multiple pitchfork payload iterations (generator restarts).
+func TestFlowMultiPayloadIteration(t *testing.T) {
+	setup()
+	ts := newMultiPayloadServer()
+	defer ts.Close()
+
+	tmpl, err := templates.Parse("testcases/flow-multi-payload-iteration.yaml", nil, executerOpts)
+	require.Nil(t, err, "could not parse template")
+
+	err = tmpl.Executer.Compile()
+	require.Nil(t, err, "could not compile template")
+
+	input := contextargs.NewWithInput(context.Background(), ts.URL)
+	ctx := scan.NewScanContext(context.Background(), input)
+	gotresults, err := tmpl.Executer.Execute(ctx)
+	require.Nil(t, err, "could not execute template")
+	require.True(t, gotresults, "expected match with flow + multi payload iteration")
+}
+
+// TestFlowRequestConditionWithPayloads is the same as above but with
+// pitchfork payloads and header-based extraction, matching the exact
+// pattern from issue #5095.
+func TestFlowRequestConditionWithPayloads(t *testing.T) {
+	setup()
+	ts := newThreeStepServerWithPayloads()
+	defer ts.Close()
+
+	t.Run("without flow (baseline)", func(t *testing.T) {
+		tmpl, err := templates.Parse("testcases/noflow-request-condition-payloads.yaml", nil, executerOpts)
+		require.Nil(t, err, "could not parse template")
+
+		err = tmpl.Executer.Compile()
+		require.Nil(t, err, "could not compile template")
+
+		input := contextargs.NewWithInput(context.Background(), ts.URL)
+		ctx := scan.NewScanContext(context.Background(), input)
+		gotresults, err := tmpl.Executer.Execute(ctx)
+		require.Nil(t, err, "could not execute template")
+		require.True(t, gotresults, "expected match without flow (payloads)")
+	})
+
+	t.Run("with flow", func(t *testing.T) {
+		tmpl, err := templates.Parse("testcases/flow-request-condition-payloads.yaml", nil, executerOpts)
+		require.Nil(t, err, "could not parse template")
+
+		err = tmpl.Executer.Compile()
+		require.Nil(t, err, "could not compile template")
+
+		input := contextargs.NewWithInput(context.Background(), ts.URL)
+		ctx := scan.NewScanContext(context.Background(), input)
+		gotresults, err := tmpl.Executer.Execute(ctx)
+		require.Nil(t, err, "could not execute template")
+		require.True(t, gotresults, "expected match with flow + payloads (issue #5095)")
 	})
 }

--- a/pkg/tmplexec/flow/testcases/flow-multi-payload-iteration.yaml
+++ b/pkg/tmplexec/flow/testcases/flow-multi-payload-iteration.yaml
@@ -1,0 +1,53 @@
+id: flow-multi-payload-iteration
+
+info:
+  name: Flow with multiple payload iterations
+  author: test
+  severity: info
+
+flow: http()
+
+http:
+  - raw:
+      - |
+        GET /step1 HTTP/1.1
+        Host: {{Hostname}}
+
+      - |
+        POST /login HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        username={{user}}&password={{pass}}
+
+      - |
+        GET /data?user={{user}} HTTP/1.1
+        Host: {{Hostname}}
+
+    attack: pitchfork
+    payloads:
+      user:
+        - admin
+        - guest
+      pass:
+        - secret1
+        - secret2
+
+    stop-at-first-match: true
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body_1
+        words:
+          - "step1-ok"
+
+      - type: word
+        part: body_2
+        words:
+          - "login-ok"
+
+      - type: word
+        part: body_3
+        words:
+          - "data-ok"

--- a/pkg/tmplexec/flow/testcases/flow-request-condition-payloads.yaml
+++ b/pkg/tmplexec/flow/testcases/flow-request-condition-payloads.yaml
@@ -1,0 +1,53 @@
+id: flow-request-condition-payloads
+
+info:
+  name: Flow with request condition and payloads
+  author: test
+  severity: info
+
+flow: http()
+
+http:
+  - raw:
+      - |
+        GET /step1 HTTP/1.1
+        Host: {{Hostname}}
+
+      - |
+        POST /login HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        username={{username}}&password={{password}}
+
+      - |
+        GET /admin?token={{auth}} HTTP/1.1
+        Host: {{Hostname}}
+
+    attack: pitchfork
+    payloads:
+      username:
+        - admin
+      password:
+        - secret123
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body_2
+        words:
+          - "login-ok"
+
+      - type: word
+        part: body_3
+        words:
+          - "admin-ok"
+
+    extractors:
+      - type: regex
+        name: auth
+        internal: true
+        part: header_2
+        group: 1
+        regex:
+          - 'X-Auth-Token: ([a-z0-9]+)'

--- a/pkg/tmplexec/flow/testcases/flow-request-condition.yaml
+++ b/pkg/tmplexec/flow/testcases/flow-request-condition.yaml
@@ -1,0 +1,48 @@
+id: flow-request-condition
+
+info:
+  name: Flow with request condition (3 raw requests)
+  author: test
+  severity: info
+
+flow: http()
+
+http:
+  - raw:
+      - |
+        GET /step1 HTTP/1.1
+        Host: {{Hostname}}
+
+      - |
+        GET /step2 HTTP/1.1
+        Host: {{Hostname}}
+
+      - |
+        GET /step3?token={{auth}} HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body_1
+        words:
+          - "step1-ok"
+
+      - type: word
+        part: body_2
+        words:
+          - "step2-ok"
+
+      - type: word
+        part: body_3
+        words:
+          - "step3-ok"
+
+    extractors:
+      - type: regex
+        name: auth
+        internal: true
+        part: body_2
+        group: 1
+        regex:
+          - 'token=([a-z0-9]+)'

--- a/pkg/tmplexec/flow/testcases/noflow-request-condition-payloads.yaml
+++ b/pkg/tmplexec/flow/testcases/noflow-request-condition-payloads.yaml
@@ -1,0 +1,51 @@
+id: noflow-request-condition-payloads
+
+info:
+  name: No flow with request condition and payloads
+  author: test
+  severity: info
+
+http:
+  - raw:
+      - |
+        GET /step1 HTTP/1.1
+        Host: {{Hostname}}
+
+      - |
+        POST /login HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        username={{username}}&password={{password}}
+
+      - |
+        GET /admin?token={{auth}} HTTP/1.1
+        Host: {{Hostname}}
+
+    attack: pitchfork
+    payloads:
+      username:
+        - admin
+      password:
+        - secret123
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body_2
+        words:
+          - "login-ok"
+
+      - type: word
+        part: body_3
+        words:
+          - "admin-ok"
+
+    extractors:
+      - type: regex
+        name: auth
+        internal: true
+        part: header_2
+        group: 1
+        regex:
+          - 'X-Auth-Token: ([a-z0-9]+)'

--- a/pkg/tmplexec/flow/testcases/noflow-request-condition.yaml
+++ b/pkg/tmplexec/flow/testcases/noflow-request-condition.yaml
@@ -1,0 +1,46 @@
+id: noflow-request-condition
+
+info:
+  name: No flow with request condition (3 raw requests)
+  author: test
+  severity: info
+
+http:
+  - raw:
+      - |
+        GET /step1 HTTP/1.1
+        Host: {{Hostname}}
+
+      - |
+        GET /step2 HTTP/1.1
+        Host: {{Hostname}}
+
+      - |
+        GET /step3?token={{auth}} HTTP/1.1
+        Host: {{Hostname}}
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body_1
+        words:
+          - "step1-ok"
+
+      - type: word
+        part: body_2
+        words:
+          - "step2-ok"
+
+      - type: word
+        part: body_3
+        words:
+          - "step3-ok"
+
+    extractors:
+      - type: regex
+        name: auth
+        internal: true
+        part: body_2
+        group: 1
+        regex:
+          - 'token=([a-z0-9]+)'


### PR DESCRIPTION
Closes #5095

Tried to reproduce the reported bug (request condition variables like `body_1`, `header_2` getting lost on the 3rd request when using `flow: http()`) but couldn't reproduce it on current dev. All numbered variables and extracted values are correctly shared across requests, both with and without flow.

That said, we had zero test coverage for this specific scenario, so I added tests that cover:

- 3 raw requests with `body_1`/`body_2`/`body_3` matchers (with and without flow)
- Same but with pitchfork payloads and header-based internal extraction (`part: header_2`) fed into the 3rd request via template substitution
- Multiple pitchfork payload iterations (generator restarts from raw[0] for each payload set)

All pass on both the generic and flow execution paths, confirming the behavior is consistent. If anyone can still reproduce the original issue on a recent version, we can reopen.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added deterministic multi-step HTTP test infrastructure and helpers for simulated endpoints.
  * Introduced flow-focused tests validating request-condition behavior across multiple requests, persistence of request variables during multi-payload iteration, and header-based token extraction scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->