### PR TITLE
feat: allow overriding default exclude-ports in CLI

### DIFF
--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -373,6 +373,7 @@ on extensive configurability, massive extensibility and ease of use.`)
 		flagSet.StringVarP(&options.Interface, "interface", "i", "", "network interface to use for network scan"),
 		flagSet.StringVarP(&options.AttackType, "attack-type", "at", "", "type of payload combinations to perform (batteringram,pitchfork,clusterbomb)"),
 		flagSet.StringVarP(&options.SourceIP, "source-ip", "sip", "", "source ip address to use for network scan"),
+		flagSet.StringSliceVarP(&options.ReservedPorts, "reserved-ports", "rport", nil, "list of reserved ports that network templates should avoid", goflags.CommaSeparatedStringSliceOptions),
 		flagSet.IntVarP(&options.ResponseReadSize, "response-size-read", "rsr", 0, "max response size to read in bytes"),
 		flagSet.IntVarP(&options.ResponseSaveSize, "response-size-save", "rss", unitutils.Mega, "max response size to read in bytes"),
 		flagSet.CallbackVar(resetCallback, "reset", "reset removes all nuclei configuration and data files (including nuclei-templates)"),

--- a/pkg/protocols/common/contextargs/contextargs.go
+++ b/pkg/protocols/common/contextargs/contextargs.go
@@ -15,8 +15,8 @@ import (
 )
 
 var (
-	// reservedPorts contains list of reserved ports for non-network requests in nuclei
-	reservedPorts = []string{"80", "443", "8080", "8443", "8081", "53"}
+	// defaultReservedPorts contains the default list of reserved ports for non-network requests in nuclei
+	defaultReservedPorts = []string{"80", "443", "8080", "8443", "8081", "53"}
 )
 
 // Context implements a shared context struct to share information across multiple templates within a workflow
@@ -110,12 +110,18 @@ func (ctx *Context) Add(key string, v interface{}) {
 
 // UseNetworkPort updates input with required/default network port for that template
 // but is ignored if input/target contains non-http ports like 80,8080,8081 etc
-func (ctx *Context) UseNetworkPort(port string, excludePorts string) error {
-	ignorePorts := reservedPorts
-	if excludePorts != "" {
-		ignorePorts = resolvePortList(strings.Split(excludePorts, ","))
+// Precedence: cliExcludePorts > templateExcludePorts > default reserved ports
+func (ctx *Context) UseNetworkPort(port string, templateExcludePorts string, cliExcludePorts []string) error {
+	ignorePorts := defaultReservedPorts
+
+	if len(cliExcludePorts) > 0 {
+		ignorePorts = resolvePortList(cliExcludePorts)
+		ignorePorts = sliceutil.Dedupe(ignorePorts)
+	} else if templateExcludePorts != "" {
+		ignorePorts = resolvePortList(strings.Split(templateExcludePorts, ","))
 		ignorePorts = sliceutil.Dedupe(ignorePorts)
 	}
+
 	if port == "" {
 		// if template does not contain port, do nothing
 		return nil

--- a/pkg/protocols/common/contextargs/contextargs.go
+++ b/pkg/protocols/common/contextargs/contextargs.go
@@ -14,8 +14,8 @@ import (
 )
 
 var (
-	// reservedPorts contains list of reserved ports for non-network requests in nuclei
-	reservedPorts = []string{"80", "443", "8080", "8443", "8081", "53"}
+	// defaultReservedPorts contains the default list of reserved ports for non-network requests in nuclei
+	defaultReservedPorts = []string{"80", "443", "8080", "8443", "8081", "53"}
 )
 
 // Context implements a shared context struct to share information across multiple templates within a workflow
@@ -109,12 +109,17 @@ func (ctx *Context) Add(key string, v interface{}) {
 
 // UseNetworkPort updates input with required/default network port for that template
 // but is ignored if input/target contains non-http ports like 80,8080,8081 etc
-func (ctx *Context) UseNetworkPort(port string, excludePorts string) error {
-	ignorePorts := reservedPorts
-	if excludePorts != "" {
+// Precedence: cliExcludePorts > templateExcludePorts > default reserved ports
+func (ctx *Context) UseNetworkPort(port string, templateExcludePorts string, cliExcludePorts []string) error {
+	ignorePorts := defaultReservedPorts
+
+	if len(cliExcludePorts) > 0 {
+		ignorePorts = cliExcludePorts
+	} else if templateExcludePorts != "" {
 		// TODO: add support for service names like http,https,ssh etc once https://github.com/projectdiscovery/netdb is ready
-		ignorePorts = sliceutil.Dedupe(strings.Split(excludePorts, ","))
+		ignorePorts = sliceutil.Dedupe(strings.Split(templateExcludePorts, ","))
 	}
+
 	if port == "" {
 		// if template does not contain port, do nothing
 		return nil

--- a/pkg/protocols/common/contextargs/contextargs.go
+++ b/pkg/protocols/common/contextargs/contextargs.go
@@ -108,9 +108,16 @@ func (ctx *Context) Add(key string, v interface{}) {
 	}
 }
 
-// UseNetworkPort updates input with required/default network port for that template
-// but is ignored if input/target contains non-http ports like 80,8080,8081 etc
-// Precedence: cliExcludePorts > templateExcludePorts > default reserved ports
+// Replace the input port with the template port when the input has no port or
+// when its port is in the active reserved-port list.
+//
+// The active reserved-port list is selected by precedence:
+//   - CLI flag -reserved-ports, when provided
+//   - template exclude-ports field, when provided
+//   - defaultReservedPorts otherwise
+//
+// This reduces redundant dials to HTTP ports when running network templates
+// aimed at other services.
 func (ctx *Context) UseNetworkPort(port string, templateExcludePorts string, cliExcludePorts []string) error {
 	ignorePorts := defaultReservedPorts
 

--- a/pkg/protocols/common/contextargs/contextargs_test.go
+++ b/pkg/protocols/common/contextargs/contextargs_test.go
@@ -13,6 +13,7 @@ func TestUseNetworkPort(t *testing.T) {
 		target       string
 		templatePort string
 		templateExcl string
+		cliReserved  []string
 		expectedHost string
 	}{
 		{
@@ -20,6 +21,7 @@ func TestUseNetworkPort(t *testing.T) {
 			target:       "example.com:80",
 			templatePort: "1234",
 			templateExcl: "",
+			cliReserved:  nil,
 			expectedHost: "example.com:1234",
 		},
 		{
@@ -27,6 +29,7 @@ func TestUseNetworkPort(t *testing.T) {
 			target:       "example.com:22",
 			templatePort: "80",
 			templateExcl: "",
+			cliReserved:  nil,
 			expectedHost: "example.com:22",
 		},
 		{
@@ -34,6 +37,7 @@ func TestUseNetworkPort(t *testing.T) {
 			target:       "example.com:80",
 			templatePort: "1234",
 			templateExcl: "0",
+			cliReserved:  nil,
 			expectedHost: "example.com:80",
 		},
 		{
@@ -41,6 +45,7 @@ func TestUseNetworkPort(t *testing.T) {
 			target:       "example.com:5353",
 			templatePort: "1234",
 			templateExcl: "5353",
+			cliReserved:  nil,
 			expectedHost: "example.com:1234",
 		},
 		{
@@ -48,6 +53,7 @@ func TestUseNetworkPort(t *testing.T) {
 			target:       "example.com:443",
 			templatePort: "1234",
 			templateExcl: "80,443",
+			cliReserved:  nil,
 			expectedHost: "example.com:1234",
 		},
 		{
@@ -55,14 +61,47 @@ func TestUseNetworkPort(t *testing.T) {
 			target:       "example.com:443",
 			templatePort: "1234",
 			templateExcl: "443 ",
+			cliReserved:  nil,
 			expectedHost: "example.com:1234",
+		},
+		{
+			name:         "cli-exclusions-take-precedence-over-template-exclusions",
+			target:       "example.com:80",
+			templatePort: "2345",
+			templateExcl: "0",
+			cliReserved:  []string{"80"},
+			expectedHost: "example.com:2345",
+		},
+		{
+			name:         "cli-exclusions-replace-default-reserved-ports",
+			target:       "example.com:80",
+			templatePort: "2345",
+			templateExcl: "",
+			cliReserved:  []string{"0"},
+			expectedHost: "example.com:80",
+		},
+		{
+			name:         "cli-excluded-port-is-applied",
+			target:       "example.com:5353",
+			templatePort: "2345",
+			templateExcl: "",
+			cliReserved:  []string{"5353"},
+			expectedHost: "example.com:2345",
+		},
+		{
+			name:         "cli-excluded-port-with-whitespace-is-applied",
+			target:       "example.com:443",
+			templatePort: "2345",
+			templateExcl: "",
+			cliReserved:  []string{"80", " 443"},
+			expectedHost: "example.com:2345",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := NewWithInput(context.Background(), tt.target)
-			err := ctx.UseNetworkPort(tt.templatePort, tt.templateExcl)
+			err := ctx.UseNetworkPort(tt.templatePort, tt.templateExcl, tt.cliReserved)
 
 			require.NoError(t, err, "unexpected error")
 			require.Equal(t, tt.expectedHost, ctx.MetaInput.Input)

--- a/pkg/protocols/common/contextargs/contextargs_test.go
+++ b/pkg/protocols/common/contextargs/contextargs_test.go
@@ -1,0 +1,86 @@
+package contextargs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUseNetworkPort(t *testing.T) {
+	tests := []struct {
+		name         string
+		target       string
+		templatePort string
+		templateExcl string
+		cliReserved  []string
+		expectedHost string
+	}{
+		{
+			name:         "default-reserved-ports-work",
+			target:       "example.com:80",
+			templatePort: "1234",
+			templateExcl: "",
+			cliReserved:  nil,
+			expectedHost: "example.com:1234",
+		},
+		{
+			name:         "default-target-works",
+			target:       "example.com:22",
+			templatePort: "80",
+			templateExcl: "",
+			cliReserved:  nil,
+			expectedHost: "example.com:22",
+		},
+		{
+			name:         "template-overwrites-defaults-no-exclusions",
+			target:       "example.com:80",
+			templatePort: "1234",
+			templateExcl: "0",
+			cliReserved:  nil,
+			expectedHost: "example.com:80",
+		},
+		{
+			name:         "template-overwrites-defaults-some-exclusions",
+			target:       "example.com:5353",
+			templatePort: "1234",
+			templateExcl: "5353",
+			cliReserved:  nil,
+			expectedHost: "example.com:1234",
+		},
+		{
+			name:         "cli-overwrites-template",
+			target:       "example.com:80",
+			templatePort: "1234",
+			templateExcl: "0",
+			cliReserved:  []string{"80"},
+			expectedHost: "example.com:1234",
+		},
+		{
+			name:         "cli-overwrites-default-no-exclusions",
+			target:       "example.com:80",
+			templatePort: "1234",
+			templateExcl: "",
+			cliReserved:  []string{"0"},
+			expectedHost: "example.com:80",
+		},
+		{
+			name:         "cli-overwrites-default-some-exclusions",
+			target:       "example.com:5353",
+			templatePort: "1234",
+			templateExcl: "",
+			cliReserved:  []string{"5353"},
+			expectedHost: "example.com:1234",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := NewWithInput(context.Background(), tt.target)
+			err := ctx.UseNetworkPort(tt.templatePort, tt.templateExcl, tt.cliReserved)
+
+			require.NoError(t, err, "unexpected error")
+			require.Equal(t, tt.expectedHost, ctx.MetaInput.Input)
+		})
+	}
+}

--- a/pkg/protocols/common/contextargs/contextargs_test.go
+++ b/pkg/protocols/common/contextargs/contextargs_test.go
@@ -1,0 +1,71 @@
+package contextargs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUseNetworkPort(t *testing.T) {
+	tests := []struct {
+		name         string
+		target       string
+		templatePort string
+		templateExcl string
+		expectedHost string
+	}{
+		{
+			name:         "default-reserved-port-is-rewritten",
+			target:       "example.com:80",
+			templatePort: "1234",
+			templateExcl: "",
+			expectedHost: "example.com:1234",
+		},
+		{
+			name:         "non-reserved-target-port-is-preserved",
+			target:       "example.com:22",
+			templatePort: "80",
+			templateExcl: "",
+			expectedHost: "example.com:22",
+		},
+		{
+			name:         "template-exclusions-replace-default-reserved-ports",
+			target:       "example.com:80",
+			templatePort: "1234",
+			templateExcl: "0",
+			expectedHost: "example.com:80",
+		},
+		{
+			name:         "template-excluded-port-is-applied",
+			target:       "example.com:5353",
+			templatePort: "1234",
+			templateExcl: "5353",
+			expectedHost: "example.com:1234",
+		},
+		{
+			name:         "template-excluded-port-list-is-applied",
+			target:       "example.com:443",
+			templatePort: "1234",
+			templateExcl: "80,443",
+			expectedHost: "example.com:1234",
+		},
+		{
+			name:         "template-excluded-port-with-whitespace-is-applied",
+			target:       "example.com:443",
+			templatePort: "1234",
+			templateExcl: "443 ",
+			expectedHost: "example.com:1234",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := NewWithInput(context.Background(), tt.target)
+			err := ctx.UseNetworkPort(tt.templatePort, tt.templateExcl)
+
+			require.NoError(t, err, "unexpected error")
+			require.Equal(t, tt.expectedHost, ctx.MetaInput.Input)
+		})
+	}
+}

--- a/pkg/protocols/javascript/js.go
+++ b/pkg/protocols/javascript/js.go
@@ -308,7 +308,7 @@ func (request *Request) executeWithResults(port string, target *contextargs.Cont
 	// use network port updates input with new port requested in template file
 	// and it is ignored if input port is not standard http(s) ports like 80,8080,8081 etc
 	// idea is to reduce redundant dials to http ports
-	if err := input.UseNetworkPort(port, request.getExcludePorts()); err != nil {
+	if err := input.UseNetworkPort(port, request.getExcludePorts(), request.options.Options.ReservedPorts); err != nil {
 		gologger.Debug().Msgf("Could not network port from constants: %s\n", err)
 	}
 

--- a/pkg/protocols/javascript/js.go
+++ b/pkg/protocols/javascript/js.go
@@ -305,9 +305,6 @@ func (request *Request) ExecuteWithResults(target *contextargs.Context, dynamicV
 // executeWithResults executes the request
 func (request *Request) executeWithResults(port string, target *contextargs.Context, dynamicValues, previous output.InternalEvent, callback protocols.OutputEventCallback) error {
 	input := target.Clone()
-	// use network port updates input with new port requested in template file
-	// and it is ignored if input port is not standard http(s) ports like 80,8080,8081 etc
-	// idea is to reduce redundant dials to http ports
 	if err := input.UseNetworkPort(port, request.getExcludePorts(), request.options.Options.ReservedPorts); err != nil {
 		gologger.Debug().Msgf("Could not network port from constants: %s\n", err)
 	}

--- a/pkg/protocols/javascript/js.go
+++ b/pkg/protocols/javascript/js.go
@@ -309,7 +309,7 @@ func (request *Request) executeWithResults(port string, target *contextargs.Cont
 	// use network port updates input with new port requested in template file
 	// and it is ignored if input port is not standard http(s) ports like 80,8080,8081 etc
 	// idea is to reduce redundant dials to http ports
-	if err := input.UseNetworkPort(port, request.getExcludePorts()); err != nil {
+	if err := input.UseNetworkPort(port, request.getExcludePorts(), request.options.Options.ReservedPorts); err != nil {
 		gologger.Debug().Msgf("Could not network port from constants: %s\n", err)
 	}
 

--- a/pkg/protocols/network/request.go
+++ b/pkg/protocols/network/request.go
@@ -55,7 +55,7 @@ func (request *Request) getOpenPorts(target *contextargs.Context) ([]string, err
 	openPorts := make([]string, 0)
 	for _, port := range request.ports {
 		cloned := target.Clone()
-		if err := cloned.UseNetworkPort(port, request.ExcludePorts); err != nil {
+		if err := cloned.UseNetworkPort(port, request.ExcludePorts, request.options.Options.ReservedPorts); err != nil {
 			errs = append(errs, err)
 			continue
 		}
@@ -119,7 +119,7 @@ func (request *Request) ExecuteWithResults(target *contextargs.Context, metadata
 		// use network port updates input with new port requested in template file
 		// and it is ignored if input port is not standard http(s) ports like 80,8080,8081 etc
 		// idea is to reduce redundant dials to http ports
-		if err := input.UseNetworkPort(port, request.ExcludePorts); err != nil {
+		if err := input.UseNetworkPort(port, request.ExcludePorts, request.options.Options.ReservedPorts); err != nil {
 			gologger.Debug().Msgf("Could not network port from constants: %s\n", err)
 		}
 		if err := request.executeOnTarget(input, visitedAddresses, metadata, previous, wrappedCallback); err != nil {

--- a/pkg/protocols/network/request.go
+++ b/pkg/protocols/network/request.go
@@ -56,7 +56,7 @@ func (request *Request) getOpenPorts(target *contextargs.Context) ([]string, err
 	openPorts := make([]string, 0)
 	for _, port := range request.ports {
 		cloned := target.Clone()
-		if err := cloned.UseNetworkPort(port, request.ExcludePorts); err != nil {
+		if err := cloned.UseNetworkPort(port, request.ExcludePorts, request.options.Options.ReservedPorts); err != nil {
 			errs = append(errs, err)
 			continue
 		}
@@ -120,7 +120,7 @@ func (request *Request) ExecuteWithResults(target *contextargs.Context, metadata
 		// use network port updates input with new port requested in template file
 		// and it is ignored if input port is not standard http(s) ports like 80,8080,8081 etc
 		// idea is to reduce redundant dials to http ports
-		if err := input.UseNetworkPort(port, request.ExcludePorts); err != nil {
+		if err := input.UseNetworkPort(port, request.ExcludePorts, request.options.Options.ReservedPorts); err != nil {
 			gologger.Debug().Msgf("Could not network port from constants: %s\n", err)
 		}
 		if err := request.executeOnTarget(input, visitedAddresses, metadata, previous, wrappedCallback); err != nil {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -466,6 +466,8 @@ type Options struct {
 	InlineTargetsList string `yaml:"targets-inline,omitempty"`
 	// ListTemplateProfiles lists all available template profiles
 	ListTemplateProfiles bool
+	// ReservedPorts is the list of ports that network templates should not use
+	ReservedPorts goflags.StringSlice
 	// LoadHelperFileFunction is a function that will be used to execute LoadHelperFile.
 	// If none is provided, then the default implementation will be used.
 	LoadHelperFileFunction LoadHelperFileFunction
@@ -696,6 +698,7 @@ func (options *Options) Copy() *Options {
 		HttpApiEndpoint:                options.HttpApiEndpoint,
 		InlineTargetsList:              options.InlineTargetsList,
 		ListTemplateProfiles:           options.ListTemplateProfiles,
+		ReservedPorts:                  options.ReservedPorts,
 		LoadHelperFileFunction:         options.LoadHelperFileFunction,
 		Logger:                         options.Logger,
 		DoNotCacheTemplates:            options.DoNotCacheTemplates,

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -465,6 +465,8 @@ type Options struct {
 	InlineTargetsList string `yaml:"targets-inline,omitempty"`
 	// ListTemplateProfiles lists all available template profiles
 	ListTemplateProfiles bool
+	// ReservedPorts is the list of ports that network templates should not use
+	ReservedPorts goflags.StringSlice
 	// LoadHelperFileFunction is a function that will be used to execute LoadHelperFile.
 	// If none is provided, then the default implementation will be used.
 	LoadHelperFileFunction LoadHelperFileFunction
@@ -695,6 +697,7 @@ func (options *Options) Copy() *Options {
 		HttpApiEndpoint:                options.HttpApiEndpoint,
 		InlineTargetsList:              options.InlineTargetsList,
 		ListTemplateProfiles:           options.ListTemplateProfiles,
+		ReservedPorts:                  options.ReservedPorts,
 		LoadHelperFileFunction:         options.LoadHelperFileFunction,
 		Logger:                         options.Logger,
 		DoNotCacheTemplates:            options.DoNotCacheTemplates,


### PR DESCRIPTION
## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->

Fixes: https://github.com/projectdiscovery/nuclei/issues/7323

This MR adds a CLI option to overwrite the default `excluded-ports` array for the whole scan.

### Proof

<!-- How has this been tested? Please describe the tests that you ran to verify your changes. -->

```bash
make build

go test ./pkg/protocols/common/contextargs/...
# ok  	github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/contextargs	0.011s

./bin/nuclei --help|grep rport
#    -rport, -reserved-ports string[]      list of reserved ports that network templates should avoid
```

Default behavior unchanged.

```bash
./bin/nuclei -verbose -t network/cves/2001/CVE-2001-1473.yaml -target TARGET:80
# [WRN] [CVE-2001-1473] Could not make network request for (147.251.125.30:22) : could not connect to server: cause="context cancelled before establishing connection" address=147.251.125.30:22 chain="context deadline exceeded"
```

We can specify array of excluded ports in CLI. Networking templates now can scan SSH running on port 80.

```bash
./nuclei -rport 0 -verbose -t network/cves/2001/CVE-2001-1473.yaml -target 147.251.125.30:80
```

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI flag (short form) to specify reserved ports so network templates and probes avoid those ports.
  * CLI-specified reserved ports now take precedence over template-level exclusions and default reserved ports.

* **Tests**
  * Added tests covering port-exclusion parsing, deduplication, and precedence scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->