### PR TITLE
fix(js): respect `allow-local-file-access` in `require`

### DIFF
--- a/pkg/js/compiler/compiler_test.go
+++ b/pkg/js/compiler/compiler_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -57,12 +58,13 @@ func TestRequireLocalFileAccessDenied(t *testing.T) {
 func TestRequireTemplateModuleAllowedWithoutLFA(t *testing.T) {
 	originalTemplatesDir := config.DefaultConfig.TemplatesDirectory
 	templatesDir := t.TempDir()
-	config.DefaultConfig.SetTemplatesDir(templatesDir)
+	configuredTemplatesDir, moduleBaseDir := templateDirAlias(t, templatesDir)
+	config.DefaultConfig.SetTemplatesDir(configuredTemplatesDir)
 	t.Cleanup(func() {
 		config.DefaultConfig.SetTemplatesDir(originalTemplatesDir)
 	})
 
-	modulePath := writeModuleFile(t, templatesDir, filepath.Join("helpers", "allowed.js"), `module.exports = { value: "sandbox-ok" };`)
+	modulePath := writeModuleFile(t, moduleBaseDir, filepath.Join("helpers", "allowed.js"), `module.exports = { value: "sandbox-ok" };`)
 	script := fmt.Sprintf(`var helper = require(%q); ExportAs("value", helper.value); true;`, modulePath)
 
 	result, err := executeScript(t, t.Name(), false, script)
@@ -129,6 +131,18 @@ func writeModuleFile(t *testing.T, baseDir string, relativePath string, contents
 	require.NoError(t, os.MkdirAll(filepath.Dir(modulePath), 0o755))
 	require.NoError(t, os.WriteFile(modulePath, []byte(contents), 0o600))
 	return modulePath
+}
+
+func templateDirAlias(t *testing.T, templateDir string) (string, string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		return templateDir, templateDir
+	}
+	aliasPath := filepath.Join(t.TempDir(), "templates-link")
+	if err := os.Symlink(templateDir, aliasPath); err != nil {
+		return templateDir, templateDir
+	}
+	return aliasPath, templateDir
 }
 
 type noopWriter struct {

--- a/pkg/js/compiler/compiler_test.go
+++ b/pkg/js/compiler/compiler_test.go
@@ -2,13 +2,20 @@ package compiler
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/Mzack9999/goja"
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/gologger/levels"
+	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/config"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
 	"github.com/projectdiscovery/nuclei/v3/pkg/types"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewCompilerConsoleDebug(t *testing.T) {
@@ -35,6 +42,93 @@ func TestNewCompilerConsoleDebug(t *testing.T) {
 	if !strings.HasSuffix(gotString, "hello world") {
 		t.Fatalf("console.log not working, got=%v", gotString)
 	}
+}
+
+func TestRequireLocalFileAccessDenied(t *testing.T) {
+	modulePath := writeModuleFile(t, t.TempDir(), "outside.js", `module.exports = { value: "outside-secret" };`)
+	script := fmt.Sprintf(`var helper = require(%q); ExportAs("value", helper.value); true;`, modulePath)
+
+	result, err := executeScript(t, t.Name(), false, script)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "-lfa is not enabled")
+	require.Equal(t, err.Error(), result["error"])
+}
+
+func TestRequireTemplateModuleAllowedWithoutLFA(t *testing.T) {
+	originalTemplatesDir := config.DefaultConfig.TemplatesDirectory
+	templatesDir := t.TempDir()
+	config.DefaultConfig.SetTemplatesDir(templatesDir)
+	t.Cleanup(func() {
+		config.DefaultConfig.SetTemplatesDir(originalTemplatesDir)
+	})
+
+	modulePath := writeModuleFile(t, templatesDir, filepath.Join("helpers", "allowed.js"), `module.exports = { value: "sandbox-ok" };`)
+	script := fmt.Sprintf(`var helper = require(%q); ExportAs("value", helper.value); true;`, modulePath)
+
+	result, err := executeScript(t, t.Name(), false, script)
+	require.NoError(t, err)
+	require.Equal(t, "sandbox-ok", result["value"])
+}
+
+func TestRequireLocalFileAccessAllowed(t *testing.T) {
+	modulePath := writeModuleFile(t, t.TempDir(), "outside.js", `module.exports = { value: "outside-ok" };`)
+	script := fmt.Sprintf(`var helper = require(%q); ExportAs("value", helper.value); true;`, modulePath)
+
+	result, err := executeScript(t, t.Name(), true, script)
+	require.NoError(t, err)
+	require.Equal(t, "outside-ok", result["value"])
+}
+
+func TestRequireDoesNotReusePrivilegedModuleCacheAcrossExecutions(t *testing.T) {
+	modulePath := writeModuleFile(t, t.TempDir(), "outside.js", `module.exports = { value: "outside-ok" };`)
+	program, err := goja.Compile("", fmt.Sprintf(`require(%q).value`, modulePath), false)
+	require.NoError(t, err)
+
+	allowExecutionID := "allow-" + t.Name()
+	denyExecutionID := "deny-" + t.Name()
+	protocolstate.SetLfaAllowed(&types.Options{ExecutionId: allowExecutionID, AllowLocalFileAccess: true})
+	protocolstate.SetLfaAllowed(&types.Options{ExecutionId: denyExecutionID, AllowLocalFileAccess: false})
+
+	runtime := createNewRuntime()
+	firstValue, err := executeWithRuntime(runtime, program, NewExecuteArgs(), &ExecuteOptions{
+		ExecutionId: allowExecutionID,
+		Context:     context.Background(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, "outside-ok", firstValue.Export())
+
+	_, err = executeWithRuntime(runtime, program, NewExecuteArgs(), &ExecuteOptions{
+		ExecutionId: denyExecutionID,
+		Context:     context.Background(),
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "-lfa is not enabled")
+}
+
+func executeScript(t *testing.T, executionID string, allowLocalFileAccess bool, script string) (ExecuteResult, error) {
+	t.Helper()
+	protocolstate.SetLfaAllowed(&types.Options{ExecutionId: executionID, AllowLocalFileAccess: allowLocalFileAccess})
+
+	compiled, err := SourceAutoMode(script, false)
+	require.NoError(t, err)
+
+	compiler := New()
+	return compiler.ExecuteWithOptions(compiled, NewExecuteArgs(), &ExecuteOptions{
+		ExecutionId: executionID,
+		Context:     context.Background(),
+		Source:      &script,
+		TimeoutVariants: &types.Timeouts{
+			JsCompilerExecutionTimeout: 5 * time.Second,
+		},
+	})
+}
+
+func writeModuleFile(t *testing.T, baseDir string, relativePath string, contents string) string {
+	t.Helper()
+	modulePath := filepath.Join(baseDir, relativePath)
+	require.NoError(t, os.MkdirAll(filepath.Dir(modulePath), 0o755))
+	require.NoError(t, os.WriteFile(modulePath, []byte(contents), 0o600))
+	return modulePath
 }
 
 type noopWriter struct {

--- a/pkg/js/compiler/pool.go
+++ b/pkg/js/compiler/pool.go
@@ -48,9 +48,7 @@ const (
 )
 
 var (
-	r                *require.Registry
 	lazyRegistryInit = sync.OnceFunc(func() {
-		r = new(require.Registry) // this can be shared by multiple runtimes
 		// autoregister console node module with default printer it uses gologger backend
 		require.RegisterNativeModule(console.ModuleName, console.RequireWithPrinter(goconsole.NewGoConsolePrinter()))
 	})
@@ -106,16 +104,17 @@ func executeWithRuntime(runtime *goja.Runtime, p *goja.Program, args *ExecuteArg
 	for k, v := range args.Args {
 		_ = runtime.Set(k, v)
 	}
+
+	runtime.SetContextValue("executionId", opts.ExecutionId)
+	runtime.SetContextValue("ctx", opts.Context)
+	enableRequire(runtime)
+
 	// register extra callbacks if any
 	if opts != nil && opts.Callback != nil {
 		if err := opts.Callback(runtime); err != nil {
 			return nil, err
 		}
 	}
-
-	// inject execution id and context
-	runtime.SetContextValue("executionId", opts.ExecutionId)
-	runtime.SetContextValue("ctx", opts.Context)
 
 	// execute the script
 	return runtime.RunProgram(p)
@@ -232,14 +231,32 @@ func InternalGetGeneratorRuntime() *goja.Runtime {
 	return runtime
 }
 
-func getRegistry() *require.Registry {
+func enableRequire(runtime *goja.Runtime) {
 	lazyRegistryInit()
-	return r
+	_ = require.NewRegistry(require.WithLoader(newSourceLoader(runtime))).Enable(runtime)
+}
+
+func newSourceLoader(runtime *goja.Runtime) require.SourceLoader {
+	return func(path string) ([]byte, error) {
+		executionID := ""
+		if value, ok := runtime.GetContextValue("executionId"); ok {
+			if id, ok := value.(string); ok {
+				executionID = id
+			}
+		}
+
+		normalizedPath, err := protocolstate.NormalizePathWithExecutionId(executionID, path)
+		if err != nil {
+			return nil, err
+		}
+
+		return require.DefaultSourceLoader(normalizedPath)
+	}
 }
 
 func createNewRuntime() *goja.Runtime {
 	runtime := protocolstate.NewJSRuntime()
-	_ = getRegistry().Enable(runtime)
+	enableRequire(runtime)
 	// by default import below modules every time
 	_ = runtime.Set("console", require.Require(runtime, console.ModuleName))
 

--- a/pkg/protocols/common/protocolstate/file.go
+++ b/pkg/protocols/common/protocolstate/file.go
@@ -1,10 +1,9 @@
 package protocolstate
 
 import (
-	"strings"
-
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/config"
 	"github.com/projectdiscovery/nuclei/v3/pkg/types"
+	filepathutil "github.com/projectdiscovery/nuclei/v3/pkg/utils/filepath"
 	"github.com/projectdiscovery/utils/errkit"
 	fileutil "github.com/projectdiscovery/utils/file"
 	mapsutil "github.com/projectdiscovery/utils/maps"
@@ -71,7 +70,7 @@ func NormalizePath(options *types.Options, filePath string) (string, error) {
 	}
 	// only allow files inside nuclei-templates directory
 	// even current working directory is not allowed
-	if strings.HasPrefix(cleaned, config.DefaultConfig.GetTemplateDir()) {
+	if filepathutil.IsPathWithinDirectory(cleaned, config.DefaultConfig.GetTemplateDir()) {
 		return cleaned, nil
 	}
 	return "", errkit.Newf("path %v is outside nuclei-template directory and -lfa is not enabled", filePath)

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -14,6 +14,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/config"
 	"github.com/projectdiscovery/nuclei/v3/pkg/model/types/severity"
 	"github.com/projectdiscovery/nuclei/v3/pkg/templates/types"
+	filepathutil "github.com/projectdiscovery/nuclei/v3/pkg/utils/filepath"
 	"github.com/projectdiscovery/utils/errkit"
 	fileutil "github.com/projectdiscovery/utils/file"
 	folderutil "github.com/projectdiscovery/utils/folder"
@@ -877,7 +878,7 @@ func (o *Options) GetValidAbsPath(helperFilePath, templatePath string) (string, 
 	resolvedPath, err := fileutil.ResolveNClean(helperFilePath, config.DefaultConfig.GetTemplateDir())
 	if err == nil {
 		// As per rule 1, if helper file is present in nuclei-templates directory, allow it
-		if strings.HasPrefix(resolvedPath, config.DefaultConfig.GetTemplateDir()) {
+		if filepathutil.IsPathWithinDirectory(resolvedPath, config.DefaultConfig.GetTemplateDir()) {
 			return resolvedPath, nil
 		}
 	}

--- a/pkg/utils/filepath/doc.go
+++ b/pkg/utils/filepath/doc.go
@@ -1,0 +1,10 @@
+// Package filepathutil provides utilities for safe filepath operations,
+// particularly for sandboxing file access in template environments.
+//
+// It includes functions to check if a path is contained within a directory,
+// with proper canonicalization to handle symlinks and platform-specific
+// path differences (such as case sensitivity on Windows).
+//
+// TODO(dwisiswant0): This package should be moved to the
+// [github.com/projectdiscovery/utils/filepath], but let see how it goes first.
+package filepathutil

--- a/pkg/utils/filepath/filepath.go
+++ b/pkg/utils/filepath/filepath.go
@@ -1,0 +1,35 @@
+package filepathutil
+
+import (
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// IsPathWithinDirectory returns true when path resolves inside directory.
+// Both values are canonicalized to handle symlinks and platform-specific case rules.
+func IsPathWithinDirectory(path string, directory string) bool {
+	canonicalPath := canonicalizePath(path)
+	canonicalDirectory := canonicalizePath(directory)
+
+	relativePath, err := filepath.Rel(canonicalDirectory, canonicalPath)
+	if err != nil {
+		return false
+	}
+	return relativePath == "." || (relativePath != ".." && !strings.HasPrefix(relativePath, ".."+string(filepath.Separator)))
+}
+
+func canonicalizePath(path string) string {
+	canonicalPath, err := filepath.Abs(path)
+	if err != nil {
+		canonicalPath = filepath.Clean(path)
+	}
+	if resolvedPath, err := filepath.EvalSymlinks(canonicalPath); err == nil {
+		canonicalPath = resolvedPath
+	}
+	canonicalPath = filepath.Clean(canonicalPath)
+	if runtime.GOOS == "windows" {
+		canonicalPath = strings.ToLower(canonicalPath)
+	}
+	return canonicalPath
+}

--- a/pkg/utils/filepath/filepath_test.go
+++ b/pkg/utils/filepath/filepath_test.go
@@ -1,0 +1,55 @@
+package filepathutil
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestIsPathWithinDirectory(t *testing.T) {
+	baseDir := t.TempDir()
+	childFile := filepath.Join(baseDir, "nested", "child.txt")
+	if err := os.MkdirAll(filepath.Dir(childFile), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(childFile, []byte("ok"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if !IsPathWithinDirectory(childFile, baseDir) {
+		t.Fatalf("expected %q to be inside %q", childFile, baseDir)
+	}
+
+	outsideFile := filepath.Join(t.TempDir(), "outside.txt")
+	if err := os.WriteFile(outsideFile, []byte("nope"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if IsPathWithinDirectory(outsideFile, baseDir) {
+		t.Fatalf("expected %q to be outside %q", outsideFile, baseDir)
+	}
+}
+
+func TestIsPathWithinDirectoryWithSymlinkedDirectory(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation is not reliable on all Windows runners")
+	}
+
+	realDir := t.TempDir()
+	aliasDir := filepath.Join(t.TempDir(), "templates-link")
+	if err := os.Symlink(realDir, aliasDir); err != nil {
+		t.Fatalf("create symlink: %v", err)
+	}
+
+	childFile := filepath.Join(realDir, "helpers", "allowed.js")
+	if err := os.MkdirAll(filepath.Dir(childFile), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(childFile, []byte("module.exports = {};"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if !IsPathWithinDirectory(childFile, aliasDir) {
+		t.Fatalf("expected %q to be inside symlinked dir %q", childFile, aliasDir)
+	}
+}


### PR DESCRIPTION
## Proposed changes

fix(js): respect `allow-local-file-access` in `require`

The goja `require() `function used the default
host filesystem loader which let JavaScript
templates import any local files even when
`allow-local-file-access` was disabled.

Pooled runtimes kept `require()` state around so
a module loaded during a privileged execution
could remain cached for a later restricted one.

Rebuild the require registry per execution after
setting the execution context, and route file-
backed module loads to preserve native modules
while enforcing the same sandbox rules (as
`nuclei/fs`).

### Proof

<details>
<summary>Template:</summary>

```yaml
id: allow-local-file-access-bypass-via-require

info:
  name: Allow Local File Access Bypass via require
  author: dwisiswant0
  severity: critical
  description: |
    Proof-of-concept template for reproducing the JavaScript require()-based
    local file access bypass.
  tags: test,javascript

# prereq:
# ```sh
# echo '{ "loaded": true, "message": "bypassed" }' > /tmp/proof.json
# ```

javascript:
  - code: |
      var proof = require("/tmp/proof.json");
      ExportAs("loaded", proof.loaded);
      ExportAs("message", proof.message);
      true;

    matchers:
      - type: dsl
        dsl:
          - 'loaded == "true"'
          - 'message == "bypassed"'
        condition: and

    # extractors:
    #   - type: dsl
    #     dsl:
    #       - '"loaded=" + loaded + " message=" + message'
```
</details>

this patch:

```console
$ ./bin/nuclei -t template.yaml -u scanme.sh

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.7.1

		projectdiscovery.io

[INF] Current nuclei version: v3.7.1 (unknown) - remove '-duc' flag to enable update checks
[INF] Current nuclei-templates version: v10.4.1 (unknown) - remove '-duc' flag to enable update checks
[INF] New templates added in latest release: 76
[INF] Templates loaded for current scan: 1
[WRN] Loading 1 unsigned templates for scan. Use with caution.
[INF] Targets loaded for current scan: 1
[INF] Scan completed in 51.961951ms. No results found.
```

dev:

```
$ ./bin/nuclei-3.7.1 -t template.yaml -u scanme.sh -silent
[allow-local-file-access-bypass-via-require] [javascript] [critical] scanme.sh
```

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for JavaScript module loading under Local File Access controls and for path containment behavior, including symlink scenarios and execution-context cache isolation.

* **Refactor**
  * Module loading initialization moved from a global shared instance to per-execution runtimes, improving isolation and permission handling.

* **Bug Fix / Security**
  * Improved path containment checks using a robust filesystem-aware utility to better enforce template-directory sandboxing.

* **Documentation**
  * Added package documentation describing safe filepath utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->