### PR TITLE
fix(interactsh): serialize `InternalEvent` access

### DIFF
--- a/pkg/protocols/common/interactsh/interactsh.go
+++ b/pkg/protocols/common/interactsh/interactsh.go
@@ -119,7 +119,7 @@ func (c *Client) poll() error {
 		}
 
 		if requestShouldStopAtFirstMatch(request) || c.options.StopAtFirstMatch {
-			if gotItem, err := c.matchedTemplates.Get(hash(request.Event.InternalEvent)); gotItem && err == nil {
+			if gotItem, err := c.matchedTemplates.Get(eventHash(request.Event)); gotItem && err == nil {
 				return
 			}
 		}
@@ -154,6 +154,7 @@ func requestShouldStopAtFirstMatch(request *RequestData) bool {
 func (c *Client) processInteractionForRequest(interaction *server.Interaction, data *RequestData) bool {
 	var result *operators.Result
 	var matched bool
+	var templateID string
 	data.Event.Lock()
 	data.Event.InternalEvent["interactsh_protocol"] = interaction.Protocol
 	if strings.EqualFold(interaction.Protocol, "dns") {
@@ -163,16 +164,16 @@ func (c *Client) processInteractionForRequest(interaction *server.Interaction, d
 	}
 	data.Event.InternalEvent["interactsh_response"] = interaction.RawResponse
 	data.Event.InternalEvent["interactsh_ip"] = interaction.RemoteAddress
-	data.Event.Unlock()
-
 	if data.Operators != nil {
 		result, matched = data.Operators.Execute(data.Event.InternalEvent, data.MatchFunc, data.ExtractFunc, c.options.Debug || c.options.DebugRequest || c.options.DebugResponse)
 	} else {
 		// this is most likely a bug so error instead of warning
-		var templateID string
 		if data.Event.InternalEvent != nil {
 			templateID = fmt.Sprint(data.Event.InternalEvent[templateIdAttribute])
 		}
+	}
+	data.Event.Unlock()
+	if data.Operators == nil {
 		gologger.Error().Msgf("missing compiled operators for '%v' template", templateID)
 	}
 
@@ -225,7 +226,7 @@ func (c *Client) processInteractionForRequest(interaction *server.Interaction, d
 		data.Event.InteractshMatched.Store(true)
 		c.matched.Store(true)
 		if requestShouldStopAtFirstMatch(data) || c.options.StopAtFirstMatch {
-			_ = c.matchedTemplates.SetWithExpire(hash(data.Event.InternalEvent), true, defaultInteractionDuration)
+			_ = c.matchedTemplates.SetWithExpire(eventHash(data.Event), true, defaultInteractionDuration)
 		}
 	}
 
@@ -233,10 +234,7 @@ func (c *Client) processInteractionForRequest(interaction *server.Interaction, d
 }
 
 func (c *Client) AlreadyMatched(data *RequestData) bool {
-	data.Event.RLock()
-	defer data.Event.RUnlock()
-
-	return c.matchedTemplates.Has(hash(data.Event.InternalEvent))
+	return c.matchedTemplates.Has(eventHash(data.Event))
 }
 
 // URL returns a new URL that can be interacted with
@@ -348,7 +346,7 @@ func (c *Client) RequestEvent(interactshURLs []string, data *RequestData) {
 		id := strings.TrimRight(strings.TrimSuffix(interactshURL, c.getHostname()), ".")
 
 		if requestShouldStopAtFirstMatch(data) || c.options.StopAtFirstMatch {
-			gotItem, err := c.matchedTemplates.Get(hash(data.Event.InternalEvent))
+			gotItem, err := c.matchedTemplates.Get(eventHash(data.Event))
 			if gotItem && err == nil {
 				break
 			}
@@ -448,6 +446,13 @@ func hash(internalEvent output.InternalEvent) string {
 	templateId := internalEvent[templateIdAttribute].(string)
 	host := internalEvent["host"].(string)
 	return fmt.Sprintf("%s:%s", templateId, host)
+}
+
+func eventHash(event *output.InternalWrappedEvent) string {
+	event.RLock()
+	defer event.RUnlock()
+
+	return hash(event.InternalEvent)
 }
 
 func (c *Client) getHostname() string {

--- a/pkg/protocols/common/interactsh/interactsh_test.go
+++ b/pkg/protocols/common/interactsh/interactsh_test.go
@@ -1,0 +1,94 @@
+package interactsh
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+
+	serverint "github.com/projectdiscovery/interactsh/pkg/server"
+	"github.com/projectdiscovery/nuclei/v3/pkg/operators"
+	"github.com/projectdiscovery/nuclei/v3/pkg/operators/extractors"
+	"github.com/projectdiscovery/nuclei/v3/pkg/operators/matchers"
+	"github.com/projectdiscovery/nuclei/v3/pkg/output"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProcessInteractionForRequestConcurrentEventUpdate(t *testing.T) {
+	const (
+		keyCount        = 4096
+		expressionCount = 256
+		mutationCount   = keyCount * 200
+	)
+
+	eventData := make(output.InternalEvent, keyCount+2)
+	eventData[templateIdAttribute] = "test-template"
+	eventData["host"] = "example.com"
+
+	var expressionBuilder strings.Builder
+	for i := 0; i < keyCount; i++ {
+		key := fmt.Sprintf("key%d", i)
+		eventData[key] = fmt.Sprintf("value%d", i)
+		if i < expressionCount {
+			expressionBuilder.WriteString("{{")
+			expressionBuilder.WriteString(key)
+			expressionBuilder.WriteString("}}")
+		}
+	}
+
+	matcher := &matchers.Matcher{
+		Type:  matchers.MatcherTypeHolder{MatcherType: matchers.WordsMatcher},
+		Words: []string{expressionBuilder.String()},
+	}
+	op := &operators.Operators{
+		Matchers:          []*matchers.Matcher{matcher},
+		MatchersCondition: "or",
+	}
+	require.NoError(t, op.Compile())
+
+	var startWriter sync.Once
+	writerStarted := make(chan struct{})
+	requestData := &RequestData{
+		Event:     &output.InternalWrappedEvent{InternalEvent: eventData},
+		Operators: op,
+		MatchFunc: func(data map[string]interface{}, matcher *matchers.Matcher) (bool, []string) {
+			startWriter.Do(func() {
+				close(writerStarted)
+			})
+			runtime.Gosched()
+			return matcher.MatchWords("not-present-in-corpus", data)
+		},
+		ExtractFunc: func(map[string]interface{}, *extractors.Extractor) map[string]struct{} {
+			return nil
+		},
+	}
+
+	var writerWG sync.WaitGroup
+	writerWG.Add(1)
+	go func() {
+		defer writerWG.Done()
+		<-writerStarted
+		for i := 0; i < mutationCount; i++ {
+			key := fmt.Sprintf("key%d", i%keyCount)
+			requestData.Event.Lock()
+			requestData.Event.InternalEvent[key] = fmt.Sprintf("mutated-%d", i)
+			if i%17 == 0 {
+				delete(requestData.Event.InternalEvent, key)
+				requestData.Event.InternalEvent[key] = fmt.Sprintf("mutated-%d", i)
+			}
+			requestData.Event.Unlock()
+		}
+	}()
+
+	client := &Client{options: &Options{}}
+	matched := client.processInteractionForRequest(&serverint.Interaction{
+		Protocol:      "dns",
+		RawRequest:    "request",
+		RawResponse:   "response",
+		RemoteAddress: "127.0.0.1",
+	}, requestData)
+	writerWG.Wait()
+
+	require.False(t, matched)
+}


### PR DESCRIPTION
## Proposed changes

fix(interactsh): serialize `InternalEvent` access

`interactsh.(*Client).processInteractionForRequest`
was updating the wrapped event under lock but
releasing it before calling `Operators.Execute()`,
allowing async interactsh updates to race with
matcher expr evaluation on the same `InternalEvent`
map, causing fatal concurrent map iteration/write
crashes.

Hold the event lock while populating interactsh
fields and running operators, and use a locked
`eventHash()` helper for matched-template cache
lookups that access the same event data.

Fixes #7319

### Proof

patch:

```console
$ go test -count=1 -v -run ^TestProcessInteractionForRequestConcurrentEventUpdate$ ./pkg/protocols/common/interactsh
=== RUN   TestProcessInteractionForRequestConcurrentEventUpdate
--- PASS: TestProcessInteractionForRequestConcurrentEventUpdate (0.50s)
PASS
ok  	github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/interactsh	0.597s
```

dev:

```
$ go test -count=1 -v -run ^TestProcessInteractionForRequestConcurrentEventUpdate$ ./pkg/protocols/common/interactsh
=== RUN   TestProcessInteractionForRequestConcurrentEventUpdate
fatal error: concurrent map iteration and map write

goroutine 34 [running]:
internal/runtime/maps.fatal({0x1bc97f5?, 0x17d79a0?})
	/usr/local/go/src/runtime/panic.go:1181 +0x18
internal/runtime/maps.(*Iter).Next(0x17d79a0?)
	/usr/local/go/src/internal/runtime/maps/table.go:819 +0x86
github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/expressions.getFunctionsNames(...)
	/home/dw1/Development/PD/nuclei/pkg/protocols/common/expressions/expressions.go:186
github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/expressions.isExpression({0x2b55c9eca002, 0x4}, 0x2b55c9c9b2f0)
	/home/dw1/Development/PD/nuclei/pkg/protocols/common/expressions/expressions.go:142 +0x1aa
github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/expressions.FindExpressions({0x2b55c9eca000?, 0x0?}, {0x1b151ba, 0x2}, {0x1b151bc, 0x2}, 0x2b55c9c9b2f0)
	/home/dw1/Development/PD/nuclei/pkg/protocols/common/expressions/expressions.go:120 +0x245
github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/expressions.evaluate({0x2b55c9eca000, 0x992}, 0x2b55c9c9b2f0)
	/home/dw1/Development/PD/nuclei/pkg/protocols/common/expressions/expressions.go:46 +0x53
github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/expressions.Evaluate(...)
	/home/dw1/Development/PD/nuclei/pkg/protocols/common/expressions/expressions.go:31
github.com/projectdiscovery/nuclei/v3/pkg/operators/matchers.(*Matcher).MatchWords(0x2b55cad9c000, {0x1b89388?, 0x428145?}, 0x60?)
	/home/dw1/Development/PD/nuclei/pkg/operators/matchers/match.go:68 +0x129
github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/interactsh.TestProcessInteractionForRequestConcurrentEventUpdate.func1(0x2b55c9c9b2f0, 0x2b55cad9c000)
	/home/dw1/Development/PD/nuclei/pkg/protocols/common/interactsh/interactsh_test.go:60 +0x6d
github.com/projectdiscovery/nuclei/v3/pkg/operators.(*Operators).Execute(0x2b55c9c200c0, 0x2b55c9c9b2f0, 0x2b55c97d40f0, 0x24ef390, 0x0)
	/home/dw1/Development/PD/nuclei/pkg/operators/operators.go:303 +0xb08
github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/interactsh.(*Client).processInteractionForRequest(0x2b55cada3e98, 0x2b55c992c4d0, 0x2b55c9d76700)
	/home/dw1/Development/PD/nuclei/pkg/protocols/common/interactsh/interactsh.go:169 +0x358
github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/interactsh.TestProcessInteractionForRequestConcurrentEventUpdate(0x2b55c98bcd88)
	/home/dw1/Development/PD/nuclei/pkg/protocols/common/interactsh/interactsh_test.go:85 +0x7f2
testing.tRunner(0x2b55c98bcd88, 0x24ef2d0)
	/usr/local/go/src/testing/testing.go:2036 +0xea
created by testing.(*T).Run in goroutine 1
	/usr/local/go/src/testing/testing.go:2101 +0x4c5
FAIL	github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/interactsh	0.100s
FAIL
```

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved concurrent event handling to prevent race conditions during template matching and event processing.
  * Enhanced error logging for operator execution to ensure proper synchronization.

* **Tests**
  * Added comprehensive testing for concurrent event updates during interaction processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->