### PR TITLE
fix(raw): preserve absolute URI in unsafe raw request line

### DIFF
--- a/pkg/protocols/http/raw/raw.go
+++ b/pkg/protocols/http/raw/raw.go
@@ -39,19 +39,14 @@ func Parse(request string, inputURL *urlutil.URL, unsafe, disablePathAutomerge b
 	}
 
 	// handle full URLs first (before checking unsafe flag) to extract relative path
+	hadFullURI := false
 	if strings.HasPrefix(rawrequest.Path, "http://") || strings.HasPrefix(rawrequest.Path, "https://") {
 		urlx, err := urlutil.ParseURL(rawrequest.Path, true)
 		if err != nil {
 			return nil, errkit.Wrapf(err, "failed to parse url %v from template", rawrequest.Path)
 		}
-		prevPath := rawrequest.Path
+		hadFullURI = true
 		relPath := urlx.GetRelativePath()
-
-		// NOTE(dwisiswant0): Use rel path instead if unsafe.
-		// See https://github.com/projectdiscovery/nuclei/issues/6558.
-		if unsafe {
-			rawrequest.UnsafeRawBytes = bytes.Replace(rawrequest.UnsafeRawBytes, []byte(prevPath), []byte(relPath), 1)
-		}
 
 		// rotate full URL with rel path
 		rawrequest.Path = relPath
@@ -65,6 +60,14 @@ func Parse(request string, inputURL *urlutil.URL, unsafe, disablePathAutomerge b
 			inputURL.Params.IncludeEquals = true
 			rawrequest.Path = inputURL.GetRelativePath()
 		}
+
+	// If the request line carries an absolute URI (RFC 7230 Section 5.3.2)
+	// in unsafe mode, leave UnsafeRawBytes untouched so the request reaches
+	// the wire verbatim. Path-automerge with the input URL is intentionally
+	// skipped because the user fully specified the request target.
+	// See https://github.com/projectdiscovery/nuclei/issues/7382.
+	case unsafe && hadFullURI:
+		// no-op: keep UnsafeRawBytes as-is
 
 	// If unsafe changes must be made in raw request string itself
 	case unsafe:

--- a/pkg/protocols/http/raw/raw_test.go
+++ b/pkg/protocols/http/raw/raw_test.go
@@ -133,69 +133,76 @@ func TestDisableMergePath(t *testing.T) {
 }
 
 func TestUnsafeWithFullURL(t *testing.T) {
-	// Test unsafe mode with full URL - should extract relative path
+	// Absolute-form request line (RFC 7230 Section 5.3.2) must reach the wire
+	// verbatim in unsafe mode. See https://github.com/projectdiscovery/nuclei/issues/7382.
 	request, err := Parse(`GET http://127.0.0.1/foo HTTP/1.1
 Host: {{Hostname}}
 User-Agent: Mozilla/5.0
 Connection: close`, parseURL(t, "http://httpbin.org/bar"), true, true)
 	require.Nil(t, err, "could not parse unsafe request with full URL")
-	require.Equal(t, "/foo", request.Path, "Could not extract relative path from full URL in unsafe mode")
-	require.Contains(t, string(request.UnsafeRawBytes), "GET /foo HTTP/1.1", "UnsafeRawBytes should contain relative path, not full URL")
-	require.NotContains(t, string(request.UnsafeRawBytes), "http://127.0.0.1", "UnsafeRawBytes should not contain full URL")
+	require.Equal(t, "/foo", request.Path, "Path field should hold the relative component for downstream bookkeeping")
+	require.Contains(t, string(request.UnsafeRawBytes), "GET http://127.0.0.1/foo HTTP/1.1", "UnsafeRawBytes should preserve the absolute URI")
 }
 
 func TestUnsafeWithFullURLAndPath(t *testing.T) {
-	// Test unsafe mode with full URL and target URL that has a path
+	// Even when the target URL has a non-root path, an explicit absolute URI in
+	// the request line should not be merged with it. The user has fully
+	// specified the request target.
 	request, err := Parse(`GET http://127.0.0.1/foo HTTP/1.1
 Host: {{Hostname}}
 User-Agent: Mozilla/5.0
 Connection: close`, parseURL(t, "http://httpbin.org/bar"), true, false)
 	require.Nil(t, err, "could not parse unsafe request with full URL and path merge")
-	require.Equal(t, "/bar/foo", request.Path, "Could not merge path correctly from full URL in unsafe mode")
-	require.Contains(t, string(request.UnsafeRawBytes), "GET /bar/foo HTTP/1.1", "UnsafeRawBytes should contain merged relative path")
-	require.NotContains(t, string(request.UnsafeRawBytes), "http://127.0.0.1", "UnsafeRawBytes should not contain full URL")
+	require.Equal(t, "/foo", request.Path, "Path field should hold the relative component from the absolute URI, not the merged target path")
+	require.Contains(t, string(request.UnsafeRawBytes), "GET http://127.0.0.1/foo HTTP/1.1", "UnsafeRawBytes should preserve the absolute URI without path automerge")
 }
 
 func TestUnsafeWithFullURLAndQueryParams(t *testing.T) {
-	// Test unsafe mode with full URL containing query parameters
 	request, err := Parse(`GET http://127.0.0.1/foo?id=123&name=test HTTP/1.1
 Host: {{Hostname}}
 User-Agent: Mozilla/5.0
 Connection: close`, parseURL(t, "http://httpbin.org/bar"), true, true)
 	require.Nil(t, err, "could not parse unsafe request with full URL and query params")
-	require.Equal(t, "/foo?id=123&name=test", request.Path, "Could not extract relative path with query params from full URL in unsafe mode")
-	require.Contains(t, string(request.UnsafeRawBytes), "GET /foo?id=123&name=test HTTP/1.1", "UnsafeRawBytes should contain relative path with query params")
-	require.NotContains(t, string(request.UnsafeRawBytes), "http://127.0.0.1", "UnsafeRawBytes should not contain full URL")
+	require.Equal(t, "/foo?id=123&name=test", request.Path, "Path field should hold relative component with query params")
+	require.Contains(t, string(request.UnsafeRawBytes), "GET http://127.0.0.1/foo?id=123&name=test HTTP/1.1", "UnsafeRawBytes should preserve the absolute URI with query params")
 }
 
 func TestUnsafeWithHTTPSFullURL(t *testing.T) {
-	// Test unsafe mode with HTTPS full URL
 	request, err := Parse(`GET https://secure.example.com/api/v1/users HTTP/1.1
 Host: {{Hostname}}
 Authorization: Bearer token123
 Connection: close`, parseURL(t, "https://target.com/test"), true, true)
 	require.Nil(t, err, "could not parse unsafe request with HTTPS full URL")
-	require.Equal(t, "/api/v1/users", request.Path, "Could not extract relative path from HTTPS full URL in unsafe mode")
-	require.Contains(t, string(request.UnsafeRawBytes), "GET /api/v1/users HTTP/1.1", "UnsafeRawBytes should contain relative path")
-	require.NotContains(t, string(request.UnsafeRawBytes), "https://secure.example.com", "UnsafeRawBytes should not contain full URL")
+	require.Equal(t, "/api/v1/users", request.Path, "Path field should hold relative component from HTTPS full URL")
+	require.Contains(t, string(request.UnsafeRawBytes), "GET https://secure.example.com/api/v1/users HTTP/1.1", "UnsafeRawBytes should preserve the HTTPS absolute URI")
 }
 
 func TestUnsafeWithFullURLRootPath(t *testing.T) {
-	// Test unsafe mode with full URL pointing to root path
-	// When disable-path-automerge is true and path is /, it becomes empty string (expected behavior)
 	request, err := Parse(`GET http://example.com/ HTTP/1.1
 Host: {{Hostname}}
 Connection: close`, parseURL(t, "http://target.com/api"), true, true)
 	require.Nil(t, err, "could not parse unsafe request with full URL root path")
-	// With disable-path-automerge=true and root path, it becomes empty per existing logic
-	require.Equal(t, "", request.Path, "Root path with disable-path-automerge should be empty")
+	require.Equal(t, "/", request.Path, "Path field should hold the relative root from the absolute URI")
+	require.Contains(t, string(request.UnsafeRawBytes), "GET http://example.com/ HTTP/1.1", "UnsafeRawBytes should preserve the absolute URI with root path")
 
-	// Test with disable-path-automerge=false
 	request, err = Parse(`GET http://example.com/ HTTP/1.1
 Host: {{Hostname}}
 Connection: close`, parseURL(t, "http://target.com/api"), true, false)
 	require.Nil(t, err, "could not parse unsafe request with full URL root path and merge")
-	require.Equal(t, "/api", request.Path, "Should merge with target path when automerge enabled")
+	require.Equal(t, "/", request.Path, "Path field should hold the relative root regardless of automerge")
+	require.Contains(t, string(request.UnsafeRawBytes), "GET http://example.com/ HTTP/1.1", "UnsafeRawBytes should preserve the absolute URI even with automerge enabled")
+}
+
+// TestUnsafeWithFullURLAndPort reproduces the scenario from
+// https://github.com/projectdiscovery/nuclei/issues/7382 where the request
+// line contains an absolute URI with an explicit port. The scheme, host, and
+// port must all reach the wire intact.
+func TestUnsafeWithFullURLAndPort(t *testing.T) {
+	request, err := Parse(`GET http://example.com:80/foo HTTP/1.1
+Host: 127.0.0.1`, parseURL(t, "http://127.0.0.1:8000"), true, false)
+	require.Nil(t, err, "could not parse unsafe request with full URL containing port")
+	require.Equal(t, "/foo", request.Path, "Path field should hold relative component from absolute URI with port")
+	require.Contains(t, string(request.UnsafeRawBytes), "GET http://example.com:80/foo HTTP/1.1", "UnsafeRawBytes should preserve scheme, host, and port verbatim")
 }
 
 func TestSafeWithFullURL(t *testing.T) {


### PR DESCRIPTION
## Proposed changes

Fixes #7382.

When a raw request uses `unsafe: true` and the request line carries an absolute URI (RFC 7230 Section 5.3.2), nuclei was stripping the scheme, host, and port from `UnsafeRawBytes` and sending only the path on the wire. That broke templates that target a proxy or otherwise need absolute-form on purpose.

Example template from the issue:

```yaml
id: full-uri-test

info:
  name: Full URI Test
  author: rjo
  severity: medium

http:
  - raw:
      - |+
        GET http://example.com:80/foo HTTP/1.1
        Host: 127.0.0.1

    unsafe: true
```

Before this PR, the bytes on the wire were `GET /foo HTTP/1.1`. After this PR they are `GET http://example.com:80/foo HTTP/1.1`, which matches the template.

The strip was introduced by the fix in #6589. The original #6558 reproduction was actually asking for the same behaviour this issue asks for (send the absolute URI verbatim, do not rewrite it), so this change is consistent with the original intent of that report.

### What changed

`pkg/protocols/http/raw/raw.go`:

1. Drop the unconditional `bytes.Replace` that rewrote the absolute URI to a relative path inside `UnsafeRawBytes`.
2. Add a dedicated switch case for `unsafe && hadFullURI` that skips path-automerge with the input URL. The user has fully specified the request target, so merging it with the input URL's path would produce a different (and unintended) absolute URI.

The `Path` field is still rotated to the relative component so that matched-URL display and other downstream bookkeeping keep working. The actual TCP connection target is taken from the `-u` input URL by `rawhttp` (independent of the bytes in the request line), so this change only affects what is written on the wire.

### Proof

Updated unit tests under `pkg/protocols/http/raw/raw_test.go`. The pre-existing `TestUnsafeWithFullURL*` tests encoded the buggy behaviour and have been updated to assert that the absolute URI is preserved. Added `TestUnsafeWithFullURLAndPort` which is the exact reproduction template from the issue, covering scheme + host + port preservation.

```
$ go test ./pkg/protocols/http/raw/... -v -run "TestUnsafe|TestSafeWithFullURL|TestParse"
...
--- PASS: TestUnsafeWithFullURL (0.00s)
--- PASS: TestUnsafeWithFullURLAndPath (0.00s)
--- PASS: TestUnsafeWithFullURLAndQueryParams (0.00s)
--- PASS: TestUnsafeWithHTTPSFullURL (0.00s)
--- PASS: TestUnsafeWithFullURLRootPath (0.00s)
--- PASS: TestUnsafeWithFullURLAndPort (0.00s)
--- PASS: TestSafeWithFullURL (0.00s)
PASS
ok  	github.com/projectdiscovery/nuclei/v3/pkg/protocols/http/raw	0.099s

$ go test ./pkg/protocols/http/...
ok  	github.com/projectdiscovery/nuclei/v3/pkg/protocols/http	11.145s
ok  	github.com/projectdiscovery/nuclei/v3/pkg/protocols/http/httpclientpool	0.267s
ok  	github.com/projectdiscovery/nuclei/v3/pkg/protocols/http/raw	0.339s

$ go vet ./...
(no output)
```

End-to-end against a local TCP listener using the issue's repro template and `-u http://127.0.0.1:8000`:

Before (current dev):
```
GET /foo HTTP/1.1
Host: 127.0.0.1
```

After (this PR):
```
GET http://example.com:80/foo HTTP/1.1
Host: 127.0.0.1
```

The captured listener bytes match the dumped request, so the absolute URI now reaches the wire intact.

## Checklist

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of absolute URI request targets in raw HTTP protocol parsing. When unsafe mode is enabled, request targets with full URIs (including scheme, host, and port) are now preserved exactly as provided, improving compatibility with clients sending absolute-form request lines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->