### PR TITLE
Feature/local http callback listener 7437

### DIFF
--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -390,6 +390,8 @@ on extensive configurability, massive extensibility and ease of use.`)
 		flagSet.BoolVarP(&options.NoInteractsh, "no-interactsh", "ni", false, "disable interactsh server for OAST testing, exclude OAST based templates"),
 		flagSet.StringVar(&options.LocalCallbackListen, "callback-listen", "", "local HTTP callback listen address for offline OAST testing (host:port)"),
 		flagSet.StringVar(&options.LocalCallbackURL, "callback-url", "", "externally reachable local HTTP callback URL for offline OAST testing"),
+		flagSet.StringVar(&options.LocalCallbackInterface, "callback-interface", "", "network interface to use for local HTTP callback listener"),
+		flagSet.IntVar(&options.LocalCallbackPort, "callback-port", 0, "local HTTP callback port when using -callback-interface (default random)"),
 	)
 
 	flagSet.CreateGroup("fuzzing", "Fuzzing",

--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -388,6 +388,8 @@ on extensive configurability, massive extensibility and ease of use.`)
 		flagSet.IntVar(&options.InteractionsPollDuration, "interactions-poll-duration", 5, "number of seconds to wait before each interaction poll request"),
 		flagSet.IntVar(&options.InteractionsCoolDownPeriod, "interactions-cooldown-period", 5, "extra time for interaction polling before exiting"),
 		flagSet.BoolVarP(&options.NoInteractsh, "no-interactsh", "ni", false, "disable interactsh server for OAST testing, exclude OAST based templates"),
+		flagSet.StringVar(&options.LocalCallbackListen, "callback-listen", "", "local HTTP callback listen address for offline OAST testing (host:port)"),
+		flagSet.StringVar(&options.LocalCallbackURL, "callback-url", "", "externally reachable local HTTP callback URL for offline OAST testing"),
 	)
 
 	flagSet.CreateGroup("fuzzing", "Fuzzing",

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -373,6 +373,8 @@ func New(options *types.Options) (*Runner, error) {
 	opts.CooldownPeriod = time.Duration(options.InteractionsCoolDownPeriod) * time.Second
 	opts.PollDuration = time.Duration(options.InteractionsPollDuration) * time.Second
 	opts.NoInteractsh = runner.options.NoInteractsh
+	opts.LocalCallbackListen = runner.options.LocalCallbackListen
+	opts.LocalCallbackURL = runner.options.LocalCallbackURL
 	opts.StopAtFirstMatch = runner.options.StopAtFirstMatch
 	opts.Debug = runner.options.Debug
 	opts.DebugRequest = runner.options.DebugRequests

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -375,6 +375,8 @@ func New(options *types.Options) (*Runner, error) {
 	opts.NoInteractsh = runner.options.NoInteractsh
 	opts.LocalCallbackListen = runner.options.LocalCallbackListen
 	opts.LocalCallbackURL = runner.options.LocalCallbackURL
+	opts.LocalCallbackInterface = runner.options.LocalCallbackInterface
+	opts.LocalCallbackPort = runner.options.LocalCallbackPort
 	opts.StopAtFirstMatch = runner.options.StopAtFirstMatch
 	opts.Debug = runner.options.Debug
 	opts.DebugRequest = runner.options.DebugRequests

--- a/pkg/protocols/common/interactsh/interactsh.go
+++ b/pkg/protocols/common/interactsh/interactsh.go
@@ -132,14 +132,15 @@ func (c *Client) handleInteraction(interaction *server.Interaction) {
 	if strings.EqualFold(os.Getenv("GITHUB_ACTIONS"), "true") && c.options.Debug {
 		gologger.DefaultLogger.Print().Msgf("[Interactsh]: got interaction of %v for request %v and error %v", interaction, request, err)
 	}
+	interactions := c.interactionVariants(interaction)
 	if errors.Is(err, gcache.KeyNotFoundError) || request == nil {
 		// If we don't have any request for this ID, add it to temporary
 		// lru cache, so we can correlate when we get an add request.
 		items, err := c.interactions.Get(interaction.UniqueID)
 		if errkit.Is(err, gcache.KeyNotFoundError) || items == nil {
-			_ = c.interactions.SetWithExpire(interaction.UniqueID, []*server.Interaction{interaction}, defaultInteractionDuration)
+			_ = c.interactions.SetWithExpire(interaction.UniqueID, interactions, defaultInteractionDuration)
 		} else {
-			items = append(items, interaction)
+			items = append(items, interactions...)
 			_ = c.interactions.SetWithExpire(interaction.UniqueID, items, defaultInteractionDuration)
 		}
 		return
@@ -151,7 +152,20 @@ func (c *Client) handleInteraction(interaction *server.Interaction) {
 		}
 	}
 
-	_ = c.processInteractionForRequest(interaction, request)
+	for _, current := range interactions {
+		if c.processInteractionForRequest(current, request) {
+			return
+		}
+	}
+}
+
+func (c *Client) interactionVariants(interaction *server.Interaction) []*server.Interaction {
+	if c.localCallback == nil || !strings.EqualFold(interaction.Protocol, "http") {
+		return []*server.Interaction{interaction}
+	}
+	dnsInteraction := *interaction
+	dnsInteraction.Protocol = "dns"
+	return []*server.Interaction{interaction, &dnsInteraction}
 }
 
 // requestShouldStopAtFirstmatch checks if further interactions should be stopped

--- a/pkg/protocols/common/interactsh/interactsh.go
+++ b/pkg/protocols/common/interactsh/interactsh.go
@@ -82,8 +82,13 @@ func (c *Client) poll() error {
 		// do not init if disabled
 		return ErrInteractshClientNotInitialized
 	}
-	if c.options.LocalCallbackListen != "" || c.options.LocalCallbackURL != "" {
-		localCallback, err := newLocalCallbackServer(c.options.LocalCallbackListen, c.options.LocalCallbackURL, c.handleInteraction)
+	if c.options.LocalCallbackListen != "" || c.options.LocalCallbackURL != "" || c.options.LocalCallbackInterface != "" {
+		localCallback, err := newLocalCallbackServer(localCallbackOptions{
+			listenAddress: c.options.LocalCallbackListen,
+			callbackURL:   c.options.LocalCallbackURL,
+			interfaceName: c.options.LocalCallbackInterface,
+			port:          c.options.LocalCallbackPort,
+		}, c.handleInteraction)
 		if err != nil {
 			return errkit.Wrap(err, "could not create local callback server")
 		}

--- a/pkg/protocols/common/interactsh/interactsh.go
+++ b/pkg/protocols/common/interactsh/interactsh.go
@@ -35,6 +35,8 @@ type Client struct {
 
 	// interactsh is a client for interactsh server.
 	interactsh *client.Client
+	// localCallback is a local HTTP callback server for offline OAST testing.
+	localCallback *localCallbackServer
 	// requests is a stored cache for interactsh-url->request-event data.
 	requests gcache.Cache[string, *RequestData]
 	// interactions is a stored cache for interactsh-interaction->interactsh-url data
@@ -80,6 +82,18 @@ func (c *Client) poll() error {
 		// do not init if disabled
 		return ErrInteractshClientNotInitialized
 	}
+	if c.options.LocalCallbackListen != "" || c.options.LocalCallbackURL != "" {
+		localCallback, err := newLocalCallbackServer(c.options.LocalCallbackListen, c.options.LocalCallbackURL, c.handleInteraction)
+		if err != nil {
+			return errkit.Wrap(err, "could not create local callback server")
+		}
+		c.localCallback = localCallback
+		c.setHostname(localCallback.hostname())
+		gologger.Info().Msgf("Using local HTTP callback listener: %s", localCallback.hostname())
+		go localCallback.start()
+		return nil
+	}
+
 	interactsh, err := client.New(&client.Options{
 		ServerURL:           c.options.ServerURL,
 		Token:               c.options.Authorization,
@@ -99,38 +113,40 @@ func (c *Client) poll() error {
 
 	c.setHostname(interactDomain)
 
-	err = interactsh.StartPolling(c.pollDuration, func(interaction *server.Interaction) {
-		request, err := c.requests.Get(interaction.UniqueID)
-		// for more context in github actions
-		if strings.EqualFold(os.Getenv("GITHUB_ACTIONS"), "true") && c.options.Debug {
-			gologger.DefaultLogger.Print().Msgf("[Interactsh]: got interaction of %v for request %v and error %v", interaction, request, err)
-		}
-		if errors.Is(err, gcache.KeyNotFoundError) || request == nil {
-			// If we don't have any request for this ID, add it to temporary
-			// lru cache, so we can correlate when we get an add request.
-			items, err := c.interactions.Get(interaction.UniqueID)
-			if errkit.Is(err, gcache.KeyNotFoundError) || items == nil {
-				_ = c.interactions.SetWithExpire(interaction.UniqueID, []*server.Interaction{interaction}, defaultInteractionDuration)
-			} else {
-				items = append(items, interaction)
-				_ = c.interactions.SetWithExpire(interaction.UniqueID, items, defaultInteractionDuration)
-			}
-			return
-		}
-
-		if requestShouldStopAtFirstMatch(request) || c.options.StopAtFirstMatch {
-			if gotItem, err := c.matchedTemplates.Get(eventHash(request.Event)); gotItem && err == nil {
-				return
-			}
-		}
-
-		_ = c.processInteractionForRequest(interaction, request)
-	})
+	err = interactsh.StartPolling(c.pollDuration, c.handleInteraction)
 
 	if err != nil {
 		return errkit.Wrap(err, "could not perform interactsh polling")
 	}
 	return nil
+}
+
+func (c *Client) handleInteraction(interaction *server.Interaction) {
+	request, err := c.requests.Get(interaction.UniqueID)
+	// for more context in github actions
+	if strings.EqualFold(os.Getenv("GITHUB_ACTIONS"), "true") && c.options.Debug {
+		gologger.DefaultLogger.Print().Msgf("[Interactsh]: got interaction of %v for request %v and error %v", interaction, request, err)
+	}
+	if errors.Is(err, gcache.KeyNotFoundError) || request == nil {
+		// If we don't have any request for this ID, add it to temporary
+		// lru cache, so we can correlate when we get an add request.
+		items, err := c.interactions.Get(interaction.UniqueID)
+		if errkit.Is(err, gcache.KeyNotFoundError) || items == nil {
+			_ = c.interactions.SetWithExpire(interaction.UniqueID, []*server.Interaction{interaction}, defaultInteractionDuration)
+		} else {
+			items = append(items, interaction)
+			_ = c.interactions.SetWithExpire(interaction.UniqueID, items, defaultInteractionDuration)
+		}
+		return
+	}
+
+	if requestShouldStopAtFirstMatch(request) || c.options.StopAtFirstMatch {
+		if gotItem, err := c.matchedTemplates.Get(eventHash(request.Event)); gotItem && err == nil {
+			return
+		}
+	}
+
+	_ = c.processInteractionForRequest(interaction, request)
 }
 
 // requestShouldStopAtFirstmatch checks if further interactions should be stopped
@@ -248,11 +264,14 @@ func (c *Client) URL() (string, error) {
 		return "", errkit.Wrap(ErrInteractshClientNotInitialized, err.Error())
 	}
 
-	if c.interactsh == nil {
+	if c.localCallback == nil && c.interactsh == nil {
 		return "", ErrInteractshClientNotInitialized
 	}
 
 	c.generated.Store(true)
+	if c.localCallback != nil {
+		return c.localCallback.newURL()
+	}
 	return c.interactsh.URL(), nil
 }
 
@@ -264,6 +283,9 @@ func (c *Client) Close() bool {
 	if c.interactsh != nil {
 		_ = c.interactsh.StopPolling()
 		_ = c.interactsh.Close()
+	}
+	if c.localCallback != nil {
+		c.localCallback.close()
 	}
 
 	c.requests.Purge()
@@ -316,11 +338,11 @@ func (c *Client) MakePlaceholders(urls []string, data map[string]interface{}) {
 			c.interactshURLs.Remove(url)
 
 			data[interactshMarker] = url
-			urlIndex := strings.Index(url, ".")
-			if urlIndex == -1 {
+			id := c.interactionIDFromURL(url)
+			if id == "" {
 				continue
 			}
-			data[strings.Replace(interactshMarker, "url", "id", 1)] = url[:urlIndex]
+			data[strings.Replace(interactshMarker, "url", "id", 1)] = id
 		}
 	}
 }
@@ -343,7 +365,7 @@ type RequestData struct {
 // RequestEvent is the event for a network request sent by nuclei.
 func (c *Client) RequestEvent(interactshURLs []string, data *RequestData) {
 	for _, interactshURL := range interactshURLs {
-		id := strings.TrimRight(strings.TrimSuffix(interactshURL, c.getHostname()), ".")
+		id := c.interactionIDFromURL(interactshURL)
 
 		if requestShouldStopAtFirstMatch(data) || c.options.StopAtFirstMatch {
 			gotItem, err := c.matchedTemplates.Get(eventHash(data.Event))
@@ -364,6 +386,13 @@ func (c *Client) RequestEvent(interactshURLs []string, data *RequestData) {
 			_ = c.requests.SetWithExpire(id, data, c.eviction)
 		}
 	}
+}
+
+func (c *Client) interactionIDFromURL(interactshURL string) string {
+	if c.localCallback != nil {
+		return c.localCallback.idFromURL(interactshURL)
+	}
+	return strings.TrimRight(strings.TrimSuffix(interactshURL, c.getHostname()), ".")
 }
 
 // HasMatchers returns true if an operator has interactsh part

--- a/pkg/protocols/common/interactsh/local_callback.go
+++ b/pkg/protocols/common/interactsh/local_callback.go
@@ -1,0 +1,195 @@
+package interactsh
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/projectdiscovery/interactsh/pkg/server"
+)
+
+const localCallbackMaxBody = 1024 * 1024
+
+type localCallbackServer struct {
+	callbackBase  *url.URL
+	httpServer    *http.Server
+	listener      net.Listener
+	onInteraction func(*server.Interaction)
+}
+
+func newLocalCallbackServer(listenAddress, callbackURL string, onInteraction func(*server.Interaction)) (*localCallbackServer, error) {
+	if listenAddress == "" && callbackURL == "" {
+		return nil, fmt.Errorf("local callback listen address or URL is required")
+	}
+	if listenAddress == "" {
+		parsed, err := parseCallbackURL(callbackURL)
+		if err != nil {
+			return nil, err
+		}
+		listenAddress = parsed.Host
+	}
+
+	listener, err := net.Listen("tcp", listenAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	callbackBase, err := callbackURLForListener(callbackURL, listener.Addr().String())
+	if err != nil {
+		_ = listener.Close()
+		return nil, err
+	}
+
+	server := &localCallbackServer{
+		callbackBase:  callbackBase,
+		listener:      listener,
+		onInteraction: onInteraction,
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", server.handle)
+	server.httpServer = &http.Server{
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	return server, nil
+}
+
+func parseCallbackURL(callbackURL string) (*url.URL, error) {
+	if !strings.Contains(callbackURL, "://") {
+		callbackURL = "http://" + callbackURL
+	}
+	parsed, err := url.Parse(callbackURL)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse callback URL: %w", err)
+	}
+	if parsed.Host == "" {
+		return nil, fmt.Errorf("callback URL must include a host")
+	}
+	return parsed, nil
+}
+
+func callbackURLForListener(callbackURL, listenAddress string) (*url.URL, error) {
+	if callbackURL != "" {
+		return parseCallbackURL(callbackURL)
+	}
+
+	host, port, err := net.SplitHostPort(listenAddress)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse callback listen address: %w", err)
+	}
+	if host == "" || host == "::" || host == "0.0.0.0" {
+		host = "127.0.0.1"
+	}
+	return &url.URL{Scheme: "http", Host: net.JoinHostPort(host, port)}, nil
+}
+
+func (s *localCallbackServer) start() {
+	_ = s.httpServer.Serve(s.listener)
+}
+
+func (s *localCallbackServer) close() {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_ = s.httpServer.Shutdown(ctx)
+}
+
+func (s *localCallbackServer) hostname() string {
+	return s.callbackBase.Host
+}
+
+func (s *localCallbackServer) newURL() (string, error) {
+	id, err := newLocalCallbackID()
+	if err != nil {
+		return "", err
+	}
+	callback := *s.callbackBase
+	basePath := strings.TrimRight(callback.Path, "/")
+	callback.Path = basePath + "/" + id
+	callback.RawPath = ""
+	return strings.TrimPrefix(callback.String(), callback.Scheme+"://"), nil
+}
+
+func (s *localCallbackServer) idFromURL(callbackURL string) string {
+	parsed, err := parseCallbackURL(callbackURL)
+	if err != nil {
+		return ""
+	}
+	return s.idFromPath(parsed.EscapedPath())
+}
+
+func (s *localCallbackServer) idFromPath(path string) string {
+	basePath := strings.Trim(s.callbackBase.EscapedPath(), "/")
+	path = strings.Trim(path, "/")
+	if basePath != "" {
+		path = strings.TrimPrefix(path, basePath)
+		path = strings.Trim(path, "/")
+	}
+	if path == "" {
+		return ""
+	}
+	return strings.Split(path, "/")[0]
+}
+
+func (s *localCallbackServer) handle(w http.ResponseWriter, request *http.Request) {
+	uniqueID := s.idFromPath(request.URL.EscapedPath())
+	if uniqueID == "" {
+		uniqueID = s.idFromPath(request.URL.Path)
+	}
+
+	rawRequest := dumpHTTPRequest(request)
+	responseBody := []byte("ok\n")
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(responseBody)
+	if uniqueID == "" {
+		return
+	}
+
+	remoteAddress := request.RemoteAddr
+	if host, _, err := net.SplitHostPort(request.RemoteAddr); err == nil {
+		remoteAddress = host
+	}
+	s.onInteraction(&server.Interaction{
+		Protocol:      "http",
+		UniqueID:      uniqueID,
+		FullId:        request.Host + request.URL.EscapedPath(),
+		RawRequest:    rawRequest,
+		RawResponse:   "HTTP/1.1 200 OK\r\nContent-Type: text/plain; charset=utf-8\r\n\r\n" + string(responseBody),
+		RemoteAddress: remoteAddress,
+		Timestamp:     time.Now(),
+	})
+}
+
+func dumpHTTPRequest(request *http.Request) string {
+	var builder bytes.Buffer
+	fmt.Fprintf(&builder, "%s %s %s\r\n", request.Method, request.URL.RequestURI(), request.Proto)
+	fmt.Fprintf(&builder, "Host: %s\r\n", request.Host)
+	for key, values := range request.Header {
+		for _, value := range values {
+			fmt.Fprintf(&builder, "%s: %s\r\n", key, value)
+		}
+	}
+	builder.WriteString("\r\n")
+	if request.Body != nil {
+		body, _ := io.ReadAll(io.LimitReader(request.Body, localCallbackMaxBody))
+		builder.Write(body)
+	}
+	return builder.String()
+}
+
+func newLocalCallbackID() (string, error) {
+	var data [16]byte
+	if _, err := rand.Read(data[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(data[:]), nil
+}

--- a/pkg/protocols/common/interactsh/local_callback.go
+++ b/pkg/protocols/common/interactsh/local_callback.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -18,6 +19,13 @@ import (
 
 const localCallbackMaxBody = 1024 * 1024
 
+type localCallbackOptions struct {
+	listenAddress string
+	callbackURL   string
+	interfaceName string
+	port          int
+}
+
 type localCallbackServer struct {
 	callbackBase  *url.URL
 	httpServer    *http.Server
@@ -25,24 +33,31 @@ type localCallbackServer struct {
 	onInteraction func(*server.Interaction)
 }
 
-func newLocalCallbackServer(listenAddress, callbackURL string, onInteraction func(*server.Interaction)) (*localCallbackServer, error) {
-	if listenAddress == "" && callbackURL == "" {
-		return nil, fmt.Errorf("local callback listen address or URL is required")
+func newLocalCallbackServer(options localCallbackOptions, onInteraction func(*server.Interaction)) (*localCallbackServer, error) {
+	if options.listenAddress == "" && options.callbackURL == "" && options.interfaceName == "" {
+		return nil, fmt.Errorf("local callback listen address, URL, or interface is required")
 	}
-	if listenAddress == "" {
-		parsed, err := parseCallbackURL(callbackURL)
+	if options.listenAddress == "" && options.interfaceName != "" {
+		listenAddress, err := listenAddressFromInterface(options.interfaceName, options.port)
 		if err != nil {
 			return nil, err
 		}
-		listenAddress = parsed.Host
+		options.listenAddress = listenAddress
+	}
+	if options.listenAddress == "" {
+		parsed, err := parseCallbackURL(options.callbackURL)
+		if err != nil {
+			return nil, err
+		}
+		options.listenAddress = parsed.Host
 	}
 
-	listener, err := net.Listen("tcp", listenAddress)
+	listener, err := net.Listen("tcp", options.listenAddress)
 	if err != nil {
 		return nil, err
 	}
 
-	callbackBase, err := callbackURLForListener(callbackURL, listener.Addr().String())
+	callbackBase, err := callbackURLForListener(options.callbackURL, listener.Addr().String())
 	if err != nil {
 		_ = listener.Close()
 		return nil, err
@@ -61,6 +76,49 @@ func newLocalCallbackServer(listenAddress, callbackURL string, onInteraction fun
 		ReadHeaderTimeout: 10 * time.Second,
 	}
 	return server, nil
+}
+
+func listenAddressFromInterface(interfaceName string, port int) (string, error) {
+	if port < 0 || port > 65535 {
+		return "", fmt.Errorf("callback port must be between 0 and 65535")
+	}
+	iface, err := net.InterfaceByName(interfaceName)
+	if err != nil {
+		return "", fmt.Errorf("could not find callback interface %q: %w", interfaceName, err)
+	}
+	addrs, err := iface.Addrs()
+	if err != nil {
+		return "", fmt.Errorf("could not get addresses for callback interface %q: %w", interfaceName, err)
+	}
+
+	var firstIPv6 net.IP
+	for _, addr := range addrs {
+		ip := ipFromInterfaceAddress(addr)
+		if ip == nil || ip.IsUnspecified() {
+			continue
+		}
+		if ipv4 := ip.To4(); ipv4 != nil {
+			return net.JoinHostPort(ipv4.String(), strconv.Itoa(port)), nil
+		}
+		if firstIPv6 == nil {
+			firstIPv6 = ip
+		}
+	}
+	if firstIPv6 != nil {
+		return net.JoinHostPort(firstIPv6.String(), strconv.Itoa(port)), nil
+	}
+	return "", fmt.Errorf("could not find a usable IP address for callback interface %q", interfaceName)
+}
+
+func ipFromInterfaceAddress(addr net.Addr) net.IP {
+	switch typed := addr.(type) {
+	case *net.IPNet:
+		return typed.IP
+	case *net.IPAddr:
+		return typed.IP
+	default:
+		return nil
+	}
 }
 
 func parseCallbackURL(callbackURL string) (*url.URL, error) {

--- a/pkg/protocols/common/interactsh/local_callback_test.go
+++ b/pkg/protocols/common/interactsh/local_callback_test.go
@@ -1,0 +1,90 @@
+package interactsh
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLocalCallbackReceivesHTTPInteraction(t *testing.T) {
+	client := newLocalCallbackTestClient(t, "", "")
+
+	generatedURL, err := client.NewURLWithData("{{interactsh-url}}")
+	require.NoError(t, err)
+	require.NotContains(t, generatedURL, "://")
+
+	id := client.interactionIDFromURL(generatedURL)
+	require.Len(t, id, 32)
+
+	httpClient := &http.Client{Timeout: 2 * time.Second}
+	request, err := http.NewRequest(http.MethodPost, "http://"+generatedURL+"?source=test", strings.NewReader("local-callback-body"))
+	require.NoError(t, err)
+	request.Header.Set("X-Nuclei-Test", "local-callback")
+
+	response, err := httpClient.Do(request)
+	require.NoError(t, err)
+	defer response.Body.Close()
+	_, _ = io.Copy(io.Discard, response.Body)
+	require.Equal(t, http.StatusOK, response.StatusCode)
+
+	require.Eventually(t, func() bool {
+		interactions, err := client.interactions.Get(id)
+		if err != nil || len(interactions) != 1 {
+			return false
+		}
+		interaction := interactions[0]
+		return interaction.Protocol == "http" &&
+			interaction.UniqueID == id &&
+			interaction.RemoteAddress != "" &&
+			strings.Contains(interaction.RawRequest, "POST /"+id+"?source=test HTTP/1.1") &&
+			strings.Contains(interaction.RawRequest, "X-Nuclei-Test: local-callback") &&
+			strings.Contains(interaction.RawRequest, "local-callback-body") &&
+			strings.Contains(interaction.RawResponse, "HTTP/1.1 200 OK")
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestLocalCallbackMakePlaceholdersUsesPathID(t *testing.T) {
+	client := newLocalCallbackTestClient(t, "", "")
+
+	generatedURL, err := client.NewURLWithData("{{interactsh-url}}")
+	require.NoError(t, err)
+
+	data := map[string]interface{}{}
+	client.MakePlaceholders([]string{generatedURL}, data)
+
+	require.Equal(t, generatedURL, data["interactsh-url"])
+	require.Equal(t, client.interactionIDFromURL(generatedURL), data["interactsh-id"])
+	require.Equal(t, client.localCallback.hostname(), data["interactsh-server"])
+}
+
+func TestParseCallbackURLSupportsSchemeLessHostPort(t *testing.T) {
+	parsed, err := parseCallbackURL("10.10.14.251:8080/callback")
+	require.NoError(t, err)
+	require.Equal(t, "http", parsed.Scheme)
+	require.Equal(t, "10.10.14.251:8080", parsed.Host)
+	require.Equal(t, "/callback", parsed.Path)
+}
+
+func newLocalCallbackTestClient(t *testing.T, listenAddress, callbackURL string) *Client {
+	t.Helper()
+	if listenAddress == "" {
+		listenAddress = "127.0.0.1:0"
+	}
+	client, err := New(&Options{
+		CacheSize:           10,
+		Eviction:            time.Second,
+		CooldownPeriod:      0,
+		PollDuration:        10 * time.Millisecond,
+		LocalCallbackListen: listenAddress,
+		LocalCallbackURL:    callbackURL,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		client.Close()
+	})
+	return client
+}

--- a/pkg/protocols/common/interactsh/local_callback_test.go
+++ b/pkg/protocols/common/interactsh/local_callback_test.go
@@ -2,6 +2,7 @@ package interactsh
 
 import (
 	"io"
+	"net"
 	"net/http"
 	"strings"
 	"testing"
@@ -61,6 +62,33 @@ func TestLocalCallbackMakePlaceholdersUsesPathID(t *testing.T) {
 	require.Equal(t, client.localCallback.hostname(), data["interactsh-server"])
 }
 
+func TestLocalCallbackInterfaceChoosesPort(t *testing.T) {
+	interfaceName := localCallbackTestInterface(t)
+	client := newLocalCallbackTestClientWithInterface(t, interfaceName, 0)
+
+	generatedURL, err := client.NewURLWithData("{{interactsh-url}}")
+	require.NoError(t, err)
+
+	parsed, err := parseCallbackURL(generatedURL)
+	require.NoError(t, err)
+	_, port, err := net.SplitHostPort(parsed.Host)
+	require.NoError(t, err)
+	require.NotEmpty(t, port)
+	require.NotEqual(t, "0", port)
+
+	id := client.interactionIDFromURL(generatedURL)
+	response, err := http.Get("http://" + generatedURL)
+	require.NoError(t, err)
+	defer response.Body.Close()
+	_, _ = io.Copy(io.Discard, response.Body)
+	require.Equal(t, http.StatusOK, response.StatusCode)
+
+	require.Eventually(t, func() bool {
+		interactions, err := client.interactions.Get(id)
+		return err == nil && len(interactions) == 1 && interactions[0].Protocol == "http"
+	}, time.Second, 10*time.Millisecond)
+}
+
 func TestParseCallbackURLSupportsSchemeLessHostPort(t *testing.T) {
 	parsed, err := parseCallbackURL("10.10.14.251:8080/callback")
 	require.NoError(t, err)
@@ -71,20 +99,68 @@ func TestParseCallbackURLSupportsSchemeLessHostPort(t *testing.T) {
 
 func newLocalCallbackTestClient(t *testing.T, listenAddress, callbackURL string) *Client {
 	t.Helper()
+	return newLocalCallbackTestClientWithOptions(t, listenAddress, callbackURL, "", 0)
+}
+
+func newLocalCallbackTestClientWithInterface(t *testing.T, interfaceName string, port int) *Client {
+	t.Helper()
+	return newLocalCallbackTestClientWithOptions(t, "", "", interfaceName, port)
+}
+
+func newLocalCallbackTestClientWithOptions(t *testing.T, listenAddress, callbackURL, interfaceName string, port int) *Client {
+	t.Helper()
 	if listenAddress == "" {
-		listenAddress = "127.0.0.1:0"
+		if callbackURL == "" && interfaceName == "" {
+			listenAddress = "127.0.0.1:0"
+		}
 	}
 	client, err := New(&Options{
-		CacheSize:           10,
-		Eviction:            time.Second,
-		CooldownPeriod:      0,
-		PollDuration:        10 * time.Millisecond,
-		LocalCallbackListen: listenAddress,
-		LocalCallbackURL:    callbackURL,
+		CacheSize:              10,
+		Eviction:               time.Second,
+		CooldownPeriod:         0,
+		PollDuration:           10 * time.Millisecond,
+		LocalCallbackListen:    listenAddress,
+		LocalCallbackURL:       callbackURL,
+		LocalCallbackInterface: interfaceName,
+		LocalCallbackPort:      port,
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		client.Close()
 	})
 	return client
+}
+
+func localCallbackTestInterface(t *testing.T) string {
+	t.Helper()
+	for _, name := range []string{"lo", "lo0"} {
+		iface, err := net.InterfaceByName(name)
+		if err == nil && interfaceHasIPv4Address(t, iface) {
+			return iface.Name
+		}
+	}
+	ifaces, err := net.Interfaces()
+	require.NoError(t, err)
+	for _, iface := range ifaces {
+		if interfaceHasIPv4Address(t, &iface) {
+			return iface.Name
+		}
+	}
+	t.Skip("no interface with an IPv4 address available")
+	return ""
+}
+
+func interfaceHasIPv4Address(t *testing.T, iface *net.Interface) bool {
+	t.Helper()
+	addrs, err := iface.Addrs()
+	if err != nil {
+		return false
+	}
+	for _, addr := range addrs {
+		ip := ipFromInterfaceAddress(addr)
+		if ip != nil && ip.To4() != nil && !ip.IsUnspecified() {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/protocols/common/interactsh/local_callback_test.go
+++ b/pkg/protocols/common/interactsh/local_callback_test.go
@@ -8,6 +8,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/projectdiscovery/nuclei/v3/pkg/operators"
+	"github.com/projectdiscovery/nuclei/v3/pkg/operators/extractors"
+	"github.com/projectdiscovery/nuclei/v3/pkg/operators/matchers"
+	"github.com/projectdiscovery/nuclei/v3/pkg/output"
 	"github.com/stretchr/testify/require"
 )
 
@@ -34,17 +38,21 @@ func TestLocalCallbackReceivesHTTPInteraction(t *testing.T) {
 
 	require.Eventually(t, func() bool {
 		interactions, err := client.interactions.Get(id)
-		if err != nil || len(interactions) != 1 {
+		if err != nil {
 			return false
 		}
-		interaction := interactions[0]
-		return interaction.Protocol == "http" &&
-			interaction.UniqueID == id &&
-			interaction.RemoteAddress != "" &&
-			strings.Contains(interaction.RawRequest, "POST /"+id+"?source=test HTTP/1.1") &&
-			strings.Contains(interaction.RawRequest, "X-Nuclei-Test: local-callback") &&
-			strings.Contains(interaction.RawRequest, "local-callback-body") &&
-			strings.Contains(interaction.RawResponse, "HTTP/1.1 200 OK")
+		for _, interaction := range interactions {
+			if interaction.Protocol == "http" &&
+				interaction.UniqueID == id &&
+				interaction.RemoteAddress != "" &&
+				strings.Contains(interaction.RawRequest, "POST /"+id+"?source=test HTTP/1.1") &&
+				strings.Contains(interaction.RawRequest, "X-Nuclei-Test: local-callback") &&
+				strings.Contains(interaction.RawRequest, "local-callback-body") &&
+				strings.Contains(interaction.RawResponse, "HTTP/1.1 200 OK") {
+				return true
+			}
+		}
+		return false
 	}, time.Second, 10*time.Millisecond)
 }
 
@@ -85,7 +93,61 @@ func TestLocalCallbackInterfaceChoosesPort(t *testing.T) {
 
 	require.Eventually(t, func() bool {
 		interactions, err := client.interactions.Get(id)
-		return err == nil && len(interactions) == 1 && interactions[0].Protocol == "http"
+		if err != nil {
+			return false
+		}
+		for _, interaction := range interactions {
+			if interaction.Protocol == "http" {
+				return true
+			}
+		}
+		return false
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestLocalCallbackHTTPInteractionSatisfiesDNSMatcher(t *testing.T) {
+	client := newLocalCallbackTestClient(t, "", "")
+
+	generatedURL, err := client.NewURLWithData("{{interactsh-url}}")
+	require.NoError(t, err)
+
+	operator := &operators.Operators{
+		Matchers: []*matchers.Matcher{{
+			Type: matchers.MatcherTypeHolder{MatcherType: matchers.DSLMatcher},
+			DSL:  []string{`interactsh_protocol == "dns"`},
+		}},
+		MatchersCondition: "and",
+	}
+	require.NoError(t, operator.Compile())
+
+	requestData := &RequestData{
+		Event: &output.InternalWrappedEvent{InternalEvent: output.InternalEvent{
+			templateIdAttribute: "local-callback-dns-compatible-test",
+		}},
+		Operators: operator,
+		MatchFunc: func(data map[string]interface{}, matcher *matchers.Matcher) (bool, []string) {
+			return matcher.Result(matcher.MatchDSL(data)), []string{}
+		},
+		ExtractFunc: func(map[string]interface{}, *extractors.Extractor) map[string]struct{} {
+			return nil
+		},
+		MakeResultFunc: func(*output.InternalWrappedEvent) []*output.ResultEvent {
+			return nil
+		},
+	}
+	client.RequestEvent([]string{generatedURL}, requestData)
+
+	response, err := http.Get("http://" + generatedURL)
+	require.NoError(t, err)
+	defer response.Body.Close()
+	_, _ = io.Copy(io.Discard, response.Body)
+	require.Equal(t, http.StatusOK, response.StatusCode)
+
+	require.Eventually(t, func() bool {
+		requestData.Event.RLock()
+		defer requestData.Event.RUnlock()
+		return requestData.Event.OperatorsResult != nil &&
+			requestData.Event.InternalEvent["interactsh_protocol"] == "dns"
 	}, time.Second, 10*time.Millisecond)
 }
 

--- a/pkg/protocols/common/interactsh/options.go
+++ b/pkg/protocols/common/interactsh/options.go
@@ -49,6 +49,10 @@ type Options struct {
 	LocalCallbackListen string
 	// LocalCallbackURL is the externally reachable local HTTP callback URL.
 	LocalCallbackURL string
+	// LocalCallbackInterface is the network interface for the local HTTP callback listener.
+	LocalCallbackInterface string
+	// LocalCallbackPort is the local HTTP callback listener port when using LocalCallbackInterface.
+	LocalCallbackPort int
 	// NoColor disables printing colors for matches
 	NoColor bool
 	// Logger is the shared logging instance

--- a/pkg/protocols/common/interactsh/options.go
+++ b/pkg/protocols/common/interactsh/options.go
@@ -45,6 +45,10 @@ type Options struct {
 	DisableHttpFallback bool
 	// NoInteractsh disables the engine
 	NoInteractsh bool
+	// LocalCallbackListen is the local HTTP callback listen address.
+	LocalCallbackListen string
+	// LocalCallbackURL is the externally reachable local HTTP callback URL.
+	LocalCallbackURL string
 	// NoColor disables printing colors for matches
 	NoColor bool
 	// Logger is the shared logging instance

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -86,6 +86,10 @@ type Options struct {
 	InteractshURL string
 	// Interactsh Authorization header value for self-hosted servers
 	InteractshToken string
+	// LocalCallbackListen is the local HTTP callback listen address for offline OAST testing.
+	LocalCallbackListen string
+	// LocalCallbackURL is the externally reachable local HTTP callback URL for offline OAST testing.
+	LocalCallbackURL string
 	// Target URLs/Domains to scan using a template
 	Targets goflags.StringSlice
 	// ExcludeTargets URLs/Domains to exclude from scanning
@@ -513,6 +517,8 @@ func (options *Options) Copy() *Options {
 		ProjectPath:                    options.ProjectPath,
 		InteractshURL:                  options.InteractshURL,
 		InteractshToken:                options.InteractshToken,
+		LocalCallbackListen:            options.LocalCallbackListen,
+		LocalCallbackURL:               options.LocalCallbackURL,
 		Targets:                        options.Targets,
 		ExcludeTargets:                 options.ExcludeTargets,
 		TargetsFilePath:                options.TargetsFilePath,

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -90,6 +90,10 @@ type Options struct {
 	LocalCallbackListen string
 	// LocalCallbackURL is the externally reachable local HTTP callback URL for offline OAST testing.
 	LocalCallbackURL string
+	// LocalCallbackInterface is the network interface to use for offline OAST testing.
+	LocalCallbackInterface string
+	// LocalCallbackPort is the local HTTP callback port when LocalCallbackInterface is used.
+	LocalCallbackPort int
 	// Target URLs/Domains to scan using a template
 	Targets goflags.StringSlice
 	// ExcludeTargets URLs/Domains to exclude from scanning
@@ -519,6 +523,8 @@ func (options *Options) Copy() *Options {
 		InteractshToken:                options.InteractshToken,
 		LocalCallbackListen:            options.LocalCallbackListen,
 		LocalCallbackURL:               options.LocalCallbackURL,
+		LocalCallbackInterface:         options.LocalCallbackInterface,
+		LocalCallbackPort:              options.LocalCallbackPort,
 		Targets:                        options.Targets,
 		ExcludeTargets:                 options.ExcludeTargets,
 		TargetsFilePath:                options.TargetsFilePath,


### PR DESCRIPTION
## Proposed changes

Closes #7437.

This PR adds a local HTTP callback listener mode for offline/internal OAST-style testing. It allows nuclei to generate local callback URLs and receive HTTP interactions directly on the scanner host, so templates that use `{{interactsh-url}}` can still confirm callbacks in lab, VPN, container, or internal-network scenarios where a public Interactsh server is not reachable.

The implementation:

* Adds local callback CLI options:

  * `-callback-listen`
  * `-callback-url`
  * `-callback-interface`
  * `-callback-port`
* Starts a local HTTP callback listener when one of the callback options is configured.
* Generates unique per-request callback URLs.
* Converts received HTTP callbacks into interactsh-style interactions so existing matcher/result handling continues to work.
* Preserves compatibility with existing `{{interactsh-url}}`, `{{interactsh-id}}`, and `interactsh_*` DSL fields.
* Adds tests covering callback receipt, placeholder generation, interface/port selection, DNS-compatible matcher behavior, and scheme-less callback URL parsing.

### Proof

Added unit tests for the local callback listener:

```console
go test ./pkg/protocols/common/interactsh
```

Test coverage includes:

* Receiving an HTTP callback and storing the interaction.
* Generating scheme-less callback URLs for `{{interactsh-url}}`.
* Populating `interactsh-url`, `interactsh-id`, and `interactsh-server` placeholders.
* Selecting an IP/port from a configured network interface.
* Treating local HTTP callbacks as DNS-compatible interactions for existing OAST matcher compatibility.
* Parsing callback URLs without an explicit scheme.

## Checklist

* [x] Pull request is created against the [[dev](https://github.com/projectdiscovery/nuclei/tree/dev)](https://github.com/projectdiscovery/nuclei/tree/dev) branch
* [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Offline OAST testing now supported via local HTTP callback listener, configurable with new CLI flags: `-callback-listen`, `-callback-url`, `-callback-interface`, and `-callback-port`.

* **Tests**
  * Added tests for local callback server functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->