### PR TITLE
fix(expressions): prefer exact placeholders over exprs

### DIFF
--- a/pkg/protocols/common/expressions/expressions.go
+++ b/pkg/protocols/common/expressions/expressions.go
@@ -150,6 +150,10 @@ func FindExpressions(data, OpenMarker, CloseMarker string, base map[string]inter
 }
 
 func isExpression(data string, base map[string]interface{}) bool {
+	if _, ok := base[data]; ok {
+		return false
+	}
+
 	if _, err := govaluate.NewEvaluableExpression(data); err == nil {
 		if stringsutil.ContainsAny(data, getFunctionsNames(base)...) {
 			return true

--- a/pkg/protocols/common/expressions/expressions_test.go
+++ b/pkg/protocols/common/expressions/expressions_test.go
@@ -122,6 +122,14 @@ func TestEvaluateDoesNotExecuteHelpersFromResolvedValues(t *testing.T) {
 	require.Zero(t, calls)
 }
 
+func TestEvaluateHyphenatedPlaceholderNames(t *testing.T) {
+	value, err := Evaluate("foo-bar: {{foo-bar}}", map[string]interface{}{
+		"foo-bar": "baz",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "foo-bar: baz", value)
+}
+
 func TestEvaluateReturnsErrorForInvalidTemplateExpression(t *testing.T) {
 	_, err := Evaluate("{{base64()}}", map[string]interface{}{})
 	require.Error(t, err)


### PR DESCRIPTION
## Proposed changes

`FindExpressions` checks marker contents with
govaluate before doing normal placeholder
replacement. That breaks valid hyphenated names
like `request-id`: govaluate reads them as
subtraction lol, and the lookup fails with a
missing request parameter.

If a marker exactly matches a key in the
replacement map, treat it as a plain placeholder
and let normal replacement handle it. Authored
expressions should still be evaluated, and
malformed helper calls should still return errors.

Fixes #7395

### Proof

patch:

```console
$ go test -v -run "TestEvaluateHyphenatedPlaceholderNames" ./pkg/protocols/common/expressions/
=== RUN   TestEvaluateHyphenatedPlaceholderNames
--- PASS: TestEvaluateHyphenatedPlaceholderNames (0.00s)
PASS
ok  	github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/expressions	0.065s
```

dev:

```console
$ git cherry-pick 4f3e77f7
[dev 9e9a4cf3] test(expressions): add TestEvaluateHyphenatedPlaceholderNames
 Date: Tue May 12 04:45:41 2026 +0700
 1 file changed, 8 insertions(+)
$ go test -v -run "TestEvaluateHyphenatedPlaceholderNames" ./pkg/protocols/common/expressions/
=== RUN   TestEvaluateHyphenatedPlaceholderNames
    expressions_test.go:129: 
        	Error Trace:	/home/dw1/Development/PD/nuclei/pkg/protocols/common/expressions/expressions_test.go:129
        	Error:      	Received unexpected error:
        	            	failed to evaluate expression "foo-bar": No parameter 'foo' found.
        	Test:       	TestEvaluateHyphenatedPlaceholderNames
--- FAIL: TestEvaluateHyphenatedPlaceholderNames (0.00s)
FAIL
FAIL	github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/expressions	0.298s
FAIL
```

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved expression detection logic to correctly handle string literals in template evaluation

* **New Features**
  * Template placeholders with hyphenated names (e.g., `{{foo-bar}}`) are now properly resolved from variable mappings

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectdiscovery/nuclei/pull/7397)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->