### PR TITLE
Fix headless JS loading with -tlsi and addheader/setheader

### DIFF
--- a/pkg/protocols/headless/engine/http_client.go
+++ b/pkg/protocols/headless/engine/http_client.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"time"
 
+	"golang.org/x/net/http2"
 	"golang.org/x/net/proxy"
 
 	"github.com/projectdiscovery/fastdialer/fastdialer/ja3/impersonate"
@@ -67,7 +68,7 @@ func newHttpClient(options *types.Options) (*http.Client, error) {
 	} else if options.AliveSocksProxy != "" {
 		socksURL, proxyErr := url.Parse(options.AliveSocksProxy)
 		if proxyErr != nil {
-			return nil, err
+			return nil, proxyErr
 		}
 		dialer, err := proxy.FromURL(socksURL, proxy.Direct)
 		if err != nil {
@@ -80,10 +81,28 @@ func newHttpClient(options *types.Options) (*http.Client, error) {
 		transport.DialContext = dc.DialContext
 	}
 
+	var roundTripper http.RoundTripper = transport
+
+	// TLS impersonation via utls advertises h2 in ALPN to mimic a real browser.
+	// Since utls returns *utls.UConn (not *tls.Conn), Go's http.Transport can't
+	// detect the negotiated protocol and tries HTTP/1.x on an h2 connection,
+	// causing "malformed HTTP response" errors. We use http2.Transport directly
+	// with utls dialing to properly handle h2 connections (see #6360).
+	if options.TlsImpersonate {
+		roundTripper = &http2.Transport{
+			DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
+				return dialers.Fastdialer.DialTLSWithConfigImpersonate(ctx, network, addr, tlsConfig, impersonate.Random, nil)
+			},
+			TLSClientConfig:    tlsConfig,
+			AllowHTTP:          false,
+			DisableCompression: false,
+		}
+	}
+
 	jar, _ := cookiejar.New(nil)
 
 	httpclient := &http.Client{
-		Transport: transport,
+		Transport: roundTripper,
 		Timeout:   time.Duration(options.Timeout*3) * time.Second,
 		Jar:       jar,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
@@ -94,3 +113,4 @@ func newHttpClient(options *types.Options) (*http.Client, error) {
 
 	return httpclient, nil
 }
+

--- a/pkg/protocols/headless/engine/rules.go
+++ b/pkg/protocols/headless/engine/rules.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-rod/rod"
 	"github.com/go-rod/rod/lib/proto"
+	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
 )
 
@@ -48,7 +49,9 @@ func (p *Page) routingRuleHandler(httpClient *http.Client) func(ctx *rod.Hijack)
 		}
 
 		// perform the request
-		_ = ctx.LoadResponse(httpClient, true)
+		if err := ctx.LoadResponse(httpClient, true); err != nil {
+			gologger.Verbose().Msgf("headless: failed to load response for %s: %s", ctx.Request.URL(), err)
+		}
 
 		if !p.options.DisableCookie {
 			// retrieve the updated cookies from the native http client and inject them into the shared cookie jar


### PR DESCRIPTION
## Proposed changes

Closes #6360

When `-tlsi` is used with headless templates containing `addheader`/`setheader`, all requests get hijacked through Go's HTTP client with utls-based TLS impersonation. utls negotiates h2 via ALPN but returns `*utls.UConn` instead of `*tls.Conn`, so Go's `http.Transport` can't detect the negotiated protocol and fails with "malformed HTTP response" when reading h2 frames.

Fix: use `http2.Transport` directly with utls dialing when TLS impersonation is enabled, properly handling h2 connections. Also log `LoadResponse` errors instead of silently discarding them.

### Proof

before:

```console
go run ./cmd/nuclei -t /tmp/headless-addheader-test.yaml -u https://example.com -headless -timeout 15 -tlsi

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.7.1

                projectdiscovery.io

[INF] Current nuclei version: v3.7.1 (latest)
[INF] Current nuclei-templates version: v10.4.1 (latest)
[INF] New templates added in latest release: 76
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] Scan completed in 20.1685435s. No results found.
```

after:

```console
go run ./cmd/nuclei -t /tmp/headless-addheader-test.yaml -u https://example.com -headless -timeout 15 -tlsi

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.7.1

                projectdiscovery.io

[INF] Current nuclei version: v3.7.1 (latest)
[INF] Current nuclei-templates version: v10.4.1 (latest)
[INF] New templates added in latest release: 76
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[headless-addheader-test] [headless] [info] https://example.com/
[INF] Scan completed in 7.376011375s. 1 matches found.
```

## Checklist

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)