### PR TITLE
fix(reporting/gitlab): bump client-go to v1.9.1, widen IDs to int64

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -124,7 +124,7 @@ require (
 	github.com/testcontainers/testcontainers-go/modules/mongodb v0.37.0
 	github.com/yassinebenaid/godump v0.11.1
 	github.com/zmap/zgrab2 v0.1.8
-	gitlab.com/gitlab-org/api/client-go v0.130.1
+	gitlab.com/gitlab-org/api/client-go v1.9.1
 	go.mongodb.org/mongo-driver v1.17.9
 	golang.org/x/term v0.42.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -425,7 +425,7 @@ require (
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/time v0.14.0 // indirect
 	golang.org/x/tools v0.44.0
-	google.golang.org/protobuf v1.36.6 // indirect
+	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6 // indirect
 	gopkg.in/corvus-ch/zbase32.v1 v1.0.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1177,8 +1177,8 @@ github.com/zmap/zflags v1.4.0-beta.1.0.20200204220219-9d95409821b6/go.mod h1:HXD
 github.com/zmap/zgrab2 v0.1.8 h1:PFnXrIBcGjYFec1JNbxMKQuSXXzS+SbqE89luuF4ORY=
 github.com/zmap/zgrab2 v0.1.8/go.mod h1:5d8HSmUwvllx4q1qG50v/KXphkg45ZzWdaQtgTFnegE=
 github.com/zmap/zlint/v3 v3.0.0/go.mod h1:paGwFySdHIBEMJ61YjoqT4h7Ge+fdYG4sUQhnTb1lJ8=
-gitlab.com/gitlab-org/api/client-go v0.130.1 h1:1xF5C5Zq3sFeNg3PzS2z63oqrxifne3n/OnbI7nptRc=
-gitlab.com/gitlab-org/api/client-go v0.130.1/go.mod h1:ZhSxLAWadqP6J9lMh40IAZOlOxBLPRh7yFOXR/bMJWM=
+gitlab.com/gitlab-org/api/client-go v1.9.1 h1:tZm+URa36sVy8UCEHQyGGJ8COngV4YqMHpM6k9O5tK8=
+gitlab.com/gitlab-org/api/client-go v1.9.1/go.mod h1:71yTJk1lnHCWcZLvM5kPAXzeJ2fn5GjaoV8gTOPd4ME=
 go.etcd.io/bbolt v1.4.3 h1:dEadXpI6G79deX5prL3QRNP6JB8UxVkqo4UPnHaNXJo=
 go.etcd.io/bbolt v1.4.3/go.mod h1:tKQlpPaYCVFctUIgFKFnAlvbmB3tpy1vkTnDWohtc0E=
 go.mongodb.org/mongo-driver v1.17.9 h1:IexDdCuuNJ3BHrELgBlyaH9p60JXAvdzWR128q+U5tU=
@@ -1585,10 +1585,10 @@ google.golang.org/genproto v0.0.0-20200729003335-053ba62fc06f/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20200804131852-c06518451d9c/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200825200019-8632dd797987/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20250122153221-138b5a5a4fd4 h1:Pw6WnI9W/LIdRxqK7T6XGugGbHIRl5Q7q3BssH6xk4s=
-google.golang.org/genproto/googleapis/api v0.0.0-20250303144028-a0af3efb3deb h1:p31xT4yrYrSM/G4Sn2+TNUkVhFCbG9y8itM2S6Th950=
-google.golang.org/genproto/googleapis/api v0.0.0-20250303144028-a0af3efb3deb/go.mod h1:jbe3Bkdp+Dh2IrslsFCklNhweNTBgSYanP1UXhJDhKg=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20250303144028-a0af3efb3deb h1:TLPQVbx1GJ8VKZxz52VAxl1EBgKXXbTiU9Fc5fZeLn4=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20250303144028-a0af3efb3deb/go.mod h1:LuRYeWDFV6WOn90g357N17oMCaxpgCnbi/44qJvDn2I=
+google.golang.org/genproto/googleapis/api v0.0.0-20250811230008-5f3141c8851a h1:DMCgtIAIQGZqJXMVzJF4MV8BlWoJh2ZuFiRdAleyr58=
+google.golang.org/genproto/googleapis/api v0.0.0-20250811230008-5f3141c8851a/go.mod h1:y2yVLIE/CSMCPXaHnSKXxu1spLPnglFLegmgdY23uuE=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20250811230008-5f3141c8851a h1:tPE/Kp+x9dMSwUm/uM0JKK0IfdiJkwAbSMSeZBXXJXc=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20250811230008-5f3141c8851a/go.mod h1:gw1tLEfykwDz2ET4a12jcXt4couGAm7IwsVaTy0Sflo=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
@@ -1619,8 +1619,8 @@ google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqw
 google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 google.golang.org/protobuf v1.30.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
-google.golang.org/protobuf v1.36.6 h1:z1NpPI8ku2WgiWnf+t9wTPsn6eP1L7ksHUlkfLvd9xY=
-google.golang.org/protobuf v1.36.6/go.mod h1:jduwjTPXsFjZGTmRluh+L6NjiWu7pchiJ2/5YcXBHnY=
+google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
+google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/pkg/reporting/trackers/gitlab/gitlab.go
+++ b/pkg/reporting/trackers/gitlab/gitlab.go
@@ -16,7 +16,7 @@ import (
 // Integration is a client for an issue tracker integration
 type Integration struct {
 	client  *gitlab.Client
-	userID  int
+	userID  int64
 	options *Options
 }
 
@@ -85,7 +85,7 @@ func (i *Integration) CreateIssue(event *output.ResultEvent) (*filters.CreateIss
 		labels = append(labels, label)
 	}
 	customLabels := gitlab.LabelOptions(labels)
-	assigneeIDs := []int{i.userID}
+	assigneeIDs := []int64{i.userID}
 
 	var issue *gitlab.Issue
 	if i.options.DuplicateIssueCheck {
@@ -113,7 +113,7 @@ func (i *Integration) CreateIssue(event *output.ResultEvent) (*filters.CreateIss
 			}
 		}
 		return &filters.CreateIssueResponse{
-			IssueID:  strconv.FormatInt(int64(issue.ID), 10),
+			IssueID:  strconv.FormatInt(issue.ID, 10),
 			IssueURL: issue.WebURL,
 		}, nil
 	}
@@ -127,7 +127,7 @@ func (i *Integration) CreateIssue(event *output.ResultEvent) (*filters.CreateIss
 		return nil, err
 	}
 	return &filters.CreateIssueResponse{
-		IssueID:  strconv.FormatInt(int64(createdIssue.ID), 10),
+		IssueID:  strconv.FormatInt(createdIssue.ID, 10),
 		IssueURL: createdIssue.WebURL,
 	}, nil
 }
@@ -177,8 +177,8 @@ func (i *Integration) findIssueByTitle(title string) (*gitlab.Issue, error) {
 			State:  &searchState,
 			Search: &title,
 			ListOptions: gitlab.ListOptions{
-				Page:    page,
-				PerPage: pageSize,
+				Page:    int64(page),
+				PerPage: int64(pageSize),
 			},
 		})
 		if err != nil {


### PR DESCRIPTION
## Summary

Upgrade the GitLab tracker to work with `gitlab.com/gitlab-org/api/client-go v1.x`. The v1 release widened ID fields from `int` to `int64` across the API surface (`User.ID`, `Issue.ID`, `ListOptions.Page/PerPage`, assignee slices). Currently nuclei is pinned at `v0.130.1` so SDK consumers wanting a current client-go version (notably pd-agent) carry a local `replace` directive in their `go.mod`. This PR bumps to `v1.9.1` and adjusts the tracker source to match.

## Changes

Dependency:
- `gitlab.com/gitlab-org/api/client-go` `v0.130.1` → `v1.9.1`
- Transitive: `google.golang.org/protobuf` `v1.36.6` → `v1.36.11` (pulled by `go mod tidy`)

Source — `pkg/reporting/trackers/gitlab/gitlab.go`, 5 line changes:
- `Integration.userID`: `int` → `int64`
- `assigneeIDs`: `[]int{i.userID}` → `[]int64{i.userID}`
- `IssueID: strconv.FormatInt(int64(issue.ID), 10)` → `FormatInt(issue.ID, 10)` (ID is already `int64`)
- Same for `createdIssue.ID`
- `ListOptions.Page` / `PerPage` now require `int64`; cast at the call site

`UpdateIssue` and `CreateIssueNote` signatures also widened (`issue int` → `issue int64`), but `gitlab.Issue.IID` is already `int64` in v1.x, so existing `issue.IID` arguments compile unchanged.

## What stays the same

`Options.DuplicateIssuePageSize` / `DuplicateIssueMaxPages` remain `int`. That struct is user-facing YAML; YAML ints round-trip into `int64` fine, so there's no reason to widen the public surface. The cast happens at the call site only.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go build ./pkg/reporting/trackers/gitlab/` clean
- [ ] Unit tests with `httptest.Server` mocking the four endpoints (`GET /user`, `POST /projects/:id/issues`, `GET /projects/:id/issues`, `PUT /projects/:id/issues/:iid`). Worth writing because the `int64` bump is the kind of change that compiles fine but can encode wrong if a forgotten cast silently truncates. **Will add in a follow-up commit on this PR.**
- [ ] Live smoke against a real GitLab project: create test project on gitlab.com, run nuclei with a reporting YAML pointing at it, verify issues created/deduplicated/closed.

## Why pd-agent cares

pd-agent currently carries a `replace gitlab.com/gitlab-org/api/client-go => …` directive to use a compatible version locally. Once this PR lands and gets tagged in a nuclei release, pd-agent can drop that replace entirely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go module dependencies to latest versions for improved stability and security.

* **Refactor**
  * Improved GitLab integration data handling to ensure compatibility with updated API requirements.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectdiscovery/nuclei/pull/7398)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->