### PR TITLE
chore(deps): update crate-ci/typos from v1.44.0 to v1.45.0

### DIFF
--- a/.github/workflows/typos.yaml
+++ b/.github/workflows/typos.yaml
@@ -17,4 +17,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: crate-ci/typos@v1.44.0
+      - uses: crate-ci/typos@v1.45.0


### PR DESCRIPTION
## Summary
- Updates `crate-ci/typos` action from v1.44.0 to v1.45.0
- Includes dictionary updates from March 2026

Closes #7330

## Type
- [ ] Bug fix
- [ ] New feature
- [x] Maintenance

## Test plan
- [ ] CI passes