### PR TITLE
[codex] add proxy-server alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ FUZZING:
    -fuzz                               enable loading fuzzing templates (Deprecated: use -dast instead)
    -dast                               enable / run dast (fuzz) nuclei templates
    -dts, -dast-server                  enable dast server mode (live fuzzing)
+   -proxy-server                       alias for -dast-server (live fuzzing)
    -dtr, -dast-report                  write dast scan report to file
    -dtst, -dast-server-token string    dast server token (optional)
    -dtsa, -dast-server-address string  dast server address (default "localhost:9055")

--- a/README_CN.md
+++ b/README_CN.md
@@ -257,6 +257,7 @@ FUZZING:
    -fuzz                               enable loading fuzzing templates (Deprecated: use -dast instead)
    -dast                               enable / run dast (fuzz) nuclei templates
    -dts, -dast-server                  enable dast server mode (live fuzzing)
+   -proxy-server                       alias for -dast-server (live fuzzing)
    -dtr, -dast-report                  write dast scan report to file
    -dtst, -dast-server-token string    dast server token (optional)
    -dtsa, -dast-server-address string  dast server address (default "localhost:9055")

--- a/README_ES.md
+++ b/README_ES.md
@@ -257,6 +257,7 @@ FUZZING:
    -fuzz                               enable loading fuzzing templates (Deprecated: use -dast instead)
    -dast                               enable / run dast (fuzz) nuclei templates
    -dts, -dast-server                  enable dast server mode (live fuzzing)
+   -proxy-server                       alias for -dast-server (live fuzzing)
    -dtr, -dast-report                  write dast scan report to file
    -dtst, -dast-server-token string    dast server token (optional)
    -dtsa, -dast-server-address string  dast server address (default "localhost:9055")

--- a/README_ID.md
+++ b/README_ID.md
@@ -257,6 +257,7 @@ FUZZING:
    -fuzz                               enable loading fuzzing templates (Deprecated: use -dast instead)
    -dast                               enable / run dast (fuzz) nuclei templates
    -dts, -dast-server                  enable dast server mode (live fuzzing)
+   -proxy-server                       alias for -dast-server (live fuzzing)
    -dtr, -dast-report                  write dast scan report to file
    -dtst, -dast-server-token string    dast server token (optional)
    -dtsa, -dast-server-address string  dast server address (default "localhost:9055")

--- a/README_JP.md
+++ b/README_JP.md
@@ -257,6 +257,7 @@ FUZZING:
    -fuzz                               enable loading fuzzing templates (Deprecated: use -dast instead)
    -dast                               enable / run dast (fuzz) nuclei templates
    -dts, -dast-server                  enable dast server mode (live fuzzing)
+   -proxy-server                       alias for -dast-server (live fuzzing)
    -dtr, -dast-report                  write dast scan report to file
    -dtst, -dast-server-token string    dast server token (optional)
    -dtsa, -dast-server-address string  dast server address (default "localhost:9055")

--- a/README_KR.md
+++ b/README_KR.md
@@ -257,6 +257,7 @@ FUZZING:
    -fuzz                               enable loading fuzzing templates (Deprecated: use -dast instead)
    -dast                               enable / run dast (fuzz) nuclei templates
    -dts, -dast-server                  enable dast server mode (live fuzzing)
+   -proxy-server                       alias for -dast-server (live fuzzing)
    -dtr, -dast-report                  write dast scan report to file
    -dtst, -dast-server-token string    dast server token (optional)
    -dtsa, -dast-server-address string  dast server address (default "localhost:9055")

--- a/README_PT-BR.md
+++ b/README_PT-BR.md
@@ -257,6 +257,7 @@ FUZZING:
    -fuzz                               enable loading fuzzing templates (Deprecated: use -dast instead)
    -dast                               enable / run dast (fuzz) nuclei templates
    -dts, -dast-server                  enable dast server mode (live fuzzing)
+   -proxy-server                       alias for -dast-server (live fuzzing)
    -dtr, -dast-report                  write dast scan report to file
    -dtst, -dast-server-token string    dast server token (optional)
    -dtsa, -dast-server-address string  dast server address (default "localhost:9055")

--- a/README_TR.md
+++ b/README_TR.md
@@ -257,6 +257,7 @@ FUZZING:
    -fuzz                               enable loading fuzzing templates (Deprecated: use -dast instead)
    -dast                               enable / run dast (fuzz) nuclei templates
    -dts, -dast-server                  enable dast server mode (live fuzzing)
+   -proxy-server                       alias for -dast-server (live fuzzing)
    -dtr, -dast-report                  write dast scan report to file
    -dtst, -dast-server-token string    dast server token (optional)
    -dtsa, -dast-server-address string  dast server address (default "localhost:9055")

--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -396,6 +396,7 @@ on extensive configurability, massive extensibility and ease of use.`)
 		flagSet.BoolVar(&fuzzFlag, "fuzz", false, "enable loading fuzzing templates (Deprecated: use -dast instead)"),
 		flagSet.BoolVar(&options.DAST, "dast", false, "enable / run dast (fuzz) nuclei templates"),
 		flagSet.BoolVarP(&options.DASTServer, "dast-server", "dts", false, "enable dast server mode (live fuzzing)"),
+		flagSet.BoolVar(&options.ProxyServer, "proxy-server", false, "alias for -dast-server (live fuzzing)"),
 		flagSet.BoolVarP(&options.DASTReport, "dast-report", "dtr", false, "write dast scan report to file"),
 		flagSet.StringVarP(&options.DASTServerToken, "dast-server-token", "dtst", "", "dast server token (optional)"),
 		flagSet.StringVarP(&options.DASTServerAddress, "dast-server-address", "dtsa", "localhost:9055", "dast server address"),

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -166,6 +166,9 @@ func ValidateOptions(options *types.Options) error {
 	if options.ShouldFollowHTTPRedirects() && options.DisableRedirects {
 		return errors.New("both follow redirects and disable redirects specified")
 	}
+	if options.ProxyServer {
+		options.DASTServer = true
+	}
 	// loading the proxy server list from file or cli and test the connectivity
 	if err := loadProxyServers(options); err != nil {
 		return err

--- a/internal/runner/options_test.go
+++ b/internal/runner/options_test.go
@@ -59,3 +59,12 @@ func TestParseHeadlessOptionalArguments(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateOptionsProxyServerAliasesDASTServer(t *testing.T) {
+	options := &types.Options{ProxyServer: true}
+
+	err := ValidateOptions(options)
+
+	require.NoError(t, err)
+	require.True(t, options.DASTServer)
+}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -450,6 +450,8 @@ type Options struct {
 	DAST bool
 	// DASTServer is the flag to start nuclei as a DAST server
 	DASTServer bool
+	// ProxyServer is a user-facing alias for DASTServer.
+	ProxyServer bool
 	// DASTServerToken is the token optional for the dast server
 	DASTServerToken string
 	// DASTServerAddress is the address for the dast server
@@ -688,6 +690,7 @@ func (options *Options) Copy() *Options {
 		ProbeConcurrency:               options.ProbeConcurrency,
 		DAST:                           options.DAST,
 		DASTServer:                     options.DASTServer,
+		ProxyServer:                    options.ProxyServer,
 		DASTServerToken:                options.DASTServerToken,
 		DASTServerAddress:              options.DASTServerAddress,
 		DASTReport:                     options.DASTReport,


### PR DESCRIPTION
/claim #4953

Add a user-facing `--proxy-server` alias for `--dast-server` in nuclei.

What changed:
- added the new CLI flag in `cmd/nuclei/main.go`
- mapped the alias to `DASTServer` during option validation
- copied the new option in `pkg/types.Options.Copy()`
- added a regression test that verifies the alias enables `DASTServer`
- updated the CLI help text across the main and translated README files

Why:
- this matches the feature request in #4953 and lets users opt into the proxy-server input mode without learning a new primary flag

Validation:
- `git diff --check`
- `go test ./internal/runner -run TestValidateOptionsProxyServerAliasesDASTServer -count=1`
- `go test ./cmd/nuclei -run '^$' -count=1`
