### PR TITLE
fix(installer): prevent unnecessary update checks

### DIFF
--- a/pkg/installer/util.go
+++ b/pkg/installer/util.go
@@ -24,6 +24,7 @@ func GetNewTemplatesInVersions(versions ...string) []string {
 	for _, v := range versions {
 		if v == config.DefaultConfig.TemplateVersion {
 			allTemplates = append(allTemplates, config.DefaultConfig.GetNewAdditions()...)
+			continue
 		}
 		_, err := semver.NewVersion(v)
 		if err != nil {


### PR DESCRIPTION
## Proposed Changes
- Add `continue` after handling default template version in `GetNewTemplatesInVersions`
- Prevent executing unnecessary semver check & GitHub API call for default version

## Evidence
- Before: logic continued to run unnecessary checks
- After: skip to next iteration immediately

## Test
- [x] make test
- [x] make vet
- [x] make build

Fixes #7336 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved performance by optimizing template version processing to skip unnecessary operations when handling default template versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->