### PR TITLE
fix(raw): preserve full URL in unsafe raw requests

### DIFF
--- a/pkg/protocols/http/raw/raw.go
+++ b/pkg/protocols/http/raw/raw.go
@@ -39,22 +39,20 @@ func Parse(request string, inputURL *urlutil.URL, unsafe, disablePathAutomerge b
 	}
 
 	// handle full URLs first (before checking unsafe flag) to extract relative path
+	fullURLInRequest := false
 	if strings.HasPrefix(rawrequest.Path, "http://") || strings.HasPrefix(rawrequest.Path, "https://") {
 		urlx, err := urlutil.ParseURL(rawrequest.Path, true)
 		if err != nil {
 			return nil, errkit.Wrapf(err, "failed to parse url %v from template", rawrequest.Path)
 		}
-		prevPath := rawrequest.Path
-		relPath := urlx.GetRelativePath()
 
-		// NOTE(dwisiswant0): Use rel path instead if unsafe.
-		// See https://github.com/projectdiscovery/nuclei/issues/6558.
-		if unsafe {
-			rawrequest.UnsafeRawBytes = bytes.Replace(rawrequest.UnsafeRawBytes, []byte(prevPath), []byte(relPath), 1)
-		}
+		// NOTE: In unsafe mode, preserve the full URL in UnsafeRawBytes.
+		// The bytes.Replace was truncating URLs when users specified absolute-form
+		// requests (e.g., for SSRF testing). See #7382.
+		fullURLInRequest = true
 
 		// rotate full URL with rel path
-		rawrequest.Path = relPath
+		rawrequest.Path = urlx.GetRelativePath()
 	}
 
 	switch {
@@ -68,6 +66,13 @@ func Parse(request string, inputURL *urlutil.URL, unsafe, disablePathAutomerge b
 
 	// If unsafe changes must be made in raw request string itself
 	case unsafe:
+		// If the original request had a full URL, preserve it as-is in UnsafeRawBytes.
+		// Do not merge paths or replace bytes. See #7382.
+		if fullURLInRequest {
+			// Path already set to relative path above, nothing else to do
+			break
+		}
+
 		prevPath := rawrequest.Path
 		cloned := inputURL.Clone()
 		cloned.Params.IncludeEquals = true

--- a/pkg/protocols/http/raw/raw_test.go
+++ b/pkg/protocols/http/raw/raw_test.go
@@ -133,27 +133,29 @@ func TestDisableMergePath(t *testing.T) {
 }
 
 func TestUnsafeWithFullURL(t *testing.T) {
-	// Test unsafe mode with full URL - should extract relative path
+	// Test unsafe mode with full URL - should preserve full URL in UnsafeRawBytes
 	request, err := Parse(`GET http://127.0.0.1/foo HTTP/1.1
 Host: {{Hostname}}
 User-Agent: Mozilla/5.0
 Connection: close`, parseURL(t, "http://httpbin.org/bar"), true, true)
 	require.Nil(t, err, "could not parse unsafe request with full URL")
 	require.Equal(t, "/foo", request.Path, "Could not extract relative path from full URL in unsafe mode")
-	require.Contains(t, string(request.UnsafeRawBytes), "GET /foo HTTP/1.1", "UnsafeRawBytes should contain relative path, not full URL")
-	require.NotContains(t, string(request.UnsafeRawBytes), "http://127.0.0.1", "UnsafeRawBytes should not contain full URL")
+	// Full URL should be preserved in UnsafeRawBytes (fix for #7382)
+	require.Contains(t, string(request.UnsafeRawBytes), "GET http://127.0.0.1/foo HTTP/1.1", "UnsafeRawBytes should preserve full URL")
 }
 
 func TestUnsafeWithFullURLAndPath(t *testing.T) {
 	// Test unsafe mode with full URL and target URL that has a path
+	// When a full URL is specified, it should be preserved as-is (fix for #7382)
 	request, err := Parse(`GET http://127.0.0.1/foo HTTP/1.1
 Host: {{Hostname}}
 User-Agent: Mozilla/5.0
 Connection: close`, parseURL(t, "http://httpbin.org/bar"), true, false)
 	require.Nil(t, err, "could not parse unsafe request with full URL and path merge")
-	require.Equal(t, "/bar/foo", request.Path, "Could not merge path correctly from full URL in unsafe mode")
-	require.Contains(t, string(request.UnsafeRawBytes), "GET /bar/foo HTTP/1.1", "UnsafeRawBytes should contain merged relative path")
-	require.NotContains(t, string(request.UnsafeRawBytes), "http://127.0.0.1", "UnsafeRawBytes should not contain full URL")
+	// Path is extracted from the full URL
+	require.Equal(t, "/foo", request.Path, "Path should be extracted from full URL")
+	// Full URL should be preserved in UnsafeRawBytes (fix for #7382)
+	require.Contains(t, string(request.UnsafeRawBytes), "GET http://127.0.0.1/foo HTTP/1.1", "UnsafeRawBytes should preserve full URL as-is")
 }
 
 func TestUnsafeWithFullURLAndQueryParams(t *testing.T) {
@@ -164,8 +166,8 @@ User-Agent: Mozilla/5.0
 Connection: close`, parseURL(t, "http://httpbin.org/bar"), true, true)
 	require.Nil(t, err, "could not parse unsafe request with full URL and query params")
 	require.Equal(t, "/foo?id=123&name=test", request.Path, "Could not extract relative path with query params from full URL in unsafe mode")
-	require.Contains(t, string(request.UnsafeRawBytes), "GET /foo?id=123&name=test HTTP/1.1", "UnsafeRawBytes should contain relative path with query params")
-	require.NotContains(t, string(request.UnsafeRawBytes), "http://127.0.0.1", "UnsafeRawBytes should not contain full URL")
+	// Full URL should be preserved in UnsafeRawBytes (fix for #7382)
+	require.Contains(t, string(request.UnsafeRawBytes), "GET http://127.0.0.1/foo?id=123&name=test HTTP/1.1", "UnsafeRawBytes should preserve full URL with query params")
 }
 
 func TestUnsafeWithHTTPSFullURL(t *testing.T) {
@@ -176,26 +178,28 @@ Authorization: Bearer token123
 Connection: close`, parseURL(t, "https://target.com/test"), true, true)
 	require.Nil(t, err, "could not parse unsafe request with HTTPS full URL")
 	require.Equal(t, "/api/v1/users", request.Path, "Could not extract relative path from HTTPS full URL in unsafe mode")
-	require.Contains(t, string(request.UnsafeRawBytes), "GET /api/v1/users HTTP/1.1", "UnsafeRawBytes should contain relative path")
-	require.NotContains(t, string(request.UnsafeRawBytes), "https://secure.example.com", "UnsafeRawBytes should not contain full URL")
+	// Full URL should be preserved in UnsafeRawBytes (fix for #7382)
+	require.Contains(t, string(request.UnsafeRawBytes), "GET https://secure.example.com/api/v1/users HTTP/1.1", "UnsafeRawBytes should preserve full URL")
 }
 
 func TestUnsafeWithFullURLRootPath(t *testing.T) {
 	// Test unsafe mode with full URL pointing to root path
-	// When disable-path-automerge is true and path is /, it becomes empty string (expected behavior)
+	// When a full URL is specified, it should be preserved as-is (fix for #7382)
 	request, err := Parse(`GET http://example.com/ HTTP/1.1
 Host: {{Hostname}}
 Connection: close`, parseURL(t, "http://target.com/api"), true, true)
 	require.Nil(t, err, "could not parse unsafe request with full URL root path")
-	// With disable-path-automerge=true and root path, it becomes empty per existing logic
-	require.Equal(t, "", request.Path, "Root path with disable-path-automerge should be empty")
+	// Path should be extracted from full URL (root path = "/")
+	require.Equal(t, "/", request.Path, "Path should be / from full URL root path")
+	// Full URL should be preserved in UnsafeRawBytes
+	require.Contains(t, string(request.UnsafeRawBytes), "GET http://example.com/ HTTP/1.1", "UnsafeRawBytes should preserve full URL")
 
-	// Test with disable-path-automerge=false
+	// Test with disable-path-automerge=false — full URL still preserved
 	request, err = Parse(`GET http://example.com/ HTTP/1.1
 Host: {{Hostname}}
 Connection: close`, parseURL(t, "http://target.com/api"), true, false)
 	require.Nil(t, err, "could not parse unsafe request with full URL root path and merge")
-	require.Equal(t, "/api", request.Path, "Should merge with target path when automerge enabled")
+	require.Equal(t, "/", request.Path, "Path should remain / from full URL")
 }
 
 func TestSafeWithFullURL(t *testing.T) {


### PR DESCRIPTION
## Description

When using unsafe mode with a full URL in the request line (e.g., `GET http://target/path HTTP/1.1`), the previous code would replace the full URL with just the relative path in `UnsafeRawBytes`. This broke use cases like SSRF testing where the absolute-form request must be preserved.

This PR replaces #7406, which was closed due to being mixed with unrelated changes. This is a clean, minimal fix.

## Changes

- **pkg/protocols/http/raw/raw.go**: Remove the `bytes.Replace` call that truncated full URLs in unsafe mode. Skip path merging when a full URL is detected in unsafe mode, preserving the original request bytes.
- **pkg/protocols/http/raw/raw_test.go**: Update tests to reflect the correct behavior — full URLs are preserved in `UnsafeRawBytes`.

## Related Issues

- Fixes #7382
- Replaces #7406 (clean version)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue in raw HTTP request parsing where absolute URLs were being truncated or rewritten in unsafe mode. The parser now correctly preserves complete URLs, including query strings, when processing raw HTTP requests containing full URLs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectdiscovery/nuclei/pull/7408?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->