### PR TITLE
fix(runner): write unsigned-templates WRN to stderr

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -397,7 +397,7 @@ func New(options *types.Options) (*Runner, error) {
 	}
 
 	if options.RateLimitMinute > 0 {
-		runner.Logger.Print().Msgf("[%v] %v", aurora.BrightYellow("WRN"), "rate limit per minute is deprecated - use rate-limit-duration")
+		fmt.Fprintf(os.Stderr, "[%v] %v\n", aurora.BrightYellow("WRN"), "rate limit per minute is deprecated - use rate-limit-duration")
 		options.RateLimit = options.RateLimitMinute
 		options.RateLimitDuration = time.Minute
 	}
@@ -616,7 +616,7 @@ func (r *Runner) RunEnumeration() error {
 	if r.options.ShouldUseHostError() {
 		maxHostError := r.options.MaxHostError
 		if r.options.TemplateThreads > maxHostError {
-			r.Logger.Print().Msgf("[%v] The concurrency value is higher than max-host-error", r.colorizer.BrightYellow("WRN"))
+			fmt.Fprintf(os.Stderr, "[%v] The concurrency value is higher than max-host-error\n", r.colorizer.BrightYellow("WRN"))
 			r.Logger.Info().Msgf("Adjusting max-host-error to the concurrency value: %d", r.options.TemplateThreads)
 
 			maxHostError = r.options.TemplateThreads
@@ -886,7 +886,7 @@ func (r *Runner) displayExecutionInfo(store *loader.Store) {
 	if tmplCount == 0 && workflowCount == 0 {
 		// if dast flag is used print explicit warning
 		if r.options.DAST {
-			r.Logger.Print().Msgf("[%v] No DAST templates found", aurora.BrightYellow("WRN"))
+			fmt.Fprintf(os.Stderr, "[%v] No DAST templates found\n", aurora.BrightYellow("WRN"))
 		}
 		stats.ForceDisplayWarning(templates.SkippedCodeTmplTamperedStats)
 	} else {

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -397,7 +397,7 @@ func New(options *types.Options) (*Runner, error) {
 	}
 
 	if options.RateLimitMinute > 0 {
-		fmt.Fprintf(os.Stderr, "[%v] %v\n", aurora.BrightYellow("WRN"), "rate limit per minute is deprecated - use rate-limit-duration")
+		runner.Logger.Warning().Msg("rate limit per minute is deprecated - use rate-limit-duration")
 		options.RateLimit = options.RateLimitMinute
 		options.RateLimitDuration = time.Minute
 	}
@@ -616,7 +616,7 @@ func (r *Runner) RunEnumeration() error {
 	if r.options.ShouldUseHostError() {
 		maxHostError := r.options.MaxHostError
 		if r.options.TemplateThreads > maxHostError {
-			fmt.Fprintf(os.Stderr, "[%v] The concurrency value is higher than max-host-error\n", r.colorizer.BrightYellow("WRN"))
+			r.Logger.Warning().Msg("The concurrency value is higher than max-host-error")
 			r.Logger.Info().Msgf("Adjusting max-host-error to the concurrency value: %d", r.options.TemplateThreads)
 
 			maxHostError = r.options.TemplateThreads
@@ -886,7 +886,7 @@ func (r *Runner) displayExecutionInfo(store *loader.Store) {
 	if tmplCount == 0 && workflowCount == 0 {
 		// if dast flag is used print explicit warning
 		if r.options.DAST {
-			fmt.Fprintf(os.Stderr, "[%v] No DAST templates found\n", aurora.BrightYellow("WRN"))
+			r.Logger.Warning().Msg("No DAST templates found")
 		}
 		stats.ForceDisplayWarning(templates.SkippedCodeTmplTamperedStats)
 	} else {
@@ -928,11 +928,7 @@ func (r *Runner) displayExecutionInfo(store *loader.Store) {
 			value := v.Load()
 			if value > 0 {
 				if k == templates.Unsigned && !r.options.Silent && !config.DefaultConfig.HideTemplateSigWarning {
-					// Write directly to stderr so the warning doesn't end up in
-					// the -j / -jsonl stdout stream and break downstream `jq`
-					// pipelines (#7314). Logger.Print() bypasses level
-					// filtering but routes to stdout, which is the bug.
-					fmt.Fprintf(os.Stderr, "[%v] Loading %d unsigned templates for scan. Use with caution.\n", r.colorizer.BrightYellow("WRN"), value)
+					r.Logger.Warning().Msgf("Loading %d unsigned templates for scan. Use with caution.", value)
 				} else {
 					r.Logger.Info().Msgf("Executing %d signed templates from %s", value, k)
 				}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -928,7 +928,11 @@ func (r *Runner) displayExecutionInfo(store *loader.Store) {
 			value := v.Load()
 			if value > 0 {
 				if k == templates.Unsigned && !r.options.Silent && !config.DefaultConfig.HideTemplateSigWarning {
-					r.Logger.Print().Msgf("[%v] Loading %d unsigned templates for scan. Use with caution.", r.colorizer.BrightYellow("WRN"), value)
+					// Write directly to stderr so the warning doesn't end up in
+					// the -j / -jsonl stdout stream and break downstream `jq`
+					// pipelines (#7314). Logger.Print() bypasses level
+					// filtering but routes to stdout, which is the bug.
+					fmt.Fprintf(os.Stderr, "[%v] Loading %d unsigned templates for scan. Use with caution.\n", r.colorizer.BrightYellow("WRN"), value)
 				} else {
 					r.Logger.Info().Msgf("Executing %d signed templates from %s", value, k)
 				}


### PR DESCRIPTION
Closes #7314.

## Background

When the user runs nuclei with `-j` / `-jsonl`, the JSON output stream is corrupted by the `[WRN] Loading N unsigned templates for scan` message:

```
$ ./nuclei -target http://example.test -j | jq .
[WRN] Loading 17 unsigned templates for scan. Use with caution.    # ← bare line breaks jq
{"template":"http/cves/2019/CVE-2019-1010287.yaml",...}
parse error: Invalid numeric literal at line 1, column 4
```

The cause is the call site at `internal/runner/runner.go:931`:

```go
r.Logger.Print().Msgf("[%v] Loading %d unsigned templates for scan. Use with caution.", r.colorizer.BrightYellow("WRN"), value)
```

`gologger`'s `(*Logger).Print()` returns a `LevelSilent` event — its docstring says "Print prints a string on **stdout** without any extra labels." It's used here to bypass level filtering (so the warning shows even at quiet verbosity), but the side-effect is that it pollutes the JSON output stream.

## Change

Write the unsigned-templates warning straight to `os.Stderr`. That preserves the original intent — always emit, regardless of log level, with the colorized `[WRN]` prefix — while keeping `os.Stdout` clean for JSON / JSONL consumers.

```go
fmt.Fprintf(os.Stderr, "[%v] Loading %d unsigned templates for scan. Use with caution.\n", r.colorizer.BrightYellow("WRN"), value)
```

`fmt` and `os` are already imported in this file.

## Verification

`go build ./...` and `go vet ./internal/runner/` both clean.

The integration suite already has `filterUnsignedTemplatesWarnings()` (`internal/tests/integration/integration_test.go:269`) that defensively strips this message — so no test churn is needed; the helper just becomes a no-op for stdout-only captures.

## Notes

- Diff is `+5 / -1` lines, single file, no public-API change.
- I deliberately scoped this PR to the unsigned-templates warning the issue calls out. There are three other `r.Logger.Print().Msgf("[WRN] ...")` call sites in the same file (lines 400, 619, 889) with the same pattern; happy to follow up with those in a separate PR if you'd like consistent stderr routing across all four.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Startup/execution warnings that were previously written to standard output (deprecated rate-limit, concurrency-above-max, missing DAST templates, and unsigned-template notices) now emit as proper warning-level messages to standard error to avoid contaminating JSON/streamed stdout. The unsigned-template notice now includes a formatted count inline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->