### PR TITLE
fix(js): probe SMBv1 support after SMB2 negotiation

### DIFF
--- a/pkg/js/libs/smb/smb.go
+++ b/pkg/js/libs/smb/smb.go
@@ -3,6 +3,7 @@ package smb
 import (
 	"context"
 	"fmt"
+	"net"
 	"time"
 
 	"github.com/praetorian-inc/fingerprintx/pkg/plugins"
@@ -49,7 +50,11 @@ func connectSMBInfoMode(ctx context.Context, executionId string, host string, po
 	if dialer == nil {
 		return nil, fmt.Errorf("dialers not initialized for %s", executionId)
 	}
-	conn, err := dialer.Fastdialer.Dial(ctx, "tcp", fmt.Sprintf("%s:%d", host, port))
+	address := net.JoinHostPort(host, fmt.Sprintf("%d", port))
+	dialSMBInfo := func(ctx context.Context) (net.Conn, error) {
+		return dialer.Fastdialer.Dial(ctx, "tcp", address)
+	}
+	conn, err := dialSMBInfo(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -57,11 +62,12 @@ func connectSMBInfoMode(ctx context.Context, executionId string, host string, po
 	result, err := getSMBInfo(conn, true, false)
 	_ = conn.Close() // close regardless of error
 	if err == nil {
+		updateSMBv1Support(ctx, result, dialSMBInfo)
 		return result, nil
 	}
 
 	// try to negotiate SMBv1
-	conn, err = dialer.Fastdialer.Dial(ctx, "tcp", fmt.Sprintf("%s:%d", host, port))
+	conn, err = dialSMBInfo(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/js/libs/smb/smb_private.go
+++ b/pkg/js/libs/smb/smb_private.go
@@ -12,6 +12,8 @@ import (
 	zgrabsmb "github.com/zmap/zgrab2/lib/smb/smb"
 )
 
+type smbInfoDialFunc func(context.Context) (net.Conn, error)
+
 // ==== private helper functions/methods ====
 
 // collectSMBv2Metadata collects metadata for SMBv2 services.
@@ -52,4 +54,24 @@ func getSMBInfo(conn net.Conn, setupSession, v1 bool) (*zgrabsmb.SMBLog, error) 
 		return nil, err
 	}
 	return result, nil
+}
+
+func updateSMBv1Support(ctx context.Context, result *zgrabsmb.SMBLog, dial smbInfoDialFunc) {
+	if result == nil || result.SupportV1 {
+		return
+	}
+
+	conn, err := dial(ctx)
+	if err != nil {
+		return
+	}
+	defer func() {
+		_ = conn.Close()
+	}()
+
+	v1Result, err := getSMBInfo(conn, false, true)
+	if err != nil || v1Result == nil || !v1Result.SupportV1 {
+		return
+	}
+	result.SupportV1 = true
 }

--- a/pkg/js/libs/smb/smb_test.go
+++ b/pkg/js/libs/smb/smb_test.go
@@ -1,0 +1,87 @@
+package smb
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	zgrabsmb "github.com/zmap/zgrab2/lib/smb/smb"
+)
+
+func TestUpdateSMBv1SupportPreservesNegotiatedSMB2Version(t *testing.T) {
+	version := &zgrabsmb.SMBVersions{
+		Major:     2,
+		Minor:     1,
+		VerString: "SMB 2.1",
+	}
+	result := &zgrabsmb.SMBLog{
+		Version: version,
+	}
+	dial, done := newSMBv1ProbeDialer()
+
+	updateSMBv1Support(context.Background(), result, dial)
+
+	require.True(t, result.SupportV1)
+	require.Same(t, version, result.Version)
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("SMBv1 probe was not performed")
+	}
+}
+
+func TestUpdateSMBv1SupportIgnoresProbeErrors(t *testing.T) {
+	result := &zgrabsmb.SMBLog{}
+
+	updateSMBv1Support(context.Background(), result, func(context.Context) (net.Conn, error) {
+		return nil, errors.New("dial failed")
+	})
+
+	require.False(t, result.SupportV1)
+}
+
+func newSMBv1ProbeDialer() (smbInfoDialFunc, <-chan error) {
+	done := make(chan error, 1)
+	return func(context.Context) (net.Conn, error) {
+		clientConn, serverConn := net.Pipe()
+		go func() {
+			defer close(done)
+			done <- serveSMBv1Probe(serverConn)
+		}()
+		return clientConn, nil
+	}, done
+}
+
+func serveSMBv1Probe(conn net.Conn) error {
+	defer func() {
+		_ = conn.Close()
+	}()
+
+	var requestSize uint32
+	if err := binary.Read(conn, binary.BigEndian, &requestSize); err != nil {
+		return err
+	}
+	request := make([]byte, requestSize)
+	if _, err := io.ReadFull(conn, request); err != nil {
+		return err
+	}
+	if len(request) < 4 {
+		return io.ErrUnexpectedEOF
+	}
+	if string(request[:4]) != zgrabsmb.ProtocolSmb {
+		return errors.New("expected SMBv1 negotiate request")
+	}
+
+	response := []byte(zgrabsmb.ProtocolSmb)
+	if err := binary.Write(conn, binary.BigEndian, uint32(len(response))); err != nil {
+		return err
+	}
+	_, err := conn.Write(response)
+	return err
+}


### PR DESCRIPTION
## Proposed changes

`ConnectSMBInfoMode` only tried SMBv1 when SMB2/3
negotiation failed so dual-stack servers could
report `SupportV1` as false even when SMBv1 was
enabled.

Run a same-target SMBv1 probe after successful
SMB2/3 negotiation and merge the support flag into
the returned log w/o changing the negotiated
SMB2/3 version.

Fixes #4832

### Proof

<!-- How has this been tested? Please describe the tests that you ran to verify your changes. -->

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced SMB protocol negotiation reliability by improving version detection and connection handling.

* **Tests**
  * Added comprehensive test coverage for SMB protocol version support detection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectdiscovery/nuclei/pull/7430?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->