### PR TITLE
fix: filter exact variable names from expression evaluation to avoid …

### DIFF
--- a/pkg/protocols/common/expressions/expressions.go
+++ b/pkg/protocols/common/expressions/expressions.go
@@ -45,6 +45,17 @@ func EvaluateByte(data []byte, base map[string]interface{}) ([]byte, error) {
 func evaluate(data string, base map[string]interface{}) (string, error) {
 	expressions := FindExpressions(data, marker.ParenthesisOpen, marker.ParenthesisClose, base)
 
+	// Filter out expressions that are exact variable names in base
+	// these are simple variable references handled by replacer.Replace and
+	// evaluating them as govaluate expressions can misparse hyphens as subtraction
+	filtered := make([]string, 0, len(expressions))
+	for _, expr := range expressions {
+		if _, ok := base[expr]; !ok {
+			filtered = append(filtered, expr)
+		}
+	}
+	expressions = filtered
+
 	// replace simple placeholders (key => value) MarkerOpen + key + MarkerClose and General + key + General to value
 	data = replacer.Replace(data, base)
 


### PR DESCRIPTION
Closes #7395

## Proposed changes

Filter out expressions that are exact keys in the variable map from govaluate evaluation. Hyphenated template variables like `request-id` are misparsed as subtraction (`request - id`) causing `"No parameter 'request' found."` on every request - these are simple variable references handled by `replacer.Replace` and should not be re-evaluated.

### Proof

- All 13 existing expression package tests pass
- HTTP protocol package tests pass
- Built binary tested against CVE-2025-55182 template: requests now appear as `[VER] Sent HTTP request` instead of `[WRN] Could not execute request`

## Checklist

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed expression evaluation to prevent parsing errors and improve handling of variable references.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectdiscovery/nuclei/pull/7396)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->