### PR TITLE
fix(installer): prevent zip-slip prefix bypass in template path validation

### DIFF
--- a/pkg/installer/template.go
+++ b/pkg/installer/template.go
@@ -17,6 +17,7 @@ import (
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/config"
 	"github.com/projectdiscovery/nuclei/v3/pkg/external/customtemplates"
+	filepathutil "github.com/projectdiscovery/nuclei/v3/pkg/utils/filepath"
 	"github.com/projectdiscovery/utils/errkit"
 	fileutil "github.com/projectdiscovery/utils/file"
 	mapsutil "github.com/projectdiscovery/utils/maps"
@@ -277,7 +278,7 @@ func (t *TemplateManager) getAbsoluteFilePath(templateDir, uri string, f fs.File
 
 	newPath := filepath.Clean(filepath.Join(templateDir, relPath))
 
-	if !strings.HasPrefix(newPath, templateDir) {
+	if !filepathutil.IsPathWithinDirectory(newPath, templateDir) {
 		// we don't allow LFI
 		return ""
 	}

--- a/pkg/installer/zipslip_unix_test.go
+++ b/pkg/installer/zipslip_unix_test.go
@@ -58,6 +58,9 @@ func TestZipSlip(t *testing.T) {
 			"nuclei-templates/././../cve/test.yaml",
 			"nuclei-templates/.././../cve/test.yaml",
 			"nuclei-templates/.././../cve/../test.yaml",
+			// path-prefix bypass: resolves to sibling path (e.g. /tmp/templates-evil)
+			// and must be rejected even though it starts with /tmp/templates as a string prefix
+			"nuclei-templates/../templates-evil/pwn.yaml",
 		}
 		tm := TemplateManager{}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Replaced path validation approach to prevent unauthorized access to directories outside the designated template location.

* **Tests**
  * Extended security test coverage with additional edge case scenarios to verify prevention of specific path traversal attack vectors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectdiscovery/nuclei/pull/7403)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->