### PR TITLE
fix(workflow): propagate context to child & race steps

### DIFF
--- a/internal/tests/integration/testdata/workflow/race-context-share-template-1.yaml
+++ b/internal/tests/integration/testdata/workflow/race-context-share-template-1.yaml
@@ -1,0 +1,17 @@
+id: race-context-share-template-1
+
+info:
+  name: race-context-share-template-1
+  author: pdteam
+  severity: info
+
+http:
+  - path:
+      - "{{BaseURL}}/context"
+
+    extractors:
+      - type: json
+        name: whoami
+        part: body
+        json:
+          - ".name"

--- a/internal/tests/integration/testdata/workflow/race-context-share-template-2.yaml
+++ b/internal/tests/integration/testdata/workflow/race-context-share-template-2.yaml
@@ -1,0 +1,29 @@
+id: race-context-share-template-2
+
+info:
+  name: race-context-share-template-2
+  author: pdteam
+  severity: info
+
+http:
+  - raw:
+      - |
+        POST / HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        name={{whoami}}
+
+    race: true
+    race_count: 1
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: body
+        words:
+          - "ok"

--- a/internal/tests/integration/testdata/workflow/race-context-share-workflow.yaml
+++ b/internal/tests/integration/testdata/workflow/race-context-share-workflow.yaml
@@ -1,0 +1,10 @@
+id: race-context-share-workflow
+info:
+  name: Race Context Share Workflow
+  author: pdteam
+  severity: info
+
+workflows:
+  - template: workflow/race-context-share-template-1.yaml
+    subtemplates:
+      - template: workflow/race-context-share-template-2.yaml

--- a/internal/tests/integration/workflow_test.go
+++ b/internal/tests/integration/workflow_test.go
@@ -24,6 +24,7 @@ var workflowTestcases = []integrationCase{
 	{Path: "workflow/matcher-name.yaml", TestCase: &workflowMatcherName{}},
 	{Path: "workflow/complex-conditions.yaml", TestCase: &workflowComplexConditions{}},
 	{Path: "workflow/http-value-share-workflow.yaml", TestCase: &workflowHttpKeyValueShare{}},
+	{Path: "workflow/race-context-share-workflow.yaml", TestCase: &workflowRaceContextShare{}},
 	{Path: "workflow/dns-value-share-workflow.yaml", TestCase: &workflowDnsKeyValueShare{}},
 	{Path: "workflow/code-value-share-workflow.yaml", TestCase: &workflowCodeKeyValueShare{}, DisableOn: isCodeDisabled}, // isCodeDisabled declared in code.go
 	{Path: "workflow/multiprotocol-value-share-workflow.yaml", TestCase: &workflowMultiProtocolKeyValueShare{}},
@@ -149,6 +150,39 @@ func (h *workflowHttpKeyValueShare) Execute(filePath string) error {
 	results, err := testutils.RunNucleiWorkflowAndGetResults(filePath, ts.URL, debug)
 	if err != nil {
 		return err
+	}
+
+	return expectResultsCount(results, 1)
+}
+
+type workflowRaceContextShare struct{}
+
+// Execute executes a test case and returns an error if occurred
+func (h *workflowRaceContextShare) Execute(filePath string) error {
+	var receivedBodies []string
+	router := httprouter.New()
+	router.GET("/context", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+		_, _ = fmt.Fprintf(w, `{"name":"foo"}`)
+	})
+	router.POST("/", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+		body, _ := io.ReadAll(r.Body)
+		receivedBodies = append(receivedBodies, string(body))
+		if string(body) != "name=foo" {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = fmt.Fprintf(w, "bad")
+			return
+		}
+		_, _ = fmt.Fprintf(w, "ok")
+	})
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+
+	results, err := testutils.RunNucleiWorkflowAndGetResults(filePath, ts.URL, debug)
+	if err != nil {
+		return err
+	}
+	if len(receivedBodies) != 1 || receivedBodies[0] != "name=foo" {
+		return fmt.Errorf("incorrect race subtemplate body: got %v", receivedBodies)
 	}
 
 	return expectResultsCount(results, 1)

--- a/pkg/core/workflow_execute.go
+++ b/pkg/core/workflow_execute.go
@@ -54,6 +54,7 @@ func (e *Engine) runWorkflowStep(template *workflows.WorkflowTemplate, ctx *scan
 
 	if len(template.Matchers) == 0 {
 		for _, executer := range template.Executers {
+			e.syncWorkflowInputToTemplateCtx(executer, ctx.Input)
 			executer.Options.Progress.AddToTotal(int64(executer.Executer.Requests()))
 
 			// Don't print results with subtemplates, only print results on template.
@@ -111,6 +112,7 @@ func (e *Engine) runWorkflowStep(template *workflows.WorkflowTemplate, ctx *scan
 	}
 	if len(template.Matchers) > 0 {
 		for _, executer := range template.Executers {
+			e.syncWorkflowInputToTemplateCtx(executer, ctx.Input)
 			executer.Options.Progress.AddToTotal(int64(executer.Executer.Requests()))
 
 			ctx.OnResult = func(event *output.InternalWrappedEvent) {
@@ -163,7 +165,7 @@ func (e *Engine) runWorkflowStep(template *workflows.WorkflowTemplate, ctx *scan
 
 			go func(template *workflows.WorkflowTemplate) {
 				// create a new context with the same input but with unset callbacks
-				subCtx := scan.NewScanContext(ctx.Context(), ctx.Input)
+				subCtx := scan.NewScanContext(ctx.Context(), ctx.Input.Clone())
 				if err := e.runWorkflowStep(template, subCtx, results, swg, w); err != nil {
 					gologger.Warning().Msgf(workflowStepExecutionError, template.Template, err)
 				}
@@ -172,4 +174,17 @@ func (e *Engine) runWorkflowStep(template *workflows.WorkflowTemplate, ctx *scan
 		}
 	}
 	return mainErr
+}
+
+func (e *Engine) syncWorkflowInputToTemplateCtx(executer *workflows.ProtocolExecuterPair, input *contextargs.Context) {
+	if executer == nil || executer.Options == nil || input == nil || !input.HasArgs() {
+		return
+	}
+
+	workflowValues := input.GetAll()
+	if len(workflowValues) == 0 {
+		return
+	}
+
+	executer.Options.GetTemplateCtx(input.MetaInput).Merge(workflowValues)
 }

--- a/pkg/core/workflow_execute_test.go
+++ b/pkg/core/workflow_execute_test.go
@@ -175,10 +175,137 @@ func TestWorkflowsSubtemplatesWithMatcherNoMatch(t *testing.T) {
 	require.Equal(t, "", secondInput, "could not get correct second input")
 }
 
+func TestWorkflowsSubtemplatesPropagateParentContextToChildTemplateCtx(t *testing.T) {
+	progressBar, _ := progress.NewStatsTicker(0, false, false, false, 0)
+
+	childOptions := &protocols.ExecutorOptions{TemplateID: "child-template", Progress: progressBar}
+	var childWhoami interface{}
+
+	workflow := &workflows.Workflow{
+		Options: &protocols.ExecutorOptions{Options: &types.Options{TemplateThreads: 10}},
+		Workflows: []*workflows.WorkflowTemplate{{
+			Executers: []*workflows.ProtocolExecuterPair{{
+				Executer: &mockExecuter{result: true, outputs: []*output.InternalWrappedEvent{{
+					OperatorsResult: &operators.Result{Extracts: map[string][]string{"whoami": {"foo"}}},
+					Results:         []*output.ResultEvent{{}},
+				}}},
+				Options: &protocols.ExecutorOptions{TemplateID: "parent-template", Progress: progressBar},
+			}},
+			Subtemplates: []*workflows.WorkflowTemplate{{
+				Executers: []*workflows.ProtocolExecuterPair{{
+					Executer: &mockExecuter{result: true, executeScanHook: func(ctx *scan.ScanContext) {
+						childWhoami, _ = childOptions.GetTemplateCtx(ctx.Input.MetaInput).Get("whoami")
+					}},
+					Options: childOptions,
+				}},
+			}},
+		}},
+	}
+
+	engine := &Engine{}
+	input := contextargs.NewWithInput(context.Background(), "https://test.com")
+	ctx := scan.NewScanContext(context.Background(), input)
+	matched := engine.executeWorkflow(ctx, workflow)
+	require.True(t, matched, "could not get correct match value")
+
+	require.Equal(t, "foo", childWhoami, "could not inherit workflow context into child template context")
+}
+
+func TestWorkflowsSubtemplatesDoNotShareSiblingContext(t *testing.T) {
+	progressBar, _ := progress.NewStatsTicker(0, false, false, false, 0)
+
+	firstSiblingReady := make(chan struct{})
+	var secondSiblingHasSiblingValue bool
+
+	workflow := &workflows.Workflow{
+		Options: &protocols.ExecutorOptions{Options: &types.Options{TemplateThreads: 10}},
+		Workflows: []*workflows.WorkflowTemplate{{
+			Executers: []*workflows.ProtocolExecuterPair{{
+				Executer: &mockExecuter{result: true, outputs: []*output.InternalWrappedEvent{{
+					OperatorsResult: &operators.Result{},
+					Results:         []*output.ResultEvent{{}},
+				}}},
+				Options: &protocols.ExecutorOptions{TemplateID: "parent-template", Progress: progressBar},
+			}},
+			Subtemplates: []*workflows.WorkflowTemplate{
+				{
+					Executers: []*workflows.ProtocolExecuterPair{{
+						Executer: &mockExecuter{result: true, executeScanHook: func(ctx *scan.ScanContext) {
+							ctx.Input.Set("sibling-only", "from-first-sibling")
+							close(firstSiblingReady)
+						}},
+						Options: &protocols.ExecutorOptions{TemplateID: "first-child-template", Progress: progressBar},
+					}},
+				},
+				{
+					Executers: []*workflows.ProtocolExecuterPair{{
+						Executer: &mockExecuter{result: true, executeScanHook: func(ctx *scan.ScanContext) {
+							<-firstSiblingReady
+							_, secondSiblingHasSiblingValue = ctx.Input.Get("sibling-only")
+						}},
+						Options: &protocols.ExecutorOptions{TemplateID: "second-child-template", Progress: progressBar},
+					}},
+				},
+			},
+		}},
+	}
+
+	engine := &Engine{}
+	input := contextargs.NewWithInput(context.Background(), "https://test.com")
+	ctx := scan.NewScanContext(context.Background(), input)
+	matched := engine.executeWorkflow(ctx, workflow)
+	require.True(t, matched, "could not get correct match value")
+
+	require.False(t, secondSiblingHasSiblingValue, "sibling subtemplate inherited workflow context from another sibling")
+}
+
+func TestWorkflowsSameStepExecutersRefreshTemplateContext(t *testing.T) {
+	progressBar, _ := progress.NewStatsTicker(0, false, false, false, 0)
+
+	secondOptions := &protocols.ExecutorOptions{TemplateID: "second-template", Progress: progressBar}
+	var secondWhoami interface{}
+
+	workflow := &workflows.Workflow{
+		Options: &protocols.ExecutorOptions{Options: &types.Options{TemplateThreads: 10}},
+		Workflows: []*workflows.WorkflowTemplate{{
+			Executers: []*workflows.ProtocolExecuterPair{
+				{
+					Executer: &mockExecuter{result: true, outputs: []*output.InternalWrappedEvent{{
+						OperatorsResult: &operators.Result{Extracts: map[string][]string{"whoami": {"foo"}}},
+						Results:         []*output.ResultEvent{{}},
+					}}},
+					Options: &protocols.ExecutorOptions{TemplateID: "first-template", Progress: progressBar},
+				},
+				{
+					Executer: &mockExecuter{result: true, executeScanHook: func(ctx *scan.ScanContext) {
+						secondWhoami, _ = secondOptions.GetTemplateCtx(ctx.Input.MetaInput).Get("whoami")
+					}},
+					Options: secondOptions,
+				},
+			},
+			Subtemplates: []*workflows.WorkflowTemplate{{
+				Executers: []*workflows.ProtocolExecuterPair{{
+					Executer: &mockExecuter{result: true},
+					Options:  &protocols.ExecutorOptions{TemplateID: "child-template", Progress: progressBar},
+				}},
+			}},
+		}},
+	}
+
+	engine := &Engine{}
+	input := contextargs.NewWithInput(context.Background(), "https://test.com")
+	ctx := scan.NewScanContext(context.Background(), input)
+	matched := engine.executeWorkflow(ctx, workflow)
+	require.True(t, matched, "could not get correct match value")
+
+	require.Equal(t, "foo", secondWhoami, "could not refresh workflow context into later executers in the same step")
+}
+
 type mockExecuter struct {
-	result      bool
-	executeHook func(input *contextargs.MetaInput)
-	outputs     []*output.InternalWrappedEvent
+	result          bool
+	executeHook     func(input *contextargs.MetaInput)
+	executeScanHook func(ctx *scan.ScanContext)
+	outputs         []*output.InternalWrappedEvent
 }
 
 // Compile compiles the execution generators preparing any requests possible.
@@ -196,6 +323,9 @@ func (m *mockExecuter) Execute(ctx *scan.ScanContext) (bool, error) {
 	if m.executeHook != nil {
 		m.executeHook(ctx.Input.MetaInput)
 	}
+	if m.executeScanHook != nil {
+		m.executeScanHook(ctx)
+	}
 	return m.result, nil
 }
 
@@ -203,6 +333,9 @@ func (m *mockExecuter) Execute(ctx *scan.ScanContext) (bool, error) {
 func (m *mockExecuter) ExecuteWithResults(ctx *scan.ScanContext) ([]*output.ResultEvent, error) {
 	if m.executeHook != nil {
 		m.executeHook(ctx.Input.MetaInput)
+	}
+	if m.executeScanHook != nil {
+		m.executeScanHook(ctx)
 	}
 	for _, output := range m.outputs {
 		ctx.LogEvent(output)

--- a/pkg/protocols/http/request.go
+++ b/pkg/protocols/http/request.go
@@ -71,7 +71,7 @@ func (request *Request) Type() templateTypes.ProtocolType {
 }
 
 // executeRaceRequest executes race condition request for a URL
-func (request *Request) executeRaceRequest(input *contextargs.Context, previous output.InternalEvent, callback protocols.OutputEventCallback) error {
+func (request *Request) executeRaceRequest(input *contextargs.Context, dynamicValues, previous output.InternalEvent, callback protocols.OutputEventCallback) error {
 	reqURL := input.MetaInput.Input
 	var generatedRequests []*generatedRequest
 
@@ -84,7 +84,7 @@ func (request *Request) executeRaceRequest(input *contextargs.Context, previous 
 		return nil
 	}
 	ctx := request.newContext(input)
-	requestForDump, err := generator.Make(ctx, input, inputData, payloads, nil)
+	requestForDump, err := generator.Make(ctx, input, inputData, payloads, dynamicValues)
 	if err != nil {
 		return err
 	}
@@ -113,7 +113,7 @@ func (request *Request) executeRaceRequest(input *contextargs.Context, previous 
 			break
 		}
 		ctx := request.newContext(input)
-		generatedRequest, err := generator.Make(ctx, input, inputData, payloads, nil)
+		generatedRequest, err := generator.Make(ctx, input, inputData, payloads, dynamicValues)
 		if err != nil {
 			return err
 		}
@@ -510,7 +510,7 @@ func (request *Request) ExecuteWithResults(input *contextargs.Context, dynamicVa
 	}
 	// verify if a basic race condition was requested
 	if request.Race && request.RaceNumberRequests > 0 {
-		return request.executeRaceRequest(input, dynamicValues, callback)
+		return request.executeRaceRequest(input, dynamicValues, previous, callback)
 	}
 
 	// verify if fuzz elaboration was requested


### PR DESCRIPTION
## Proposed changes

Workflow inputs get updated with extracted values,
but later executors don't refresh their template
contexts from that state. Child subtemplates reuse
the same input object, letting sibling state leak
across concurrent executions. HTTP race requests
also ignore dynamic values when building requests.

Fix this by syncing the current workflow input
into each executor's template context, cloning
inputs passed to subtemplates, and forwarding
dynamic values to race request generation.

Fixes #5399

### Proof

dev:

```console
$ git cherry-pick 3e996ebc
[dev b4a13141] test(workflow): added unit tests for parent-to-child
 Date: Fri May 8 02:59:10 2026 +0700
 5 files changed, 226 insertions(+), 3 deletions(-)
 create mode 100644 internal/tests/integration/testdata/workflow/race-context-share-template-1.yaml
 create mode 100644 internal/tests/integration/testdata/workflow/race-context-share-template-2.yaml
 create mode 100644 internal/tests/integration/testdata/workflow/race-context-share-workflow.yaml
$ go test -v -run "^TestWorkflowsS(ubtemplates(PropagateParentContextToChildTemplateCtx|DoNotShareSiblingContext)|ameStepExecutersRefreshTemplateContext)$" ./pkg/core
=== RUN   TestWorkflowsSubtemplatesPropagateParentContextToChildTemplateCtx
    workflow_execute_test.go:211: 
        	Error Trace:	/home/dw1/Development/PD/nuclei/pkg/core/workflow_execute_test.go:211
        	Error:      	Not equal: 
        	            	expected: string("foo")
        	            	actual  : <nil>(<nil>)
        	Test:       	TestWorkflowsSubtemplatesPropagateParentContextToChildTemplateCtx
        	Messages:   	could not inherit workflow context into child template context
--- FAIL: TestWorkflowsSubtemplatesPropagateParentContextToChildTemplateCtx (0.00s)
=== RUN   TestWorkflowsSubtemplatesDoNotShareSiblingContext
    workflow_execute_test.go:259: 
        	Error Trace:	/home/dw1/Development/PD/nuclei/pkg/core/workflow_execute_test.go:259
        	Error:      	Should be false
        	Test:       	TestWorkflowsSubtemplatesDoNotShareSiblingContext
        	Messages:   	sibling subtemplate inherited workflow context from another sibling
--- FAIL: TestWorkflowsSubtemplatesDoNotShareSiblingContext (0.00s)
=== RUN   TestWorkflowsSameStepExecutersRefreshTemplateContext
    workflow_execute_test.go:301: 
        	Error Trace:	/home/dw1/Development/PD/nuclei/pkg/core/workflow_execute_test.go:301
        	Error:      	Not equal: 
        	            	expected: string("foo")
        	            	actual  : <nil>(<nil>)
        	Test:       	TestWorkflowsSameStepExecutersRefreshTemplateContext
        	Messages:   	could not refresh workflow context into later executers in the same step
--- FAIL: TestWorkflowsSameStepExecutersRefreshTemplateContext (0.00s)
FAIL
FAIL	github.com/projectdiscovery/nuclei/v3/pkg/core	0.099s
FAIL
```

patch:

```console
$ go test -v -run "^TestWorkflowsS(ubtemplates(PropagateParentContextToChildTemplateCtx|DoNotShareSiblingContext)|ameStepExecutersRefreshTemplateContext)$" ./pkg/core
=== RUN   TestWorkflowsSubtemplatesPropagateParentContextToChildTemplateCtx
--- PASS: TestWorkflowsSubtemplatesPropagateParentContextToChildTemplateCtx (0.00s)
=== RUN   TestWorkflowsSubtemplatesDoNotShareSiblingContext
--- PASS: TestWorkflowsSubtemplatesDoNotShareSiblingContext (0.00s)
=== RUN   TestWorkflowsSameStepExecutersRefreshTemplateContext
--- PASS: TestWorkflowsSameStepExecutersRefreshTemplateContext (0.00s)
PASS
ok  	github.com/projectdiscovery/nuclei/v3/pkg/core	0.084s
```

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved workflow context propagation—values from parent templates are now properly available in child template execution contexts.
  * Race-condition requests now consistently apply dynamic values.

* **Tests**
  * Added integration test for workflow race context sharing.
  * Expanded test coverage for template context isolation and propagation across workflow subtemplates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->