### PR TITLE
fix(expressions): avoid helper eval in literal checks

### DIFF
--- a/pkg/protocols/common/expressions/expressions.go
+++ b/pkg/protocols/common/expressions/expressions.go
@@ -1,10 +1,10 @@
 package expressions
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/Knetic/govaluate"
-	"github.com/projectdiscovery/gologger"
 
 	"github.com/projectdiscovery/nuclei/v3/pkg/operators/common/dsl"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/marker"
@@ -53,28 +53,40 @@ func evaluate(data string, base map[string]interface{}) (string, error) {
 	// - complex: containing helper functions [ + variables]
 	// literals like {{2+2}} are not considered expressions
 	for _, expression := range expressions {
+		originalExpression := expression
 		// replace variable placeholders with base values
 		expression = replacer.Replace(expression, base)
+
 		// turns expressions (either helper functions+base values or base values)
 		compiled, err := govaluate.NewEvaluableExpressionWithFunctions(expression, dsl.HelperFunctions)
 		if err != nil {
-			gologger.Warning().Msgf("Failed to compile expression '%s': %v", expression, err)
-			continue
+			return data, fmt.Errorf("failed to compile expression %q: %w", originalExpression, err)
 		}
-		// propagate unresolved {{...}} markers from variable values so the
-		// downstream ContainsUnresolvedVariables check can detect them instead
-		// of having encoding functions (e.g. base64) hide them
-		if markers := unresolvedVarMarkers(compiled.Vars(), base); markers != "" {
-			data = replacer.ReplaceOne(data, expression, markers)
-			continue
-		}
+
 		result, err := compiled.Evaluate(base)
 		if err != nil {
-			gologger.Warning().Msgf("Failed to evaluate expression '%s': %v", expression, err)
-			continue
+			return data, fmt.Errorf("failed to evaluate expression %q: %w", originalExpression, err)
 		}
+
+		replacement := result
+		// Preserve unresolved markers only when a helper call would otherwise
+		// hide them from downstream validation. Plain expressions such as
+		// comparisons should evaluate normally.
+		if markers := unresolvedVarMarkers(compiled.Vars(), base); markers != "" {
+			usesFunctions := false
+			for _, token := range compiled.Tokens() {
+				if token.Kind == govaluate.FUNCTION {
+					usesFunctions = true
+					break
+				}
+			}
+			if usesFunctions && ContainsUnresolvedVariables(fmt.Sprint(result)) == nil {
+				replacement = markers
+			}
+		}
+
 		// replace incrementally
-		data = replacer.ReplaceOne(data, expression, result)
+		data = replacer.ReplaceOne(data, expression, replacement)
 	}
 	return data, nil
 }

--- a/pkg/protocols/common/expressions/expressions_test.go
+++ b/pkg/protocols/common/expressions/expressions_test.go
@@ -105,3 +105,50 @@ func TestEvaluateDoesNotReinterpretResolvedValues(t *testing.T) {
 		})
 	}
 }
+
+func TestEvaluateDoesNotExecuteHelpersFromResolvedValues(t *testing.T) {
+	var calls int
+
+	withTestHelperFunction(t, "test_side_effect", func(args ...interface{}) (interface{}, error) {
+		calls++
+		return "ok", nil
+	})
+
+	value, err := Evaluate("{{body}}", map[string]interface{}{
+		"body": "{{test_side_effect(1)}}",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "{{test_side_effect(1)}}", value)
+	require.Zero(t, calls)
+}
+
+func TestEvaluateReturnsErrorForInvalidTemplateExpression(t *testing.T) {
+	_, err := Evaluate("{{base64()}}", map[string]interface{}{})
+	require.Error(t, err)
+	require.ErrorContains(t, err, `failed to evaluate expression "base64()"`)
+}
+
+func TestEvaluateErrorDoesNotLeakResolvedValues(t *testing.T) {
+	_, err := Evaluate("{{base64('{{secret_token}}', 'extra')}}", map[string]interface{}{
+		"secret_token": "top-secret-cia-mi6-kgb-mossad-classified",
+	})
+	require.Error(t, err)
+	require.ErrorContains(t, err, `failed to evaluate expression "base64('{{secret_token}}', 'extra')"`)
+	require.NotContains(t, err.Error(), "top-secret-cia-mi6-kgb-mossad-classified")
+}
+
+func TestEvaluatePlainExpressionsWithMarkerLikeValues(t *testing.T) {
+	value, err := Evaluate("{{body != ''}}", map[string]interface{}{
+		"body": "{{contact_id}}",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "true", value)
+}
+
+func TestEvaluatePreservesVisibleMarkersFromHelperResults(t *testing.T) {
+	value, err := Evaluate("{{concat(body, '-x')}}", map[string]interface{}{
+		"body": "{{contact_id}}",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "{{contact_id}}-x", value)
+}

--- a/pkg/protocols/common/expressions/variables.go
+++ b/pkg/protocols/common/expressions/variables.go
@@ -120,9 +120,10 @@ func hasLiteralsOnly(data string) bool {
 	if err != nil {
 		return false
 	}
-	if expr != nil {
-		_, err = expr.Evaluate(nil)
-		return err == nil
+
+	if expr == nil {
+		return true
 	}
-	return true
+
+	return len(expr.Vars()) == 0
 }

--- a/pkg/protocols/common/expressions/variables_test.go
+++ b/pkg/protocols/common/expressions/variables_test.go
@@ -4,8 +4,25 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/Knetic/govaluate"
+	"github.com/projectdiscovery/nuclei/v3/pkg/operators/common/dsl"
 	"github.com/stretchr/testify/require"
 )
+
+func withTestHelperFunction(t *testing.T, name string, fn govaluate.ExpressionFunction) {
+	t.Helper()
+
+	originalFn, hadFn := dsl.HelperFunctions[name]
+	dsl.HelperFunctions[name] = fn
+
+	t.Cleanup(func() {
+		if hadFn {
+			dsl.HelperFunctions[name] = originalFn
+			return
+		}
+		delete(dsl.HelperFunctions, name)
+	})
+}
 
 func TestUnresolvedVariablesCheck(t *testing.T) {
 	tests := []struct {
@@ -25,4 +42,16 @@ func TestUnresolvedVariablesCheck(t *testing.T) {
 		err := ContainsUnresolvedVariables(test.data)
 		require.Equal(t, test.err, err, "could not get unresolved variables")
 	}
+}
+
+func TestUnresolvedVariablesCheckDoesNotExecuteHelpers(t *testing.T) {
+	var calls int
+	withTestHelperFunction(t, "test_side_effect", func(args ...interface{}) (interface{}, error) {
+		calls++
+		return "ok", nil
+	})
+
+	err := ContainsUnresolvedVariables("{{test_side_effect(1)}}")
+	require.NoError(t, err)
+	require.Zero(t, calls)
 }

--- a/pkg/protocols/javascript/js.go
+++ b/pkg/protocols/javascript/js.go
@@ -701,6 +701,7 @@ func (request *Request) getArgsCopy(input *contextargs.Context, payloadValues ma
 	if err != nil {
 		requestOptions.Output.Request(requestOptions.TemplateID, input.MetaInput.Input, request.Type().String(), err)
 		requestOptions.Progress.IncrementFailedRequestsBy(1)
+		return nil, err
 	}
 	// "Port" is a special variable that is considered as network port
 	// and is conditional based on input port and default port specified in input

--- a/pkg/protocols/javascript/js_test.go
+++ b/pkg/protocols/javascript/js_test.go
@@ -9,8 +9,11 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/config"
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/disk"
 	"github.com/projectdiscovery/nuclei/v3/pkg/loader/workflow"
+	"github.com/projectdiscovery/nuclei/v3/pkg/output"
 	"github.com/projectdiscovery/nuclei/v3/pkg/progress"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/contextargs"
+	javascript "github.com/projectdiscovery/nuclei/v3/pkg/protocols/javascript"
 	"github.com/projectdiscovery/nuclei/v3/pkg/templates"
 	"github.com/projectdiscovery/nuclei/v3/pkg/testutils"
 	"github.com/projectdiscovery/ratelimit"
@@ -72,4 +75,36 @@ func TestCompile(t *testing.T) {
 			require.Equal(t, 1, template.TotalRequests, "template : %v", tpl)
 		}
 	}
+}
+
+func TestExecuteWithResultsReturnsArgEvaluationErrorWithoutPanic(t *testing.T) {
+	options := testutils.DefaultOptions
+	tmplInfo := &testutils.TemplateInfo{ID: "execute-with-results-arg-evaluation-error"}
+
+	testutils.Init(options)
+
+	t.Cleanup(func() {
+		testutils.Cleanup(options)
+	})
+
+	executorOptions := testutils.NewMockExecuterOptions(options, tmplInfo)
+	executorOptions.JsCompiler = templates.GetJsCompiler()
+
+	request := &javascript.Request{
+		Args: map[string]interface{}{
+			"token": "{{base64()}}",
+		},
+		Code: `module.exports = { success: true, response: "ok" }`,
+	}
+	require.NoError(t, request.Compile(executorOptions))
+
+	target := contextargs.NewWithInput(context.Background(), "https://example.com:443")
+
+	var err error
+	require.NotPanics(t, func() {
+		err = request.ExecuteWithResults(target, nil, nil, func(*output.InternalWrappedEvent) {
+			t.Fatal("unexpected callback on argument evaluation failure")
+		})
+	})
+	require.ErrorContains(t, err, `failed to evaluate expression "base64()"`)
 }


### PR DESCRIPTION
## Proposed changes

fix(expressions): avoid helper eval in literal checks

`hasLiteralsOnly()` currently evaluates helper
expressions while deciding whether "{{...}}"
contains unresolved variables, which makes
validation paths run side-effectful helpers.

Just replace that runtime eval with a
`Vars()` len check so unresolved-variable
detection literally stays literal (am I writing it
right?), and of course side-effect free.

Also make `Evaluate()` return template-authored
expression compile/eval errors instead of
logging and then keep continuing, so malformed
helper calls still fail in the rendering path.

Fixes #7320

### Proof

```console
$ time ./bin/nuclei -t eval-while-validating.yaml -u "http://localhost:8088/" -var "func=wait_for" -var "args=5" -debug

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.7.1

		projectdiscovery.io

[INF] Current nuclei version: v3.7.1 (unknown) - remove '-duc' flag to enable update checks
[INF] Current nuclei-templates version: v10.4.1 (unknown) - remove '-duc' flag to enable update checks
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 76
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] [eval-while-validating] Dumped HTTP request for http://localhost:8088/?func=wait_for&args=5

GET /?func=wait_for&args=5 HTTP/1.1
Host: localhost:8088
User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:72.0) Gecko/20100101 Firefox/72.0
Connection: close
Accept-Encoding: gzip

[DBG] [eval-while-validating] Dumped HTTP response http://localhost:8088/?func=wait_for&args=5

HTTP/1.1 200 OK
Connection: close
Content-Length: 15
Content-Type: text/plain; charset=utf-8
Date: Thu, 02 Apr 2026 02:37:39 GMT

{{wait_for(5)}}
[INF] [eval-while-validating] Dumped HTTP request for http://localhost:8088/reuse

POST /reuse HTTP/1.1
Host: localhost:8088
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.13; rv:78.0) Gecko/20100101 Firefox/78.0
Connection: close
Content-Length: 20
Accept-Encoding: gzip

data={{wait_for(5)}}
[DBG] [eval-while-validating] Dumped HTTP response http://localhost:8088/reuse

HTTP/1.1 204 No Content
Connection: close
Content-Length: 0
Date: Thu, 02 Apr 2026 02:37:39 GMT

[INF] Scan completed in 3.026557ms. No results found.

real	0m0.816s
user	0m0.472s
sys	0m0.145s
```

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Expression evaluation now fails immediately with clear error messages instead of skipping, and avoids leaking resolved secret values.
  * Helper/template-like syntax embedded in resolved inputs is no longer executed.
  * Request argument processing aborts correctly on argument-evaluation errors.

* **Tests**
  * Added tests covering expression error handling, helper isolation, unresolved-variable behavior, and argument-evaluation failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->