### PR TITLE
fix(reporting/jira): match status-not against transition target status name

### DIFF
--- a/pkg/reporting/trackers/jira/jira.go
+++ b/pkg/reporting/trackers/jira/jira.go
@@ -408,14 +408,16 @@ func (i *Integration) CloseIssue(event *output.ResultEvent) error {
 	if err != nil {
 		return err
 	} else if issue.ID != "" {
-		// Lazy load the transitions ID in case it's not set
+		// Lazy load the transitions ID in case it's not set.
+		// StatusNot is a target status name (matches JQL usage below and the
+		// field's semantics); find the transition that moves to that status.
 		i.once.Do(func() {
 			transitions, _, err := i.jira.Issue.GetTransitions(issue.ID)
 			if err != nil {
 				return
 			}
 			for _, transition := range transitions {
-				if transition.Name == i.options.StatusNot {
+				if transition.To.Name == i.options.StatusNot {
 					i.transitionID = transition.ID
 					break
 				}


### PR DESCRIPTION
## Summary

`CloseIssue` builds a JQL clause `status != \"<StatusNot>\"` to find tickets that aren't yet in the resolved state, and later iterates available transitions to find the one to invoke to close the ticket. Previously the transition loop compared `transition.Name` against `StatusNot`, while the JQL clause (same field, same package) treats `StatusNot` as a status name.

This inconsistency silently breaks Jira close for any customer workflow where transition names differ from target status names — which is common in customized enterprise workflows (e.g., a transition named \"Resolve as Duplicate\" or \"SecHub Finding Resolved (automation only)\" that lands on status \"Done\"). Default Atlassian workflows use auto-generated transition names identical to target status names, so the bug is masked for default-workflow users.

The fix: compare against `transition.To.Name` (target status name) instead of `transition.Name`. Behaviour unchanged for default workflows; custom workflows where transition and target-status names diverge now transition correctly.

## Context

`StatusNot` is declared `yaml:\"status-not\" json:\"status_not\"` — semantically a status name. Aurora's PDCP UI populates this field from `/rest/api/2/project/{id}/statuses` (status names, not transition names), further confirming the field's expected semantic.

Without this fix, `CloseIssue` on affected workflows:
- Finds the existing issue via JQL (OK — JQL uses status name correctly).
- Fetches transitions, loops looking for `transition.Name == StatusNot`, finds nothing.
- Returns `nil` silently — no API call, no error, no log.

Customers with custom workflows have been silently losing auto-close for an unknown duration with no visible error signal anywhere in the stack.

## Test plan

- [x] Default Atlassian classic workflow where transition.Name == transition.To.Name: unchanged behaviour (validated with existing Jira test harness).
- [x] Custom workflow where transition name differs from target status: close now fires via the correct transition (validated with a standalone debug script against a real Jira Cloud instance with a custom workflow).
- [ ] CI.

## Observability follow-ups (not in this PR)

- Consider logging at `Warn` when `transitionID == \"\"` after the lookup (\"no transition leads to status %q; close skipped\").
- Consider returning a typed error from `CloseIssue` instead of `nil` in the silent-return paths so callers can surface misconfigs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Jira issue closure behavior to correctly identify transitions based on target status name, ensuring issues are closed with the appropriate status mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->