### PR TITLE
fix: malformed JSON lines output

### DIFF
--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -99,7 +99,7 @@ func main() {
 					if err != templates.ErrNotATemplate {
 						// skip warnings and errors as given items are not templates
 						errorCounter++
-						options.Logger.Error().Msgf("could not sign '%s': %s\n", iterItem, err)
+						options.Logger.Error().Msgf("Could not sign %q template: %s", iterItem, err)
 					}
 				} else {
 					successCounter++
@@ -108,10 +108,10 @@ func main() {
 				return nil
 			})
 			if err != nil {
-				options.Logger.Error().Msgf("%s\n", err)
+				options.Logger.Error().Msg(err.Error())
 			}
 		}
-		options.Logger.Info().Msgf("All templates signatures were elaborated success=%d failed=%d\n", successCounter, errorCounter)
+		options.Logger.Info().Msgf("All templates signatures were elaborated success=%d failed=%d", successCounter, errorCounter)
 		return
 	}
 
@@ -122,7 +122,7 @@ func main() {
 		createProfileFile := func(ext, profileType string) *os.File {
 			f, err := os.Create(memProfile + ext)
 			if err != nil {
-				options.Logger.Fatal().Msgf("profile: could not create %s profile %q file: %v", profileType, f.Name(), err)
+				options.Logger.Fatal().Msgf("Could not create %s profile %q file: %v", profileType, f.Name(), err)
 			}
 			return f
 		}
@@ -136,18 +136,18 @@ func main() {
 
 		// Start tracing
 		if err := trace.Start(traceFile); err != nil {
-			options.Logger.Fatal().Msgf("profile: could not start trace: %v", err)
+			options.Logger.Fatal().Msgf("Could not start trace: %v", err)
 		}
 
 		// Start CPU profiling
 		if err := pprof.StartCPUProfile(cpuProfileFile); err != nil {
-			options.Logger.Fatal().Msgf("profile: could not start CPU profile: %v", err)
+			options.Logger.Fatal().Msgf("Could not start CPU profile: %v", err)
 		}
 
 		defer func() {
 			// Start heap memory snapshot
 			if err := pprof.WriteHeapProfile(memProfileFile); err != nil {
-				options.Logger.Fatal().Msgf("profile: could not write memory profile: %v", err)
+				options.Logger.Fatal().Msgf("Could not write memory profile: %v", err)
 			}
 
 			pprof.StopCPUProfile()
@@ -192,7 +192,7 @@ func main() {
 				options.Logger.Info().Msgf("Uploading scan results to cloud...")
 			}
 			nucleiRunner.Close()
-			options.Logger.Info().Msgf("Creating resume file: %s\n", resumeFileName)
+			options.Logger.Info().Msgf("Creating resume file: %s", resumeFileName)
 			err := nucleiRunner.SaveResumeConfig(resumeFileName)
 			if err != nil {
 				return errkit.Wrap(err, "couldn't create crash resume file")
@@ -210,7 +210,7 @@ func main() {
 	signal.Notify(c, os.Interrupt)
 	go func() {
 		<-c
-		options.Logger.Info().Msgf("CTRL+C pressed: Exiting\n")
+		options.Logger.Info().Msgf("CTRL+C pressed: Exiting")
 		if options.DASTServer {
 			nucleiRunner.Close()
 			os.Exit(1)
@@ -222,10 +222,10 @@ func main() {
 		}
 		nucleiRunner.Close()
 		if options.ShouldSaveResume() {
-			options.Logger.Info().Msgf("Creating resume file: %s\n", resumeFileName)
+			options.Logger.Info().Msgf("Creating resume file: %s", resumeFileName)
 			err := nucleiRunner.SaveResumeConfig(resumeFileName)
 			if err != nil {
-				options.Logger.Error().Msgf("Couldn't create resume file: %s\n", err)
+				options.Logger.Error().Msgf("Couldn't create resume file: %s", err)
 			}
 		}
 		for _, f := range inlineSecretsTempFiles {
@@ -629,7 +629,7 @@ Additional documentation is available at: https://docs.nuclei.sh/getting-started
 						if strVal, ok := value.(string); ok {
 							err = options.Vars.Set(strVal)
 							if err != nil {
-								gologger.Warning().Msgf("Could not set variable from config file: %s\n", err)
+								gologger.Warning().Msgf("Could not set variable from config file: %s", err)
 							}
 						} else {
 							gologger.Warning().Msgf("Skipping non-string variable in config: %#v", value)
@@ -741,25 +741,25 @@ func readFlagsConfig(flagset *goflags.FlagSet) {
 	if err != nil {
 		// something went wrong either dir is not readable or something else went wrong upstream in `goflags`
 		// warn and exit in this case
-		options.Logger.Warning().Msgf("Could not read config file: %s\n", err)
+		options.Logger.Warning().Msgf("Could not read config file: %s", err)
 		return
 	}
 	cfgFile := config.DefaultConfig.GetFlagsConfigFilePath()
 	if !fileutil.FileExists(cfgFile) {
 		if !fileutil.FileExists(defaultCfgFile) {
 			// if default config does not exist, warn and exit
-			options.Logger.Warning().Msgf("missing default config file : %s", defaultCfgFile)
+			options.Logger.Warning().Msgf("Missing default config %q file", defaultCfgFile)
 			return
 		}
 		// if does not exist copy it from the default config
 		if err = fileutil.CopyFile(defaultCfgFile, cfgFile); err != nil {
-			options.Logger.Warning().Msgf("Could not copy config file: %s\n", err)
+			options.Logger.Warning().Msgf("Could not copy config file: %s", err)
 		}
 		return
 	}
 	// if config file exists, merge it with the default config
 	if err = flagset.MergeConfigFile(cfgFile); err != nil {
-		options.Logger.Warning().Msgf("failed to merge configfile with flags got: %s\n", err)
+		options.Logger.Warning().Msgf("Could not merge config file with flags: %s", err)
 	}
 }
 
@@ -780,19 +780,19 @@ func printVersion() {
 // printTemplateVersion prints the nuclei template version and exits.
 func printTemplateVersion() {
 	cfg := config.DefaultConfig
-	options.Logger.Info().Msgf("Public nuclei-templates version: %s (%s)\n", cfg.TemplateVersion, cfg.TemplatesDirectory)
+	options.Logger.Info().Msgf("Public nuclei-templates version: %s (%q)", cfg.TemplateVersion, cfg.TemplatesDirectory)
 
 	if fileutil.FolderExists(cfg.CustomS3TemplatesDirectory) {
-		options.Logger.Info().Msgf("Custom S3 templates location: %s\n", cfg.CustomS3TemplatesDirectory)
+		options.Logger.Info().Msgf("Custom S3 templates location: %s", cfg.CustomS3TemplatesDirectory)
 	}
 	if fileutil.FolderExists(cfg.CustomGitHubTemplatesDirectory) {
-		options.Logger.Info().Msgf("Custom GitHub templates location: %s ", cfg.CustomGitHubTemplatesDirectory)
+		options.Logger.Info().Msgf("Custom GitHub templates location: %s", cfg.CustomGitHubTemplatesDirectory)
 	}
 	if fileutil.FolderExists(cfg.CustomGitLabTemplatesDirectory) {
-		options.Logger.Info().Msgf("Custom GitLab templates location: %s ", cfg.CustomGitLabTemplatesDirectory)
+		options.Logger.Info().Msgf("Custom GitLab templates location: %s", cfg.CustomGitLabTemplatesDirectory)
 	}
 	if fileutil.FolderExists(cfg.CustomAzureTemplatesDirectory) {
-		options.Logger.Info().Msgf("Custom Azure templates location: %s ", cfg.CustomAzureTemplatesDirectory)
+		options.Logger.Info().Msgf("Custom Azure templates location: %s", cfg.CustomAzureTemplatesDirectory)
 	}
 	os.Exit(0)
 }
@@ -858,7 +858,7 @@ func findProfilePathById(profileId, templatesDir string) string {
 		return nil
 	})
 	if err != nil && err.Error() != "FOUND" {
-		options.Logger.Error().Msgf("%s\n", err)
+		options.Logger.Error().Msg(err.Error())
 	}
 	return profilePath
 }

--- a/cmd/tmc/main.go
+++ b/cmd/tmc/main.go
@@ -126,7 +126,7 @@ func main() {
 		gologger.DefaultLogger.SetMaxLevel(levels.LevelDebug)
 	}
 	if err := process(opts); err != nil {
-		gologger.Error().Msgf("could not process: %s\n", err)
+		gologger.Error().Msgf("could not process: %s", err)
 	}
 }
 

--- a/cmd/tools/signer/main.go
+++ b/cmd/tools/signer/main.go
@@ -52,7 +52,7 @@ func main() {
 	if err != nil {
 		gologger.Fatal().Msgf("failed to create signer: %s", err)
 	}
-	gologger.Info().Msgf("Template Signer: %v\n", tmplSigner.Identifier())
+	gologger.Info().Msgf("Template Signer: %v", tmplSigner.Identifier())
 
 	// read file
 	bin, err := os.ReadFile(template)
@@ -67,7 +67,7 @@ func main() {
 	gologger.Info().Msgf("Signature Details:")
 	gologger.Info().Msgf("----------------")
 	gologger.Info().Msgf("Signature: %s", sig)
-	gologger.Info().Msgf("Content Hash (SHA256): %s\n", hex.EncodeToString(hash[:]))
+	gologger.Info().Msgf("Content Hash (SHA256): %s", hex.EncodeToString(hash[:]))
 
 	execOpts := defaultExecutorOpts(template)
 
@@ -75,7 +75,7 @@ func main() {
 	if err != nil {
 		gologger.Fatal().Msgf("failed to parse template: %s", err)
 	}
-	gologger.Info().Msgf("Template Verified: %v\n", tmpl.Verified)
+	gologger.Info().Msgf("Template Verified: %v", tmpl.Verified)
 
 	if !tmpl.Verified {
 		gologger.Info().Msgf("------------------------")
@@ -94,7 +94,7 @@ func main() {
 		gologger.Info().Msgf("Updated Signature Details:")
 		gologger.Info().Msgf("------------------------")
 		gologger.Info().Msgf("Signature: %s", sig2)
-		gologger.Info().Msgf("Content Hash (SHA256): %s\n", hex.EncodeToString(hash2[:]))
+		gologger.Info().Msgf("Content Hash (SHA256): %s", hex.EncodeToString(hash2[:]))
 	}
 	gologger.Info().Msgf("✓ Template signed & verified successfully")
 }

--- a/internal/runner/inputs.go
+++ b/internal/runner/inputs.go
@@ -63,7 +63,7 @@ func (r *Runner) initializeTemplatesHTTPInput() (*hybrid.HybridMap, error) {
 
 		if r.options.ProbeConcurrency > 0 && swg.Size != r.options.ProbeConcurrency {
 			if err := swg.Resize(context.Background(), r.options.ProbeConcurrency); err != nil {
-				r.Logger.Error().Msgf("Could not resize workpool: %s\n", err)
+				r.Logger.Error().Msgf("Could not resize workpool: %s", err)
 			}
 		}
 

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -100,12 +100,12 @@ func ParseOptions(options *types.Options) {
 			return nil
 		})
 		if err != nil {
-			options.Logger.Error().Msgf("%s\n", err)
+			options.Logger.Error().Msg(err.Error())
 		}
 		os.Exit(0)
 	}
 	if options.StoreResponseDir != DefaultDumpTrafficOutputFolder && !options.StoreResponse {
-		options.Logger.Debug().Msgf("Store response directory specified, enabling \"store-resp\" flag automatically\n")
+		options.Logger.Debug().Msgf("Store response directory specified, enabling \"store-resp\" flag automatically")
 		options.StoreResponse = true
 	}
 	// Validate the options passed by the user and if any

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -51,10 +51,10 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/automaticscan"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/contextargs"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/globalmatchers"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/honeypotdetector"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/hosterrorscache"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/interactsh"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolinit"
-	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/honeypotdetector"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/uncover"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/utils/excludematchers"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/headless/engine"
@@ -124,7 +124,7 @@ func New(options *types.Options) (*Runner, error) {
 	if config.DefaultConfig.CanCheckForUpdates() {
 		if err := installer.NucleiVersionCheck(); err != nil {
 			if options.Verbose || options.Debug {
-				runner.Logger.Error().Msgf("nuclei version check failed got: %s\n", err)
+				runner.Logger.Error().Msgf("nuclei version check failed: %s", err)
 			}
 		}
 
@@ -141,15 +141,15 @@ func New(options *types.Options) (*Runner, error) {
 			DisablePublicTemplates: options.PublicTemplateDisableDownload,
 		}
 		if err := tm.FreshInstallIfNotExists(); err != nil {
-			runner.Logger.Warning().Msgf("failed to install nuclei templates: %s\n", err)
+			runner.Logger.Warning().Msgf("Failed to install nuclei-templates: %s", err)
 		}
 		if err := tm.UpdateIfOutdated(); err != nil {
-			runner.Logger.Warning().Msgf("failed to update nuclei templates: %s\n", err)
+			runner.Logger.Warning().Msgf("Failed to update nuclei-templates: %s", err)
 		}
 
 		if config.DefaultConfig.NeedsIgnoreFileUpdate() {
 			if err := installer.UpdateIgnoreFile(); err != nil {
-				runner.Logger.Warning().Msgf("failed to update nuclei ignore file: %s\n", err)
+				runner.Logger.Warning().Msgf("Failed to update nuclei ignore file: %s", err)
 			}
 		}
 
@@ -157,7 +157,7 @@ func New(options *types.Options) (*Runner, error) {
 			// we automatically check for updates unless explicitly disabled
 			// this print statement is only to inform the user that there are no updates
 			if !config.DefaultConfig.NeedsTemplateUpdate() {
-				runner.Logger.Info().Msgf("No new updates found for nuclei templates")
+				runner.Logger.Info().Msgf("No new updates found for nuclei-templates")
 			}
 			// manually trigger update of custom templates
 			if ctm != nil {
@@ -184,7 +184,7 @@ func New(options *types.Options) (*Runner, error) {
 
 	if options.Headless {
 		if engine.MustDisableSandbox() {
-			runner.Logger.Warning().Msgf("The current platform and privileged user will run the browser without sandbox\n")
+			runner.Logger.Warning().Msgf("The current platform and privileged user will run the browser without sandbox")
 		}
 		browser, err := engine.New(options)
 		if err != nil {
@@ -397,7 +397,7 @@ func New(options *types.Options) (*Runner, error) {
 	}
 
 	if options.RateLimitMinute > 0 {
-		runner.Logger.Print().Msgf("[%v] %v", aurora.BrightYellow("WRN"), "rate limit per minute is deprecated - use rate-limit-duration")
+		runner.Logger.Warning().Msg("The rate-limit-minute flag is deprecated, use rate-limit-duration flag instead")
 		options.RateLimit = options.RateLimitMinute
 		options.RateLimitDuration = time.Minute
 	}
@@ -481,14 +481,14 @@ func (r *Runner) setupPDCPUpload(writer output.Writer) output.Writer {
 	creds, err := h.GetCreds()
 	if err != nil {
 		if err != pdcpauth.ErrNoCreds && !HideAutoSaveMsg {
-			r.Logger.Verbose().Msgf("Could not get credentials for cloud upload: %s\n", err)
+			r.Logger.Verbose().Msgf("Could not get credentials for cloud upload: %s", err)
 		}
-		r.pdcpUploadErrMsg = fmt.Sprintf("To view results on Cloud Dashboard, configure API key from %v", pdcpauth.DashBoardURL)
+		r.pdcpUploadErrMsg = fmt.Sprintf("To view results on Cloud Dashboard, configure API key from %s", pdcpauth.DashBoardURL)
 		return writer
 	}
 	uploadWriter, err := pdcp.NewUploadWriter(context.Background(), r.Logger, creds)
 	if err != nil {
-		r.pdcpUploadErrMsg = fmt.Sprintf("PDCP (%v) Auto-Save Failed: %s\n", pdcpauth.DashBoardURL, err)
+		r.pdcpUploadErrMsg = fmt.Sprintf("PDCP (%s) auto-save failed: %s\n", pdcpauth.DashBoardURL, err)
 		return writer
 	}
 	if r.options.ScanID != "" {
@@ -886,7 +886,7 @@ func (r *Runner) displayExecutionInfo(store *loader.Store) {
 	if tmplCount == 0 && workflowCount == 0 {
 		// if dast flag is used print explicit warning
 		if r.options.DAST {
-			r.Logger.Print().Msgf("[%v] No DAST templates found", aurora.BrightYellow("WRN"))
+			r.Logger.Warning().Msg("No DAST templates found")
 		}
 		stats.ForceDisplayWarning(templates.SkippedCodeTmplTamperedStats)
 	} else {
@@ -901,7 +901,7 @@ func (r *Runner) displayExecutionInfo(store *loader.Store) {
 	updateutils.Aurora = r.colorizer
 	versionInfo := func(version, latestVersion, versionType string) string {
 		if !cfg.CanCheckForUpdates() {
-			return fmt.Sprintf("Current %s version: %v (%s) - remove '-duc' flag to enable update checks", versionType, version, r.colorizer.BrightYellow("unknown"))
+			return fmt.Sprintf("Current %s version: %v (%s) - remove disable-update-check flag for updates", versionType, version, r.colorizer.BrightYellow("unknown"))
 		}
 		return fmt.Sprintf("Current %s version: %v %v", versionType, version, updateutils.GetVersionDescription(version, latestVersion))
 	}
@@ -910,7 +910,7 @@ func (r *Runner) displayExecutionInfo(store *loader.Store) {
 	gologger.Info().Msg(versionInfo(cfg.TemplateVersion, cfg.LatestNucleiTemplatesVersion, "nuclei-templates"))
 	if !HideAutoSaveMsg {
 		if r.pdcpUploadErrMsg != "" {
-			r.Logger.Warning().Msgf("%s", r.pdcpUploadErrMsg)
+			r.Logger.Warning().Msg(r.pdcpUploadErrMsg)
 		} else {
 			r.Logger.Info().Msgf("To view results on cloud dashboard, visit %v/scans upon scan completion.", pdcpauth.DashBoardURL)
 		}
@@ -928,7 +928,7 @@ func (r *Runner) displayExecutionInfo(store *loader.Store) {
 			value := v.Load()
 			if value > 0 {
 				if k == templates.Unsigned && !r.options.Silent && !config.DefaultConfig.HideTemplateSigWarning {
-					r.Logger.Print().Msgf("[%v] Loading %d unsigned templates for scan. Use with caution.", r.colorizer.BrightYellow("WRN"), value)
+					r.Logger.Warning().Msgf("Loading %d unsigned templates for scan. Use with caution.", value)
 				} else {
 					r.Logger.Info().Msgf("Executing %d signed templates from %s", value, k)
 				}
@@ -993,11 +993,11 @@ func UploadResultsToCloud(options *types.Options) error {
 		var r output.ResultEvent
 		err := dec.Decode(&r)
 		if err != nil {
-			options.Logger.Warning().Msgf("Could not decode jsonl: %s\n", err)
+			options.Logger.Warning().Msgf("Could not decode jsonl: %s", err)
 			continue
 		}
 		if err = uploadWriter.Write(&r); err != nil {
-			options.Logger.Warning().Msgf("[%s] failed to upload: %s\n", r.TemplateID, err)
+			options.Logger.Warning().Msgf("[%s] Failed to upload: %s", r.TemplateID, err)
 		}
 	}
 	uploadWriter.Close()

--- a/internal/runner/templates.go
+++ b/internal/runner/templates.go
@@ -24,7 +24,7 @@ func (r *Runner) logAvailableTemplate(tplPath string) {
 		panic("not a template")
 	}
 	if err != nil {
-		r.Logger.Error().Msgf("Could not parse file '%s': %s\n", tplPath, err)
+		r.Logger.Error().Msgf("Could not parse file '%s': %s", tplPath, err)
 	} else {
 		r.verboseTemplate(tpl)
 	}

--- a/internal/server/requests_worker.go
+++ b/internal/server/requests_worker.go
@@ -13,38 +13,38 @@ func (s *DASTServer) consumeTaskRequest(req PostRequestsHandlerRequest) {
 
 	parsedReq, err := types.ParseRawRequestWithURL(req.RawHTTP, req.URL)
 	if err != nil {
-		gologger.Warning().Msgf("Could not parse raw request: %s\n", err)
+		gologger.Warning().Msgf("Could not parse raw request: %s", err)
 		return
 	}
 
 	if parsedReq.URL.Scheme != "http" && parsedReq.URL.Scheme != "https" {
-		gologger.Warning().Msgf("Invalid scheme: %s\n", parsedReq.URL.Scheme)
+		gologger.Warning().Msgf("Invalid scheme: %s", parsedReq.URL.Scheme)
 		return
 	}
 
 	// Check filenames and don't allow non-interesting files
 	extension := path.Base(parsedReq.URL.Path)
 	if extension != "/" && extension != "" && scope.IsUninterestingPath(extension) {
-		gologger.Warning().Msgf("Uninteresting path: %s\n", parsedReq.URL.Path)
+		gologger.Warning().Msgf("Uninteresting path: %s", parsedReq.URL.Path)
 		return
 	}
 
 	inScope, err := s.scopeManager.Validate(parsedReq.URL.URL)
 	if err != nil {
-		gologger.Warning().Msgf("Could not validate scope: %s\n", err)
+		gologger.Warning().Msgf("Could not validate scope: %s", err)
 		return
 	}
 	if !inScope {
-		gologger.Warning().Msgf("Request is out of scope: %s %s\n", parsedReq.Request.Method, parsedReq.URL.String())
+		gologger.Warning().Msgf("Request is out of scope: %s %s", parsedReq.Request.Method, parsedReq.URL.String())
 		return
 	}
 
 	if s.deduplicator.isDuplicate(parsedReq) {
-		gologger.Warning().Msgf("Duplicate request detected: %s %s\n", parsedReq.Request.Method, parsedReq.URL.String())
+		gologger.Warning().Msgf("Duplicate request detected: %s %s", parsedReq.Request.Method, parsedReq.URL.String())
 		return
 	}
 
-	gologger.Verbose().Msgf("Fuzzing request: %s %s\n", parsedReq.Request.Method, parsedReq.URL.String())
+	gologger.Verbose().Msgf("Fuzzing request: %s %s", parsedReq.Request.Method, parsedReq.URL.String())
 
 	s.endpointsBeingTested.Add(1)
 	defer s.endpointsBeingTested.Add(-1)
@@ -52,7 +52,7 @@ func (s *DASTServer) consumeTaskRequest(req PostRequestsHandlerRequest) {
 	// Fuzz the request finally
 	err = s.nucleiExecutor.ExecuteScan(req)
 	if err != nil {
-		gologger.Warning().Msgf("Could not run nuclei: %s\n", err)
+		gologger.Warning().Msgf("Could not run nuclei: %s", err)
 		return
 	}
 }

--- a/pkg/catalog/config/ignorefile.go
+++ b/pkg/catalog/config/ignorefile.go
@@ -17,7 +17,7 @@ type IgnoreFile struct {
 func ReadIgnoreFile() IgnoreFile {
 	file, err := os.Open(DefaultConfig.GetIgnoreFilePath())
 	if err != nil {
-		gologger.Error().Msgf("Could not read nuclei-ignore file: %s\n", err)
+		gologger.Error().Msgf("Could not read nuclei-ignore file: %s", err)
 		return IgnoreFile{}
 	}
 	defer func() {
@@ -26,7 +26,7 @@ func ReadIgnoreFile() IgnoreFile {
 
 	ignore := IgnoreFile{}
 	if err := yaml.NewDecoder(file).Decode(&ignore); err != nil {
-		gologger.Error().Msgf("Could not parse nuclei-ignore file: %s\n", err)
+		gologger.Error().Msgf("Could not parse nuclei-ignore file: %s", err)
 		return IgnoreFile{}
 	}
 	return ignore

--- a/pkg/catalog/disk/find.go
+++ b/pkg/catalog/disk/find.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/logrusorgru/aurora"
 	"github.com/pkg/errors"
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/config"
 	stringsutil "github.com/projectdiscovery/utils/strings"
@@ -258,6 +257,6 @@ func PrintDeprecatedPathsMsgIfApplicable(isSilent bool) {
 		return
 	}
 	if deprecatedPathsCounter > 0 && !isSilent {
-		config.DefaultConfig.Logger.Print().Msgf("[%v] Found %v template[s] loaded with deprecated paths, update before v3 for continued support.\n", aurora.Yellow("WRN").String(), deprecatedPathsCounter)
+		config.DefaultConfig.Logger.Warning().Msgf("Found %v templates loaded with deprecated paths, update before v3 for continued support.", deprecatedPathsCounter)
 	}
 }

--- a/pkg/catalog/loader/loader.go
+++ b/pkg/catalog/loader/loader.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/logrusorgru/aurora"
 	"github.com/pkg/errors"
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog"
@@ -432,7 +431,7 @@ func (store *Store) LoadTemplateTags() (map[string]int, error) {
 			if strings.Contains(err.Error(), templates.ErrExcluded.Error()) {
 				stats.Increment(templates.TemplatesExcludedStats)
 				if config.DefaultConfig.LogAllEvents {
-					store.logger.Print().Msgf("[%v] %v\n", aurora.Yellow("WRN").String(), err.Error())
+					store.logger.Warning().Msg(err.Error())
 				}
 				continue
 			}
@@ -492,7 +491,7 @@ func (store *Store) LoadTemplatesOnlyMetadata() error {
 						if err != nil && strings.Contains(err.Error(), templates.ErrExcluded.Error()) {
 							stats.Increment(templates.TemplatesExcludedStats)
 							if config.DefaultConfig.LogAllEvents {
-								store.logger.Print().Msgf("[%v] %v\n", aurora.Yellow("WRN").String(), err.Error())
+								store.logger.Warning().Msg(err.Error())
 							}
 						}
 						continue
@@ -533,7 +532,7 @@ func (store *Store) LoadTemplatesOnlyMetadata() error {
 			if strings.Contains(err.Error(), templates.ErrExcluded.Error()) {
 				stats.Increment(templates.TemplatesExcludedStats)
 				if config.DefaultConfig.LogAllEvents {
-					store.logger.Print().Msgf("[%v] %v\n", aurora.Yellow("WRN").String(), err.Error())
+					store.logger.Warning().Msg(err.Error())
 				}
 				continue
 			}
@@ -671,7 +670,7 @@ func (store *Store) areWorkflowOrTemplatesValid(filteredTemplatePaths map[string
 				// TODO: until https://github.com/projectdiscovery/nuclei-templates/issues/11324 is deployed
 				// disable strict validation to allow GH actions to run
 				// areTemplatesValid = false
-				store.logger.Warning().Msgf("Found duplicate template ID during validation '%s' => '%s': %s\n", templatePath, existingTemplatePath, template.ID)
+				store.logger.Warning().Msgf("Found duplicate template ID during validation %q => %q: %s", templatePath, existingTemplatePath, template.ID)
 			}
 
 			if !isWorkflow && template.HasWorkflows() {
@@ -735,13 +734,13 @@ func (store *Store) LoadWorkflows(workflowsList []string) []*templates.Template 
 	for _, workflowPath := range includedWorkflows {
 		loaded, err := store.config.ExecutorOptions.Parser.LoadWorkflow(workflowPath, store.config.Catalog)
 		if err != nil {
-			store.logger.Warning().Msgf("Could not load workflow %s: %s\n", workflowPath, err)
+			store.logger.Warning().Msgf("Could not load %q workflow template: %s", workflowPath, err)
 		}
 
 		if loaded {
 			parsed, err := templates.Parse(workflowPath, store.preprocessor, store.config.ExecutorOptions)
 			if err != nil {
-				store.logger.Warning().Msgf("Could not parse workflow %s: %s\n", workflowPath, err)
+				store.logger.Warning().Msgf("Could not parse %q workflow template: %s", workflowPath, err)
 			} else if parsed != nil {
 				loadedWorkflows = append(loadedWorkflows, parsed)
 			}
@@ -851,7 +850,7 @@ func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) ([]*temp
 					if !errors.Is(err, templates.ErrIncompatibleWithOfflineMatching) {
 						stats.Increment(templates.RuntimeWarningsStats)
 					}
-					store.logger.Warning().Msgf("Could not parse template %s: %s\n", templatePath, err)
+					store.logger.Warning().Msgf("Could not parse %q template: %s", templatePath, err)
 				} else if parsed != nil {
 					if !parsed.Verified && typesOpts.DisableUnsignedTemplates {
 						// skip unverified templates when prompted to
@@ -883,7 +882,7 @@ func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) ([]*temp
 							if parsed.HasHeadlessRequest() && !typesOpts.Headless {
 								stats.Increment(templates.ExcludedHeadlessTmplStats)
 								if config.DefaultConfig.LogAllEvents {
-									store.logger.Print().Msgf("[%v] Headless flag is required for headless template '%s'.\n", aurora.Yellow("WRN").String(), templatePath)
+									store.logger.Warning().Msgf("The headless flag is required for %q headless template", templatePath)
 								}
 							} else {
 								loadTemplate(parsed)
@@ -893,13 +892,13 @@ func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) ([]*temp
 						// donot include headless template in final list if headless flag is not set
 						stats.Increment(templates.ExcludedHeadlessTmplStats)
 						if config.DefaultConfig.LogAllEvents {
-							store.logger.Print().Msgf("[%v] Headless flag is required for headless template '%s'.\n", aurora.Yellow("WRN").String(), templatePath)
+							store.logger.Warning().Msgf("The headless flag is required for %q headless template", templatePath)
 						}
 					} else if parsed.HasCodeRequest() && !typesOpts.EnableCodeTemplates {
 						// donot include 'Code' protocol custom template in final list if code flag is not set
 						stats.Increment(templates.ExcludedCodeTmplStats)
 						if config.DefaultConfig.LogAllEvents {
-							store.logger.Print().Msgf("[%v] Code flag is required for code protocol template '%s'.\n", aurora.Yellow("WRN").String(), templatePath)
+							store.logger.Warning().Msgf("The code flag is required for %q code protocol template", templatePath)
 						}
 					} else if parsed.HasCodeRequest() && !parsed.Verified && !parsed.HasWorkflows() {
 						// donot include unverified 'Code' protocol custom template in final list
@@ -907,12 +906,12 @@ func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) ([]*temp
 						// these will be skipped so increment skip counter
 						stats.Increment(templates.SkippedUnsignedStats)
 						if config.DefaultConfig.LogAllEvents {
-							store.logger.Print().Msgf("[%v] Tampered/Unsigned template at %v.\n", aurora.Yellow("WRN").String(), templatePath)
+							store.logger.Warning().Msgf("Template %q is unverified and will be skipped", templatePath)
 						}
 					} else if parsed.IsFuzzableRequest() && !typesOpts.DAST {
 						stats.Increment(templates.ExcludedDastTmplStats)
 						if config.DefaultConfig.LogAllEvents {
-							store.logger.Print().Msgf("[%v] -dast flag is required for DAST template '%s'.\n", aurora.Yellow("WRN").String(), templatePath)
+							store.logger.Warning().Msgf("The dast flag is required for %q DAST template", templatePath)
 						}
 					} else {
 						loadTemplate(parsed)
@@ -923,7 +922,7 @@ func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) ([]*temp
 				if strings.Contains(err.Error(), templates.ErrExcluded.Error()) {
 					stats.Increment(templates.TemplatesExcludedStats)
 					if config.DefaultConfig.LogAllEvents {
-						store.logger.Print().Msgf("[%v] %v\n", aurora.Yellow("WRN").String(), err.Error())
+						store.logger.Warning().Msg(err.Error())
 					}
 					return
 				}
@@ -984,7 +983,7 @@ func workflowContainsProtocol(workflow []*workflows.WorkflowTemplate) bool {
 func (s *Store) logErroredTemplates(erred map[string]error) {
 	for template, err := range erred {
 		if s.NotFoundCallback == nil || !s.NotFoundCallback(template) {
-			s.logger.Error().Msgf("Could not find template '%s': %s", template, err)
+			s.logger.Error().Msgf("Could not find %q template: %s", template, err)
 		}
 	}
 }

--- a/pkg/core/executors.go
+++ b/pkg/core/executors.go
@@ -39,7 +39,7 @@ func (e *Engine) executeAllSelfContained(ctx context.Context, alltemplates []*te
 				match, err = template.Executer.Execute(ctx)
 			}
 			if err != nil {
-				e.options.Logger.Warning().Msgf("[%s] Could not execute step (self-contained): %s\n", e.executerOpts.Colorizer.BrightBlue(template.ID), err)
+				e.options.Logger.Warning().Msgf("[%s] Could not execute step (self-contained): %s", e.executerOpts.Colorizer.BrightBlue(template.ID), err)
 			}
 			results.CompareAndSwap(false, match)
 		}(v)
@@ -110,7 +110,7 @@ func (e *Engine) executeTemplateWithTargets(ctx context.Context, template *templ
 
 					match, err := e.executeTemplateOnInput(ctx, template, t.value)
 					if err != nil {
-						e.options.Logger.Warning().Msgf("[%s] Could not execute step on %s: %s\n", template.ID, t.value.Input, err)
+						e.options.Logger.Warning().Msgf("[%s] Could not execute step on %s: %s", template.ID, t.value.Input, err)
 					}
 					results.CompareAndSwap(false, match)
 				}()
@@ -236,7 +236,7 @@ func (e *Engine) executeTemplatesOnTarget(ctx context.Context, alltemplates []*t
 
 			match, err := e.executeTemplateOnInput(ctx, template, value)
 			if err != nil {
-				e.options.Logger.Warning().Msgf("[%s] Could not execute step on %s: %s\n", template.ID, value.Input, err)
+				e.options.Logger.Warning().Msgf("[%s] Could not execute step on %s: %s", template.ID, value.Input, err)
 			}
 			results.CompareAndSwap(false, match)
 		}(tpl, target, sg)

--- a/pkg/core/workpool.go
+++ b/pkg/core/workpool.go
@@ -80,12 +80,12 @@ func (w *WorkPool) RefreshWithConfig(config WorkPoolConfig) {
 func (w *WorkPool) Refresh(ctx context.Context) {
 	if w.Default.Size != w.config.TypeConcurrency {
 		if err := w.Default.Resize(ctx, w.config.TypeConcurrency); err != nil {
-			gologger.Warning().Msgf("Could not resize workpool: %s\n", err)
+			gologger.Warning().Msgf("Could not resize workpool: %s", err)
 		}
 	}
 	if w.Headless.Size != w.config.HeadlessTypeConcurrency {
 		if err := w.Headless.Resize(ctx, w.config.HeadlessTypeConcurrency); err != nil {
-			gologger.Warning().Msgf("Could not resize workpool: %s\n", err)
+			gologger.Warning().Msgf("Could not resize workpool: %s", err)
 		}
 	}
 }

--- a/pkg/external/customtemplates/github.go
+++ b/pkg/external/customtemplates/github.go
@@ -35,9 +35,9 @@ func (customTemplate *customTemplateGitHubRepo) Download(ctx context.Context) {
 	if !fileutil.FolderExists(clonePath) {
 		err := customTemplate.cloneRepo(clonePath, customTemplate.githubToken)
 		if err != nil {
-			gologger.Error().Msgf("%s", err)
+			gologger.Error().Msg(err.Error())
 		} else {
-			gologger.Info().Msgf("Repo %s/%s cloned successfully at %s", customTemplate.owner, customTemplate.reponame, clonePath)
+			gologger.Info().Msgf("Repository %s/%s cloned successfully at %s", customTemplate.owner, customTemplate.reponame, clonePath)
 		}
 		return
 	}
@@ -73,17 +73,17 @@ func (customTemplate *customTemplateGitHubRepo) handlePullChanges(clonePath stri
 
 // logPullSuccess logs a success message when changes are pulled
 func (customTemplate *customTemplateGitHubRepo) logPullSuccess() {
-	gologger.Info().Msgf("Repo %s/%s successfully pulled the changes.\n", customTemplate.owner, customTemplate.reponame)
+	gologger.Info().Msgf("Repository %s/%s successfully pulled the changes", customTemplate.owner, customTemplate.reponame)
 }
 
 // logAlreadyUpToDate logs an info message when repo is already up to date
 func (customTemplate *customTemplateGitHubRepo) logAlreadyUpToDate(err error) {
-	gologger.Info().Msgf("%s", err)
+	gologger.Info().Msg(err.Error())
 }
 
 // logPullError logs an error message when pull fails
 func (customTemplate *customTemplateGitHubRepo) logPullError(err error) {
-	gologger.Error().Msgf("%s", err)
+	gologger.Error().Msg(err.Error())
 }
 
 // NewGitHubProviders returns new instance of GitHub providers for downloading custom templates
@@ -98,12 +98,12 @@ func NewGitHubProviders(options *types.Options) ([]*customTemplateGitHubRepo, er
 	for _, repoName := range options.GitHubTemplateRepo {
 		owner, repo, err := getOwnerAndRepo(repoName)
 		if err != nil {
-			gologger.Error().Msgf("%s", err)
+			gologger.Error().Msg(err.Error())
 			continue
 		}
 		githubRepo, err := getGitHubRepo(gitHubClient, owner, repo, options.GitHubToken)
 		if err != nil {
-			gologger.Error().Msgf("%s", err)
+			gologger.Error().Msg(err.Error())
 			continue
 		}
 		customTemplateRepo := &customTemplateGitHubRepo{

--- a/pkg/fuzz/component/body.go
+++ b/pkg/fuzz/component/body.go
@@ -69,7 +69,7 @@ func (b *Body) Parse(req *retryablehttp.Request) (bool, error) {
 	}
 	parsed, err := b.parseBody(dataformat.FormDataFormat, req)
 	if err != nil {
-		gologger.Warning().Msgf("Could not parse body as form data: %s\n", err)
+		gologger.Warning().Msgf("Could not parse body as form data: %s", err)
 		return b.parseBody(dataformat.RawDataFormat, req)
 	}
 	return parsed, err

--- a/pkg/fuzz/component/value.go
+++ b/pkg/fuzz/component/value.go
@@ -5,7 +5,6 @@ import (
 	"strconv"
 
 	"github.com/leslie-qiwa/flat"
-	"github.com/logrusorgru/aurora"
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz/dataformat"
 )
@@ -123,7 +122,7 @@ func (v *Value) SetParsedValue(key, value string) bool {
 			origValue = val
 		} else {
 			// make it default warning instead of error
-			gologger.DefaultLogger.Print().Msgf("[%v] unknown type %T for value %s", aurora.BrightYellow("WARN"), v, v)
+			gologger.DefaultLogger.Warning().Msgf("Unknown type %T for value %s", v, v)
 		}
 	}
 	v.parsed.Set(key, origValue)

--- a/pkg/fuzz/execute.go
+++ b/pkg/fuzz/execute.go
@@ -106,7 +106,7 @@ func (rule *Rule) Execute(input *ExecuteRuleInput) (err error) {
 		component := component.New(componentName)
 		discovered, err := component.Parse(input.BaseRequest)
 		if err != nil {
-			gologger.Verbose().Msgf("Could not parse component %s: %s\n", componentName, err)
+			gologger.Verbose().Msgf("Could not parse %q component: %s", componentName, err)
 			continue
 		}
 		if !discovered {
@@ -141,7 +141,7 @@ func (rule *Rule) Execute(input *ExecuteRuleInput) (err error) {
 	}
 	if len(displayDebugFuzzPoints) > 0 {
 		marshalled, _ := json.MarshalIndent(displayDebugFuzzPoints, "", "  ")
-		gologger.Info().Msgf("[%s] Fuzz points for %s [%s]\n%s\n", rule.options.TemplateID, input.Input.MetaInput.Input, input.BaseRequest.Method, string(marshalled))
+		gologger.Info().Msgf("[%s] Fuzz points for %s [%s]\n%s", rule.options.TemplateID, input.Input.MetaInput.Input, input.BaseRequest.Method, string(marshalled))
 	}
 
 	if len(finalComponentList) == 0 {
@@ -183,7 +183,7 @@ mainLoop:
 				if err == io.EOF {
 					return nil
 				}
-				gologger.Warning().Msgf("[%s] Could not execute rule: %s\n", rule.options.TemplateID, err)
+				gologger.Warning().Msgf("[%s] Could not execute rule: %s", rule.options.TemplateID, err)
 				return err
 			}
 		}

--- a/pkg/input/formats/json/json.go
+++ b/pkg/input/formats/json/json.go
@@ -62,7 +62,7 @@ func (j *JSONFormat) Parse(input io.Reader, resultsCb formats.ParseReqRespCallba
 		}
 		rawRequest, err := types.ParseRawRequestWithURL(request.Request.Raw, request.URL)
 		if err != nil {
-			gologger.Warning().Msgf("jsonl: Could not parse raw request %s: %s\n", request.URL, err)
+			gologger.Warning().Msgf("jsonl: Could not parse raw request %q: %s", request.URL, err)
 			continue
 		}
 		resultsCb(rawRequest)

--- a/pkg/input/formats/openapi/generator.go
+++ b/pkg/input/formats/openapi/generator.go
@@ -55,11 +55,11 @@ func GenerateRequestsFromSchema(schema *openapi3.T, opts formats.InputFormatOpti
 		} else {
 			// if missing check for validation
 			if opts.SkipFormatValidation {
-				gologger.Verbose().Msgf("openapi: skipping all requests due to missing global auth parameter: %s\n", param.Value.Name)
+				gologger.Verbose().Msgf("openapi: Skipping all requests due to missing global auth parameter: %s", param.Value.Name)
 				return nil
 			} else {
 				// fatal error
-				gologger.Fatal().Msgf("openapi: missing global auth parameter: %s\n", param.Value.Name)
+				gologger.Fatal().Msgf("openapi: Missing global auth parameter: %s\n", param.Value.Name)
 			}
 		}
 	}
@@ -105,15 +105,16 @@ func GenerateRequestsFromSchema(schema *openapi3.T, opts formats.InputFormatOpti
 					callback:                  callback,
 					missingParamValueCallback: missingParamValueCallback,
 				}); err != nil {
-					gologger.Warning().Msgf("Could not generate requests from op: %s\n", err)
+					gologger.Warning().Msgf("Could not generate requests for %q operation: %s", ov.OperationID, err)
 				}
 			}
 		}
 	}
 
 	if len(missingVarMap) > 0 && !opts.SkipFormatValidation {
-		gologger.Error().Msgf("openapi: Found %d missing parameters, use -skip-format-validation flag to skip requests or update missing parameters generated in %s file,you can also specify these vars using -var flag in (key=value) format\n", len(missingVarMap), formats.DefaultVarDumpFileName)
-		gologger.Verbose().Msgf("openapi: missing params: %+v", mapsutil.GetSortedKeys(missingVarMap))
+		gologger.Error().Msgf("openapi: Found %d missing parameters, use skip-format-validation flag to skip requests or update missing parameters generated in %q file", len(missingVarMap), formats.DefaultVarDumpFileName)
+		gologger.Info().Msg("openapi: You can also specify these vars using var flag in key=value format")
+		gologger.Verbose().Msgf("openapi: Missing params: %+v", mapsutil.GetSortedKeys(missingVarMap))
 		if config.CurrentAppMode == config.AppModeCLI {
 			// generate var dump file
 			vars := &formats.OpenAPIParamsCfgFile{}
@@ -122,7 +123,7 @@ func GenerateRequestsFromSchema(schema *openapi3.T, opts formats.InputFormatOpti
 			}
 			vars.OptionalVars = mapsutil.GetSortedKeys(optionalVarMap)
 			if err := formats.WriteOpenAPIVarDumpFile(vars); err != nil {
-				gologger.Error().Msgf("openapi: could not write params file: %s\n", err)
+				gologger.Error().Msgf("openapi: Could not write params file: %s", err)
 			}
 			// exit with status code 1
 			os.Exit(1)
@@ -213,13 +214,13 @@ func generateRequestsFromOp(opts *generateReqOptions) error {
 				}
 				// skip request if param in path else skip this param only
 				if value.Required {
-					// gologger.Verbose().Msgf("skipping request [%s] %s due to missing value (%v)\n", opts.method, opts.requestPath, value.Name)
+					// gologger.Verbose().Msgf("skipping request [%s] %s due to missing value (%v)", opts.method, opts.requestPath, value.Name)
 					return nil
 				} else {
 					// if it is in path then remove it from path
 					opts.requestPath = strings.ReplaceAll(opts.requestPath, fmt.Sprintf("{%s}", value.Name), "")
 					if !opts.opts.RequiredOnly {
-						gologger.Verbose().Msgf("openapi: skipping optional param (%s) in (%v) in request [%s] %s due to missing value (%v)\n", value.Name, value.In, opts.method, opts.requestPath, value.Name)
+						gologger.Verbose().Msgf("openapi: Skipping optional %q param in %q for %s %s request due to missing %q value", value.Name, value.In, opts.method, opts.requestPath, value.Name)
 					}
 					continue
 				}
@@ -229,13 +230,13 @@ func generateRequestsFromOp(opts *generateReqOptions) error {
 				// when failed to generate example
 				// skip request if param in path else skip this param only
 				if value.Required {
-					gologger.Verbose().Msgf("openapi: skipping request [%s] %s due to missing value (%v)\n", opts.method, opts.requestPath, value.Name)
+					gologger.Verbose().Msgf("openapi: Skipping %s %s request due to missing %q value", opts.method, opts.requestPath, value.Name)
 					return nil
 				} else {
 					// if it is in path then remove it from path
 					opts.requestPath = strings.ReplaceAll(opts.requestPath, fmt.Sprintf("{%s}", value.Name), "")
 					if !opts.opts.RequiredOnly {
-						gologger.Verbose().Msgf("openapi: skipping optional param (%s) in (%v) in request [%s] %s due to missing value (%v)\n", value.Name, value.In, opts.method, opts.requestPath, value.Name)
+						gologger.Verbose().Msgf("openapi: Skipping optional %q param in %q for %s %s request due to missing %q value", value.Name, value.In, opts.method, opts.requestPath, value.Name)
 					}
 					continue
 				}
@@ -299,7 +300,7 @@ func generateRequestsFromOp(opts *generateReqOptions) error {
 					cloned.ContentLength = int64(len(marshalled))
 					cloned.Header.Set("Content-Type", "application/xml")
 				} else {
-					gologger.Warning().Msgf("openapi: could not encode xml")
+					gologger.Warning().Msgf("openapi: Could not encode XML for %s %s request", opts.method, opts.requestPath)
 				}
 			case "application/x-www-form-urlencoded":
 				if values, ok := val.(map[string]interface{}); ok {
@@ -356,7 +357,7 @@ func generateRequestsFromOp(opts *generateReqOptions) error {
 					cloned.Header.Set("Content-Type", "text/plain")
 				}
 			default:
-				gologger.Verbose().Msgf("openapi: no correct content type found for body: %s\n", content)
+				gologger.Verbose().Msgf("openapi: No correct content type found for body: %s", content)
 				// LOG:	return errors.New("no correct content type found for body")
 				continue
 			}

--- a/pkg/input/provider/http/multiformat.go
+++ b/pkg/input/provider/http/multiformat.go
@@ -109,7 +109,7 @@ func (i *HttpInputProvider) Iterate(callback func(value *contextargs.MetaInput) 
 		return callback(metaInput)
 	}, i.inputFile)
 	if err != nil {
-		gologger.Warning().Msgf("Could not parse input file while iterating: %s\n", err)
+		gologger.Warning().Msgf("Could not parse input file while iterating: %s", err)
 	}
 }
 

--- a/pkg/input/provider/interface.go
+++ b/pkg/input/provider/interface.go
@@ -92,7 +92,7 @@ func NewInputProvider(opts InputOptions) (InputProvider, error) {
 	val, err := formats.ReadOpenAPIVarDumpFile()
 	if err != nil && !errors.Is(err, formats.ErrNoVarsDumpFile) {
 		// log error and continue
-		gologger.Error().Msgf("Could not read vars dump file: %s\n", err)
+		gologger.Error().Msgf("Could not read vars dump file: %s", err)
 	}
 	extraVars := make(map[string]interface{})
 	if val != nil {

--- a/pkg/input/provider/list/hmap.go
+++ b/pkg/input/provider/list/hmap.go
@@ -97,13 +97,13 @@ func New(opts *Options) (*ListInputProvider, error) {
 		return nil, initErr
 	}
 	if input.excludedCount > 0 {
-		gologger.Info().Msgf("Number of hosts excluded from input: %d", input.excludedCount)
+		gologger.Info().Msgf("%d hosts excluded from input", input.excludedCount)
 	}
 	if input.dupeCount > 0 {
 		gologger.Info().Msgf("Supplied input was automatically deduplicated (%d removed).", input.dupeCount)
 	}
 	if input.skippedCount > 0 {
-		gologger.Info().Msgf("Number of hosts skipped from input due to exclusion: %d", input.skippedCount)
+		gologger.Info().Msgf("%d hosts skipped from input due to exclusion", input.skippedCount)
 	}
 	return input, nil
 }
@@ -118,7 +118,7 @@ func (i *ListInputProvider) Iterate(callback func(value *contextargs.MetaInput) 
 	if i.hostMapStream != nil {
 		i.hostMapStreamOnce.Do(func() {
 			if err := i.hostMapStream.Process(); err != nil {
-				gologger.Warning().Msgf("error in stream mode processing: %s\n", err)
+				gologger.Warning().Msgf("Error in stream mode processing: %s", err)
 			}
 		})
 	}
@@ -150,9 +150,9 @@ func (i *ListInputProvider) Set(executionId string, value string) {
 	if err != nil || (urlx != nil && urlx.Host == "") {
 		gologger.Debug().Label("url").MsgFunc(func() string {
 			if err != nil {
-				return fmt.Sprintf("failed to parse url %v got %v skipping ip selection", URL, err)
+				return fmt.Sprintf("Failed to parse %q URL for skipping IP selection: %v", URL, err)
 			}
-			return fmt.Sprintf("got empty hostname for %v skipping ip selection", URL)
+			return fmt.Sprintf("Failed to parse %q URL for skipping IP selection due to empty hostname", URL)
 		})
 		metaInput := contextargs.NewMetaInput()
 		metaInput.Input = URL
@@ -196,11 +196,11 @@ func (i *ListInputProvider) Set(executionId string, value string) {
 				}
 				return
 			} else {
-				gologger.Debug().Msgf("scanAllIps: no ip's found reverting to default")
+				gologger.Debug().Msgf("scanAllIps: no IPs found for %q, reverting to default", URL)
 			}
 		} else {
 			// failed to scanallips falling back to defaults
-			gologger.Debug().Msgf("scanAllIps: dns resolution failed: %v", err)
+			gologger.Debug().Msgf("scanAllIps: DNS resolution failed for %q URL: %v", URL, err)
 		}
 	}
 
@@ -217,7 +217,7 @@ func (i *ListInputProvider) Set(executionId string, value string) {
 			// pick/ prefer 1st
 			ips = append(ips, dnsData.AAAA[0])
 		} else {
-			gologger.Warning().Msgf("target does not have ipv6 address falling back to ipv4 %v\n", err)
+			gologger.Warning().Msgf("Target %q does not have IPv6 address, falling back to IPv4: %v", URL, err)
 		}
 	}
 	if i.ipOptions.IPV4 {
@@ -315,7 +315,7 @@ func (i *ListInputProvider) initializeInputSources(opts *Options) error {
 		}
 	}
 	if options.Uncover && options.UncoverQuery != nil {
-		gologger.Info().Msgf("Running uncover query against: %s", strings.Join(options.UncoverEngine, ","))
+		gologger.Info().Msgf("Running uncover query against for %q", strings.Join(options.UncoverEngine, ","))
 		uncoverOpts := &uncoverlib.Options{
 			Agents:        options.UncoverEngine,
 			Queries:       options.UncoverQuery,
@@ -379,7 +379,7 @@ func (i *ListInputProvider) isExcluded(URL string) bool {
 	metaInput.Input = URL
 	key, err := metaInput.MarshalString()
 	if err != nil {
-		gologger.Warning().Msgf("%s\n", err)
+		gologger.Warning().Msg(err.Error())
 		return false
 	}
 
@@ -397,9 +397,9 @@ func (i *ListInputProvider) Del(executionId string, value string) {
 	if err != nil || (urlx != nil && urlx.Host == "") {
 		gologger.Debug().Label("url").MsgFunc(func() string {
 			if err != nil {
-				return fmt.Sprintf("failed to parse url %v got %v skipping ip selection", URL, err)
+				return fmt.Sprintf("Failed to parse %q URL for skipping IP selection: %v", URL, err)
 			}
-			return fmt.Sprintf("got empty hostname for %v skipping ip selection", URL)
+			return fmt.Sprintf("Failed to parse %q URL for skipping IP selection due to empty hostname", URL)
 		})
 		metaInput := contextargs.NewMetaInput()
 		metaInput.Input = URL
@@ -443,11 +443,11 @@ func (i *ListInputProvider) Del(executionId string, value string) {
 				}
 				return
 			} else {
-				gologger.Debug().Msgf("scanAllIps: no ip's found reverting to default")
+				gologger.Debug().Msgf("scanAllIps: no IPs found, reverting to default")
 			}
 		} else {
 			// failed to scanallips falling back to defaults
-			gologger.Debug().Msgf("scanAllIps: dns resolution failed: %v", err)
+			gologger.Debug().Msgf("scanAllIps: DNS resolution failed: %v", err)
 		}
 	}
 
@@ -464,7 +464,7 @@ func (i *ListInputProvider) Del(executionId string, value string) {
 			// pick/ prefer 1st
 			ips = append(ips, dnsData.AAAA[0])
 		} else {
-			gologger.Warning().Msgf("target does not have ipv6 address falling back to ipv4 %v\n", err)
+			gologger.Warning().Msgf("Target does not have IPv6 address, falling back to IPv4: %v", err)
 		}
 	}
 	if i.ipOptions.IPV4 {
@@ -489,7 +489,7 @@ func (i *ListInputProvider) Del(executionId string, value string) {
 func (i *ListInputProvider) setItem(metaInput *contextargs.MetaInput) {
 	key, err := metaInput.MarshalString()
 	if err != nil {
-		gologger.Warning().Msgf("%s\n", err)
+		gologger.Warning().Msg(err.Error())
 		return
 	}
 	if _, ok := i.hostMap.Get(key); ok {
@@ -560,7 +560,7 @@ func (i *ListInputProvider) delItem(targets ...*contextargs.MetaInput) {
 // setHostMapStream sets item in stream mode
 func (i *ListInputProvider) setHostMapStream(data string) {
 	if _, err := i.hostMapStream.Merge([][]byte{[]byte(data)}); err != nil {
-		gologger.Warning().Msgf("%s\n", err)
+		gologger.Warning().Msg(err.Error())
 		return
 	}
 }

--- a/pkg/installer/template.go
+++ b/pkg/installer/template.go
@@ -165,9 +165,9 @@ func (t *TemplateManager) updateTemplatesAt(dir string) error {
 	currentVersion := config.DefaultConfig.TemplateVersion
 
 	if config.IsOutdatedVersion(currentVersion, latestVersion) {
-		gologger.Info().Msgf("Your current nuclei-templates %s are outdated. Latest is %s\n", currentVersion, latestVersion)
+		gologger.Info().Msgf("Your current nuclei-templates %s are outdated. Latest is %s", currentVersion, latestVersion)
 	} else {
-		gologger.Debug().Msgf("Updating nuclei-templates from %s to %s (forced update)\n", currentVersion, latestVersion)
+		gologger.Debug().Msgf("Updating nuclei-templates from %s to %s (forced update)", currentVersion, latestVersion)
 	}
 
 	// write templates to disk

--- a/pkg/js/compiler/pool.go
+++ b/pkg/js/compiler/pool.go
@@ -61,7 +61,7 @@ var (
 		// resize check point
 		if pooljsc.Size != PoolingJsVmConcurrency {
 			if err := pooljsc.Resize(ctx, PoolingJsVmConcurrency); err != nil {
-				gologger.Warning().Msgf("Could not resize workpool: %s\n", err)
+				gologger.Warning().Msgf("Could not resize workpool: %s", err)
 			}
 		}
 	}
@@ -216,7 +216,7 @@ func createNewRuntime() *goja.Runtime {
 
 	// Register embedded javascript helpers
 	if err := global.RegisterNativeScripts(runtime); err != nil {
-		gologger.Error().Msgf("Could not register scripts: %s\n", err)
+		gologger.Error().Msgf("Could not register scripts: %s", err)
 	}
 	return runtime
 }

--- a/pkg/js/devtools/tsgen/parser.go
+++ b/pkg/js/devtools/tsgen/parser.go
@@ -81,7 +81,7 @@ func (p *EntityParser) Parse() error {
 				}
 				entity, err := p.extractFunctionFromNode(fn)
 				if err != nil {
-					gologger.Error().Msgf("Could not extract function %s: %s\n", fn.Name.Name, err)
+					gologger.Error().Msgf("Could not extract function %s: %s", fn.Name.Name, err)
 					return false
 				}
 

--- a/pkg/js/global/scripts.go
+++ b/pkg/js/global/scripts.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/Mzack9999/goja"
-	"github.com/logrusorgru/aurora"
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/nuclei/v3/pkg/js/gojs"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
@@ -81,11 +80,11 @@ func initBuiltInFunc(runtime *goja.Runtime) {
 			arg := call.Argument(0).Export()
 			switch value := arg.(type) {
 			case string:
-				gologger.DefaultLogger.Print().Msgf("[%v] %v", aurora.BrightCyan("JS"), value)
+				gologger.DefaultLogger.Info().Msgf("[%v] %v", "JS", value)
 			case map[string]interface{}:
-				gologger.DefaultLogger.Print().Msgf("[%v] %v", aurora.BrightCyan("JS"), vardump.DumpVariables(value))
+				gologger.DefaultLogger.Info().Msgf("[%v] %v", "JS", vardump.DumpVariables(value))
 			default:
-				gologger.DefaultLogger.Print().Msgf("[%v] %v", aurora.BrightCyan("JS"), value)
+				gologger.DefaultLogger.Info().Msgf("[%v] %v", "JS", value)
 			}
 			return call.Argument(0)
 		},

--- a/pkg/progress/progress.go
+++ b/pkg/progress/progress.go
@@ -101,7 +101,7 @@ func (p *StatsTicker) Init(hostCount int64, rulesCount int, requestCount int64) 
 		// Note: this is needed and is responsible for the tick event
 		p.stats.GetStatResponse(p.tickDuration, func(s string, err error) error {
 			if err != nil {
-				gologger.Warning().Msgf("Could not read statistics: %s\n", err)
+				gologger.Warning().Msgf("Could not read statistics: %s", err)
 			}
 			return nil
 		})

--- a/pkg/protocols/code/code.go
+++ b/pkg/protocols/code/code.go
@@ -184,7 +184,7 @@ func (request *Request) ExecuteWithResults(input *contextargs.Context, dynamicVa
 	}
 	defer func() {
 		if err := metaSrc.Cleanup(); err != nil {
-			gologger.Warning().Msgf("%s\n", err)
+			gologger.Warning().Msg(err.Error())
 		}
 	}()
 
@@ -213,7 +213,7 @@ func (request *Request) ExecuteWithResults(input *contextargs.Context, dynamicVa
 
 	if request.PreCondition != "" {
 		if request.options.Options.Debug || request.options.Options.DebugRequests {
-			gologger.Debug().Msgf("[%s] Executing Precondition for Code request\n", request.TemplateID)
+			gologger.Debug().Msgf("[%s] Executing pre-condition for code request", request.TemplateID)
 			var highlightFormatter = "terminal256"
 			if request.options.Options.NoColor {
 				highlightFormatter = "text"
@@ -239,12 +239,12 @@ func (request *Request) ExecuteWithResults(input *contextargs.Context, dynamicVa
 			return errkit.Newf("could not execute pre-condition: %s", err)
 		}
 		if !result.GetSuccess() || types.ToString(result["error"]) != "" {
-			gologger.Warning().Msgf("[%s] Precondition for request %s was not satisfied\n", request.TemplateID, request.PreCondition)
+			gologger.Warning().Msgf("[%s] Pre-condition for request %q was not satisfied", request.TemplateID, request.PreCondition)
 			request.options.Progress.IncrementFailedRequestsBy(1)
 			return nil
 		}
 		if request.options.Options.Debug || request.options.Options.DebugRequests {
-			gologger.Debug().Msgf("[%s] Precondition for request was satisfied\n", request.TemplateID)
+			gologger.Debug().Msgf("[%s] Pre-condition for request %q was satisfied", request.TemplateID, request.PreCondition)
 		}
 	}
 
@@ -283,26 +283,25 @@ func (request *Request) ExecuteWithResults(input *contextargs.Context, dynamicVa
 	gologger.Verbose().Msgf("[%s] Executed code on local machine %v", request.options.TemplateID, input.MetaInput.Input)
 
 	if vardump.EnableVarDump {
-		gologger.Debug().Msgf("Code Protocol request variables: %s\n", vardump.DumpVariables(allvars))
+		gologger.Debug().Msgf("Code protocol request variables: %s", vardump.DumpVariables(allvars))
 	}
 
 	if request.options.Options.Debug || request.options.Options.DebugRequests {
 		gologger.Debug().MsgFunc(func() string {
 			dashes := strings.Repeat("-", 15)
 			sb := &strings.Builder{}
-			fmt.Fprintf(sb, "[%s] Dumped Executed Source Code for input/stdin: '%v'", request.options.TemplateID, input.MetaInput.Input)
-			fmt.Fprintf(sb, "\n%v\n%v\n%v\n", dashes, "Source Code:", dashes)
+			fmt.Fprintf(sb, "[%s] Dumped executed source code for input or STDIN: '%v'", request.options.TemplateID, input.MetaInput.Input)
+			fmt.Fprintf(sb, "\n%v\n%v\n%v\n", dashes, "Source code:", dashes)
 			sb.WriteString(interpretEnvVars(request.Source, allvars))
 			sb.WriteString("\n")
-			fmt.Fprintf(sb, "\n%v\n%v\n%v\n", dashes, "Command Executed:", dashes)
+			fmt.Fprintf(sb, "\n%v\n%v\n%v\n", dashes, "Command executed:", dashes)
 			sb.WriteString(interpretEnvVars(gOutput.Command, allvars))
 			sb.WriteString("\n")
-			fmt.Fprintf(sb, "\n%v\n%v\n%v\n", dashes, "Command Output:", dashes)
+			fmt.Fprintf(sb, "\n%v\n%v\n%v\n", dashes, "Command output:", dashes)
 			sb.WriteString(gOutput.DebugData.String())
-			sb.WriteString("\n")
-			sb.WriteString("[WRN] Command Output here is stdout+sterr, in response variables they are separate (use -v -svd flags for more details)")
 			return sb.String()
 		})
+		gologger.Debug().Msgf("[%s] Command output are combined STDOUT and STDERR, in response variables they are separate (use verbose or show-var-dump flags for more details)", request.options.TemplateID)
 	}
 
 	dataOutputString := fmtStdout(gOutput.Stdout.String())
@@ -351,12 +350,12 @@ func (request *Request) ExecuteWithResults(input *contextargs.Context, dynamicVa
 	}
 
 	if request.options.Options.Debug || request.options.Options.DebugResponse || request.options.Options.StoreResponse {
-		msg := fmt.Sprintf("[%s] Dumped Code Execution for %s\n\n", request.options.TemplateID, input.MetaInput.Input)
+		msg := fmt.Sprintf("[%s] Dumped code execution for %s\n\n", request.options.TemplateID, input.MetaInput.Input)
 		if request.options.Options.Debug || request.options.Options.DebugResponse {
 			gologger.Debug().Msg(msg)
 			gologger.Print().Msgf("%s\n\n", responsehighlighter.Highlight(event.OperatorsResult, dataOutputString, request.options.Options.NoColor, false))
 			if gOutput.Stderr.Len() > 0 {
-				gologger.Debug().Msgf("[%s] Code Stderr:\n%s", request.options.TemplateID, gOutput.Stderr.String())
+				gologger.Debug().Msgf("[%s] Code STDERR:\n%s", request.options.TemplateID, gOutput.Stderr.String())
 			}
 		}
 		if request.options.Options.StoreResponse {
@@ -474,7 +473,7 @@ func prettyPrint(templateId string, buff string) {
 			final = append(final, "\t"+v)
 		}
 	}
-	gologger.Debug().Msgf(" [%v] Pre-condition Code:\n\n%v\n\n", templateId, strings.Join(final, "\n"))
+	gologger.Debug().Msgf(" [%v] Pre-condition code:\n\n%v", templateId, strings.Join(final, "\n"))
 }
 
 // UpdateOptions replaces this request's options with a new copy

--- a/pkg/protocols/common/automaticscan/automaticscan.go
+++ b/pkg/protocols/common/automaticscan/automaticscan.go
@@ -80,7 +80,7 @@ func New(opts Options) (*Service, error) {
 		_ = file.Close()
 	}
 	if opts.ExecuterOpts.Options.Verbose {
-		gologger.Verbose().Msgf("Normalized mapping (%d): %v\n", len(mappingData), mappingData)
+		gologger.Verbose().Msgf("Normalized mapping (%d): %v", len(mappingData), mappingData)
 	}
 
 	// get template directories
@@ -125,7 +125,7 @@ func (s *Service) Close() bool {
 
 // Execute automatic scan on each target with -bs host concurrency
 func (s *Service) Execute() error {
-	gologger.Info().Msgf("Executing Automatic scan on %d target[s]", s.target.Count())
+	gologger.Info().Msgf("Executing automatic scan for %d target(s)", s.target.Count())
 	// setup host concurrency
 	sg, err := syncutil.New(syncutil.WithSize(s.opts.Options.BulkSize))
 	if err != nil {
@@ -163,26 +163,26 @@ func (s *Service) executeAutomaticScanOnTarget(input *contextargs.MetaInput) {
 	}
 	finalTags = sliceutil.Dedupe(finalTags)
 
-	gologger.Info().Msgf("Found %d tags and %d matches on detection templates on %v [wappalyzer: %d, detection: %d]\n", len(finalTags), matched, input.Input, len(tagsFromWappalyzer), len(tagsFromDetectTemplates))
+	gologger.Info().Msgf("Found %d tags and %d matches on detection templates for %q [wappalyzer: %d, detection: %d]", len(finalTags), matched, input.Input, len(tagsFromWappalyzer), len(tagsFromDetectTemplates))
 
 	// also include any extra tags passed by user
 	finalTags = append(finalTags, s.opts.Options.Tags...)
 	finalTags = sliceutil.Dedupe(finalTags)
 
 	if len(finalTags) == 0 {
-		gologger.Warning().Msgf("Skipping automatic scan since no tags were found on %v\n", input.Input)
+		gologger.Warning().Msg("Skipping automatic scan since no tags were found")
 		return
 	}
 	if s.opts.Options.VerboseVerbose {
-		gologger.Print().Msgf("Final tags identified for %v: %+v\n", input.Input, finalTags)
+		gologger.Print().Msgf("Final tags identified for %q: %+v\n", input.Input, finalTags)
 	}
 
 	finalTemplates, err := LoadTemplatesWithTags(s.ServiceOpts, s.templateDirs, finalTags, false)
 	if err != nil {
-		gologger.Error().Msgf("%v Error loading templates: %s\n", input.Input, err)
+		gologger.Error().Msgf("Error loading templates for %q: %s", input.Input, err)
 		return
 	}
-	gologger.Info().Msgf("Executing %d templates on %v", len(finalTemplates), input.Input)
+	gologger.Info().Msgf("Executing %d templates for %q", len(finalTemplates), input.Input)
 	eng := core.New(s.opts.Options)
 	execOptions := s.opts.Copy()
 	execOptions.Progress = &testutils.MockProgressClient{} // stats are not supported yet due to centralized logic and cannot be reinitialized
@@ -220,7 +220,7 @@ func (s *Service) getTagsUsingWappalyzer(input *contextargs.MetaInput) []string 
 	for k := range fingerprints {
 		normalized[normalizeAppName(k)] = struct{}{}
 	}
-	gologger.Verbose().Msgf("Found %d fingerprints for %s\n", len(normalized), input.Input)
+	gologger.Verbose().Msgf("Found %d fingerprints for %s", len(normalized), input.Input)
 
 	// normalize fingerprints using mapping data
 	for k := range normalized {
@@ -303,7 +303,7 @@ func (s *Service) getTagsUsingDetectionTemplates(input *contextargs.MetaInput) (
 
 			_, err := template.Executer.ExecuteWithResults(ctx)
 			if err != nil {
-				gologger.Verbose().Msgf("[%s] error executing template: %s\n", aurora.BrightYellow(template.ID), err)
+				gologger.Verbose().Msgf("[%s] error executing template: %s", aurora.BrightYellow(template.ID), err)
 				return
 			}
 		}(t)

--- a/pkg/protocols/common/contextargs/contextargs.go
+++ b/pkg/protocols/common/contextargs/contextargs.go
@@ -48,7 +48,7 @@ func NewWithMetaInput(ctx context.Context, input *MetaInput) *Context {
 func NewWithInput(ctx context.Context, input string) *Context {
 	jar, err := cookiejar.New(nil)
 	if err != nil {
-		gologger.Error().Msgf("contextargs: could not create cookie jar: %s\n", err)
+		gologger.Error().Msgf("contextargs: Could not create cookie jar: %s", err)
 	}
 	metaInput := NewMetaInput()
 	metaInput.Input = input

--- a/pkg/protocols/common/helpers/eventcreator/eventcreator.go
+++ b/pkg/protocols/common/helpers/eventcreator/eventcreator.go
@@ -24,7 +24,7 @@ func CreateEventWithAdditionalOptions(request protocols.Request, outputEvent out
 	// Dump response variables if ran in debug mode
 	if vardump.EnableVarDump {
 		protoName := cases.Title(language.English).String(request.Type().String())
-		gologger.Debug().Msgf("%v Protocol response variables: %s\n", protoName, vardump.DumpVariables(outputEvent))
+		gologger.Debug().Msgf("%v protocol response variables: %s", protoName, vardump.DumpVariables(outputEvent))
 	}
 	for _, compiledOperator := range request.GetCompiledOperators() {
 		if compiledOperator != nil {

--- a/pkg/protocols/common/helpers/writer/writer.go
+++ b/pkg/protocols/common/helpers/writer/writer.go
@@ -24,7 +24,7 @@ func WriteResult(data *output.InternalWrappedEvent, out output.Writer, progress 
 			if stderrors.Is(err, output.ErrHoneypotSuppressed) {
 				suppressed = true
 			} else {
-				gologger.Warning().Msgf("Could not write output event: %s\n", err)
+				gologger.Warning().Msgf("Could not write output event: %s", err)
 			}
 		}
 

--- a/pkg/protocols/dns/request.go
+++ b/pkg/protocols/dns/request.go
@@ -109,7 +109,7 @@ func (request *Request) ExecuteWithResults(input *contextargs.Context, metadata,
 func (request *Request) execute(input *contextargs.Context, domain string, metadata, previous output.InternalEvent, vars map[string]interface{}, callback protocols.OutputEventCallback) error {
 	var err error
 	if vardump.EnableVarDump {
-		gologger.Debug().Msgf("DNS Protocol request variables: %s\n", vardump.DumpVariables(vars))
+		gologger.Debug().Msgf("DNS protocol request variables: %s", vardump.DumpVariables(vars))
 	}
 
 	// Compile each request for the template based on the URL
@@ -123,7 +123,7 @@ func (request *Request) execute(input *contextargs.Context, domain string, metad
 	dnsClient := request.dnsClient
 	if varErr := expressions.ContainsUnresolvedVariables(request.Resolvers...); varErr != nil {
 		if dnsClient, varErr = request.getDnsClient(request.options, metadata); varErr != nil {
-			gologger.Warning().Msgf("[%s] Could not make dns request for %s: %v\n", request.options.TemplateID, domain, varErr)
+			gologger.Warning().Msgf("[%s] Could not make DNS request for %q: %s", request.options.TemplateID, domain, varErr)
 			return nil
 		}
 	}
@@ -137,11 +137,11 @@ func (request *Request) execute(input *contextargs.Context, domain string, metad
 
 	requestString := compiledRequest.String()
 	if varErr := expressions.ContainsUnresolvedVariables(requestString); varErr != nil {
-		gologger.Warning().Msgf("[%s] Could not make dns request for %s: %v\n", request.options.TemplateID, question, varErr)
+		gologger.Warning().Msgf("[%s] Could not make DNS request for %q: %s", request.options.TemplateID, question, varErr)
 		return nil
 	}
 	if request.options.Options.Debug || request.options.Options.DebugRequests || request.options.Options.StoreResponse {
-		msg := fmt.Sprintf("[%s] Dumped DNS request for %s", request.options.TemplateID, question)
+		msg := fmt.Sprintf("[%s] Dumped DNS request for %q", request.options.TemplateID, question)
 		if request.options.Options.Debug || request.options.Options.DebugRequests {
 			gologger.Info().Str("domain", domain).Msg(msg)
 			gologger.Print().Msgf("%s", requestString)
@@ -166,7 +166,7 @@ func (request *Request) execute(input *contextargs.Context, domain string, metad
 	}
 
 	request.options.Output.Request(request.options.TemplatePath, domain, request.Type().String(), err)
-	gologger.Verbose().Msgf("[%s] Sent DNS request to %s\n", request.options.TemplateID, question)
+	gologger.Verbose().Msgf("[%s] Sent DNS request to %s", request.options.TemplateID, question)
 
 	// perform trace if necessary
 	var traceData *retryabledns.TraceData
@@ -245,6 +245,6 @@ func dumpTraceData(event *output.InternalWrappedEvent, requestOptions *protocols
 			traceData = hex.Dump([]byte(traceData))
 		}
 		highlightedResponse := responsehighlighter.Highlight(event.OperatorsResult, traceData, cliOptions.NoColor, hexDump)
-		gologger.Debug().Msgf("[%s] Dumped DNS Trace data for %s\n\n%s", requestOptions.TemplateID, domain, highlightedResponse)
+		gologger.Debug().Msgf("[%s] Dumped DNS trace data for %q\n\n%s", requestOptions.TemplateID, domain, highlightedResponse)
 	}
 }

--- a/pkg/protocols/file/find.go
+++ b/pkg/protocols/file/find.go
@@ -138,7 +138,7 @@ func (request *Request) validatePath(absPath, item string, inArchive bool) bool 
 	}
 
 	if matchingRule, ok := request.isInDenyList(absPath, item); ok {
-		gologger.Verbose().Msgf("Ignoring path %s due to denylist item %s\n", item, matchingRule)
+		gologger.Verbose().Msgf("Ignoring %q path due to denylist item %s", item, matchingRule)
 		return false
 	}
 

--- a/pkg/protocols/file/request.go
+++ b/pkg/protocols/file/request.go
@@ -63,7 +63,7 @@ func (request *Request) ExecuteWithResults(input *contextargs.Context, metadata,
 			defer wg.Done()
 			fi, err := os.Open(filePath)
 			if err != nil {
-				gologger.Error().Msgf("%s\n", err)
+				gologger.Error().Msg(err.Error())
 				return
 			}
 			defer func() {
@@ -83,7 +83,7 @@ func (request *Request) ExecuteWithResults(input *contextargs.Context, metadata,
 						archiveFileName := filepath.Join(filePath, file.Name())
 						reader, err := file.Open()
 						if err != nil {
-							gologger.Error().Msgf("%s\n", err)
+							gologger.Error().Msg(err.Error())
 							return err
 						}
 						defer func() {
@@ -96,7 +96,7 @@ func (request *Request) ExecuteWithResults(input *contextargs.Context, metadata,
 								request.options.Progress.IncrementRequests()
 								return nil
 							}
-							gologger.Error().Msgf("%s\n", err)
+							gologger.Error().Msg(err.Error())
 							// error while elaborating the file
 							request.options.Progress.IncrementFailedRequestsBy(1)
 							return err
@@ -108,7 +108,7 @@ func (request *Request) ExecuteWithResults(input *contextargs.Context, metadata,
 						return nil
 					})
 					if err != nil {
-						gologger.Error().Msgf("%s\n", err)
+						gologger.Error().Msg(err.Error())
 						return
 					}
 				case archives.Decompressor:
@@ -116,7 +116,7 @@ func (request *Request) ExecuteWithResults(input *contextargs.Context, metadata,
 					request.options.Progress.AddToTotal(1)
 					reader, err := archiveInstance.OpenReader(stream)
 					if err != nil {
-						gologger.Error().Msgf("%s\n", err)
+						gologger.Error().Msg(err.Error())
 						// error while elaborating the file
 						request.options.Progress.IncrementFailedRequestsBy(1)
 						return
@@ -124,7 +124,7 @@ func (request *Request) ExecuteWithResults(input *contextargs.Context, metadata,
 					fileStat, _ := fi.Stat()
 					tmpFileOut, err := os.CreateTemp("", "")
 					if err != nil {
-						gologger.Error().Msgf("%s\n", err)
+						gologger.Error().Msg(err.Error())
 						// error while elaborating the file
 						request.options.Progress.IncrementFailedRequestsBy(1)
 						return
@@ -140,7 +140,7 @@ func (request *Request) ExecuteWithResults(input *contextargs.Context, metadata,
 					}()
 					_, err = io.Copy(tmpFileOut, reader)
 					if err != nil {
-						gologger.Error().Msgf("%s\n", err)
+						gologger.Error().Msg(err.Error())
 						// error while elaborating the file
 						request.options.Progress.IncrementFailedRequestsBy(1)
 						return
@@ -155,7 +155,7 @@ func (request *Request) ExecuteWithResults(input *contextargs.Context, metadata,
 							request.options.Progress.IncrementRequests()
 							return
 						}
-						gologger.Error().Msgf("%s\n", err)
+						gologger.Error().Msg(err.Error())
 						// error while elaborating the file
 						request.options.Progress.IncrementFailedRequestsBy(1)
 						return
@@ -175,7 +175,7 @@ func (request *Request) ExecuteWithResults(input *contextargs.Context, metadata,
 						request.options.Progress.IncrementRequests()
 						return
 					}
-					gologger.Error().Msgf("%s\n", err)
+					gologger.Error().Msg(err.Error())
 					// error while elaborating the file
 					request.options.Progress.IncrementFailedRequestsBy(1)
 					return
@@ -212,7 +212,7 @@ func (request *Request) processFile(filePath string, input *contextargs.Context,
 	}
 	if stat.Size() >= request.maxSize {
 		maxSizeString := units.HumanSize(float64(request.maxSize))
-		gologger.Verbose().Msgf("Limiting %s processed data to %s bytes: exceeded max size\n", filePath, maxSizeString)
+		gologger.Verbose().Msgf("Limiting %q processed data to %s bytes: exceeded max size", filePath, maxSizeString)
 	}
 
 	return request.processReader(file, filePath, input, stat.Size(), previousInternalEvent)
@@ -275,7 +275,7 @@ func (request *Request) findMatchesWithReader(reader io.Reader, input *contextar
 		currentBytes := bytesCount + n
 		processedBytes := units.BytesSize(float64(currentBytes))
 
-		gologger.Verbose().Msgf("[%s] Processing file %s chunk %s/%s", request.options.TemplateID, filePath, processedBytes, totalBytesString)
+		gologger.Verbose().Msgf("[%s] Processing %q file chunk %s/%s", request.options.TemplateID, filePath, processedBytes, totalBytesString)
 		dslMap := request.responseToDSLMap(lineContent, input.MetaInput.Input, filePath)
 		maps.Copy(dslMap, previous)
 		// add vars to template context
@@ -382,7 +382,7 @@ func dumpResponse(event *output.InternalWrappedEvent, requestOptions *protocols.
 				lineContent = hex.Dump([]byte(lineContent))
 			}
 			highlightedResponse := responsehighlighter.Highlight(event.OperatorsResult, lineContent, cliOptions.NoColor, hexDump)
-			gologger.Debug().Msgf("[%s] Dumped match/extract file snippet for %s at line %d\n\n%s", requestOptions.TemplateID, filePath, fileMatch.Line, highlightedResponse)
+			gologger.Debug().Msgf("[%s] Dumped match or extract file snippet for %q at line %d\n\n%s", requestOptions.TemplateID, filePath, fileMatch.Line, highlightedResponse)
 		}
 	}
 }

--- a/pkg/protocols/headless/engine/page.go
+++ b/pkg/protocols/headless/engine/page.go
@@ -89,7 +89,7 @@ func (i *Instance) Run(ctx *contextargs.Context, actions []*Action, payloads map
 	variables = generators.MergeMaps(variables, payloads)
 
 	if vardump.EnableVarDump {
-		gologger.Debug().Msgf("Headless Protocol request variables: %s\n", vardump.DumpVariables(variables))
+		gologger.Debug().Msgf("Headless protocol request variables: %s", vardump.DumpVariables(variables))
 	}
 
 	createdPage := &Page{

--- a/pkg/protocols/headless/engine/page_actions.go
+++ b/pkg/protocols/headless/engine/page_actions.go
@@ -562,13 +562,13 @@ func (p *Page) Screenshot(act *Action, out ActionData) error {
 
 	if fileutil.FileExists(filePath) {
 		// return custom error as overwriting files is not supported
-		return errkit.Newf("failed to write screenshot, file %v already exists", filePath)
+		return errkit.Newf("failed to write screenshot, file %q already exists", filePath)
 	}
 	err = os.WriteFile(filePath, data, 0540)
 	if err != nil {
 		return errors.Wrap(err, "could not write screenshot")
 	}
-	gologger.Info().Msgf("Screenshot successfully saved at %v\n", filePath)
+	gologger.Info().Msgf("Screenshot successfully saved to %q", filePath)
 	return nil
 }
 

--- a/pkg/protocols/http/build_request.go
+++ b/pkg/protocols/http/build_request.go
@@ -129,7 +129,7 @@ func (g *generatedRequest) ApplyAuth(provider authprovider.AuthProvider) {
 	if g.rawRequest != nil {
 		parsed, err := urlutil.ParseAbsoluteURL(g.rawRequest.FullURL, true)
 		if err != nil {
-			gologger.Warning().Msgf("[authprovider] Could not parse URL %s: %s\n", g.rawRequest.FullURL, err)
+			gologger.Warning().Msgf("[authprovider] Could not parse %q URL: %s", g.rawRequest.FullURL, err)
 			return
 		}
 		authStrategies := provider.LookupURLX(parsed)
@@ -229,7 +229,7 @@ func (r *requestGenerator) Make(ctx context.Context, input *contextargs.Context,
 	finalVars := generators.MergeMaps(allVars, payloads)
 
 	if vardump.EnableVarDump {
-		gologger.Debug().Msgf("HTTP Protocol request variables: %s\n", vardump.DumpVariables(finalVars))
+		gologger.Debug().Msgf("HTTP protocol request variables: %s", vardump.DumpVariables(finalVars))
 	}
 
 	// Note: If possible any changes to current logic (i.e evaluate -> then parse URL)

--- a/pkg/protocols/http/request.go
+++ b/pkg/protocols/http/request.go
@@ -606,7 +606,7 @@ func (request *Request) ExecuteWithResults(input *contextargs.Context, dynamicVa
 
 				// if applicable mark the host as unresponsive
 				reqKitErr := errkit.FromError(execReqErr)
-				reqKitErr.Msgf("got err while executing %v", generatedHttpRequest.URL())
+				reqKitErr.Msgf("got err while executing %q", generatedHttpRequest.URL())
 
 				requestErr = reqKitErr
 				request.options.Progress.IncrementFailedRequestsBy(1)
@@ -716,7 +716,7 @@ func (request *Request) executeRequest(input *contextargs.Context, generatedRequ
 				generatedRequest.request.ContentLength = length
 			} else {
 				// log error and continue
-				gologger.Verbose().Msgf("[%v] Could not read request body while forcing transfer encoding: %s\n", request.options.TemplateID, err)
+				gologger.Verbose().Msgf("[%v] Could not read request body while forcing transfer encoding: %s", request.options.TemplateID, err)
 				err = nil
 			}
 		}
@@ -741,12 +741,12 @@ func (request *Request) executeRequest(input *contextargs.Context, generatedRequ
 
 		if ignoreList := GetVariablesNamesSkipList(generatedRequest.original.Signature.Value); ignoreList != nil {
 			if varErr := expressions.ContainsVariablesWithIgnoreList(ignoreList, dumpedRequestString); varErr != nil && !request.SkipVariablesCheck {
-				gologger.Warning().Msgf("[%s] Could not make http request for %s: %v\n", request.options.TemplateID, input.MetaInput.Input, varErr)
+				gologger.Warning().Msgf("[%s] Could not make HTTP request for %q: %v", request.options.TemplateID, input.MetaInput.Input, varErr)
 				return ErrMissingVars
 			}
 		} else { // Check if are there any unresolved variables. If yes, skip unless overridden by user.
 			if varErr := expressions.ContainsUnresolvedVariables(dumpedRequestString); varErr != nil && !request.SkipVariablesCheck {
-				gologger.Warning().Msgf("[%s] Could not make http request for %s: %v\n", request.options.TemplateID, input.MetaInput.Input, varErr)
+				gologger.Warning().Msgf("[%s] Could not make HTTP request for %q: %v", request.options.TemplateID, input.MetaInput.Input, varErr)
 				return ErrMissingVars
 			}
 		}
@@ -946,7 +946,7 @@ func (request *Request) executeRequest(input *contextargs.Context, generatedRequ
 		}
 	}
 
-	gologger.Verbose().Msgf("[%s] Sent HTTP request to %s", request.options.TemplateID, formedURL)
+	gologger.Verbose().Msgf("[%s] Sent HTTP request to %q", request.options.TemplateID, formedURL)
 	request.options.Output.Request(request.options.TemplatePath, formedURL, request.Type().String(), err)
 
 	duration := time.Since(timeStart)
@@ -1025,7 +1025,7 @@ func (request *Request) executeRequest(input *contextargs.Context, generatedRequ
 				AnalyzerParameters: request.Analyzer.Parameters,
 			})
 			if err != nil {
-				gologger.Warning().Msgf("Could not analyze response: %v\n", err)
+				gologger.Warning().Msgf("Could not analyze response: %v", err)
 			}
 			if analysisMatched {
 				finalEvent["analyzer_details"] = analysisDetails

--- a/pkg/protocols/http/request_fuzz.go
+++ b/pkg/protocols/http/request_fuzz.go
@@ -44,9 +44,9 @@ func (request *Request) executeFuzzingRule(input *contextargs.Context, previous 
 	if !request.ShouldFuzzTarget(input) {
 		urlx, _ := input.MetaInput.URL()
 		if urlx != nil {
-			gologger.Verbose().Msgf("[%s] fuzz: target(%s) not applicable for fuzzing\n", request.options.TemplateID, urlx.String())
+			gologger.Verbose().Msgf("[%s] fuzz: %q not applicable for fuzzing", request.options.TemplateID, urlx.String())
 		} else {
-			gologger.Verbose().Msgf("[%s] fuzz: target(%s) not applicable for fuzzing\n", request.options.TemplateID, input.MetaInput.Input)
+			gologger.Verbose().Msgf("[%s] fuzz: %q not applicable for fuzzing", request.options.TemplateID, input.MetaInput.Input)
 		}
 		return nil
 	}
@@ -70,13 +70,13 @@ func (request *Request) executeFuzzingRule(input *contextargs.Context, previous 
 			// in case of any error, return it
 			if fuzz.IsErrRuleNotApplicable(err) {
 				// log and fail silently
-				gologger.Verbose().Msgf("[%s] fuzz: %s\n", request.options.TemplateID, err)
+				gologger.Verbose().Msgf("[%s] fuzz: %s", request.options.TemplateID, err)
 				return nil
 			}
 			if errors.Is(err, ErrMissingVars) {
 				return err
 			}
-			gologger.Verbose().Msgf("[%s] fuzz: payload request execution failed: %s\n", request.options.TemplateID, err)
+			gologger.Verbose().Msgf("[%s] fuzz: payload request execution failed: %s", request.options.TemplateID, err)
 		}
 		return nil
 	}
@@ -103,13 +103,13 @@ func (request *Request) executeFuzzingRule(input *contextargs.Context, previous 
 		// in case of any error, return it
 		if fuzz.IsErrRuleNotApplicable(err) {
 			// log and fail silently
-			gologger.Verbose().Msgf("[%s] fuzz: %s\n", request.options.TemplateID, err)
+			gologger.Verbose().Msgf("[%s] fuzz: %s", request.options.TemplateID, err)
 			return nil
 		}
 		if errors.Is(err, ErrMissingVars) {
 			return err
 		}
-		gologger.Verbose().Msgf("[%s] fuzz: payload request execution failed: %s\n", request.options.TemplateID, err)
+		gologger.Verbose().Msgf("[%s] fuzz: payload request execution failed: %s", request.options.TemplateID, err)
 	}
 	return nil
 }
@@ -158,7 +158,7 @@ func (request *Request) executeAllFuzzingRules(input *contextargs.Context, value
 			continue
 		}
 		if fuzz.IsErrRuleNotApplicable(err) {
-			gologger.Verbose().Msgf("[%s] fuzz: %s\n", request.options.TemplateID, err)
+			gologger.Verbose().Msgf("[%s] fuzz: %s", request.options.TemplateID, err)
 			continue
 		}
 		if err == types.ErrNoMoreRequests {
@@ -232,7 +232,7 @@ func (request *Request) executeGeneratedFuzzingRequest(gr fuzz.GeneratedRequest,
 		return false
 	}
 	if requestErr != nil {
-		gologger.Verbose().Msgf("[%s] Error occurred in request: %s\n", request.options.TemplateID, requestErr)
+		gologger.Verbose().Msgf("[%s] Error occurred in request: %s", request.options.TemplateID, requestErr)
 	}
 	if request.options.HostErrorsCache != nil {
 		request.options.HostErrorsCache.MarkFailedOrRemove(request.options.ProtocolType.String(), input, requestErr)
@@ -257,12 +257,12 @@ func (request *Request) ShouldFuzzTarget(input *contextargs.Context) bool {
 		dataMap := request.filterDataMap(input)
 		// dump if svd is enabled
 		if request.options.Options.ShowVarDump {
-			gologger.Debug().Msgf("Fuzz Filter Variables: \n%s\n", vardump.DumpVariables(dataMap))
+			gologger.Debug().Msgf("Fuzz filter variables: \n%s", vardump.DumpVariables(dataMap))
 		}
 		isMatch, _ := request.Match(dataMap, filter)
 		status = append(status, isMatch)
 		if request.options.Options.MatcherStatus {
-			gologger.Debug().Msgf("[%s] [%s] Filter => %s : %v", input.MetaInput.Target(), request.options.TemplateID, operators.GetMatcherName(filter, index), isMatch)
+			gologger.Debug().Msgf("[%s] Filter for %q => %s : %v", request.options.TemplateID, input.MetaInput.Target(), operators.GetMatcherName(filter, index), isMatch)
 		}
 	}
 	if len(status) == 0 {
@@ -275,7 +275,7 @@ func (request *Request) ShouldFuzzTarget(input *contextargs.Context) bool {
 		matched = operators.EvalBoolSlice(status, false)
 	}
 	if request.options.Options.MatcherStatus {
-		gologger.Debug().Msgf("[%s] [%s] Final Filter Status =>  %v", input.MetaInput.Target(), request.options.TemplateID, matched)
+		gologger.Debug().Msgf("[%s] Final filter status for %q => %v", request.options.TemplateID, input.MetaInput.Target(), matched)
 	}
 	return matched
 }

--- a/pkg/protocols/javascript/js.go
+++ b/pkg/protocols/javascript/js.go
@@ -137,14 +137,14 @@ func (request *Request) Compile(options *protocols.ExecutorOptions) error {
 	ports := request.getPorts()
 	for _, port := range ports {
 		if strings.Contains(port, "{{") {
-			return errkit.New("'Port' variable cannot contain any dsl expressions")
+			return errkit.New("'Port' variable cannot contain any DSL expressions")
 		}
 	}
 
 	if request.Init != "" {
 		// execute init code if any
 		if request.options.Options.Debug || request.options.Options.DebugRequests {
-			gologger.Debug().Msgf("[%s] Executing Template Init\n", request.TemplateID)
+			gologger.Debug().Msgf("[%s] Executing template initialization", request.TemplateID)
 			var highlightFormatter = "terminal256"
 			if request.options.Options.NoColor {
 				highlightFormatter = "text"
@@ -222,19 +222,19 @@ func (request *Request) Compile(options *protocols.ExecutorOptions) error {
 
 		initCompiled, err := compiler.SourceAutoMode(request.Init, false)
 		if err != nil {
-			return errkit.Newf("could not compile init code: %s", err)
+			return errkit.Newf("could not compile initialization code: %s", err)
 		}
 		result, err := request.options.JsCompiler.ExecuteWithOptions(initCompiled, args, opts)
 		if err != nil {
-			return errkit.Newf("could not execute pre-condition: %s", err)
+			return errkit.Newf("could not execute initialization code: %s", err)
 		}
 		if types.ToString(result["error"]) != "" {
-			gologger.Warning().Msgf("[%s] Init failed with error %v\n", request.TemplateID, result["error"])
+			gologger.Warning().Msgf("[%s] Could not execute initialization: %v", request.TemplateID, result["error"])
 			return nil
 		} else {
 			if request.options.Options.Debug || request.options.Options.DebugResponse {
-				gologger.Debug().Msgf("[%s] Init executed successfully\n", request.TemplateID)
-				gologger.Debug().Msgf("[%s] Init result: %v\n", request.TemplateID, result["response"])
+				gologger.Debug().Msgf("[%s] Initialization executed successfully", request.TemplateID)
+				gologger.Debug().Msgf("[%s] Initialization result: %v", request.TemplateID, result["response"])
 			}
 		}
 	}
@@ -310,7 +310,7 @@ func (request *Request) executeWithResults(port string, target *contextargs.Cont
 	// and it is ignored if input port is not standard http(s) ports like 80,8080,8081 etc
 	// idea is to reduce redundant dials to http ports
 	if err := input.UseNetworkPort(port, request.getExcludePorts()); err != nil {
-		gologger.Debug().Msgf("Could not network port from constants: %s\n", err)
+		gologger.Debug().Msgf("Could not use network port from constants: %s", err)
 	}
 
 	hostPort, err := getAddress(input.MetaInput.Input)
@@ -354,14 +354,14 @@ func (request *Request) executeWithResults(port string, target *contextargs.Cont
 	templateCtx.Merge(payloadValues)
 
 	if vardump.EnableVarDump {
-		gologger.Debug().Msgf("JavaScript Protocol request variables: %s\n", vardump.DumpVariables(payloadValues))
+		gologger.Debug().Msgf("JavaScript protocol request variables: %s", vardump.DumpVariables(payloadValues))
 	}
 
 	if request.PreCondition != "" {
 		payloads := generators.MergeMaps(payloadValues, previous)
 
 		if request.options.Options.Debug || request.options.Options.DebugRequests {
-			gologger.Debug().Msgf("[%s] Executing Precondition for request\n", request.TemplateID)
+			gologger.Debug().Msgf("[%s] Executing pre-condition for request", request.TemplateID)
 			var highlightFormatter = "terminal256"
 			if requestOptions.Options.NoColor {
 				highlightFormatter = "text"
@@ -387,16 +387,16 @@ func (request *Request) executeWithResults(port string, target *contextargs.Cont
 		if err == nil && result.GetSuccess() {
 			if request.options.Options.Debug || request.options.Options.DebugRequests {
 				request.options.Progress.IncrementRequests()
-				gologger.Debug().Msgf("[%s] Precondition for request was satisfied\n", request.TemplateID)
+				gologger.Debug().Msgf("[%s] Pre-condition for request was satisfied", request.TemplateID)
 			}
 		} else {
 			var outError error
 			// if js code failed to execute
 			if err != nil {
-				outError = errkit.Append(errkit.New("pre-condition not satisfied skipping template execution"), err)
+				outError = errkit.Append(errkit.New("pre-condition not satisfied, skipping template execution"), err)
 			} else {
 				// execution successful but pre-condition returned false
-				outError = errkit.New("pre-condition not satisfied skipping template execution")
+				outError = errkit.New("pre-condition not satisfied, skipping template execution")
 			}
 			results := map[string]interface{}(result)
 			results["error"] = outError.Error()
@@ -442,7 +442,7 @@ func (request *Request) executeWithResults(port string, target *contextargs.Cont
 				callback(result)
 			}, requestOptions, interactshURLs); err != nil {
 				if errkit.IsNetworkPermanentErr(err) {
-					// gologger.Verbose().Msgf("Could not execute request: %s\n", err)
+					// gologger.Verbose().Msgf("Could not execute request: %s", err)
 					return err
 				}
 			}
@@ -488,7 +488,7 @@ func (request *Request) executeRequestParallel(ctxParent context.Context, hostPo
 			// resize check point - nop if there are no changes
 			if shouldFollowGlobal && sg.Size != request.options.Options.PayloadConcurrency {
 				if err := sg.Resize(ctxParent, request.options.Options.PayloadConcurrency); err != nil {
-					gologger.Warning().Msgf("Could not resize workpool: %s\n", err)
+					gologger.Warning().Msgf("Could not resize workpool: %s", err)
 				}
 			}
 
@@ -564,10 +564,10 @@ func (request *Request) executeRequestWithPayloads(hostPort string, input *conte
 	}
 	request.options.Progress.IncrementRequests()
 	requestOptions.Output.Request(requestOptions.TemplateID, hostPort, request.Type().String(), err)
-	gologger.Verbose().Msgf("[%s] Sent Javascript request to %s", request.options.TemplateID, hostPort)
+	gologger.Verbose().Msgf("[%s] Sent JavaScript request to %s", request.options.TemplateID, hostPort)
 
 	if requestOptions.Options.Debug || requestOptions.Options.DebugRequests || requestOptions.Options.StoreResponse {
-		msg := fmt.Sprintf("[%s] Dumped Javascript request for %s:\nVariables:\n %v", requestOptions.TemplateID, input.MetaInput.Input, vardump.DumpVariables(argsCopy.Args))
+		msg := fmt.Sprintf("[%s] Dumped JavaScript request variables: %v", requestOptions.TemplateID, vardump.DumpVariables(argsCopy.Args))
 
 		if requestOptions.Options.Debug || requestOptions.Options.DebugRequests {
 			gologger.Debug().Str("address", input.MetaInput.Input).Msg(msg)
@@ -593,7 +593,7 @@ func (request *Request) executeRequestWithPayloads(hostPort string, input *conte
 	data = generators.MergeMaps(data, request.options.GetTemplateCtx(input.MetaInput).GetAll())
 
 	if requestOptions.Options.Debug || requestOptions.Options.DebugRequests || requestOptions.Options.StoreResponse {
-		msg := fmt.Sprintf("[%s] Dumped Javascript response for %s:\n%v", requestOptions.TemplateID, input.MetaInput.Input, vardump.DumpVariables(results))
+		msg := fmt.Sprintf("[%s] Dumped JavaScript response for %s:\n%v", requestOptions.TemplateID, input.MetaInput.Input, vardump.DumpVariables(results))
 		if requestOptions.Options.Debug || requestOptions.Options.DebugRequests {
 			gologger.Debug().Str("address", input.MetaInput.Input).Msg(msg)
 		}
@@ -852,7 +852,7 @@ func prettyPrint(templateId string, buff string) {
 			final = append(final, "\t"+v)
 		}
 	}
-	gologger.Debug().Msgf(" [%v] Javascript Code:\n\n%v\n\n", templateId, strings.Join(final, "\n"))
+	gologger.Debug().Msgf(" [%v] JavaScript code:\n%v", templateId, strings.Join(final, "\n"))
 }
 
 // UpdateOptions replaces this request's options with a new copy

--- a/pkg/protocols/network/request.go
+++ b/pkg/protocols/network/request.go
@@ -102,7 +102,7 @@ func (request *Request) ExecuteWithResults(target *contextargs.Context, metadata
 	}
 	if err != nil {
 		// TODO: replace this after scan context is implemented
-		gologger.Verbose().Msgf("[%v] got errors while checking open ports: %s\n", request.options.TemplateID, err)
+		gologger.Verbose().Msgf("[%v] Could not get open ports: %s", request.options.TemplateID, err)
 	}
 
 	// stop at first match if requested
@@ -121,7 +121,7 @@ func (request *Request) ExecuteWithResults(target *contextargs.Context, metadata
 		// and it is ignored if input port is not standard http(s) ports like 80,8080,8081 etc
 		// idea is to reduce redundant dials to http ports
 		if err := input.UseNetworkPort(port, request.ExcludePorts); err != nil {
-			gologger.Debug().Msgf("Could not network port from constants: %s\n", err)
+			gologger.Debug().Msgf("Could not use network port from constants: %s", err)
 		}
 		if err := request.executeOnTarget(input, visitedAddresses, metadata, previous, wrappedCallback); err != nil {
 			return err
@@ -186,7 +186,7 @@ func (request *Request) executeOnTarget(input *contextargs.Context, visited maps
 		if err = request.executeAddress(variables, actualAddress, address, input, kv.tls, previous, wrappedCallback); err != nil {
 			outputEvent := request.responseToDSLMap("", "", "", address, "")
 			callback(&output.InternalWrappedEvent{InternalEvent: outputEvent})
-			gologger.Warning().Msgf("[%v] Could not make network request for (%s) : %s\n", request.options.TemplateID, actualAddress, err)
+			gologger.Warning().Msgf("[%v] Could not make network request for %q: %s", request.options.TemplateID, actualAddress, err)
 		}
 		if shouldStopAtFirstMatch && atomicBool.Load() {
 			break
@@ -315,7 +315,7 @@ func (request *Request) executeRequestWithPayloads(variables map[string]interfac
 	interimValues := generators.MergeMaps(variables, payloads)
 
 	if vardump.EnableVarDump {
-		gologger.Debug().Msgf("Network Protocol request variables: %s\n", vardump.DumpVariables(interimValues))
+		gologger.Debug().Msgf("Network protocol request variables: %s", vardump.DumpVariables(interimValues))
 	}
 
 	inputEvents := make(map[string]interface{})
@@ -340,7 +340,7 @@ func (request *Request) executeRequestWithPayloads(variables map[string]interfac
 		reqBuilder.Write(dataInBytes)
 
 		if err := expressions.ContainsUnresolvedVariables(data); err != nil {
-			gologger.Warning().Msgf("[%s] Could not make network request for %s: %v\n", request.options.TemplateID, actualAddress, err)
+			gologger.Warning().Msgf("[%s] Could not make network request for %q: %v", request.options.TemplateID, actualAddress, err)
 			return nil
 		}
 
@@ -385,7 +385,7 @@ func (request *Request) executeRequestWithPayloads(variables map[string]interfac
 
 	if request.options.Options.Debug || request.options.Options.DebugRequests || request.options.Options.StoreResponse {
 		requestBytes := []byte(reqBuilder.String())
-		msg := fmt.Sprintf("[%s] Dumped Network request for %s\n%s", request.options.TemplateID, actualAddress, hex.Dump(requestBytes))
+		msg := fmt.Sprintf("[%s] Dumped network request for %q:\n%s", request.options.TemplateID, actualAddress, hex.Dump(requestBytes))
 		if request.options.Options.Debug || request.options.Options.DebugRequests {
 			gologger.Info().Str("address", actualAddress).Msg(msg)
 		}
@@ -398,7 +398,7 @@ func (request *Request) executeRequestWithPayloads(variables map[string]interfac
 	}
 
 	request.options.Output.Request(request.options.TemplatePath, actualAddress, request.Type().String(), err)
-	gologger.Verbose().Msgf("Sent TCP request to %s", actualAddress)
+	gologger.Verbose().Msgf("Sent network request to %s", actualAddress)
 
 	bufferSize := 1024
 	if request.ReadSize != 0 {
@@ -411,7 +411,7 @@ func (request *Request) executeRequestWithPayloads(variables map[string]interfac
 	final, err := ConnReadNWithTimeout(conn, int64(bufferSize), request.options.Options.GetTimeouts().TcpReadTimeout)
 	if err != nil {
 		request.options.Output.Request(request.options.TemplatePath, address, request.Type().String(), err)
-		gologger.Verbose().Msgf("could not read more data from %s: %s", actualAddress, err)
+		gologger.Verbose().Msgf("could not read more data from %q: %s", actualAddress, err)
 	}
 	responseBuilder.Write(final)
 
@@ -463,7 +463,7 @@ func dumpResponse(event *output.InternalWrappedEvent, request *Request, response
 	if cliOptions.Debug || cliOptions.DebugResponse || cliOptions.StoreResponse {
 		requestBytes := []byte(response)
 		highlightedResponse := responsehighlighter.Highlight(event.OperatorsResult, hex.Dump(requestBytes), cliOptions.NoColor, true)
-		msg := fmt.Sprintf("[%s] Dumped Network response for %s\n\n", request.options.TemplateID, actualAddress)
+		msg := fmt.Sprintf("[%s] Dumped network response for %q:\n", request.options.TemplateID, actualAddress)
 		if cliOptions.Debug || cliOptions.DebugResponse {
 			gologger.Debug().Msg(fmt.Sprintf("%s%s", msg, highlightedResponse))
 		}

--- a/pkg/protocols/offlinehttp/request.go
+++ b/pkg/protocols/offlinehttp/request.go
@@ -54,7 +54,7 @@ func (request *Request) ExecuteWithResults(input *contextargs.Context, metadata,
 
 			file, err := os.Open(data)
 			if err != nil {
-				gologger.Error().Msgf("Could not open file path %s: %s\n", data, err)
+				gologger.Error().Msgf("Could not open %q file: %s", data, err)
 				return
 			}
 			defer func() {
@@ -63,23 +63,23 @@ func (request *Request) ExecuteWithResults(input *contextargs.Context, metadata,
 
 			stat, err := file.Stat()
 			if err != nil {
-				gologger.Error().Msgf("Could not stat file path %s: %s\n", data, err)
+				gologger.Error().Msgf("Could not get %q file info: %s", data, err)
 				return
 			}
 			if stat.Size() >= int64(maxSize) {
-				gologger.Verbose().Msgf("Could not process path %s: exceeded max size\n", data)
+				gologger.Verbose().Msgf("Could not process %q file: exceeded max size", data)
 				return
 			}
 
 			buffer, err := io.ReadAll(file)
 			if err != nil {
-				gologger.Error().Msgf("Could not read file path %s: %s\n", data, err)
+				gologger.Error().Msgf("Could not read %q file: %s", data, err)
 				return
 			}
 			dataStr := conversion.String(buffer)
 
 			if err := request.executeRawInput(dataStr, data, input, callback); err != nil {
-				gologger.Error().Msgf("Could not execute raw input %s: %s\n", data, err)
+				gologger.Error().Msgf("Could not execute raw %q input: %s", data, err)
 				return
 			}
 		}(data)
@@ -101,14 +101,14 @@ func (request *Request) executeRawInput(data, inputString string, input *context
 	}
 
 	if request.options.Options.Debug || request.options.Options.DebugRequests {
-		gologger.Info().Msgf("[%s] Dumped offline-http request for %s", request.options.TemplateID, data)
+		gologger.Info().Msgf("[%s] Dumped offline-http request for %q:", request.options.TemplateID, data)
 		gologger.Print().Msgf("%s", data)
 	}
-	gologger.Verbose().Msgf("[%s] Sent OFFLINE-HTTP request to %s", request.options.TemplateID, data)
+	gologger.Verbose().Msgf("[%s] Sent offline-http request to %q", request.options.TemplateID, data)
 
 	dumpedResponse, err := httputil.DumpResponse(resp, true)
 	if err != nil {
-		return errors.Wrap(err, "could not dump raw http response")
+		return errors.Wrap(err, "could not dump raw HTTP response")
 	}
 
 	body, err := io.ReadAll(resp.Body)

--- a/pkg/protocols/ssl/ssl.go
+++ b/pkg/protocols/ssl/ssl.go
@@ -224,7 +224,7 @@ func (request *Request) ExecuteWithResults(input *contextargs.Context, dynamicVa
 	payloadValues = generators.MergeMaps(variablesMap, payloadValues, request.options.Constants)
 
 	if vardump.EnableVarDump {
-		gologger.Debug().Msgf("SSL Protocol request variables: %s\n", vardump.DumpVariables(payloadValues))
+		gologger.Debug().Msgf("SSL protocol request variables: %s", vardump.DumpVariables(payloadValues))
 	}
 
 	finalAddress, dataErr := expressions.EvaluateByte([]byte(request.Address), payloadValues)
@@ -254,10 +254,10 @@ func (request *Request) ExecuteWithResults(input *contextargs.Context, dynamicVa
 	}
 
 	requestOptions.Output.Request(requestOptions.TemplateID, hostPort, request.Type().String(), err)
-	gologger.Verbose().Msgf("[%s] Sent SSL request to %s", request.options.TemplateID, hostPort)
+	gologger.Verbose().Msgf("[%s] Sent SSL request to %q", request.options.TemplateID, hostPort)
 
 	if requestOptions.Options.Debug || requestOptions.Options.DebugRequests || requestOptions.Options.StoreResponse {
-		msg := fmt.Sprintf("[%s] Dumped SSL request for %s", requestOptions.TemplateID, input.MetaInput.Input)
+		msg := fmt.Sprintf("[%s] Dumped SSL request for %q", requestOptions.TemplateID, input.MetaInput.Input)
 		if requestOptions.Options.Debug || requestOptions.Options.DebugRequests {
 			gologger.Debug().Str("address", input.MetaInput.Input).Msg(msg)
 		}

--- a/pkg/protocols/websocket/websocket.go
+++ b/pkg/protocols/websocket/websocket.go
@@ -209,7 +209,7 @@ func (request *Request) executeRequestWithPayloads(target *contextargs.Context, 
 	}
 
 	if vardump.EnableVarDump {
-		gologger.Debug().Msgf("WebSocket Protocol request variables: %s\n", vardump.DumpVariables(payloadValues))
+		gologger.Debug().Msgf("WebSocket protocol request variables: %s", vardump.DumpVariables(payloadValues))
 	}
 
 	finalAddress, dataErr := expressions.EvaluateByte([]byte(request.Address), payloadValues)
@@ -255,12 +255,12 @@ func (request *Request) executeRequestWithPayloads(target *contextargs.Context, 
 	requestOptions.Progress.IncrementRequests()
 
 	if requestOptions.Options.Debug || requestOptions.Options.DebugRequests {
-		gologger.Debug().Str("address", input).Msgf("[%s] Dumped Websocket request for %s", requestOptions.TemplateID, input)
+		gologger.Debug().Str("address", input).Msgf("[%s] Dumped WebSocket request for %q", requestOptions.TemplateID, input)
 		gologger.Print().Msgf("%s", requestOutput)
 	}
 
 	requestOptions.Output.Request(requestOptions.TemplateID, input, request.Type().String(), err)
-	gologger.Verbose().Msgf("Sent Websocket request to %s", input)
+	gologger.Verbose().Msgf("Sent WebSocket request to %q", input)
 
 	data := make(map[string]interface{})
 
@@ -284,7 +284,7 @@ func (request *Request) executeRequestWithPayloads(target *contextargs.Context, 
 	})
 	if requestOptions.Options.Debug || requestOptions.Options.DebugResponse {
 		responseOutput := responseBuilder.String()
-		gologger.Debug().Msgf("[%s] Dumped Websocket response for %s", requestOptions.TemplateID, input)
+		gologger.Debug().Msgf("[%s] Dumped WebSocket response for %q", requestOptions.TemplateID, input)
 		gologger.Print().Msgf("%s", responsehighlighter.Highlight(event.OperatorsResult, responseOutput, requestOptions.Options.NoColor, false))
 	}
 

--- a/pkg/protocols/whois/whois.go
+++ b/pkg/protocols/whois/whois.go
@@ -99,7 +99,7 @@ func (request *Request) ExecuteWithResults(input *contextargs.Context, dynamicVa
 	variables := generators.MergeMaps(vars, defaultVars, optionVars, dynamicValues, request.options.Constants)
 
 	if vardump.EnableVarDump {
-		gologger.Debug().Msgf("Whois Protocol request variables: %s\n", vardump.DumpVariables(variables))
+		gologger.Debug().Msgf("Whois Protocol request variables: %s", vardump.DumpVariables(variables))
 	}
 
 	// and replace placeholders

--- a/pkg/reporting/reporting.go
+++ b/pkg/reporting/reporting.go
@@ -276,7 +276,7 @@ func (c *ReportingClient) Close() {
 				if failed > 0 {
 					fmt.Fprintf(&msgBuilder, ", %d failed", failed)
 				}
-				gologger.Info().Msgf("%v", msgBuilder.String())
+				gologger.Info().Msg(msgBuilder.String())
 			}
 		}
 	}

--- a/pkg/templates/cluster.go
+++ b/pkg/templates/cluster.go
@@ -286,7 +286,7 @@ func (e *ClusterExecuter) Execute(ctx *scan.ScanContext) (bool, error) {
 				_ = writer.WriteResult(clonedEvent, e.options.Output, e.options.Progress, e.options.IssuesClient)
 			} else if !matched && e.options.Options.MatcherStatus {
 				if err := e.options.Output.WriteFailure(clonedEvent); err != nil {
-					gologger.Warning().Msgf("Could not write failure event to output: %s\n", err)
+					gologger.Warning().Msgf("Could not write failure event to output: %s", err)
 				}
 			}
 		}
@@ -323,7 +323,7 @@ func (e *ClusterExecuter) Execute(ctx *scan.ScanContext) (bool, error) {
 				},
 			}
 			if err := e.options.Output.WriteFailure(fakeEvent); err != nil {
-				gologger.Warning().Msgf("Could not write failure event to output: %s\n", err)
+				gologger.Warning().Msgf("Could not write failure event to output: %s", err)
 			}
 		}
 	}

--- a/pkg/templates/compile.go
+++ b/pkg/templates/compile.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/logrusorgru/aurora"
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 
@@ -437,7 +436,7 @@ func ParseTemplateFromReader(reader io.Reader, preprocessor Preprocessor, option
 		}
 		if !template.Verified && len(template.Workflows) == 0 {
 			if config.DefaultConfig.LogAllEvents {
-				gologger.DefaultLogger.Print().Msgf("[%v] Template %s is not signed or tampered\n", aurora.Yellow("WRN").String(), template.ID)
+				gologger.DefaultLogger.Warning().Msgf("Template %s is unverified", template.ID)
 			}
 		}
 		return template, nil
@@ -470,7 +469,7 @@ func ParseTemplateFromReader(reader io.Reader, preprocessor Preprocessor, option
 	if !template.Verified && len(template.Workflows) == 0 {
 		// workflows are not signed by default
 		if config.DefaultConfig.LogAllEvents {
-			gologger.DefaultLogger.Print().Msgf("[%v] Template %s is not signed or tampered\n", aurora.Yellow("WRN").String(), template.ID)
+			gologger.DefaultLogger.Warning().Msgf("Template %s is unverified", template.ID)
 		}
 	}
 
@@ -614,7 +613,7 @@ func applyTemplateVerification(template *Template, data []byte) {
 	for _, verifier = range signer.DefaultTemplateVerifiers {
 		template.Verified, _ = verifier.Verify(data, template)
 		if config.DefaultConfig.LogAllEvents {
-			gologger.Verbose().Msgf("template %v verified by %s : %v", template.ID, verifier.Identifier(), template.Verified)
+			gologger.Verbose().Msgf("[%s] Template verified by %q: %v", template.ID, verifier.Identifier(), template.Verified)
 		}
 		if template.Verified {
 			template.TemplateVerifier = verifier.Identifier()

--- a/pkg/templates/log.go
+++ b/pkg/templates/log.go
@@ -56,7 +56,7 @@ func PrintDeprecatedProtocolNameMsgIfApplicable(isSilent bool, verbose bool) {
 		return nil
 	})
 	if count > 0 && !isSilent {
-		gologger.Print().Msgf("[%v] Found %v templates loaded with deprecated protocol syntax, update before v3 for continued support.\n", aurora.Yellow("WRN").String(), count)
+		gologger.Warning().Msgf("Found %v templates loaded with deprecated protocol syntax, update before v3 for continued support.", count)
 	}
 	if config.DefaultConfig.LogAllEvents {
 		_ = deprecatedProtocolNameTemplates.Iterate(func(k string, v bool) error {

--- a/pkg/templates/signer/default.go
+++ b/pkg/templates/signer/default.go
@@ -15,7 +15,7 @@ func init() {
 		UserCert: keys.NucleiCert,
 	}
 	if err := h.ParseUserCert(); err != nil {
-		gologger.Error().Msgf("Could not parse pd nuclei certificate: %s\n", err)
+		gologger.Error().Msgf("Could not parse nuclei certificate: %s", err)
 		return
 	}
 	DefaultTemplateVerifiers = append(DefaultTemplateVerifiers, &TemplateSigner{handler: h})
@@ -24,7 +24,7 @@ func init() {
 	usr := &KeyHandler{}
 	if err := usr.ReadCert(CertEnvVarName, config.DefaultConfig.GetKeysDir()); err == nil {
 		if err := usr.ParseUserCert(); err != nil {
-			gologger.Error().Msgf("malformed user cert found: %s\n", err)
+			gologger.Error().Msgf("Malformed user certificate found: %s", err)
 			return
 		}
 		DefaultTemplateVerifiers = append(DefaultTemplateVerifiers, &TemplateSigner{handler: usr})

--- a/pkg/templates/signer/tmpl_signer.go
+++ b/pkg/templates/signer/tmpl_signer.go
@@ -192,7 +192,7 @@ func NewTemplateSigner(cert, privateKey []byte) (*TemplateSigner, error) {
 	}
 	if err != nil && !SkipGeneratingKeys {
 		if err != ErrNoCertificate && err != ErrNoPrivateKey {
-			gologger.Info().Msgf("Invalid user cert found : %s\n", err)
+			gologger.Info().Msgf("Invalid user cert found : %s", err)
 		}
 		// generating new keys
 		handler.GenerateKeyPair()

--- a/pkg/templates/tag_filter.go
+++ b/pkg/templates/tag_filter.go
@@ -330,7 +330,7 @@ func isConditionMatch(tagFilter *TagFilter, template *Template) bool {
 		// in case of errors  => skip
 		if err != nil {
 			// Using debug as the failure here might be legitimate (eg. template not having optional metadata fields => missing required fields)
-			gologger.Debug().Msgf("The expression condition couldn't be evaluated correctly for template \"%s\": %s\n", template.ID, err)
+			gologger.Debug().Msgf("[%s] Expression condition could not be evaluated: %s", template.ID, err)
 			return false
 		}
 		resultBool, ok := result.(bool)

--- a/pkg/templates/workflows.go
+++ b/pkg/templates/workflows.go
@@ -15,7 +15,7 @@ import (
 func compileWorkflow(path string, preprocessor Preprocessor, options *protocols.ExecutorOptions, workflow *workflows.Workflow, loader model.WorkflowLoader) {
 	for _, workflow := range workflow.Workflows {
 		if err := parseWorkflow(preprocessor, workflow, options, loader); err != nil {
-			gologger.Warning().Msgf("Could not parse workflow %s: %v\n", path, err)
+			gologger.Warning().Msgf("Could not parse %q workflow template: %v", path, err)
 			continue
 		}
 	}
@@ -36,7 +36,7 @@ func parseWorkflow(preprocessor Preprocessor, workflow *workflows.WorkflowTempla
 	}
 	for _, subtemplates := range workflow.Subtemplates {
 		if err := parseWorkflow(preprocessor, subtemplates, options, loader); err != nil {
-			gologger.Warning().Msgf("Could not parse workflow: %v\n", err)
+			gologger.Warning().Msgf("Could not parse %q workflow template: %v", workflow.Template, err)
 			continue
 		}
 	}
@@ -48,7 +48,7 @@ func parseWorkflow(preprocessor Preprocessor, workflow *workflows.WorkflowTempla
 		}
 		for _, subtemplates := range matcher.Subtemplates {
 			if err := parseWorkflow(preprocessor, subtemplates, options, loader); err != nil {
-				gologger.Warning().Msgf("Could not parse workflow: %v\n", err)
+				gologger.Warning().Msgf("Could not parse %q workflow template: %v", workflow.Template, err)
 				continue
 			}
 		}
@@ -74,14 +74,14 @@ func parseWorkflowTemplate(workflow *workflows.WorkflowTemplate, preprocessor Pr
 	for _, path := range paths {
 		template, err := Parse(path, preprocessor, options.Copy())
 		if err != nil {
-			gologger.Warning().Msgf("Could not parse workflow template %s: %v\n", path, err)
+			gologger.Warning().Msgf("Could not parse %q workflow template: %v", path, err)
 			continue
 		}
 		if template == nil {
 			continue
 		}
 		if template.Executer == nil {
-			gologger.Warning().Msgf("Could not parse workflow template %s: no executer found\n", path)
+			gologger.Warning().Msgf("Could not parse %q workflow template: no executer found", path)
 			continue
 		}
 
@@ -103,12 +103,12 @@ func parseWorkflowTemplate(workflow *workflows.WorkflowTemplate, preprocessor Pr
 				// prevents adding to workflow's executer list and suppresses
 				// warning messages.
 				if !options.Options.Validate {
-					gologger.Warning().Msgf("`-code` flag not found, skipping code template from workflow: %v\n", path)
+					gologger.Warning().Msgf("The code flag not found, skipping code template from %q workflow template", path)
 				}
 				continue
 			} else if !template.Verified {
 				// unverified code templates are not allowed in workflows
-				gologger.Warning().Msgf("skipping unverified code template from workflow: %v\n", path)
+				gologger.Warning().Msgf("Skipping unverified code template from %q workflow template", path)
 				continue
 			}
 		}

--- a/pkg/tmplexec/exec.go
+++ b/pkg/tmplexec/exec.go
@@ -141,7 +141,7 @@ func (e *TemplateExecuter) Execute(ctx *scan.ScanContext) (bool, error) {
 	writeFailureCallback := func(event *output.InternalWrappedEvent, matcherStatus bool) {
 		if !matched.Load() && matcherStatus {
 			if err := e.options.Output.WriteFailure(event); err != nil {
-				gologger.Warning().Msgf("Could not write failure event to output: %s\n", err)
+				gologger.Warning().Msgf("Could not write failure event to output: %s", err)
 			}
 			executed.CompareAndSwap(false, true)
 		}

--- a/pkg/tmplexec/flow/vm.go
+++ b/pkg/tmplexec/flow/vm.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 
 	"github.com/Mzack9999/goja"
-	"github.com/logrusorgru/aurora"
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/nuclei/v3/pkg/js/gojs"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
@@ -64,11 +63,11 @@ func registerBuiltins(runtime *goja.Runtime) {
 			arg := call.Argument(0).Export()
 			switch value := arg.(type) {
 			case string:
-				gologger.DefaultLogger.Print().Msgf("[%v] %v", aurora.BrightCyan("JS"), value)
+				gologger.DefaultLogger.Info().Msgf("[%v] %v", "JS", value)
 			case map[string]interface{}:
-				gologger.DefaultLogger.Print().Msgf("[%v] %v", aurora.BrightCyan("JS"), vardump.DumpVariables(value))
+				gologger.DefaultLogger.Info().Msgf("[%v] %v", "JS", vardump.DumpVariables(value))
 			default:
-				gologger.DefaultLogger.Print().Msgf("[%v] %v", aurora.BrightCyan("JS"), value)
+				gologger.DefaultLogger.Info().Msgf("[%v] %v", "JS", value)
 			}
 			return call.Argument(0) // return the same value
 		},

--- a/pkg/tmplexec/generic/exec.go
+++ b/pkg/tmplexec/generic/exec.go
@@ -76,7 +76,7 @@ func (g *Generic) ExecuteWithResults(ctx *scan.ScanContext) error {
 		})
 		if err != nil {
 			ctx.LogError(err)
-			gologger.Warning().Msgf("[%s] Could not execute request for %s: %s\n", g.options.TemplateID, ctx.Input.MetaInput.PrettyPrint(), err)
+			gologger.Warning().Msgf("[%s] Could not execute request for %q: %s", g.options.TemplateID, ctx.Input.MetaInput.PrettyPrint(), err)
 		}
 		if g.options.HostErrorsCache != nil {
 			g.options.HostErrorsCache.MarkFailedOrRemove(g.options.ProtocolType.String(), ctx.Input, err)

--- a/pkg/utils/monitor/monitor.go
+++ b/pkg/utils/monitor/monitor.go
@@ -99,9 +99,9 @@ func (s *Agent) monitorWorker(cancel context.CancelFunc) {
 		cancel()
 		dumpID := xid.New().String()
 		stackTraceFile := fmt.Sprintf("nuclei-stacktrace-%s.dump", dumpID)
-		gologger.Error().Msgf("Detected hanging goroutine (count=%d/%d) = %s\n", current, s.goroutineCount, stackTraceFile)
+		gologger.Error().Msgf("Detected hanging goroutine (count=%d/%d), stack trace saved to %q", current, s.goroutineCount, stackTraceFile)
 		if err := os.WriteFile(stackTraceFile, currentStack, permissionutil.ConfigFilePermission); err != nil {
-			gologger.Error().Msgf("Could not write stack trace for goroutines: %s\n", err)
+			gologger.Error().Msgf("Could not write stack trace for goroutines: %s", err)
 		}
 
 		s.lock.Lock()
@@ -109,7 +109,7 @@ func (s *Agent) monitorWorker(cancel context.CancelFunc) {
 		s.lock.Unlock()
 		for _, callback := range callbacks {
 			if err := callback(dumpID); err != nil {
-				gologger.Error().Msgf("Stack monitor callback error: %s\n", err)
+				gologger.Error().Msgf("Stack monitor callback error: %s", err)
 			}
 		}
 


### PR DESCRIPTION
## Proposed changes

fix: malformed JSON lines output

fix WRN output routing & clean up some message
formatting.

Use `Warning()` method instead of manually tagged
`Print()` method warnings in the runner and template-
loading paths, which avoids mixing human-readable
warnings into the plain `Print()` output path.

Closes: #7314

Also, normalize logger calls at the same time by
dropping redundant newline suffixes, trimming
trivial `Msgf` wrappers and making user-facing log
messages more consistent across the tree.

### Proof

<!-- How has this been tested? Please describe the tests that you ran to verify your changes. -->

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved internal logging consistency across the application by standardizing message formatting, removing redundant newline characters, and replacing deprecated colored output utilities with native logger methods for cleaner and more maintainable code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->