### PR TITLE
fix(loader): warn when templates are excluded by .nuclei-ignore tags

### DIFF
--- a/pkg/catalog/loader/loader.go
+++ b/pkg/catalog/loader/loader.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/url"
 	"os"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -786,6 +787,20 @@ func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) ([]*temp
 		}
 	}
 
+	// noteExcludedByTag surfaces a template the index filter dropped because it
+	// carries an excluded tag (e.g. the .nuclei-ignore defaults). Without it the
+	// exclusion is silent at every verbosity level.
+	noteExcludedByTag := func(templatePath string, metadata *index.Metadata) {
+		if len(indexFilter.ExcludeTags) == 0 || !slices.ContainsFunc(indexFilter.ExcludeTags, metadata.HasTag) {
+			return
+		}
+
+		stats.Increment(templates.TemplatesExcludedStats)
+		if config.DefaultConfig.LogAllEvents {
+			store.logger.Print().Msgf("[%v] %v excluded from default run using .nuclei-ignore\n", aurora.Yellow("WRN").String(), templatePath)
+		}
+	}
+
 	typesOpts := store.config.ExecutorOptions.Options
 	concurrency := typesOpts.TemplateLoadingConcurrency
 	if concurrency <= 0 {
@@ -820,6 +835,7 @@ func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) ([]*temp
 				if cachedMetadata, found := store.metadataIndex.Get(templatePath); found {
 					metadata = cachedMetadata
 					if !indexFilter.Matches(metadata) {
+						noteExcludedByTag(templatePath, metadata)
 						return
 					}
 					// NOTE(dwisiswant0): else, tagFilter probably exists (for
@@ -842,6 +858,7 @@ func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) ([]*temp
 					}
 
 					if metadata != nil && !indexFilter.Matches(metadata) {
+						noteExcludedByTag(templatePath, metadata)
 						return
 					}
 				}

--- a/pkg/catalog/loader/loader.go
+++ b/pkg/catalog/loader/loader.go
@@ -788,10 +788,16 @@ func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) ([]*temp
 	}
 
 	// noteExcludedByTag surfaces a template the index filter dropped because it
-	// carries an excluded tag (e.g. the .nuclei-ignore defaults). Without it the
-	// exclusion is silent at every verbosity level.
+	// carries a tag from the .nuclei-ignore defaults. Without it the exclusion is
+	// silent at every verbosity level.
+	//
+	// indexFilter.ExcludeTags is a merge of CLI -exclude-tags and the ignore-file
+	// tags, so it must be matched against the ignore-file tags specifically:
+	// otherwise user-requested -exclude-tags drops would be mislabeled as
+	// .nuclei-ignore exclusions.
+	ignoreFileTags := config.ReadIgnoreFile().Tags
 	noteExcludedByTag := func(templatePath string, metadata *index.Metadata) {
-		if len(indexFilter.ExcludeTags) == 0 || !slices.ContainsFunc(indexFilter.ExcludeTags, metadata.HasTag) {
+		if len(ignoreFileTags) == 0 || !slices.ContainsFunc(ignoreFileTags, metadata.HasTag) {
 			return
 		}
 

--- a/pkg/protocols/headless/engine/page.go
+++ b/pkg/protocols/headless/engine/page.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -287,8 +288,26 @@ func (p *Page) addInteractshURL(URLs ...string) {
 	p.InteractshURLs = append(p.InteractshURLs, URLs...)
 }
 
+// appendRule records a request/response modification rule. The hijack handler
+// reads p.rules from a separate goroutine, so writes must be synchronized.
+func (p *Page) appendRule(r rule) {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	p.rules = append(p.rules, r)
+}
+
+// rulesSnapshot returns a copy of the current rules for lock-free iteration by
+// the hijack handler (which performs network I/O and must not hold the lock).
+func (p *Page) rulesSnapshot() []rule {
+	p.mutex.RLock()
+	defer p.mutex.RUnlock()
+
+	return slices.Clone(p.rules)
+}
+
 func (p *Page) hasModificationRules() bool {
-	for _, rule := range p.rules {
+	for _, rule := range p.rulesSnapshot() {
 		if containsAnyModificationActionType(rule.Action) {
 			return true
 		}

--- a/pkg/protocols/headless/engine/page_actions.go
+++ b/pkg/protocols/headless/engine/page_actions.go
@@ -286,7 +286,7 @@ func (p *Page) ActionAddHeader(act *Action, out ActionData) error {
 		return err
 	}
 
-	p.rules = append(p.rules, rule{
+	p.appendRule(rule{
 		Action: ActionAddHeader,
 		Part:   part,
 		Args:   args,
@@ -314,7 +314,7 @@ func (p *Page) ActionSetHeader(act *Action, out ActionData) error {
 		return err
 	}
 
-	p.rules = append(p.rules, rule{
+	p.appendRule(rule{
 		Action: ActionSetHeader,
 		Part:   part,
 		Args:   args,
@@ -337,7 +337,7 @@ func (p *Page) ActionDeleteHeader(act *Action, out ActionData) error {
 		return err
 	}
 
-	p.rules = append(p.rules, rule{
+	p.appendRule(rule{
 		Action: ActionDeleteHeader,
 		Part:   part,
 		Args:   args,
@@ -360,7 +360,7 @@ func (p *Page) ActionSetBody(act *Action, out ActionData) error {
 		return err
 	}
 
-	p.rules = append(p.rules, rule{
+	p.appendRule(rule{
 		Action: ActionSetBody,
 		Part:   part,
 		Args:   args,
@@ -383,7 +383,7 @@ func (p *Page) ActionSetMethod(act *Action, out ActionData) error {
 		return err
 	}
 
-	p.rules = append(p.rules, rule{
+	p.appendRule(rule{
 		Action: ActionSetMethod,
 		Part:   part,
 		Args:   args,

--- a/pkg/protocols/headless/engine/rules.go
+++ b/pkg/protocols/headless/engine/rules.go
@@ -17,7 +17,10 @@ func (p *Page) routingRuleHandler(httpClient *http.Client) func(ctx *rod.Hijack)
 	return func(ctx *rod.Hijack) {
 		// usually browsers don't use chunked transfer encoding, so we set the content-length nevertheless
 		ctx.Request.Req().ContentLength = int64(len(ctx.Request.Body()))
-		for _, rule := range p.rules {
+		// snapshot the rules once: ExecuteActions may still be appending rules
+		// from another goroutine while this hijack handler runs.
+		rules := p.rulesSnapshot()
+		for _, rule := range rules {
 			if rule.Part != "request" {
 				continue
 			}
@@ -61,7 +64,7 @@ func (p *Page) routingRuleHandler(httpClient *http.Client) func(ctx *rod.Hijack)
 			}
 		}
 
-		for _, rule := range p.rules {
+		for _, rule := range rules {
 			if rule.Part != "response" {
 				continue
 			}


### PR DESCRIPTION
## Proposed changes

Closes #7431

Since the metadata-cache refactor (#6630), tag filtering moved into `index.Filter` but the stat increment + log the old `TagFilter` path performed were not carried over. Templates dropped by default `.nuclei-ignore` tags (e.g. `local`) now vanish with no warning at any verbosity, leaving only `[FTL] no templates provided for scan`.

This re-feeds the existing `TemplatesExcludedStats` machinery at the filter drop sites, guarded to actual exclude-tag exclusions so include-filter mismatches (`-tags`, `-severity`) are not mislabeled.

### Proof

Running `-code -t <local-tagged code template>`:

Before:
```
[FTL] Could not run nuclei: no templates provided for scan
```

After:
```
[WRN] Excluded 1 template[s] with known weak matchers / tags excluded from default run using .nuclei-ignore
[FTL] Could not run nuclei: no templates provided for scan
```

A template dropped by an include filter (no excluded tag) prints no `.nuclei-ignore` line.

## Checklist

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced tracking of excluded templates: Templates filtered out by tag rules (such as `.nuclei-ignore`) are now properly counted and logged with warnings for better visibility into exclusion reasons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->