### PR TITLE
fix(templates): reject unknown fields when loading JSON templates

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -181,7 +181,6 @@ func New(options *types.Options) (*Runner, error) {
 	}
 
 	yaml.StrictSyntax = !options.NoStrictSyntax
-	templates.NoStrictJSON = options.NoStrictSyntax
 
 	if options.Headless {
 		if engine.MustDisableSandbox() {

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -181,6 +181,7 @@ func New(options *types.Options) (*Runner, error) {
 	}
 
 	yaml.StrictSyntax = !options.NoStrictSyntax
+	templates.NoStrictJSON = options.NoStrictSyntax
 
 	if options.Headless {
 		if engine.MustDisableSandbox() {

--- a/pkg/templates/parser.go
+++ b/pkg/templates/parser.go
@@ -1,7 +1,6 @@
 package templates
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"strings"
@@ -167,9 +166,7 @@ func (p *Parser) ParseTemplate(templatePath string, catalog catalog.Catalog) (an
 		if p.NoStrictSyntax {
 			err = json.Unmarshal(data, template)
 		} else {
-			dec := json.NewDecoder(bytes.NewReader(data))
-			dec.DisallowUnknownFields()
-			err = dec.Decode(template)
+			err = template.unmarshalJSONStrict(data)
 		}
 	case config.YAML:
 		if data != nil {

--- a/pkg/templates/parser.go
+++ b/pkg/templates/parser.go
@@ -1,6 +1,7 @@
 package templates
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"strings"
@@ -163,7 +164,13 @@ func (p *Parser) ParseTemplate(templatePath string, catalog catalog.Catalog) (an
 				return nil, err
 			}
 		}
-		err = json.Unmarshal(data, template)
+		if p.NoStrictSyntax {
+			err = json.Unmarshal(data, template)
+		} else {
+			dec := json.NewDecoder(bytes.NewReader(data))
+			dec.DisallowUnknownFields()
+			err = dec.Decode(template)
+		}
 	case config.YAML:
 		if data != nil {
 			// Already read and preprocessed

--- a/pkg/templates/parser_test.go
+++ b/pkg/templates/parser_test.go
@@ -121,8 +121,8 @@ func TestLoadTemplate(t *testing.T) {
 	// That meant `-validate` would pass templates that contained typoed fields
 	// or HTTP-only fields on a network.Request block, which then failed at
 	// runtime with the unknown-field error. Strict mode is the default and
-	// must be opt-out via [NoStrictJSON] (set from the runner's
-	// `-no-strict-syntax` flag).
+	// must be opt-out via the parser's [Parser.NoStrictSyntax] field (set
+	// from the runner's `-no-strict-syntax` flag).
 	t.Run("strictJSONRejectsUnknownFields", func(t *testing.T) {
 		const tmpl = `{
   "id": "JSON-UNKNOWN-FIELD",
@@ -143,28 +143,89 @@ func TestLoadTemplate(t *testing.T) {
   }]
 }`
 		dir := t.TempDir()
-		path := filepath.Join(dir, "tmpl.json")
-		require.NoError(t, os.WriteFile(path, []byte(tmpl), 0o600))
+		strictPath := filepath.Join(dir, "tmpl-strict.json")
+		require.NoError(t, os.WriteFile(strictPath, []byte(tmpl), 0o600))
 
 		// Strict mode (default): unknown fields must be rejected.
-		prev := NoStrictJSON
-		t.Cleanup(func() { NoStrictJSON = prev })
-
-		NoStrictJSON = false
 		strictParser := NewParser()
-		_, err := strictParser.ParseTemplate(path, disk.NewCatalog(""))
+		_, err := strictParser.ParseTemplate(strictPath, disk.NewCatalog(""))
 		require.Error(t, err, "expected strict JSON decode to reject unknown fields")
 		require.Contains(t, err.Error(), "unknown field", "expected unknown-field error, got: %v", err)
 
-		// Lax mode: when NoStrictJSON is set (via the -no-strict-syntax flag)
-		// the same template must still parse, preserving the historical opt-out.
-		NoStrictJSON = true
+		// Lax mode: when the parser opts out via NoStrictSyntax (set from the
+		// `-no-strict-syntax` flag) the same template must still parse.
 		laxParser := NewParser()
 		laxParser.NoStrictSyntax = true
 		laxPath := filepath.Join(dir, "tmpl-lax.json")
 		require.NoError(t, os.WriteFile(laxPath, []byte(tmpl), 0o600))
 		_, err = laxParser.ParseTemplate(laxPath, disk.NewCatalog(""))
-		require.NoError(t, err, "NoStrictJSON should allow unknown fields")
+		require.NoError(t, err, "NoStrictSyntax should allow unknown fields")
+	})
+
+	// json.Decoder by design only consumes one top-level value. Without an
+	// explicit EOF check, concatenated JSON documents would silently load
+	// only the first — e.g. `{"id":"safe"...}{"id":"hijack"...}` would scan
+	// under the safe id while the second document is ignored.
+	t.Run("strictJSONRejectsTrailingData", func(t *testing.T) {
+		const tmpl = `{
+  "id": "JSON-TRAILING-DATA",
+  "info": {
+    "name": "trailing data regression",
+    "author": "anonymous",
+    "severity": "info"
+  },
+  "http": [{
+    "method": "GET",
+    "path": ["{{BaseURL}}"],
+    "matchers": [{"type": "word", "words": ["HTTP"]}]
+  }]
+}
+{"id":"HIJACK","info":{"name":"x","author":"y","severity":"high"}}
+`
+		dir := t.TempDir()
+		path := filepath.Join(dir, "tmpl.json")
+		require.NoError(t, os.WriteFile(path, []byte(tmpl), 0o600))
+
+		_, err := NewParser().ParseTemplate(path, disk.NewCatalog(""))
+		require.Error(t, err, "expected strict JSON to reject trailing data")
+		require.Contains(t, err.Error(), "trailing data", "expected trailing-data error, got: %v", err)
+	})
+
+	// Strictness is a per-parser setting (not a process global) so two
+	// parsers in the same process with different `-no-strict-syntax` values
+	// must not interfere with each other. Cf. concurrent-engines support
+	// introduced in #6322.
+	t.Run("strictJSONIsPerParser", func(t *testing.T) {
+		const tmpl = `{
+  "id": "JSON-PER-PARSER",
+  "info": {
+    "name": "per-parser strictness",
+    "author": "anonymous",
+    "severity": "info"
+  },
+  "http": [{
+    "method": "GET",
+    "path": ["{{BaseURL}}"],
+    "matchers": [{"type": "word", "words": ["HTTP"]}],
+    "bogus_field": "ignore me"
+  }]
+}`
+		dir := t.TempDir()
+		strictPath := filepath.Join(dir, "per-parser-strict.json")
+		laxPath := filepath.Join(dir, "per-parser-lax.json")
+		require.NoError(t, os.WriteFile(strictPath, []byte(tmpl), 0o600))
+		require.NoError(t, os.WriteFile(laxPath, []byte(tmpl), 0o600))
+
+		strictParser := NewParser()
+		laxParser := NewParser()
+		laxParser.NoStrictSyntax = true
+
+		_, strictErr := strictParser.ParseTemplate(strictPath, disk.NewCatalog(""))
+		_, laxErr := laxParser.ParseTemplate(laxPath, disk.NewCatalog(""))
+
+		require.Error(t, strictErr, "strict parser must reject unknown field")
+		require.Contains(t, strictErr.Error(), "unknown field")
+		require.NoError(t, laxErr, "lax parser must accept the same template")
 	})
 
 	t.Run("invalidTemplateID", func(t *testing.T) {

--- a/pkg/templates/parser_test.go
+++ b/pkg/templates/parser_test.go
@@ -3,6 +3,8 @@ package templates
 import (
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/disk"
@@ -111,6 +113,59 @@ func TestLoadTemplate(t *testing.T) {
 			require.Equal(t, tc.isValid, success)
 		})
 	}
+
+	// Regression test for projectdiscovery/nuclei#7448.
+	//
+	// Templates loaded from JSON used to silently accept unknown fields because
+	// [Template.UnmarshalJSON] delegated to a non-strict json.Unmarshal call.
+	// That meant `-validate` would pass templates that contained typoed fields
+	// or HTTP-only fields on a network.Request block, which then failed at
+	// runtime with the unknown-field error. Strict mode is the default and
+	// must be opt-out via [NoStrictJSON] (set from the runner's
+	// `-no-strict-syntax` flag).
+	t.Run("strictJSONRejectsUnknownFields", func(t *testing.T) {
+		const tmpl = `{
+  "id": "JSON-UNKNOWN-FIELD",
+  "info": {
+    "name": "strict json regression",
+    "author": "anonymous",
+    "severity": "info",
+    "tags": "test"
+  },
+  "tcp": [{
+    "host": ["{{Hostname}}"],
+    "port": "80",
+    "name": "first_read",
+    "req-condition": true,
+    "bogus_field_42": "anything",
+    "inputs": [{"data": "X"}],
+    "matchers": [{"type": "word", "words": ["HTTP"]}]
+  }]
+}`
+		dir := t.TempDir()
+		path := filepath.Join(dir, "tmpl.json")
+		require.NoError(t, os.WriteFile(path, []byte(tmpl), 0o600))
+
+		// Strict mode (default): unknown fields must be rejected.
+		prev := NoStrictJSON
+		t.Cleanup(func() { NoStrictJSON = prev })
+
+		NoStrictJSON = false
+		strictParser := NewParser()
+		_, err := strictParser.ParseTemplate(path, disk.NewCatalog(""))
+		require.Error(t, err, "expected strict JSON decode to reject unknown fields")
+		require.Contains(t, err.Error(), "unknown field", "expected unknown-field error, got: %v", err)
+
+		// Lax mode: when NoStrictJSON is set (via the -no-strict-syntax flag)
+		// the same template must still parse, preserving the historical opt-out.
+		NoStrictJSON = true
+		laxParser := NewParser()
+		laxParser.NoStrictSyntax = true
+		laxPath := filepath.Join(dir, "tmpl-lax.json")
+		require.NoError(t, os.WriteFile(laxPath, []byte(tmpl), 0o600))
+		_, err = laxParser.ParseTemplate(laxPath, disk.NewCatalog(""))
+		require.NoError(t, err, "NoStrictJSON should allow unknown fields")
+	})
 
 	t.Run("invalidTemplateID", func(t *testing.T) {
 		tt := []struct {

--- a/pkg/templates/templates.go
+++ b/pkg/templates/templates.go
@@ -560,42 +560,67 @@ func (template *Template) MarshalJSON() ([]byte, error) {
 	return out, multierr.Append(marshalErr, errValidate)
 }
 
-// NoStrictJSON disables strict JSON schema validation when unmarshaling
-// templates from JSON. When false (the default), unknown fields are rejected,
-// matching the strict YAML decode path used by [yaml.UnmarshalStrict].
-//
-// This package-level toggle mirrors the YAML strict-mode pattern: the decoder
-// for the outer JSON document cannot propagate strictness through a custom
-// [Template.UnmarshalJSON], so the option is consulted directly from the
-// inner unmarshal call. Set from the runner alongside Parser.NoStrictSyntax.
-var NoStrictJSON bool
+// templateAlias is an internal alias of [Template] that intentionally
+// drops Template's custom JSON/YAML methods so the JSON decoder reflects
+// over the underlying fields. Used by both the lax and strict JSON paths.
+type templateAlias Template
 
-// UnmarshalJSON forces recursive struct validation after unmarshal operation
+// UnmarshalJSON forces recursive struct validation after unmarshal operation.
+// This is the permissive path used by external callers of [json.Unmarshal];
+// strict template loading goes through [Template.unmarshalJSONStrict] which
+// is what the parser uses by default — see [Parser.ParseTemplate].
 func (template *Template) UnmarshalJSON(data []byte) error {
-	type Alias Template
-	alias := &Alias{}
-	var err error
-	if NoStrictJSON {
-		err = json.Unmarshal(data, alias)
-	} else {
-		dec := json.NewDecoder(bytes.NewReader(data))
-		dec.DisallowUnknownFields()
-		err = dec.Decode(alias)
-	}
-	if err != nil {
+	alias := &templateAlias{}
+	if err := json.Unmarshal(data, alias); err != nil {
 		return err
 	}
 	*template = Template(*alias)
-	err = tplValidator.Struct(template)
-	if err != nil {
+	return template.finalizeFromJSON(data)
+}
+
+// unmarshalJSONStrict is the strict equivalent of [Template.UnmarshalJSON]:
+// it rejects unknown fields and any trailing data after the JSON document,
+// matching the [yaml.UnmarshalStrict] semantics used for YAML templates.
+//
+// The encoding/json contract cannot propagate [DisallowUnknownFields] through
+// a custom [Template.UnmarshalJSON], so the strict path decodes into the
+// internal alias directly. Per-call (rather than a process-wide toggle) so
+// concurrent parsers with different strictness settings (cf. #6322) cannot
+// interfere with each other.
+func (template *Template) unmarshalJSONStrict(data []byte) error {
+	alias := &templateAlias{}
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(alias); err != nil {
+		return err
+	}
+	// Reject trailing data after the first JSON value. json.Decoder by
+	// design only consumes one top-level value, so without this check a
+	// template like `{"id":"a",...}{"id":"hijack",...}` would silently
+	// load the first document. A second Decode into a throwaway must
+	// return io.EOF (i.e. only whitespace remained).
+	var rest interface{}
+	if err := dec.Decode(&rest); err != io.EOF {
+		if err == nil {
+			return errkit.Newf("unexpected trailing data after JSON template")
+		}
+		return err
+	}
+	*template = Template(*alias)
+	return template.finalizeFromJSON(data)
+}
+
+// finalizeFromJSON runs the post-decode struct validation and multi-protocol
+// bookkeeping shared by the lax and strict JSON paths.
+func (template *Template) finalizeFromJSON(data []byte) error {
+	if err := tplValidator.Struct(template); err != nil {
 		return err
 	}
 	// check if the template contains more than 1 protocol request
 	// if so  preserve the order of the protocols and requests
 	if template.hasMultipleRequests() {
 		var tempMap map[string]interface{}
-		err = json.Unmarshal(data, &tempMap)
-		if err != nil {
+		if err := json.Unmarshal(data, &tempMap); err != nil {
 			return errkit.Wrapf(err, "failed to unmarshal multi protocol template %s", template.ID)
 		}
 		arr := []string{}

--- a/pkg/templates/templates.go
+++ b/pkg/templates/templates.go
@@ -2,6 +2,7 @@
 package templates
 
 import (
+	"bytes"
 	"io"
 	"path/filepath"
 	"strconv"
@@ -559,11 +560,28 @@ func (template *Template) MarshalJSON() ([]byte, error) {
 	return out, multierr.Append(marshalErr, errValidate)
 }
 
+// NoStrictJSON disables strict JSON schema validation when unmarshaling
+// templates from JSON. When false (the default), unknown fields are rejected,
+// matching the strict YAML decode path used by [yaml.UnmarshalStrict].
+//
+// This package-level toggle mirrors the YAML strict-mode pattern: the decoder
+// for the outer JSON document cannot propagate strictness through a custom
+// [Template.UnmarshalJSON], so the option is consulted directly from the
+// inner unmarshal call. Set from the runner alongside Parser.NoStrictSyntax.
+var NoStrictJSON bool
+
 // UnmarshalJSON forces recursive struct validation after unmarshal operation
 func (template *Template) UnmarshalJSON(data []byte) error {
 	type Alias Template
 	alias := &Alias{}
-	err := json.Unmarshal(data, alias)
+	var err error
+	if NoStrictJSON {
+		err = json.Unmarshal(data, alias)
+	} else {
+		dec := json.NewDecoder(bytes.NewReader(data))
+		dec.DisallowUnknownFields()
+		err = dec.Decode(alias)
+	}
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

`-validate` (and the runtime loader) silently accepts JSON templates with unknown or HTTP-only fields on non-HTTP request blocks. This is the JSON corollary of the YAML schema-validation gap reported in #7448 — same root cause, different decoder.

The YAML branch was already strict on `dev` (`yaml.UnmarshalStrict` + `Template.UnmarshalYAML`'s `unmarshal()` callback propagating the strict flag), so the original v3.3.2 repro from #7448 now fails to validate as expected. The JSON branch still allows unknown fields because `Template.UnmarshalJSON` delegated to a non-strict `json.Unmarshal`, and the outer decoder cannot propagate `DisallowUnknownFields` through a custom unmarshaler.

## Before

```console
$ cat repro.json
{
  "id": "REPRO-JSON-UNKNOWN",
  "info": { "name": "x", "author": "anon", "severity": "info" },
  "tcp": [{
    "host": ["{{Hostname}}"],
    "port": "80",
    "name": "first_read",        // HTTP-only field
    "req-condition": true,       // HTTP-only field
    "bogus_field_42": "anything",
    "inputs": [{"data": "X"}],
    "matchers": [{"type":"word","words":["HTTP"]}]
  }]
}

$ nuclei -validate -t repro.json -duc
[INF] All templates validated successfully       # ❌ passes silently

$ nuclei -t repro.json -u 127.0.0.1 -duc -timeout 1
[INF] Templates loaded for current scan: 1       # ❌ runs the template,
[INF] Scan completed.                            #    silently dropping the unknown fields
```

## After

```console
$ nuclei -validate -t repro.json -duc
[ERR] Error occurred loading template repro.json: ... json: unknown field "name"
[FTL] Could not validate templates: errors occurred during template validation

$ nuclei -t repro.json -u 127.0.0.1 -duc -timeout 1
[FTL] Could not run nuclei: no templates provided for scan

$ nuclei -validate -t repro.json -duc -nss     # opt-out preserved
[INF] All templates validated successfully
```

## Fix

Mirror the YAML strict-mode pattern for JSON:

- **`pkg/templates/parser.go`** — gate the outer JSON decoder on `Parser.NoStrictSyntax`, using `DisallowUnknownFields()` by default. Same shape as the YAML branch above it.
- **`pkg/templates/templates.go`** — add `templates.NoStrictJSON`, a package-level toggle consulted from inside `Template.UnmarshalJSON`. The decoder cannot propagate strictness through a custom unmarshaler, hence the global — matching the existing `yaml.StrictSyntax` idiom in `pkg/utils/yaml/preprocess.go`.
- **`internal/runner/runner.go`** — set `templates.NoStrictJSON = options.NoStrictSyntax` alongside the existing `yaml.StrictSyntax` line, so `-no-strict-syntax` (`-nss`) continues to opt out for both formats.

## Test plan

- [x] Added `TestLoadTemplate/strictJSONRejectsUnknownFields` that asserts a JSON template with HTTP-only fields on a `tcp:` block:
  - fails to parse under the default strict mode (`require.Contains(err, "unknown field")`)
  - parses cleanly when `NoStrictJSON = true` (preserves the `-nss` opt-out)
- [x] `go test ./pkg/templates/... ./pkg/catalog/...` — all green
- [x] `go vet ./...` — clean
- [x] Manual end-to-end repro with the binary, both with and without `-nss`, confirms the before/after above
- [x] YAML strict path unchanged (the original #7448 YAML repro still fails to validate exactly as it does on `dev` today)

Fixes #7448

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * JSON template parsing now enforces strict validation by default, rejecting templates with unknown fields and trailing content. Lenient parsing mode available as an option.

* **Tests**
  * Added regression tests covering strict JSON validation behavior, including unknown fields rejection, trailing data handling, and parser instance isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->