### PR TITLE
ci(tests): parallelize functional & integration runners

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -109,6 +109,7 @@ jobs:
     needs: ["tests"]
     env:
       GITHUB_TOKEN: "${{ github.token }}"
+      FUNCTIONAL_TEST_WORKERS: "4"
     strategy:
       fail-fast: false
       matrix:

--- a/cmd/functional-test/main.go
+++ b/cmd/functional-test/main.go
@@ -6,7 +6,10 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"runtime"
+	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/kitabisa/go-ci"
 	"github.com/logrusorgru/aurora"
@@ -22,7 +25,14 @@ var (
 	mainNucleiBinary = flag.String("main", "", "Main Branch Nuclei Binary")
 	devNucleiBinary  = flag.String("dev", "", "Dev Branch Nuclei Binary")
 	testcases        = flag.String("testcases", "", "Test cases file for nuclei functional tests")
+	workers          = flag.Int("workers", defaultWorkerCount(), "Workers for nuclei functional tests")
 )
+
+type functionalTestResult struct {
+	index    int
+	testCase string
+	err      error
+}
 
 func main() {
 	flag.Parse()
@@ -37,20 +47,18 @@ func main() {
 }
 
 func runFunctionalTests(debug bool) (error, bool) {
-	file, err := os.Open(*testcases)
+	testCaseList, err := loadTestCases(*testcases)
 	if err != nil {
 		return errors.Wrap(err, "could not open test cases"), true
 	}
-	defer func() {
-		_ = file.Close()
-	}()
 
-	errored, failedTestCases := runTestCases(file, debug)
+	errored, failedTestCases := runTestCases(testCaseList, debug, *workers)
 
-	if ci.IsCI() {
+	if ci.IsCI() && len(failedTestCases) > 0 {
 		fmt.Println("::group::Failed tests with debug")
 		for _, failedTestCase := range failedTestCases {
-			_ = runTestCase(failedTestCase, true)
+			result := runTestCase(-1, failedTestCase, true)
+			printTestCaseResult(result)
 		}
 		fmt.Println("::endgroup::")
 	}
@@ -58,65 +66,126 @@ func runFunctionalTests(debug bool) (error, bool) {
 	return nil, errored
 }
 
-func runTestCases(file *os.File, debug bool) (bool, []string) {
-	errored := false
-	var failedTestCases []string
+func defaultWorkerCount() int {
+	if value := strings.TrimSpace(os.Getenv("FUNCTIONAL_TEST_WORKERS")); value != "" {
+		parsed, err := strconv.Atoi(value)
+		if err == nil && parsed > 0 {
+			return parsed
+		}
+	}
+	return min(4, max(1, runtime.NumCPU()))
+}
 
+func loadTestCases(testCasesFile string) ([]string, error) {
+	file, err := os.Open(testCasesFile)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = file.Close()
+	}()
+
+	var loaded []string
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
 		testCase := strings.TrimSpace(scanner.Text())
-		if testCase == "" {
+		if testCase == "" || strings.HasPrefix(testCase, "#") {
 			continue
 		}
-		// skip comments
-		if strings.HasPrefix(testCase, "#") {
-			continue
-		}
-		if runTestCase(testCase, debug) {
+		loaded = append(loaded, testCase)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return loaded, nil
+}
+
+func runTestCases(testCases []string, debug bool, workerCount int) (bool, []string) {
+	results := executeTestCases(testCases, debug, workerCount)
+	errored := false
+	failedTestCases := make([]string, 0)
+
+	for _, result := range results {
+		printTestCaseResult(result)
+		if result.err != nil {
 			errored = true
-			failedTestCases = append(failedTestCases, testCase)
+			failedTestCases = append(failedTestCases, result.testCase)
 		}
 	}
 	return errored, failedTestCases
 }
 
-func runTestCase(testCase string, debug bool) bool {
-	if err := runIndividualTestCase(testCase, debug); err != nil {
-		fmt.Fprintf(os.Stderr, "%s Test \"%s\" failed: %s\n", failed, testCase, err)
-		return true
-	} else {
-		fmt.Printf("%s Test \"%s\" passed!\n", success, testCase)
+func executeTestCases(testCases []string, debug bool, workerCount int) []functionalTestResult {
+	results := make([]functionalTestResult, len(testCases))
+	if len(testCases) == 0 {
+		return results
 	}
-	return false
+
+	if workerCount <= 1 {
+		for index, testCase := range testCases {
+			results[index] = runTestCase(index, testCase, debug)
+		}
+		return results
+	}
+
+	jobIndexes := make(chan int)
+	resultChan := make(chan functionalTestResult, len(testCases))
+	workerTotal := min(workerCount, len(testCases))
+
+	var workerGroup sync.WaitGroup
+	workerGroup.Add(workerTotal)
+	for range workerTotal {
+		go func() {
+			defer workerGroup.Done()
+			for index := range jobIndexes {
+				resultChan <- runTestCase(index, testCases[index], debug)
+			}
+		}()
+	}
+
+	for index := range testCases {
+		jobIndexes <- index
+	}
+	close(jobIndexes)
+
+	workerGroup.Wait()
+	close(resultChan)
+
+	for result := range resultChan {
+		results[result.index] = result
+	}
+
+	return results
+}
+
+func runTestCase(index int, testCase string, debug bool) functionalTestResult {
+	result := functionalTestResult{index: index, testCase: testCase}
+	if err := runIndividualTestCase(testCase, debug); err != nil {
+		result.err = err
+	}
+	return result
+}
+
+func printTestCaseResult(result functionalTestResult) {
+	if result.err != nil {
+		fmt.Fprintf(os.Stderr, "%s Test \"%s\" failed: %s\n", failed, result.testCase, result.err)
+		return
+	}
+	fmt.Printf("%s Test \"%s\" passed!\n", success, result.testCase)
 }
 
 func runIndividualTestCase(testcase string, debug bool) error {
-	quoted := false
-
-	// split upon unquoted spaces
-	parts := strings.FieldsFunc(testcase, func(r rune) bool {
-		if r == '"' {
-			quoted = !quoted
-		}
-		return !quoted && r == ' '
-	})
-
-	// Quoted strings containing spaces are expressions and must have trailing \" removed
-	for index, part := range parts {
-		if strings.Contains(part, " ") {
-			parts[index] = strings.Trim(part, "\"")
-		}
-	}
+	parts := splitTestCaseArgs(testcase)
 
 	var finalArgs []string
 	if len(parts) > 1 {
 		finalArgs = parts[1:]
 	}
-	mainOutput, err := testutils.RunNucleiBinaryAndGetLoadedTemplates(*mainNucleiBinary, debug, finalArgs)
+	mainOutput, err := testutils.RunNucleiBinaryWithEnvAndGetLoadedTemplates(*mainNucleiBinary, debug, nil, finalArgs)
 	if err != nil {
 		return errors.Wrap(err, "could not run nuclei main test")
 	}
-	devOutput, err := testutils.RunNucleiBinaryAndGetLoadedTemplates(*devNucleiBinary, debug, finalArgs)
+	devOutput, err := testutils.RunNucleiBinaryWithEnvAndGetLoadedTemplates(*devNucleiBinary, debug, nil, finalArgs)
 	if err != nil {
 		return errors.Wrap(err, "could not run nuclei dev test")
 	}
@@ -124,4 +193,21 @@ func runIndividualTestCase(testcase string, debug bool) error {
 		return nil
 	}
 	return fmt.Errorf("%s main is not equal to %s dev", mainOutput, devOutput)
+}
+
+func splitTestCaseArgs(testcase string) []string {
+	quoted := false
+
+	parts := strings.FieldsFunc(testcase, func(r rune) bool {
+		if r == '"' {
+			quoted = !quoted
+		}
+		return !quoted && r == ' '
+	})
+
+	for index, part := range parts {
+		parts[index] = strings.Trim(part, "\"'")
+	}
+
+	return parts
 }

--- a/cmd/functional-test/run.sh
+++ b/cmd/functional-test/run.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
 
-if [ "${RUNNER_OS}" == "Windows" ]; then
+set -euo pipefail
+
+export NUCLEI_CONFIG_DIR="$PWD/.nuclei-config"
+
+EXT=""
+if [ "${RUNNER_OS:-}" == "Windows" ]; then
     EXT=".exe"
-elif [ "${RUNNER_OS}" == "macOS" ]; then
-    if [ "${CI}" == "true" ]; then
+elif [ "${RUNNER_OS:-}" == "macOS" ]; then
+    if [ "${CI:-}" == "true" ]; then
         sudo sysctl -w kern.maxfiles{,perproc}=524288
         sudo launchctl limit maxfiles 65536 524288
     fi
@@ -12,8 +17,8 @@ elif [ "${RUNNER_OS}" == "macOS" ]; then
     ulimit -n 65536 || true
 fi
 
-mkdir -p .nuclei-config/nuclei/
-touch .nuclei-config/nuclei/.nuclei-ignore
+mkdir -p "$NUCLEI_CONFIG_DIR"
+touch "$NUCLEI_CONFIG_DIR/.nuclei-ignore"
 
 echo "::group::Building functional-test binary"
 go build -o "functional-test${EXT}"
@@ -38,6 +43,6 @@ echo "::endgroup::"
 echo "Starting Nuclei functional test"
 eval "./functional-test${EXT} -main ./nuclei${EXT} -dev ./nuclei-dev${EXT} -testcases testcases.txt"
 
-if [ "${RUNNER_OS}" == "macOS" ]; then
+if [ "${RUNNER_OS:-}" == "macOS" ]; then
     ulimit -n "${ORIGINAL_ULIMIT}" || true
 fi

--- a/cmd/integration-test/code.go
+++ b/cmd/integration-test/code.go
@@ -45,12 +45,12 @@ func init() {
 	// in order to sign them for testing purposes
 	templates.TemplateSignerLFA()
 
-	tsigner, err := signer.NewTemplateSignerFromFiles(testCertFile, testKeyFile)
+	tsigner, err := signer.NewTemplateSignerFromFiles(integrationTestPath(testCertFile), integrationTestPath(testKeyFile))
 	if err != nil {
 		panic(err)
 	}
 
-	testcertpath, _ = filepath.Abs(testCertFile)
+	testcertpath, _ = filepath.Abs(integrationTestPath(testCertFile))
 
 	for _, v := range codeTestCases {
 		templatePath := v.Path
@@ -61,7 +61,7 @@ func init() {
 			continue
 		}
 
-		templatePath, err := filepath.Abs(templatePath)
+		templatePath, err := filepath.Abs(integrationTestPath(templatePath))
 		if err != nil {
 			panic(err)
 		}
@@ -74,11 +74,23 @@ func init() {
 		if _, ok := testCase.(*codePyNoSig); ok {
 			continue
 		}
-		if err := templates.SignTemplate(tsigner, templatePath); err != nil {
+		if err := ensureSignedTemplate(tsigner, templatePath); err != nil {
 			log.Fatalf("Could not sign template %v got: %s\n", templatePath, err)
 		}
 	}
 
+}
+
+func ensureSignedTemplate(tsigner *signer.TemplateSigner, templatePath string) error {
+	bin, err := os.ReadFile(templatePath)
+	if err != nil {
+		return err
+	}
+	existingSignature, _ := signer.ExtractSignatureAndContent(bin)
+	if len(existingSignature) > 0 {
+		return nil
+	}
+	return templates.SignTemplate(tsigner, templatePath)
 }
 
 func getEnvValues() []string {

--- a/cmd/integration-test/integration-test.go
+++ b/cmd/integration-test/integration-test.go
@@ -24,6 +24,12 @@ type TestCaseInfo struct {
 	DisableOn func() bool
 }
 
+type ProtocolSuite struct {
+	Name         string
+	Tests        []TestCaseInfo
+	ParallelSafe bool
+}
+
 var (
 	debug       = isDebugMode()
 	customTests = os.Getenv("TESTS")
@@ -32,35 +38,36 @@ var (
 	success = aurora.Green("[✓]").String()
 	failed  = aurora.Red("[✘]").String()
 
-	protocolTests = map[string][]TestCaseInfo{
-		"http":            httpTestcases,
-		"interactsh":      interactshTestCases,
-		"network":         networkTestcases,
-		"dns":             dnsTestCases,
-		"workflow":        workflowTestcases,
-		"loader":          loaderTestcases,
-		"profile-loader":  profileLoaderTestcases,
-		"websocket":       websocketTestCases,
-		"headless":        headlessTestcases,
-		"whois":           whoisTestCases,
-		"ssl":             sslTestcases,
-		"library":         libraryTestcases,
-		"templatesPath":   templatesPathTestCases,
-		"templatesDir":    templatesDirTestCases,
-		"env_vars":        templatesDirEnvTestCases,
-		"file":            fileTestcases,
-		"offlineHttp":     offlineHttpTestcases,
-		"customConfigDir": customConfigDirTestCases,
-		"fuzzing":         fuzzingTestCases,
-		"code":            codeTestCases,
-		"multi":           multiProtoTestcases,
-		"generic":         genericTestcases,
-		"dsl":             dslTestcases,
-		"flow":            flowTestcases,
-		"javascript":      jsTestcases,
-		"matcher-status":  matcherStatusTestcases,
-		"exporters":       exportersTestCases,
+	protocolSuites = []ProtocolSuite{
+		{Name: "http", Tests: httpTestcases, ParallelSafe: true},
+		{Name: "interactsh", Tests: interactshTestCases, ParallelSafe: false},
+		{Name: "network", Tests: networkTestcases, ParallelSafe: false},
+		{Name: "dns", Tests: dnsTestCases, ParallelSafe: true},
+		{Name: "workflow", Tests: workflowTestcases, ParallelSafe: true},
+		{Name: "loader", Tests: loaderTestcases, ParallelSafe: false},
+		{Name: "profile-loader", Tests: profileLoaderTestcases, ParallelSafe: true},
+		{Name: "websocket", Tests: websocketTestCases, ParallelSafe: true},
+		{Name: "headless", Tests: headlessTestcases, ParallelSafe: false},
+		{Name: "whois", Tests: whoisTestCases, ParallelSafe: true},
+		{Name: "ssl", Tests: sslTestcases, ParallelSafe: false},
+		{Name: "library", Tests: libraryTestcases, ParallelSafe: false},
+		{Name: "templatesPath", Tests: templatesPathTestCases, ParallelSafe: true},
+		{Name: "templatesDir", Tests: templatesDirTestCases, ParallelSafe: true},
+		{Name: "env_vars", Tests: templatesDirEnvTestCases, ParallelSafe: true},
+		{Name: "file", Tests: fileTestcases, ParallelSafe: true},
+		{Name: "offlineHttp", Tests: offlineHttpTestcases, ParallelSafe: true},
+		{Name: "customConfigDir", Tests: customConfigDirTestCases, ParallelSafe: true},
+		{Name: "fuzzing", Tests: fuzzingTestCases, ParallelSafe: false},
+		{Name: "code", Tests: codeTestCases, ParallelSafe: true},
+		{Name: "multi", Tests: multiProtoTestcases, ParallelSafe: true},
+		{Name: "generic", Tests: genericTestcases, ParallelSafe: false},
+		{Name: "dsl", Tests: dslTestcases, ParallelSafe: true},
+		{Name: "flow", Tests: flowTestcases, ParallelSafe: true},
+		{Name: "javascript", Tests: jsTestcases, ParallelSafe: false},
+		{Name: "matcher-status", Tests: matcherStatusTestcases, ParallelSafe: true},
+		{Name: "exporters", Tests: exportersTestCases, ParallelSafe: false},
 	}
+	protocolTests = buildProtocolTests(protocolSuites)
 
 	// flakyTests are run with a retry count of 3
 	flakyTests = map[string]bool{
@@ -70,6 +77,9 @@ var (
 	// For debug purposes
 	runProtocol          = ""
 	runTemplate          = ""
+	listProtocolsMode    = ""
+	protocolGroupMode    = ""
+	protocolGroupLanes   = 1
 	extraArgs            = []string{}
 	interactshRetryCount = 3
 )
@@ -77,6 +87,9 @@ var (
 func main() {
 	flag.StringVar(&runProtocol, "protocol", "", "run integration tests of given protocol")
 	flag.StringVar(&runTemplate, "template", "", "run integration test of given template")
+	flag.StringVar(&listProtocolsMode, "list-protocols", "", "list protocols for scheduling: all, parallel, or serial")
+	flag.StringVar(&protocolGroupMode, "list-protocol-groups", "", "list comma-separated protocol groups for scheduling: parallel or serial")
+	flag.IntVar(&protocolGroupLanes, "group-count", 1, "number of protocol groups to emit")
 	flag.Parse()
 
 	// allows passing extra args to nuclei
@@ -87,26 +100,29 @@ func main() {
 	}
 
 	if runProtocol != "" {
-		debugTests()
-		os.Exit(1)
+		if debugTests() {
+			os.Exit(1)
+		}
+		return
 	}
 
-	// start fuzz playground server
-	server := fuzzplayground.GetPlaygroundServer()
-	defer func() {
-		fuzzplayground.Cleanup()
-		_ = server.Close()
-	}()
+	if listProtocolsMode != "" {
+		listProtocols()
+		return
+	}
 
-	go func() {
-		if err := server.Start("localhost:8082"); err != nil {
-			if !strings.Contains(err.Error(), "Server closed") {
-				gologger.Fatal().Msgf("Could not start server: %s\n", err)
-			}
-		}
-	}()
+	if protocolGroupMode != "" {
+		listProtocolGroups()
+		return
+	}
 
 	customTestsList := normalizeSplit(customTests)
+	stopFuzzPlayground, err := maybeStartFuzzPlayground(customTestsList)
+	if err != nil {
+		gologger.Fatal().Msgf("Could not start fuzz playground: %s\n", err)
+	}
+	defer stopFuzzPlayground()
+
 	failedTestTemplatePaths := runTests(customTestsList)
 
 	if len(failedTestTemplatePaths) > 0 {
@@ -131,6 +147,115 @@ func main() {
 
 		os.Exit(1)
 	}
+}
+
+func buildProtocolTests(suites []ProtocolSuite) map[string][]TestCaseInfo {
+	protocolMap := make(map[string][]TestCaseInfo, len(suites))
+	for _, suite := range suites {
+		protocolMap[suite.Name] = suite.Tests
+	}
+	return protocolMap
+}
+
+func listProtocols() {
+	protocols, err := protocolNames(listProtocolsMode)
+	if err != nil {
+		gologger.Fatal().Msg(err.Error())
+	}
+	for _, name := range protocols {
+		fmt.Println(name)
+	}
+}
+
+func listProtocolGroups() {
+	protocols, err := protocolNames(protocolGroupMode)
+	if err != nil {
+		gologger.Fatal().Msg(err.Error())
+	}
+	for _, group := range groupProtocolNames(protocols, protocolGroupLanes) {
+		fmt.Println(strings.Join(group, ","))
+	}
+}
+
+func protocolNames(mode string) ([]string, error) {
+	mode = strings.ToLower(strings.TrimSpace(mode))
+	protocols := make([]string, 0, len(protocolSuites))
+	for _, suite := range protocolSuites {
+		switch mode {
+		case "all":
+			protocols = append(protocols, suite.Name)
+		case "parallel":
+			if suite.ParallelSafe {
+				protocols = append(protocols, suite.Name)
+			}
+		case "serial":
+			if !suite.ParallelSafe {
+				protocols = append(protocols, suite.Name)
+			}
+		default:
+			return nil, fmt.Errorf("invalid protocol mode %q", mode)
+		}
+	}
+	return protocols, nil
+}
+
+func groupProtocolNames(protocols []string, lanes int) [][]string {
+	if len(protocols) == 0 {
+		return nil
+	}
+	if lanes < 1 {
+		lanes = 1
+	}
+	if lanes > len(protocols) {
+		lanes = len(protocols)
+	}
+
+	groups := make([][]string, 0, lanes)
+	start := 0
+	for lane := 0; lane < lanes; lane++ {
+		remaining := len(protocols) - start
+		lanesLeft := lanes - lane
+		groupSize := (remaining + lanesLeft - 1) / lanesLeft
+		groups = append(groups, append([]string{}, protocols[start:start+groupSize]...))
+		start += groupSize
+	}
+	return groups
+}
+
+func maybeStartFuzzPlayground(customTemplatePaths []string) (func(), error) {
+	if !shouldStartFuzzPlayground(customTemplatePaths) {
+		return func() {}, nil
+	}
+
+	server := fuzzplayground.GetPlaygroundServer()
+	go func() {
+		if err := server.Start("localhost:8082"); err != nil {
+			if !strings.Contains(err.Error(), "Server closed") {
+				gologger.Fatal().Msgf("Could not start server: %s\n", err)
+			}
+		}
+	}()
+
+	return func() {
+		fuzzplayground.Cleanup()
+		_ = server.Close()
+	}, nil
+}
+
+func shouldStartFuzzPlayground(customTemplatePaths []string) bool {
+	selectedProtocol := strings.TrimSpace(protocol)
+	if selectedProtocol != "" {
+		return strings.EqualFold(selectedProtocol, "fuzzing")
+	}
+	if len(customTemplatePaths) == 0 {
+		return true
+	}
+	for _, templatePath := range customTemplatePaths {
+		if strings.Contains(strings.ToLower(templatePath), "fuzz/") {
+			return true
+		}
+	}
+	return false
 }
 
 // isDebugMode checks if debug mode is enabled via any of the supported debug
@@ -169,7 +294,8 @@ func executeWithRetry(testCase testutils.TestCase, templatePath string, retryCou
 	return templatePath, err
 }
 
-func debugTests() {
+func debugTests() bool {
+	errored := false
 	testCaseInfos := protocolTests[runProtocol]
 	for _, testCaseInfo := range testCaseInfos {
 		if (runTemplate != "" && !strings.Contains(testCaseInfo.Path, runTemplate)) ||
@@ -178,20 +304,25 @@ func debugTests() {
 		}
 		if runProtocol == "interactsh" {
 			if _, err := executeWithRetry(testCaseInfo.TestCase, testCaseInfo.Path, interactshRetryCount); err != nil {
+				errored = true
 				fmt.Printf("\n%v", err.Error())
 			}
 		} else {
 			if _, err := execute(testCaseInfo.TestCase, testCaseInfo.Path); err != nil {
+				errored = true
 				fmt.Printf("\n%v", err.Error())
 			}
 		}
 	}
+	return errored
 }
 
 func runTests(customTemplatePaths []string) []string {
 	var failedTestTemplatePaths []string
 
-	for proto, testCaseInfos := range protocolTests {
+	for _, suite := range protocolSuites {
+		proto := suite.Name
+		testCaseInfos := suite.Tests
 		if protocol != "" {
 			if !strings.EqualFold(proto, protocol) {
 				continue

--- a/cmd/integration-test/paths.go
+++ b/cmd/integration-test/paths.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+func integrationTestPath(path string) string {
+	if filepath.IsAbs(path) {
+		return path
+	}
+	if _, err := os.Stat(path); err == nil {
+		return path
+	}
+	_, currentFile, _, ok := runtime.Caller(0)
+	if !ok {
+		return path
+	}
+	baseDir := filepath.Join(filepath.Dir(currentFile), "..", "..", "integration_tests")
+	return filepath.Join(baseDir, filepath.FromSlash(path))
+}

--- a/cmd/integration-test/workflow.go
+++ b/cmd/integration-test/workflow.go
@@ -38,7 +38,7 @@ func init() {
 		templates.TemplateSignerLFA()
 
 		// testCertFile and testKeyFile are declared in code.go
-		tsigner, err := signer.NewTemplateSignerFromFiles(testCertFile, testKeyFile)
+		tsigner, err := signer.NewTemplateSignerFromFiles(integrationTestPath(testCertFile), integrationTestPath(testKeyFile))
 		if err != nil {
 			panic(err)
 		}
@@ -49,7 +49,7 @@ func init() {
 			"workflow/code-template-2.yaml",
 		}
 		for _, templatePath := range templatesToSign {
-			if err := templates.SignTemplate(tsigner, templatePath); err != nil {
+			if err := ensureSignedTemplate(tsigner, integrationTestPath(templatePath)); err != nil {
 				log.Fatalf("Could not sign template %v got: %s\n", templatePath, err)
 			}
 		}

--- a/integration_tests/run.sh
+++ b/integration_tests/run.sh
@@ -1,27 +1,156 @@
 #!/bin/bash
 
+set -euo pipefail
+
+CONFIG_ROOT="$PWD/.nuclei-config"
+RUN_LOG_DIR="$PWD/.integration-logs"
+SETUP_CONFIG_DIR="$CONFIG_ROOT/setup"
+INTEGRATION_PARALLELISM="${INTEGRATION_PARALLELISM:-2}"
+
+mkdir -p "$CONFIG_ROOT" "$RUN_LOG_DIR" "$SETUP_CONFIG_DIR"
+touch "$SETUP_CONFIG_DIR/.nuclei-ignore"
+export NUCLEI_CONFIG_DIR="$SETUP_CONFIG_DIR"
+
+run_protocol() {
+  local proto="$1"
+  local config_dir
+  local cache_dir
+  local appdata_dir
+  local home_dir
+  config_dir="$(mktemp -d "$CONFIG_ROOT/run-${proto}.XXXXXX")"
+  cache_dir="$config_dir/cache"
+  appdata_dir="$config_dir/appdata"
+  home_dir="$config_dir/home"
+
+  mkdir -p "$cache_dir" "$appdata_dir" "$home_dir"
+  touch "$config_dir/.nuclei-ignore"
+
+  echo "Running protocol ${proto}"
+  if env \
+    NUCLEI_CONFIG_DIR="$config_dir" \
+    XDG_CACHE_HOME="$cache_dir" \
+    XDG_CONFIG_HOME="$config_dir" \
+    HOME="$home_dir" \
+    USERPROFILE="$home_dir" \
+    APPDATA="$appdata_dir" \
+    LOCALAPPDATA="$appdata_dir" \
+    PROTO="$proto" \
+    ./integration-test; then
+    echo "[✓] ${proto}"
+    rm -rf "$config_dir"
+    return 0
+  fi
+
+  echo "[✘] ${proto}"
+  rm -rf "$config_dir"
+  return 1
+}
+
+run_protocol_group() {
+  local group="$1"
+  local status=0
+  local protocol_csv="$group"
+  local old_ifs="$IFS"
+  IFS=','
+  read -r -a protocols <<< "$protocol_csv"
+  IFS="$old_ifs"
+
+  for proto in "${protocols[@]}"; do
+    if ! run_protocol "$proto"; then
+      status=1
+    fi
+  done
+
+  return "$status"
+}
+
+list_protocols() {
+  local mode="$1"
+  ./integration-test -list-protocols "$mode"
+}
+
+join_protocols() {
+  local old_ifs="$IFS"
+  IFS=','
+  echo "$*"
+  IFS="$old_ifs"
+}
+
+read_protocols_into_array() {
+  local mode="$1"
+  local array_name="$2"
+  local value
+
+  eval "$array_name=()"
+  while IFS= read -r value; do
+    if [ -n "$value" ]; then
+      eval "$array_name+=(\"$value\")"
+    fi
+  done <<EOF
+$(list_protocols "$mode")
+EOF
+}
+
 echo "::group::Build nuclei"
-rm integration-test fuzzplayground nuclei 2>/dev/null
+rm -f integration-test fuzzplayground nuclei
 cd ../cmd/nuclei
 go build -race .
-mv nuclei ../../integration_tests/nuclei 
+mv nuclei ../../integration_tests/nuclei
 echo "::endgroup::"
 
 echo "::group::Build nuclei integration-test"
 cd ../integration-test
 go build
-mv integration-test ../../integration_tests/integration-test 
+mv integration-test ../../integration_tests/integration-test
 cd ../../integration_tests
 echo "::endgroup::"
+
+read_protocols_into_array parallel parallel_protocols
+read_protocols_into_array serial serial_protocols
+
+parallel_protocol_groups=()
+while IFS= read -r group; do
+  if [ -n "$group" ]; then
+    parallel_protocol_groups+=("$group")
+  fi
+done <<EOF
+$(./integration-test -list-protocol-groups parallel -group-count "$INTEGRATION_PARALLELISM")
+EOF
 
 echo "::group::Installing nuclei templates"
 ./nuclei -update-templates
 echo "::endgroup::"
 
-./integration-test
-if [ $? -eq 0 ]
-then
-  exit 0
-else
+parallel_failed=0
+parallel_pids=()
+parallel_logs=()
+
+for idx in "${!parallel_protocol_groups[@]}"; do
+  lane=$((idx + 1))
+  lane_log="$RUN_LOG_DIR/parallel-lane-${lane}.log"
+  parallel_logs+=("$lane_log")
+  (
+    run_protocol_group "${parallel_protocol_groups[$idx]}"
+  ) >"$lane_log" 2>&1 &
+  parallel_pids+=("$!")
+done
+
+for idx in "${!parallel_pids[@]}"; do
+  if ! wait "${parallel_pids[$idx]}"; then
+    parallel_failed=1
+  fi
+  cat "${parallel_logs[$idx]}"
+done
+
+serial_failed=0
+for proto in "${serial_protocols[@]}"; do
+  proto_log="$RUN_LOG_DIR/serial-${proto}.log"
+  if ! run_protocol "$proto" >"$proto_log" 2>&1; then
+    serial_failed=1
+  fi
+  cat "$proto_log"
+done
+
+if [ "$parallel_failed" -ne 0 ] || [ "$serial_failed" -ne 0 ]; then
   exit 1
 fi

--- a/pkg/testutils/integration.go
+++ b/pkg/testutils/integration.go
@@ -26,6 +26,13 @@ var (
 	}
 )
 
+func buildCommandEnv(env []string) []string {
+	commandEnv := append([]string{}, os.Environ()...)
+	commandEnv = append(commandEnv, ExtraEnvVars...)
+	commandEnv = append(commandEnv, env...)
+	return commandEnv
+}
+
 // RunNucleiTemplateAndGetResults returns a list of results for a template
 func RunNucleiTemplateAndGetResults(template, url string, debug bool, extra ...string) ([]string, error) {
 	return RunNucleiAndGetResults(true, template, url, debug, extra...)
@@ -60,10 +67,7 @@ func RunNucleiBareArgsAndGetResults(debug bool, env []string, extra ...string) (
 	cmd.Args = append(cmd.Args, "-interactions-poll-duration", "1")
 	cmd.Args = append(cmd.Args, "-interactions-cooldown-period", "10")
 	cmd.Args = append(cmd.Args, "-allow-local-file-access")
-	if env != nil {
-		cmd.Env = append(os.Environ(), env...)
-	}
-	cmd.Env = append(cmd.Env, ExtraEnvVars...)
+	cmd.Env = buildCommandEnv(env)
 	if debug {
 		cmd.Args = append(cmd.Args, "-debug")
 		cmd.Stderr = os.Stderr
@@ -97,7 +101,7 @@ func RunNucleiBareArgsAndGetResults(debug bool, env []string, extra ...string) (
 // RunNucleiWithArgsAndGetResults returns result,and runtime errors
 func RunNucleiWithArgsAndGetResults(debug bool, args ...string) ([]string, error) {
 	cmd := exec.Command("./nuclei", args...)
-	cmd.Env = append(cmd.Env, ExtraEnvVars...)
+	cmd.Env = buildCommandEnv(nil)
 	if debug {
 		cmd.Args = append(cmd.Args, "-debug")
 		cmd.Stderr = os.Stderr
@@ -131,14 +135,13 @@ func RunNucleiWithArgsAndGetResults(debug bool, args ...string) ([]string, error
 func RunNucleiArgsAndGetErrors(debug bool, env []string, extra ...string) ([]string, error) {
 	cmd := exec.Command("./nuclei")
 	extra = append(extra, ExtraDebugArgs...)
-	cmd.Env = append(os.Environ(), env...)
+	cmd.Env = buildCommandEnv(env)
 	cmd.Args = append(cmd.Args, extra...)
 	cmd.Args = append(cmd.Args, "-duc") // disable auto updates
 	cmd.Args = append(cmd.Args, "-interactions-poll-duration", "1")
 	cmd.Args = append(cmd.Args, "-interactions-cooldown-period", "10")
 	cmd.Args = append(cmd.Args, "-allow-local-file-access")
 	cmd.Args = append(cmd.Args, "-nc") // disable color
-	cmd.Env = append(cmd.Env, ExtraEnvVars...)
 	dataOutput, err := cmd.CombinedOutput()
 	if debug {
 		fmt.Println(string(dataOutput))
@@ -166,8 +169,7 @@ func RunNucleiArgsAndGetErrors(debug bool, env []string, extra ...string) ([]str
 func RunNucleiArgsWithEnvAndGetResults(debug bool, env []string, extra ...string) ([]string, error) {
 	cmd := exec.Command("./nuclei")
 	extra = append(extra, ExtraDebugArgs...)
-	cmd.Env = append(os.Environ(), env...)
-	cmd.Env = append(cmd.Env, ExtraEnvVars...)
+	cmd.Env = buildCommandEnv(env)
 	cmd.Args = append(cmd.Args, extra...)
 	cmd.Args = append(cmd.Args, "-duc") // disable auto updates
 	cmd.Args = append(cmd.Args, "-interactions-poll-duration", "5")
@@ -205,8 +207,12 @@ var templateLoaded = regexp.MustCompile(`(?:Templates|Workflows) loaded[^:]*: (\
 
 // RunNucleiBinaryAndGetLoadedTemplates returns a list of results for a template
 func RunNucleiBinaryAndGetLoadedTemplates(nucleiBinary string, debug bool, args []string) (string, error) {
+	return RunNucleiBinaryWithEnvAndGetLoadedTemplates(nucleiBinary, debug, nil, args)
+}
+
+func RunNucleiBinaryWithEnvAndGetLoadedTemplates(nucleiBinary string, debug bool, env []string, args []string) (string, error) {
 	cmd := exec.Command(nucleiBinary, args...)
-	cmd.Env = append(cmd.Env, ExtraEnvVars...)
+	cmd.Env = buildCommandEnv(env)
 	cmd.Args = append(cmd.Args, "-duc") // disable auto updates
 	if debug {
 		cmd.Args = append(cmd.Args, "-debug")
@@ -228,7 +234,7 @@ func RunNucleiBinaryAndGetLoadedTemplates(nucleiBinary string, debug bool, args 
 func RunNucleiBinaryAndGetCombinedOutput(debug bool, args []string) (string, error) {
 	args = append(args, "-interactions-cooldown-period", "10", "-interactions-poll-duration", "1")
 	cmd := exec.Command("./nuclei", args...)
-	cmd.Env = append(cmd.Env, ExtraEnvVars...)
+	cmd.Env = buildCommandEnv(nil)
 	if debug {
 		cmd.Args = append(cmd.Args, "-debug")
 		fmt.Println(cmd.String())


### PR DESCRIPTION
## Proposed changes

ci(tests): parallelize functional & integration runners

Add a worker pool to the functional test runner
and make the worker count configurable from CI.
This keeps the existing failure/debug flow while
reducing the amount of serial work done in the job.

Refactor the integration test scheduling so
protocol metadata lives in the Go runner instead
of the shell script.

### Proof

<!-- How has this been tested? Please describe the tests that you ran to verify your changes. -->

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a workers flag for parallel functional tests with CPU-aware defaults
  * Added protocol listing (all/parallel/serial) and ordered protocol suites
  * Introduced protocol-aware parallel execution and per-protocol/parallel-lane runs

* **Improvements**
  * More robust shell scripts with strict error handling and configurable config dir
  * Cleaner test output, deterministic result ordering, and improved environment handling for test runs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->