### PR TITLE
fix(sdk): respect `WithOptions` rate limit

### DIFF
--- a/lib/sdk_private.go
+++ b/lib/sdk_private.go
@@ -50,15 +50,19 @@ func (e *NucleiEngine) applyRequiredDefaults(ctx context.Context) {
 			}
 			return
 		}
+
 		sb := strings.Builder{}
 		fmt.Fprintf(&sb, "[%v] ", event.TemplateID)
+
 		if event.Matched != "" {
 			sb.WriteString(event.Matched)
 		} else {
 			sb.WriteString(event.Host)
 		}
+
 		fmt.Println(sb.String())
 	}
+
 	if e.onFailureCallback != nil {
 		mockoutput.FailureCallback = e.onFailureCallback
 	}
@@ -72,9 +76,11 @@ func (e *NucleiEngine) applyRequiredDefaults(ctx context.Context) {
 	if e.customProgress == nil {
 		e.customProgress = &testutils.MockProgressClient{}
 	}
+
 	if e.hostErrCache == nil && e.opts.ShouldUseHostError() {
 		e.hostErrCache = hosterrorscache.New(30, hosterrorscache.DefaultMaxHostsCount, nil)
 	}
+
 	// setup interactsh
 	if e.interactshOpts != nil {
 		e.interactshOpts.Output = e.customWriter
@@ -82,12 +88,23 @@ func (e *NucleiEngine) applyRequiredDefaults(ctx context.Context) {
 	} else {
 		e.interactshOpts = interactsh.DefaultOptions(e.customWriter, e.rc, e.customProgress)
 	}
+
 	if e.rateLimiter == nil {
-		e.rateLimiter = ratelimit.New(ctx, 150, time.Second)
+		if e.opts.RateLimitMinute > 0 {
+			e.opts.RateLimit = e.opts.RateLimitMinute
+			e.opts.RateLimitDuration = time.Minute
+		}
+
+		if e.opts.RateLimit > 0 && e.opts.RateLimitDuration == 0 {
+			e.opts.RateLimitDuration = time.Second
+		}
+		e.rateLimiter = nucleiUtils.GetRateLimiter(ctx, e.opts.RateLimit, e.opts.RateLimitDuration)
 	}
+
 	if e.opts.ExcludeTags == nil {
 		e.opts.ExcludeTags = []string{}
 	}
+
 	// these templates are known to have weak matchers
 	// and idea is to disable them to avoid false positives
 	e.opts.ExcludeTags = append(e.opts.ExcludeTags, config.ReadIgnoreFile().Tags...)

--- a/lib/sdk_test.go
+++ b/lib/sdk_test.go
@@ -103,3 +103,20 @@ http:
 	err = ne.ExecuteNucleiWithOptsCtx(context.TODO(), []string{"scanme.sh"})
 	require.NoError(t, err, "nuclei execution should not return an error")
 }
+
+func TestWithOptionsRateLimitSetsRuntimeLimiter(t *testing.T) {
+	opts := types.DefaultOptions().Copy()
+	opts.RateLimit = 500
+	opts.RateLimitDuration = time.Second
+
+	ne, err := nuclei.NewNucleiEngineCtx(context.Background(), nuclei.WithOptions(opts))
+	require.NoError(t, err, "could not create nuclei engine")
+	t.Cleanup(func() {
+		ne.Close()
+	})
+
+	execOpts := ne.GetExecuterOptions()
+	require.NotNil(t, execOpts, "executor options should be initialized")
+	require.NotNil(t, execOpts.RateLimiter, "rate limiter should be initialized")
+	require.Equal(t, opts.RateLimit, int(execOpts.RateLimiter.GetLimit()), "runtime limiter should match rate limit from WithOptions")
+}


### PR DESCRIPTION
## Proposed changes

Respect `WithOptions` rate limit when creating
default limiter.

The engine could be set up with custom rate limits
through `WithOptions()`, but internal was still
hardcoding `e.rateLimiter` to 150 RPS when no
global limiter was explicitly set.

Now it builds the default limiter from the
resolved options:
1. Applies `RateLimitMinute` translation,
2. Defaults `RateLimitDuration` to 1s when
   `RateLimit > 0` and no duration is given, then
3. Creates the limiter via `GetRateLimiter()`.


Fixes #7341

### Proof

before:

```console
$ go test ./lib -run TestWithOptionsRateLimitSetsRuntimeLimiter -count=1
--- FAIL: TestWithOptionsRateLimitSetsRuntimeLimiter (1.39s)
    sdk_test.go:121: 
                Error Trace:    /home/dw1/Development/PD/nuclei/lib/sdk_test.go:121
                Error:          Not equal: 
                                expected: 500
                                actual  : 150
                Test:           TestWithOptionsRateLimitSetsRuntimeLimiter
                Messages:       runtime limiter should match rate limit from WithOptions
FAIL
FAIL    github.com/projectdiscovery/nuclei/v3/lib       1.462s
FAIL
```

after:

```console
$ go test ./lib -run TestWithOptionsRateLimitSetsRuntimeLimiter -count=1
ok      github.com/projectdiscovery/nuclei/v3/lib       1.457s
```

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rate limiting in the SDK is now configurable through options, replacing the previously fixed default rate limit.
  * Intelligent default duration values are automatically derived based on provided rate limit settings.

* **Tests**
  * Added test to validate rate limit configuration and runtime limiter setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->