### PR TITLE
refactor: switch from Knetic/govaluate to projectdiscovery fork (#7380)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/projectdiscovery/nuclei/v3
 go 1.25.7
 
 require (
-	github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible
 	github.com/andygrunwald/go-jira v1.16.1
 	github.com/antchfx/htmlquery v1.3.5
 	github.com/bluele/gcache v0.0.2
@@ -31,7 +30,7 @@ require (
 	github.com/rs/xid v1.6.0
 	github.com/segmentio/ksuid v1.0.4
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
-	github.com/spf13/cast v1.9.2
+	github.com/spf13/cast v1.10.0
 	github.com/syndtr/goleveldb v1.0.0
 	github.com/valyala/fasttemplate v1.2.2
 	github.com/weppos/publicsuffix-go v0.50.3
@@ -426,8 +425,11 @@ require (
 require (
 	github.com/alecthomas/chroma v0.10.0
 	github.com/go-echarts/go-echarts/v2 v2.6.0
+	github.com/projectdiscovery/govaluate v0.0.0-20260504230327-80320480bb6e
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 )
 
 // https://go.dev/ref/mod#go-mod-file-retract
 retract v3.2.0 // retract due to broken js protocol issue
+
+replace github.com/projectdiscovery/dsl => github.com/ChrisJr404/dsl v0.8.18-0.20260505142052-693673de4fe2

--- a/go.sum
+++ b/go.sum
@@ -75,10 +75,10 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8=
 github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/ChrisJr404/dsl v0.8.18-0.20260505142052-693673de4fe2 h1:nwzpuaF9XVbDwtKk8SAVwH591wmU2wcm1FM+PFeUb2g=
+github.com/ChrisJr404/dsl v0.8.18-0.20260505142052-693673de4fe2/go.mod h1:M3IFrupPJ3xj6qauHvzGd1qKF+Bd3tnHI59EQ9ACoIw=
 github.com/DataDog/gostackparse v0.7.0 h1:i7dLkXHvYzHV308hnkvVGDL3BR4FWl7IsXNPz/IGQh4=
 github.com/DataDog/gostackparse v0.7.0/go.mod h1:lTfqcJKqS9KnXQGnyQMCugq3u1FP6UZMfWR0aitKFMM=
-github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible h1:1G1pk05UrOh0NlF1oeaaix1x8XzrfjIDK47TY0Zehcw=
-github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=
@@ -844,8 +844,6 @@ github.com/projectdiscovery/cdncheck v1.2.33 h1:r8IEiI6i8O256BxFrzj8odj5UVIMDbwh
 github.com/projectdiscovery/cdncheck v1.2.33/go.mod h1:noT6kz0Ifep16n/TiUC6PGZCO3WbLiZ54HDFpAgpDoY=
 github.com/projectdiscovery/clistats v0.1.2 h1:Fnh9ut2CODOtO9/RsBF0WO1eLgf+t+epOmQpdVZp0+M=
 github.com/projectdiscovery/clistats v0.1.2/go.mod h1:J4lcP9K2yfNRtsliKEECE50+GmFD8er/O+ECIfQFpnM=
-github.com/projectdiscovery/dsl v0.8.16 h1:/yzToykrWbR/SYWVOMGxnhJ3a79AyIVkeICWhjKZVQE=
-github.com/projectdiscovery/dsl v0.8.16/go.mod h1:3kecwVVf55VRyBW24mFpkl0PLifAp0w1O1gQMG8Hc0E=
 github.com/projectdiscovery/fastdialer v0.5.6 h1:kIBFmzbXrua41uf4fGsQClTZmT7cm7E3vVgcSj8gs6Q=
 github.com/projectdiscovery/fastdialer v0.5.6/go.mod h1:QxvCe02Jii+j8vA3hWYkymgZIY8cqMgs2s3Jbz6mvbs=
 github.com/projectdiscovery/fasttemplate v0.0.2 h1:h2cISk5xDhlJEinlBQS6RRx0vOlOirB2y3Yu4PJzpiA=
@@ -862,6 +860,8 @@ github.com/projectdiscovery/gologger v1.1.68 h1:KfdIO/3X7BtHssWZuqhxPZ+A946epCCx
 github.com/projectdiscovery/gologger v1.1.68/go.mod h1:Xae0t4SeqJVa0RQGK9iECx/+HfXhvq70nqOQp2BuW+o=
 github.com/projectdiscovery/gostruct v0.0.2 h1:s8gP8ApugGM4go1pA+sVlPDXaWqNP5BBDDSv7VEdG1M=
 github.com/projectdiscovery/gostruct v0.0.2/go.mod h1:H86peL4HKwMXcQQtEa6lmC8FuD9XFt6gkNR0B/Mu5PE=
+github.com/projectdiscovery/govaluate v0.0.0-20260504230327-80320480bb6e h1:o+ulEIaC2+9V2Ezr6mI5xEhKWsf0V/+FUQIS723Aj6U=
+github.com/projectdiscovery/govaluate v0.0.0-20260504230327-80320480bb6e/go.mod h1:xH7bPwHxUlz1yx9UlVeTF+UVCUaKhTnZgaxHb5z362E=
 github.com/projectdiscovery/gozero v0.1.1-0.20251027191944-a4ea43320b81 h1:yHh46pJovYbyiaHCV7oIDinFmy+Fyq36H1BowJgb0M0=
 github.com/projectdiscovery/gozero v0.1.1-0.20251027191944-a4ea43320b81/go.mod h1:9lmGPBDGZVANzCGjQg+V32n8Y3Cgjo/4kT0E88lsVTI=
 github.com/projectdiscovery/hmap v0.0.100 h1:DBZ3Req9lWf4P1YC9PRa4eiMvLY0Uxud43NRBcocPfs=
@@ -984,8 +984,8 @@ github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0b
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.15.0 h1:b/YBCLWAJdFWJTN9cLhiXXcD7mzKn9Dm86dNnfyQw1I=
 github.com/spf13/afero v1.15.0/go.mod h1:NC2ByUVxtQs4b3sIUphxK0NioZnmxgyCrfzeuq8lxMg=
-github.com/spf13/cast v1.9.2 h1:SsGfm7M8QOFtEzumm7UZrZdLLquNdzFYfIbEXntcFbE=
-github.com/spf13/cast v1.9.2/go.mod h1:jNfB8QC9IA6ZuY2ZjDp0KtFO2LZZlg4S/7bzP6qqeHo=
+github.com/spf13/cast v1.10.0 h1:h2x0u2shc1QuLHfxi+cTJvs30+ZAHOGRic8uyGTDWxY=
+github.com/spf13/cast v1.10.0/go.mod h1:jNfB8QC9IA6ZuY2ZjDp0KtFO2LZZlg4S/7bzP6qqeHo=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=

--- a/pkg/operators/cache/cache.go
+++ b/pkg/operators/cache/cache.go
@@ -4,7 +4,7 @@ import (
 	"regexp"
 	"sync"
 
-	"github.com/Knetic/govaluate"
+	"github.com/projectdiscovery/govaluate"
 	"github.com/projectdiscovery/gcache"
 )
 

--- a/pkg/operators/cache/cache_test.go
+++ b/pkg/operators/cache/cache_test.go
@@ -4,7 +4,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/Knetic/govaluate"
+	"github.com/projectdiscovery/govaluate"
 )
 
 func TestRegexCache_SetGet(t *testing.T) {

--- a/pkg/operators/common/dsl/dsl.go
+++ b/pkg/operators/common/dsl/dsl.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/Knetic/govaluate"
+	"github.com/projectdiscovery/govaluate"
 	"github.com/miekg/dns"
 	"github.com/projectdiscovery/dsl"
 	"github.com/projectdiscovery/gologger"

--- a/pkg/operators/common/dsl/dsl_test.go
+++ b/pkg/operators/common/dsl/dsl_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/Knetic/govaluate"
+	"github.com/projectdiscovery/govaluate"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/dns/dnsclientpool"
 	"github.com/projectdiscovery/nuclei/v3/pkg/types"
 	"github.com/stretchr/testify/require"

--- a/pkg/operators/extractors/compile.go
+++ b/pkg/operators/extractors/compile.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/Knetic/govaluate"
+	"github.com/projectdiscovery/govaluate"
 	"github.com/itchyny/gojq"
 	"github.com/projectdiscovery/nuclei/v3/pkg/operators/cache"
 	"github.com/projectdiscovery/nuclei/v3/pkg/operators/common/dsl"

--- a/pkg/operators/extractors/extractors.go
+++ b/pkg/operators/extractors/extractors.go
@@ -3,7 +3,7 @@ package extractors
 import (
 	"regexp"
 
-	"github.com/Knetic/govaluate"
+	"github.com/projectdiscovery/govaluate"
 	"github.com/itchyny/gojq"
 )
 

--- a/pkg/operators/matchers/compile.go
+++ b/pkg/operators/matchers/compile.go
@@ -6,7 +6,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/Knetic/govaluate"
+	"github.com/projectdiscovery/govaluate"
 	"github.com/projectdiscovery/nuclei/v3/pkg/operators/cache"
 	"github.com/projectdiscovery/nuclei/v3/pkg/operators/common/dsl"
 )

--- a/pkg/operators/matchers/match.go
+++ b/pkg/operators/matchers/match.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/Knetic/govaluate"
+	"github.com/projectdiscovery/govaluate"
 	"github.com/antchfx/htmlquery"
 	"github.com/antchfx/xmlquery"
 

--- a/pkg/operators/matchers/match_test.go
+++ b/pkg/operators/matchers/match_test.go
@@ -3,7 +3,7 @@ package matchers
 import (
 	"testing"
 
-	"github.com/Knetic/govaluate"
+	"github.com/projectdiscovery/govaluate"
 	"github.com/projectdiscovery/nuclei/v3/pkg/operators/common/dsl"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/operators/matchers/matchers.go
+++ b/pkg/operators/matchers/matchers.go
@@ -3,7 +3,7 @@ package matchers
 import (
 	"regexp"
 
-	"github.com/Knetic/govaluate"
+	"github.com/projectdiscovery/govaluate"
 )
 
 // Matcher is used to match a part in the output from a protocol.

--- a/pkg/protocols/common/expressions/expressions.go
+++ b/pkg/protocols/common/expressions/expressions.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/Knetic/govaluate"
+	"github.com/projectdiscovery/govaluate"
 
 	"github.com/projectdiscovery/nuclei/v3/pkg/operators/common/dsl"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/marker"

--- a/pkg/protocols/common/expressions/variables.go
+++ b/pkg/protocols/common/expressions/variables.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/Knetic/govaluate"
+	"github.com/projectdiscovery/govaluate"
 	"github.com/projectdiscovery/nuclei/v3/pkg/operators/common/dsl"
 )
 

--- a/pkg/protocols/common/expressions/variables_test.go
+++ b/pkg/protocols/common/expressions/variables_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/Knetic/govaluate"
+	"github.com/projectdiscovery/govaluate"
 	"github.com/projectdiscovery/nuclei/v3/pkg/operators/common/dsl"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/protocols/common/variables/variables.go
+++ b/pkg/protocols/common/variables/variables.go
@@ -3,7 +3,7 @@ package variables
 import (
 	"strings"
 
-	"github.com/Knetic/govaluate"
+	"github.com/projectdiscovery/govaluate"
 	"github.com/invopop/jsonschema"
 	"github.com/projectdiscovery/nuclei/v3/pkg/operators/common/dsl"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/expressions"

--- a/pkg/templates/tag_filter.go
+++ b/pkg/templates/tag_filter.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/Knetic/govaluate"
+	"github.com/projectdiscovery/govaluate"
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/nuclei/v3/pkg/model/types/severity"
 	"github.com/projectdiscovery/nuclei/v3/pkg/operators/common/dsl"


### PR DESCRIPTION
Closes #7380.

## Summary

`github.com/Knetic/govaluate` is archived. Switch to the maintained fork at `github.com/projectdiscovery/govaluate` (bug fixes + perf improvements, including the nuclei#5580 quote-string parsing called out in the issue). All 17 source files swapped, plus go.mod/go.sum.

## Why this is a draft

`projectdiscovery/dsl` still re-exports Knetic/govaluate types in its public API (`HelperFunctions() map[string]Knetic/govaluate.ExpressionFunction`). Without the matching swap on the dsl side, this PR fails to build with:

```
cannot use dsl.HelperFunctions() (value of type map[string]"github.com/Knetic/govaluate".ExpressionFunction) as map[string]"github.com/projectdiscovery/govaluate".ExpressionFunction value
```

go modules can't satisfy two different module paths from the same source, so the dsl swap has to land first.

**Companion PR: [projectdiscovery/dsl#305](https://github.com/projectdiscovery/dsl/pull/305)** — same refactor, no public-API shape change.

## Current state of this PR

- Source-file import paths: swapped everywhere (15 files under pkg/).
- go.mod / go.sum: drop Knetic, add projectdiscovery/govaluate.
- Temporary replace: `github.com/projectdiscovery/dsl => github.com/ChrisJr404/dsl <hash>` pinned at the dsl#305 commit so this PR builds green for review. **This needs to come out before merge** — once dsl#305 is tagged, bump the projectdiscovery/dsl version in the require block and drop the replace.

## Tests

go test ./pkg/operators/... ./pkg/protocols/common/... ./pkg/templates/... — all packages pass (matchers, extractors, dsl, variables, expressions, templates).

## Path to merge

1. Land dsl#305.
2. Tag a new projectdiscovery/dsl release.
3. On this PR: go get github.com/projectdiscovery/dsl@<new-tag>, drop the replace directive, mark ready for review.

Happy to do step 3 once the dsl PR is in.