### PR TITLE
perf(catalog): split exact matches & pattern

### DIFF
--- a/pkg/catalog/index/filter.go
+++ b/pkg/catalog/index/filter.go
@@ -19,7 +19,7 @@ import (
 // IncludeTemplates and IncludeTags can force inclusion of templates even if
 // they match exclusion criteria.
 type Filter struct {
-	// once ensures that IDs and ExcludedIDs are compiled the firs ttime Matches is called.
+	// once ensures that IDs and ExcludedIDs are compiled the first time Matches is called.
 	once sync.Once
 
 	// Authors to include.
@@ -204,12 +204,13 @@ func matchesID(templateID, pattern string) bool {
 // Compile pre-processes IDs and ExcludeIDs into fast lookup structures.
 // The first time Matches is called, this is called automatically.
 // If IDs or ExcludeIDs are modified after calling Matches, this must be called manually.
+// This method is not thread-safe, so make sure noone is using the filter when calling it.
 func (f *Filter) Compile() {
 	f.includeIDPatterns = nil
 	f.includeIDs = make(map[string]struct{}, len(f.IDs))
 	for _, p := range f.IDs {
 		idOrPattern := strings.ToLower(p)
-		if strings.ContainsAny(idOrPattern, "*?") {
+		if strings.ContainsAny(idOrPattern, "*?[") {
 			f.includeIDPatterns = append(f.includeIDPatterns, idOrPattern)
 		} else {
 			f.includeIDs[idOrPattern] = struct{}{}
@@ -220,7 +221,7 @@ func (f *Filter) Compile() {
 	f.excludeIDs = make(map[string]struct{}, len(f.ExcludeIDs))
 	for _, p := range f.ExcludeIDs {
 		idOrPattern := strings.ToLower(p)
-		if strings.ContainsAny(idOrPattern, "*?") {
+		if strings.ContainsAny(idOrPattern, "*?[") {
 			f.excludeIDPatterns = append(f.excludeIDPatterns, idOrPattern)
 		} else {
 			f.excludeIDs[idOrPattern] = struct{}{}

--- a/pkg/catalog/index/filter.go
+++ b/pkg/catalog/index/filter.go
@@ -184,23 +184,6 @@ func (f *Filter) matchesIncludes(m *Metadata) bool {
 	return true
 }
 
-// matchesID checks if template ID matches pattern (supports wildcards).
-// Deprecated: replaced by matchesIncludeID, only here for benchmark (and PR)
-// TODO: Remove before PR merged.
-func matchesID(templateID, pattern string) bool {
-	// Convert to lowercase for case-insensitive matching
-	templateID = strings.ToLower(templateID)
-	pattern = strings.ToLower(pattern)
-
-	if templateID == pattern {
-		return true
-	}
-
-	matched, _ := filepath.Match(pattern, templateID)
-
-	return matched
-}
-
 // Compile pre-processes IDs and ExcludeIDs into fast lookup structures.
 // The first time Matches is called, this is called automatically.
 // If IDs or ExcludeIDs are modified after calling Matches, this must be called manually.

--- a/pkg/catalog/index/filter.go
+++ b/pkg/catalog/index/filter.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
 
 	"github.com/projectdiscovery/nuclei/v3/pkg/model/types/severity"
 	"github.com/projectdiscovery/nuclei/v3/pkg/templates/types"
@@ -18,6 +19,9 @@ import (
 // IncludeTemplates and IncludeTags can force inclusion of templates even if
 // they match exclusion criteria.
 type Filter struct {
+	// once ensures that IDs and ExcludedIDs are compiled the firs ttime Matches is called.
+	once sync.Once
+
 	// Authors to include.
 	Authors []string
 
@@ -30,11 +34,23 @@ type Filter struct {
 	// IncludeTags to force include even if excluded.
 	IncludeTags []string
 
-	// IDs to include (supports wildcards, OR logic).
+	// IDs to include (supports wildcards).
 	IDs []string
+
+	// includeIDs is a map of IDs for a quick lookup.
+	includeIDs map[string]struct{}
+
+	// includeIDPatterns are the patterns extracted from IDs.
+	includeIDPatterns []string
 
 	// ExcludeIDs to exclude (supports wildcards).
 	ExcludeIDs []string
+
+	// excludeIDs is a map of ExcludeIDs for a quick lookup.
+	excludeIDs map[string]struct{}
+
+	// excludeIDPatterns are the patterns extracted from ExcludeIDs.
+	excludeIDPatterns []string
 
 	// IncludeTemplates paths to force include even if excluded.
 	IncludeTemplates []string
@@ -57,6 +73,8 @@ type Filter struct {
 
 // Matches checks if metadata matches the filter criteria.
 func (f *Filter) Matches(m *Metadata) bool {
+	f.once.Do(f.Compile)
+
 	if f.isForcedInclude(m) {
 		return true
 	}
@@ -108,10 +126,8 @@ func (f *Filter) isExcluded(m *Metadata) bool {
 	}
 
 	if len(f.ExcludeIDs) > 0 {
-		for _, excludeID := range f.ExcludeIDs {
-			if matchesID(m.ID, excludeID) {
-				return true
-			}
+		if f.matchesExcludeID(m.ID) {
+			return true
 		}
 	}
 
@@ -148,14 +164,7 @@ func (f *Filter) matchesIncludes(m *Metadata) bool {
 	}
 
 	if len(f.IDs) > 0 {
-		matched := false
-		for _, id := range f.IDs {
-			if matchesID(m.ID, id) {
-				matched = true
-				break
-			}
-		}
-		if !matched {
+		if !f.matchesIncludeID(m.ID) {
 			return false
 		}
 	}
@@ -176,6 +185,8 @@ func (f *Filter) matchesIncludes(m *Metadata) bool {
 }
 
 // matchesID checks if template ID matches pattern (supports wildcards).
+// Deprecated: replaced by matchesIncludeID, only here for benchmark (and PR)
+// TODO: Remove before PR merged.
 func matchesID(templateID, pattern string) bool {
 	// Convert to lowercase for case-insensitive matching
 	templateID = strings.ToLower(templateID)
@@ -188,6 +199,65 @@ func matchesID(templateID, pattern string) bool {
 	matched, _ := filepath.Match(pattern, templateID)
 
 	return matched
+}
+
+// Compile pre-processes IDs and ExcludeIDs into fast lookup structures.
+// The first time Matches is called, this is called automatically.
+// If IDs or ExcludeIDs are modified after calling Matches, this must be called manually.
+func (f *Filter) Compile() {
+	f.includeIDPatterns = nil
+	f.includeIDs = make(map[string]struct{}, len(f.IDs))
+	for _, p := range f.IDs {
+		idOrPattern := strings.ToLower(p)
+		if strings.ContainsAny(idOrPattern, "*?") {
+			f.includeIDPatterns = append(f.includeIDPatterns, idOrPattern)
+		} else {
+			f.includeIDs[idOrPattern] = struct{}{}
+		}
+	}
+
+	f.excludeIDPatterns = nil
+	f.excludeIDs = make(map[string]struct{}, len(f.ExcludeIDs))
+	for _, p := range f.ExcludeIDs {
+		idOrPattern := strings.ToLower(p)
+		if strings.ContainsAny(idOrPattern, "*?") {
+			f.excludeIDPatterns = append(f.excludeIDPatterns, idOrPattern)
+		} else {
+			f.excludeIDs[idOrPattern] = struct{}{}
+		}
+	}
+}
+
+// matchesIncludeID reports whether templateID matches any entry in includeIDs or includeIDPatterns.
+func (f *Filter) matchesIncludeID(templateID string) bool {
+	templateID = strings.ToLower(templateID)
+	if _, ok := f.includeIDs[templateID]; ok {
+		return true
+	}
+
+	for _, pattern := range f.includeIDPatterns {
+		if matched, _ := filepath.Match(pattern, templateID); matched {
+			return true
+		}
+	}
+
+	return false
+}
+
+// matchesExcludeID reports whether templateID matches any entry in excludeIDs or excludeIDPatterns.
+func (f *Filter) matchesExcludeID(templateID string) bool {
+	templateID = strings.ToLower(templateID)
+	if _, ok := f.excludeIDs[templateID]; ok {
+		return true
+	}
+
+	for _, pattern := range f.excludeIDPatterns {
+		if matched, _ := filepath.Match(pattern, templateID); matched {
+			return true
+		}
+	}
+
+	return false
 }
 
 // matchesPath checks if template path matches pattern.
@@ -316,6 +386,10 @@ func (f *Filter) String() string {
 
 	if len(f.IDs) > 0 {
 		parts = append(parts, "ids="+strings.Join(f.IDs, ","))
+	}
+
+	if len(f.ExcludeIDs) > 0 {
+		parts = append(parts, "exclude-ids="+strings.Join(f.ExcludeIDs, ","))
 	}
 
 	if len(f.Severities) > 0 {

--- a/pkg/catalog/index/filter_bench_test.go
+++ b/pkg/catalog/index/filter_bench_test.go
@@ -1,0 +1,104 @@
+package index
+
+import (
+	"fmt"
+	"testing"
+)
+
+// templateCount simulates a realistic nuclei template corpus size.
+const templateCount = 10_000
+
+// makeMetadataCorpus returns a slice of metadata entries with sequential IDs.
+func makeMetadataCorpus(n int) []*Metadata {
+	corpus := make([]*Metadata, n)
+	for i := range n {
+		corpus[i] = &Metadata{
+			ID:           fmt.Sprintf("cve-2021-%04d", i),
+			Tags:         []string{"cve", "http"},
+			Authors:      []string{"tester"},
+			Severity:     "critical",
+			ProtocolType: "http",
+		}
+	}
+	return corpus
+}
+
+// mixedFilter builds a realistic filter: exactIDs exact IDs (~1/3 match corpus)
+// + wildcardPatterns glob patterns (no match), reflecting typical usage
+// of nuclei -id flags alongside tag-style wildcards.
+func mixedFilter(exactIDs, wildcardPatterns int) *Filter {
+	ids := make([]string, 0, exactIDs+wildcardPatterns)
+	for i := range exactIDs {
+		ids = append(ids, fmt.Sprintf("cve-202%d-%04d", i%3, i)) // ~1/3 hit corpus (year 2021)
+	}
+	for i := range wildcardPatterns {
+		ids = append(ids, fmt.Sprintf("sqli-%04d-*", i)) // wildcard, no match
+	}
+	return &Filter{IDs: ids}
+}
+
+// BenchmarkFilterMatches_Mixed benchmarks a realistic mix of exact IDs and
+// wildcard patterns against the full 7000-template corpus.
+// Sub-benchmarks vary the number of wildcard patterns (0-5) at a fixed
+// base of 100 exact IDs, matching typical production invocations.
+func BenchmarkFilterMatches_Mixed(b *testing.B) {
+	corpus := makeMetadataCorpus(templateCount)
+
+	cases := []struct{ exact, wildcards int }{
+		{10, 0},
+		{100, 0},
+		{1000, 0},
+		{100, 1},
+		{100, 3},
+		{100, 5},
+	}
+
+	for _, tc := range cases {
+		b.Run(fmt.Sprintf("ids=%d,patterns=%d", tc.exact, tc.wildcards), func(b *testing.B) {
+			b.ReportAllocs()
+
+			filter := mixedFilter(tc.exact, tc.wildcards)
+			filter.Compile()
+			for b.Loop() {
+				for _, meta := range corpus {
+					_ = filter.matchesIncludeID(meta.ID)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkFilterMatches_Mixed_Old is the equivalent pre-fix scan for comparison:
+// raw matchesID loop over all IDs+patterns per template.
+func BenchmarkFilterMatches_Mixed_Old(b *testing.B) {
+	corpus := makeMetadataCorpus(templateCount)
+
+	cases := []struct{ exact, wildcards int }{
+		{10, 0},
+		{100, 0},
+		{1000, 0},
+		{100, 1},
+		{100, 3},
+		{100, 5},
+	}
+
+	for _, tc := range cases {
+		b.Run(fmt.Sprintf("ids=%d,patterns=%d", tc.exact, tc.wildcards), func(b *testing.B) {
+			b.ReportAllocs()
+
+			ids := mixedFilter(tc.exact, tc.wildcards).IDs
+			for b.Loop() {
+				for _, meta := range corpus {
+					matched := false
+					for _, id := range ids {
+						if matchesID(meta.ID, id) {
+							matched = true
+							break
+						}
+					}
+					_ = matched
+				}
+			}
+		})
+	}
+}

--- a/pkg/catalog/index/filter_bench_test.go
+++ b/pkg/catalog/index/filter_bench_test.go
@@ -59,36 +59,3 @@ func BenchmarkFilterMatches(b *testing.B) {
 		})
 	}
 }
-
-func BenchmarkFilterMatches_Old(b *testing.B) {
-	corpus := makeMetadataCorpus(templateCount)
-
-	cases := []struct{ exact, wildcards int }{
-		{10, 0},
-		{100, 0},
-		{1000, 0},
-		{100, 1},
-		{100, 3},
-		{100, 5},
-	}
-
-	for _, tc := range cases {
-		b.Run(fmt.Sprintf("ids=%d,patterns=%d", tc.exact, tc.wildcards), func(b *testing.B) {
-			b.ReportAllocs()
-
-			ids := mixedFilter(tc.exact, tc.wildcards).IDs
-			for b.Loop() {
-				for _, meta := range corpus {
-					matched := false
-					for _, id := range ids {
-						if matchesID(meta.ID, id) {
-							matched = true
-							break
-						}
-					}
-					_ = matched
-				}
-			}
-		})
-	}
-}

--- a/pkg/catalog/index/filter_bench_test.go
+++ b/pkg/catalog/index/filter_bench_test.go
@@ -5,10 +5,8 @@ import (
 	"testing"
 )
 
-// templateCount simulates a realistic nuclei template corpus size.
 const templateCount = 10_000
 
-// makeMetadataCorpus returns a slice of metadata entries with sequential IDs.
 func makeMetadataCorpus(n int) []*Metadata {
 	corpus := make([]*Metadata, n)
 	for i := range n {
@@ -23,9 +21,7 @@ func makeMetadataCorpus(n int) []*Metadata {
 	return corpus
 }
 
-// mixedFilter builds a realistic filter: exactIDs exact IDs (~1/3 match corpus)
-// + wildcardPatterns glob patterns (no match), reflecting typical usage
-// of nuclei -id flags alongside tag-style wildcards.
+// mixedFilter builds a realistic filter: exactIDs exact IDs (~1/3 match corpus) + wildcardPatterns glob patterns (no match)
 func mixedFilter(exactIDs, wildcardPatterns int) *Filter {
 	ids := make([]string, 0, exactIDs+wildcardPatterns)
 	for i := range exactIDs {
@@ -37,11 +33,7 @@ func mixedFilter(exactIDs, wildcardPatterns int) *Filter {
 	return &Filter{IDs: ids}
 }
 
-// BenchmarkFilterMatches_Mixed benchmarks a realistic mix of exact IDs and
-// wildcard patterns against the full 7000-template corpus.
-// Sub-benchmarks vary the number of wildcard patterns (0-5) at a fixed
-// base of 100 exact IDs, matching typical production invocations.
-func BenchmarkFilterMatches_Mixed(b *testing.B) {
+func BenchmarkFilterMatches(b *testing.B) {
 	corpus := makeMetadataCorpus(templateCount)
 
 	cases := []struct{ exact, wildcards int }{
@@ -68,9 +60,7 @@ func BenchmarkFilterMatches_Mixed(b *testing.B) {
 	}
 }
 
-// BenchmarkFilterMatches_Mixed_Old is the equivalent pre-fix scan for comparison:
-// raw matchesID loop over all IDs+patterns per template.
-func BenchmarkFilterMatches_Mixed_Old(b *testing.B) {
+func BenchmarkFilterMatches_Old(b *testing.B) {
 	corpus := makeMetadataCorpus(templateCount)
 
 	cases := []struct{ exact, wildcards int }{

--- a/pkg/catalog/index/filter_test.go
+++ b/pkg/catalog/index/filter_test.go
@@ -5,9 +5,10 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/projectdiscovery/nuclei/v3/pkg/model/types/severity"
 	"github.com/projectdiscovery/nuclei/v3/pkg/templates/types"
-	"github.com/stretchr/testify/require"
 )
 
 func TestFilterMatches(t *testing.T) {
@@ -196,8 +197,8 @@ func TestMatchesID(t *testing.T) {
 		expected bool
 	}{
 		{"exact match", "CVE-2021-1234", "CVE-2021-1234", true},
-		{"wildcard prefix", "CVE-2021-1234", "CVE-*", true},
-		{"wildcard suffix", "CVE-2021-1234", "*-1234", true},
+		{"wildcard suffix", "CVE-2021-1234", "CVE-*", true},
+		{"wildcard prefix", "CVE-2021-1234", "*-1234", true},
 		{"wildcard middle", "CVE-2021-1234", "CVE-*-1234", true},
 		{"no match", "CVE-2021-1234", "CVE-2022-*", false},
 		{"partial no match", "CVE-2021-1234", "CVE-2021-12", false},
@@ -207,7 +208,9 @@ func TestMatchesID(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := matchesID(tt.id, tt.pattern)
+			filter := &Filter{IDs: []string{tt.pattern}}
+			filter.Compile()
+			result := filter.matchesIncludeID(tt.id)
 			require.Equal(t, tt.expected, result)
 		})
 	}


### PR DESCRIPTION
Reason for change:
<img width="2206" height="1294" alt="image" src="https://github.com/user-attachments/assets/71805eb3-a56e-427b-b374-20f4f917b955" />

## Proposed changes

Instead of treating IDs (and ExcludedIDs) as both 'exact' matches and pattern matches, I now pre-compile a list and split them out.
Especially for a high list of 'exact matches' the performance with the current implementation is extremely taxing, for the following reasons:
1. For each existing template (N) it checks all included IDs (M) `O(N*M)`. Given that N is in the order of 10_000, this make it very expensive if you want to run on a small subset of them (say 1_000 IDs).
2. Each ID is treated as an pattern, making it very cpu expensive to have many ID filters.

Fixes:
1. Convert slices.Contains into a map lookup to speedup lookup drastically.
2. Filter out IDs that contain a pattern, to be checked individually, but only after exact matches checks.

### Proof

```
goos: darwin
goarch: arm64
pkg: github.com/projectdiscovery/nuclei/v3/pkg/catalog/index
cpu: Apple M1 Pro
BenchmarkFilterMatches_Mixed
BenchmarkFilterMatches_Mixed/ids=10,patterns=0
BenchmarkFilterMatches_Mixed/ids=10,patterns=0-10         	    4730	    236437 ns/op	       0 B/op	       0 allocs/op
BenchmarkFilterMatches_Mixed/ids=100,patterns=0
BenchmarkFilterMatches_Mixed/ids=100,patterns=0-10        	    4096	    299793 ns/op	       0 B/op	       0 allocs/op
BenchmarkFilterMatches_Mixed/ids=1000,patterns=0
BenchmarkFilterMatches_Mixed/ids=1000,patterns=0-10       	    4863	    245167 ns/op	       0 B/op	       0 allocs/op
BenchmarkFilterMatches_Mixed/ids=100,patterns=1
BenchmarkFilterMatches_Mixed/ids=100,patterns=1-10        	    1766	    675314 ns/op	       0 B/op	       0 allocs/op
BenchmarkFilterMatches_Mixed/ids=100,patterns=3
BenchmarkFilterMatches_Mixed/ids=100,patterns=3-10        	     784	   1530580 ns/op	       0 B/op	       0 allocs/op
BenchmarkFilterMatches_Mixed/ids=100,patterns=5
BenchmarkFilterMatches_Mixed/ids=100,patterns=5-10        	     537	   2229378 ns/op	       0 B/op	       0 allocs/op
BenchmarkFilterMatches_Mixed_Old
BenchmarkFilterMatches_Mixed_Old/ids=10,patterns=0
BenchmarkFilterMatches_Mixed_Old/ids=10,patterns=0-10     	     133	   8941001 ns/op	       0 B/op	       0 allocs/op
BenchmarkFilterMatches_Mixed_Old/ids=100,patterns=0
BenchmarkFilterMatches_Mixed_Old/ids=100,patterns=0-10    	      13	  89216647 ns/op	       0 B/op	       0 allocs/op
BenchmarkFilterMatches_Mixed_Old/ids=1000,patterns=0
BenchmarkFilterMatches_Mixed_Old/ids=1000,patterns=0-10   	       2	 879078188 ns/op	       0 B/op	       0 allocs/op
BenchmarkFilterMatches_Mixed_Old/ids=100,patterns=1
BenchmarkFilterMatches_Mixed_Old/ids=100,patterns=1-10    	      13	  89648577 ns/op	       0 B/op	       0 allocs/op
BenchmarkFilterMatches_Mixed_Old/ids=100,patterns=3
BenchmarkFilterMatches_Mixed_Old/ids=100,patterns=3-10    	      12	  91140938 ns/op	       0 B/op	       0 allocs/op
BenchmarkFilterMatches_Mixed_Old/ids=100,patterns=5
BenchmarkFilterMatches_Mixed_Old/ids=100,patterns=5-10    	      12	  92591368 ns/op	       0 B/op	       0 allocs/op
```

Especially when using many 'exact' IDs (aka not patterns), the improvement is drastic (3000x). 
- `BenchmarkFilterMatches_Mixed/ids=1000,patterns=0` 245167 ns/op
- `BenchmarkFilterMatches_Mixed_Old/ids=1000,patterns=0` 879078188 ns/op

## Checklist

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Disclaimer

(Logic) Code is written by human, benchmark is written with AI assistance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Filters can be pre-compiled for faster matching; matching now distinguishes exact IDs from wildcard patterns for improved performance.
  * Filter string output now includes configured exclude-ID details.

* **Tests**
  * Added benchmarks measuring filter performance across varied exact/wildcard mixes and corpus sizes.
  * Updated unit tests to exercise the new compile-and-match behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->