### PR TITLE
fix: route warning messages to stderr instead of stdout

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -51,10 +51,10 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/automaticscan"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/contextargs"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/globalmatchers"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/honeypotdetector"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/hosterrorscache"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/interactsh"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolinit"
-	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/honeypotdetector"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/uncover"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/utils/excludematchers"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/headless/engine"
@@ -397,7 +397,7 @@ func New(options *types.Options) (*Runner, error) {
 	}
 
 	if options.RateLimitMinute > 0 {
-		runner.Logger.Print().Msgf("[%v] %v", aurora.BrightYellow("WRN"), "rate limit per minute is deprecated - use rate-limit-duration")
+		runner.Logger.Warning().Msgf("rate limit per minute is deprecated - use rate-limit-duration")
 		options.RateLimit = options.RateLimitMinute
 		options.RateLimitDuration = time.Minute
 	}
@@ -616,7 +616,7 @@ func (r *Runner) RunEnumeration() error {
 	if r.options.ShouldUseHostError() {
 		maxHostError := r.options.MaxHostError
 		if r.options.TemplateThreads > maxHostError {
-			r.Logger.Print().Msgf("[%v] The concurrency value is higher than max-host-error", r.colorizer.BrightYellow("WRN"))
+			r.Logger.Warning().Msg("The concurrency value is higher than max-host-error")
 			r.Logger.Info().Msgf("Adjusting max-host-error to the concurrency value: %d", r.options.TemplateThreads)
 
 			maxHostError = r.options.TemplateThreads
@@ -886,7 +886,7 @@ func (r *Runner) displayExecutionInfo(store *loader.Store) {
 	if tmplCount == 0 && workflowCount == 0 {
 		// if dast flag is used print explicit warning
 		if r.options.DAST {
-			r.Logger.Print().Msgf("[%v] No DAST templates found", aurora.BrightYellow("WRN"))
+			r.Logger.Warning().Msg("No DAST templates found")
 		}
 		stats.ForceDisplayWarning(templates.SkippedCodeTmplTamperedStats)
 	} else {
@@ -928,7 +928,7 @@ func (r *Runner) displayExecutionInfo(store *loader.Store) {
 			value := v.Load()
 			if value > 0 {
 				if k == templates.Unsigned && !r.options.Silent && !config.DefaultConfig.HideTemplateSigWarning {
-					r.Logger.Print().Msgf("[%v] Loading %d unsigned templates for scan. Use with caution.", r.colorizer.BrightYellow("WRN"), value)
+					r.Logger.Warning().Msgf("Loading %d unsigned templates for scan. Use with caution.", value)
 				} else {
 					r.Logger.Info().Msgf("Executing %d signed templates from %s", value, k)
 				}

--- a/pkg/catalog/disk/find.go
+++ b/pkg/catalog/disk/find.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/logrusorgru/aurora"
 	"github.com/pkg/errors"
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/config"
 	stringsutil "github.com/projectdiscovery/utils/strings"
@@ -258,6 +257,6 @@ func PrintDeprecatedPathsMsgIfApplicable(isSilent bool) {
 		return
 	}
 	if deprecatedPathsCounter > 0 && !isSilent {
-		config.DefaultConfig.Logger.Print().Msgf("[%v] Found %v template[s] loaded with deprecated paths, update before v3 for continued support.\n", aurora.Yellow("WRN").String(), deprecatedPathsCounter)
+		config.DefaultConfig.Logger.Warning().Msgf("Found %v template[s] loaded with deprecated paths, update before v3 for continued support.", deprecatedPathsCounter)
 	}
 }

--- a/pkg/fuzz/component/value.go
+++ b/pkg/fuzz/component/value.go
@@ -5,7 +5,6 @@ import (
 	"strconv"
 
 	"github.com/leslie-qiwa/flat"
-	"github.com/logrusorgru/aurora"
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz/dataformat"
 )
@@ -123,7 +122,7 @@ func (v *Value) SetParsedValue(key, value string) bool {
 			origValue = val
 		} else {
 			// make it default warning instead of error
-			gologger.DefaultLogger.Print().Msgf("[%v] unknown type %T for value %s", aurora.BrightYellow("WARN"), v, v)
+			gologger.DefaultLogger.Warning().Msgf("unknown type %T for value %s", v, v)
 		}
 	}
 	v.parsed.Set(key, origValue)

--- a/pkg/templates/compile.go
+++ b/pkg/templates/compile.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/logrusorgru/aurora"
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 
@@ -437,7 +436,7 @@ func ParseTemplateFromReader(reader io.Reader, preprocessor Preprocessor, option
 		}
 		if !template.Verified && len(template.Workflows) == 0 {
 			if config.DefaultConfig.LogAllEvents {
-				gologger.DefaultLogger.Print().Msgf("[%v] Template %s is not signed or tampered\n", aurora.Yellow("WRN").String(), template.ID)
+				gologger.DefaultLogger.Warning().Msgf("Template %s is not signed or tampered", template.ID)
 			}
 		}
 		return template, nil
@@ -470,7 +469,7 @@ func ParseTemplateFromReader(reader io.Reader, preprocessor Preprocessor, option
 	if !template.Verified && len(template.Workflows) == 0 {
 		// workflows are not signed by default
 		if config.DefaultConfig.LogAllEvents {
-			gologger.DefaultLogger.Print().Msgf("[%v] Template %s is not signed or tampered\n", aurora.Yellow("WRN").String(), template.ID)
+			gologger.DefaultLogger.Warning().Msgf("Template %s is not signed or tampered", template.ID)
 		}
 	}
 


### PR DESCRIPTION
## Summary

Fixes #7314

Warning messages using `Logger.Print()` with manually formatted `[WRN]` labels were being written to **stdout** instead of **stderr**, corrupting JSON output when using the `-j` flag.

## Root Cause

In gologger, `Print()` creates events at `LevelSilent`, which the CLI writer routes to `os.Stdout`. This means any warning message using `Print().Msgf("[%v] ...", BrightYellow("WRN"), ...)` ends up in stdout, mixing with structured scan output.

`Warning()` creates events at `LevelWarning`, which the CLI writer routes to `os.Stderr` (the correct destination for diagnostic messages).

## Changes

Replaced all `Logger.Print()` calls that manually format `[WRN]` labels with `Logger.Warning()`, which:
- Routes output to **stderr** via gologger's `LevelWarning`
- Automatically adds the `[WRN]` label prefix
- Prevents warning text from corrupting `-j` JSON output on stdout

### Files changed (4 files, 8 instances):

| File | Warning Message |
|------|----------------|
| `internal/runner/runner.go` | Rate limit deprecation warning |
| `internal/runner/runner.go` | Concurrency > max-host-error warning |
| `internal/runner/runner.go` | No DAST templates warning |
| `internal/runner/runner.go` | Unsigned templates warning |
| `pkg/catalog/disk/find.go` | Deprecated template paths warning |
| `pkg/templates/compile.go` | Unsigned/tampered template warning (2 instances) |
| `pkg/fuzz/component/value.go` | Unknown value type warning |

## Not Changed

- `cmd/nuclei/main.go:812` — `Print().Msg(warning)` for the interactive reset prompt. This is intentional stdout output before a user confirmation prompt, not a warning message.

## Testing

- `go build ./cmd/nuclei/` — compiles successfully
- `go vet` — no issues


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized warning log formatting across the application for more consistent output presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->