### PR TITLE
fix: avoid panic when dialers are missing in httpclientpool

### DIFF
--- a/pkg/protocols/http/httpclientpool/clientpool.go
+++ b/pkg/protocols/http/httpclientpool/clientpool.go
@@ -128,9 +128,17 @@ func (c *Configuration) HasStandardOptions() bool {
 
 // GetRawHTTP returns the rawhttp request client
 func GetRawHTTP(options *protocols.ExecutorOptions) *rawhttp.Client {
+	rawHttpOptionsCopy := *rawhttp.DefaultOptions
+	if options.Options.AliveHttpProxy != "" {
+		rawHttpOptionsCopy.Proxy = options.Options.AliveHttpProxy
+	} else if options.Options.AliveSocksProxy != "" {
+		rawHttpOptionsCopy.Proxy = options.Options.AliveSocksProxy
+	}
+	rawHttpOptionsCopy.Timeout = options.Options.GetTimeouts().HttpTimeout
+
 	dialers := protocolstate.GetDialersWithId(options.Options.ExecutionId)
 	if dialers == nil {
-		panic("dialers not initialized for execution id: " + options.Options.ExecutionId)
+		return rawhttp.NewClient(&rawHttpOptionsCopy)
 	}
 
 	// Lock the dialers to avoid a race when setting RawHTTPClient
@@ -141,15 +149,9 @@ func GetRawHTTP(options *protocols.ExecutorOptions) *rawhttp.Client {
 		return dialers.RawHTTPClient
 	}
 
-	rawHttpOptionsCopy := *rawhttp.DefaultOptions
-	if options.Options.AliveHttpProxy != "" {
-		rawHttpOptionsCopy.Proxy = options.Options.AliveHttpProxy
-	} else if options.Options.AliveSocksProxy != "" {
-		rawHttpOptionsCopy.Proxy = options.Options.AliveSocksProxy
-	} else if dialers.Fastdialer != nil {
+	if rawHttpOptionsCopy.Proxy == "" && dialers.Fastdialer != nil {
 		rawHttpOptionsCopy.FastDialer = dialers.Fastdialer
 	}
-	rawHttpOptionsCopy.Timeout = options.Options.GetTimeouts().HttpTimeout
 	dialers.RawHTTPClient = rawhttp.NewClient(&rawHttpOptionsCopy)
 	return dialers.RawHTTPClient
 }

--- a/pkg/protocols/http/httpclientpool/clientpool_test.go
+++ b/pkg/protocols/http/httpclientpool/clientpool_test.go
@@ -4,6 +4,9 @@ import (
 	"net/http"
 	"net/url"
 	"testing"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols"
+	"github.com/projectdiscovery/nuclei/v3/pkg/types"
 )
 
 func TestNormalizeHost(t *testing.T) {
@@ -208,5 +211,14 @@ func TestMaxRedirects(t *testing.T) {
 	}
 	if err := checkFn3(req, via4); err != nil {
 		t.Errorf("should allow within default maxRedirects (10) with 9 via requests, got: %v", err)
+	}
+}
+
+func TestGetRawHTTPWithoutInitializedDialers(t *testing.T) {
+	executorOptions := &protocols.ExecutorOptions{Options: &types.Options{ExecutionId: "missing-dialer-id", Timeout: 5}}
+
+	client := GetRawHTTP(executorOptions)
+	if client == nil {
+		t.Fatalf("expected rawhttp client, got nil")
 	}
 }


### PR DESCRIPTION
Motivation:
Prevent panic when dialers are missing for a given execution context.

Root cause:
GetDialersWithId may return nil, but current logic panics instead of handling it.

Fix:
Return a fallback rawhttp client when dialers are not initialized.

Testing:
- Added regression test
- Verified client is returned without panic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Fixed a potential application crash in the HTTP client pool when network dialers were not properly initialized. The system now gracefully handles this edge case while ensuring timeout configuration is applied consistently across all HTTP request execution paths.

## Tests
- Added test coverage for HTTP client pool operations in scenarios where the network dialer initialization process has not yet been completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->