### PR TITLE
fix memogen context skip and scope auto-push to upstream

### DIFF
--- a/.github/workflows/memogen.yaml
+++ b/.github/workflows/memogen.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   memogen:
-    if: ${{ !endsWith(github.actor, '[bot]') }}
+    if: ${{ github.repository == 'projectdiscovery/nuclei' && !endsWith(github.actor, '[bot]') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/cmd/memogen/function.tpl
+++ b/cmd/memogen/function.tpl
@@ -11,7 +11,7 @@ import (
 
 {{range .Functions}}
     {{ .SignatureWithPrefix "memoized" }} {
-        hash := "{{ .Name }}" {{range .Params}}{{if ne .Type "&{context Context}"}} + ":" + fmt.Sprint({{.Name}}){{end}}{{end}}
+        hash := "{{ .Name }}" {{range .Params}}{{if ne .Type "context.Context"}} + ":" + fmt.Sprint({{.Name}}){{end}}{{end}}
 
         v, err, _ := protocolstate.Memoizer.Do(hash, func() (interface{}, error) {
             return {{.Name}}({{.ParamsNames}})


### PR DESCRIPTION
## Summary

- The memo template skipped `context.Context` from the hash key via a stale AST-string sentinel (`&{context Context}`). After an upstream `memoize` bump, param types are now rendered as `context.Context`, so the skip stopped matching and `fmt.Sprint(ctx)` ended up in every hash, effectively killing memoization on the JS libs (redis, mysql, mssql, postgres, etc.). Updates the sentinel.
- The `Memoize Functions` workflow runs on any push to a branch named `dev`, including contributor forks where Actions are enabled by default. That had it auto-commit regenerated memo files into external PRs whose head branch happens to be `dev`. Adds a `github.repository == 'projectdiscovery/nuclei'` guard.

## Test plan

- [x] `make memogen` after the template fix produces zero diff against the committed `pkg/js/libs/**/memo.*.go` files on `dev`
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./cmd/memogen/... ./pkg/js/libs/...` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed memoization cache key generation to properly exclude context.Context parameters from the caching mechanism.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectdiscovery/nuclei/pull/7419?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->