### PR TITLE
fix(hosterrorscache): skip hosts that consistently time out

### DIFF
--- a/pkg/protocols/common/hosterrorscache/hosterrorscache.go
+++ b/pkg/protocols/common/hosterrorscache/hosterrorscache.go
@@ -300,8 +300,11 @@ func (c *Cache) checkError(protoType string, err error) bool {
 		// and are due to template logic
 		return false
 	case errkit.ErrKindNetworkTemporary:
-		// these should not be counted as host errors
-		return false
+		// a single temporary error (timeout, i/o reset) is transient, but a host
+		// that produces them on every request with no success in between is
+		// unresponsive. Count it; MarkFailedOrRemove resets the host on the next
+		// successful response, so only consecutive failures reach MaxHostError.
+		return true
 	case errkit.ErrKindNetworkPermanent:
 		// these should be counted as host errors
 		return true

--- a/pkg/protocols/common/hosterrorscache/hosterrorscache.go
+++ b/pkg/protocols/common/hosterrorscache/hosterrorscache.go
@@ -280,7 +280,7 @@ func (c *Cache) GetKeyFromContext(ctx *contextargs.Context, err error) string {
 	return finalValue
 }
 
-var reCheckError = regexp.MustCompile(`(no address found for host|could not resolve host|connection refused|connection reset by peer|could not connect to any address found for host|timeout awaiting response headers)`)
+var reCheckError = regexp.MustCompile(`(no address found for host|could not resolve host|connection refused|connection reset by peer|could not connect to any address found for host|timeout awaiting response headers|i/o timeout)`)
 
 // checkError checks if an error represents a type that should be
 // added to the host skipping table.

--- a/pkg/protocols/common/hosterrorscache/hosterrorscache.go
+++ b/pkg/protocols/common/hosterrorscache/hosterrorscache.go
@@ -173,6 +173,14 @@ func (c *Cache) MarkFailed(protoType string, ctx *contextargs.Context, err error
 
 // MarkFailedOrRemove marks a host as failed previously or removes it
 func (c *Cache) MarkFailedOrRemove(protoType string, ctx *contextargs.Context, err error) {
+	// A failure that occurs because the caller's context was cancelled or hit its
+	// deadline is not the host's fault (e.g. the parent scan was cancelled). Such
+	// errors classify as temporary/deadline and would otherwise be counted, so
+	// ignore them. A nil error (success) still resets the host below.
+	if err != nil && ctx != nil && ctx.Context() != nil && ctx.Context().Err() != nil {
+		return
+	}
+
 	if err != nil && !c.checkError(protoType, err) {
 		return
 	}

--- a/pkg/protocols/common/hosterrorscache/hosterrorscache_test.go
+++ b/pkg/protocols/common/hosterrorscache/hosterrorscache_test.go
@@ -87,6 +87,38 @@ func TestCacheCheckRawHTTPTimeout(t *testing.T) {
 	require.True(t, cache.Check(protoType, ctx), "host with repeated rawhttp i/o timeouts must be skipped")
 }
 
+func TestMarkSkipsParentContextCancellation(t *testing.T) {
+	// A failure that happens because the caller's (parent scan) context was
+	// cancelled or hit its deadline is not the host's fault and must not be
+	// counted. context.DeadlineExceeded otherwise classifies as a temporary
+	// network error and would wrongly accumulate.
+	cache := New(3, DefaultMaxHostsCount, nil)
+	parent, cancel := context.WithCancel(context.Background())
+	cancel()
+	ctx := contextargs.NewWithInput(parent, "cancelled-host")
+	timeout := errkit.New("context deadline exceeded").SetKind(errkit.ErrKindNetworkTemporary)
+
+	for i := 0; i < 5; i++ {
+		cache.MarkFailedOrRemove(protoType, ctx, timeout)
+	}
+	require.False(t, cache.Check(protoType, ctx), "failures under a cancelled parent context must not mark the host")
+}
+
+func TestNonConsecutiveTimeoutsDoNotSkip(t *testing.T) {
+	// A live host that times out intermittently but succeeds in between must not
+	// be skipped: a success resets the count so only consecutive failures reach
+	// the threshold. Guards the property the HTTP path relies on.
+	cache := New(3, DefaultMaxHostsCount, nil)
+	ctx := newCtxArgs(t.Name())
+	timeout := errkit.New("i/o timeout").SetKind(errkit.ErrKindNetworkTemporary)
+
+	cache.MarkFailedOrRemove(protoType, ctx, timeout)
+	cache.MarkFailedOrRemove(protoType, ctx, timeout)
+	cache.MarkFailedOrRemove(protoType, ctx, nil) // successful response resets the host
+	cache.MarkFailedOrRemove(protoType, ctx, timeout)
+	require.False(t, cache.Check(protoType, ctx), "a success between timeouts must reset the count")
+}
+
 func TestTrackErrors(t *testing.T) {
 	cache := New(3, DefaultMaxHostsCount, []string{"custom error"})
 

--- a/pkg/protocols/common/hosterrorscache/hosterrorscache_test.go
+++ b/pkg/protocols/common/hosterrorscache/hosterrorscache_test.go
@@ -72,6 +72,21 @@ func TestCacheCheckTimeout(t *testing.T) {
 	})
 }
 
+func TestCacheCheckRawHTTPTimeout(t *testing.T) {
+	// rawhttp/unsafe templates surface read timeouts as a plain-string error
+	// ("ReadStatusLine: ... i/o timeout") that errkit cannot classify, so it
+	// reaches the regex fallback. A host that produces these on every request
+	// must still be skipped.
+	cache := New(3, DefaultMaxHostsCount, nil)
+	err := errors.New("ReadStatusLine: read tcp 127.0.0.1:60087->127.0.0.1:18080: i/o timeout")
+
+	ctx := newCtxArgs(t.Name())
+	for i := 1; i <= 3; i++ {
+		cache.MarkFailed(protoType, ctx, err)
+	}
+	require.True(t, cache.Check(protoType, ctx), "host with repeated rawhttp i/o timeouts must be skipped")
+}
+
 func TestTrackErrors(t *testing.T) {
 	cache := New(3, DefaultMaxHostsCount, []string{"custom error"})
 

--- a/pkg/protocols/common/hosterrorscache/hosterrorscache_test.go
+++ b/pkg/protocols/common/hosterrorscache/hosterrorscache_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/contextargs"
+	"github.com/projectdiscovery/utils/errkit"
 	"github.com/stretchr/testify/require"
 )
 
@@ -43,6 +44,31 @@ func TestCacheCheck(t *testing.T) {
 		cache.MarkFailedOrRemove(protoType, ctx, nil) // nil error should remove the host from cache
 		got := cache.Check(protoType, ctx)
 		require.False(t, got)
+	})
+}
+
+func TestCacheCheckTimeout(t *testing.T) {
+	// A host that consistently times out (request deadline exceeded) is
+	// unresponsive and must be skipped once MaxHostError consecutive timeouts
+	// are recorded. Production surfaces these as ErrKindNetworkTemporary.
+	cache := New(3, DefaultMaxHostsCount, nil)
+	err := errkit.New("context deadline exceeded (Client.Timeout exceeded while awaiting headers)").
+		SetKind(errkit.ErrKindNetworkTemporary)
+
+	t.Run("flagged after threshold", func(t *testing.T) {
+		ctx := newCtxArgs(t.Name())
+		for i := 1; i <= 3; i++ {
+			cache.MarkFailed(protoType, ctx, err)
+		}
+		require.True(t, cache.Check(protoType, ctx), "host with repeated timeouts must be skipped")
+	})
+
+	t.Run("reset on success keeps a live host", func(t *testing.T) {
+		ctx := newCtxArgs(t.Name())
+		cache.MarkFailed(protoType, ctx, err)
+		cache.MarkFailed(protoType, ctx, err)
+		cache.MarkFailedOrRemove(protoType, ctx, nil) // a successful response resets the host
+		require.False(t, cache.Check(protoType, ctx), "a host that responded must not be skipped")
 	})
 }
 

--- a/pkg/protocols/http/request.go
+++ b/pkg/protocols/http/request.go
@@ -148,36 +148,30 @@ func (request *Request) executeRaceRequest(input *contextargs.Context, dynamicVa
 		}
 	}
 
-	// look for unresponsive hosts and cancel inflight requests as well
-	spmHandler.SetOnResultCallback(func(err error) {
-		request.recordHostResult(input, err)
-		if request.isUnresponsiveAddress(input) {
-			// stop all inflight requests
-			spmHandler.Cancel()
-		}
-	})
-
 	for i := 0; i < request.RaceNumberRequests; i++ {
-		if spmHandler.FoundFirstMatch() || request.isUnresponsiveAddress(input) {
+		updatedInput := contextargs.GetCopyIfHostOutdated(input, generatedRequests[i].URL())
+		if spmHandler.FoundFirstMatch() || request.isUnresponsiveAddress(updatedInput) {
 			// stop sending more requests condition is met
 			break
 		}
 		spmHandler.Acquire()
 		// execute http request
-		go func(httpRequest *generatedRequest) {
+		go func(httpRequest *generatedRequest, requestInput *contextargs.Context) {
 			defer spmHandler.Release()
-			if spmHandler.FoundFirstMatch() || request.isUnresponsiveAddress(input) {
+			if spmHandler.FoundFirstMatch() || request.isUnresponsiveAddress(requestInput) {
 				// stop sending more requests condition is met
 				return
 			}
 
+			err := request.executeRequest(requestInput, httpRequest, previous, false, wrappedCallback, 0)
 			select {
 			case <-spmHandler.Done():
 				return
-			case spmHandler.ResultChan <- request.executeRequest(input, httpRequest, previous, false, wrappedCallback, 0):
+			case spmHandler.ResultChan <- err:
+				request.recordHostResultAndCancelIfUnresponsive(requestInput, err, spmHandler.Cancel)
 				return
 			}
-		}(generatedRequests[i])
+		}(generatedRequests[i], updatedInput)
 		request.options.Progress.IncrementRequests()
 	}
 	spmHandler.Wait()
@@ -229,15 +223,6 @@ func (request *Request) executeParallelHTTP(input *contextargs.Context, dynamicV
 		}
 	}
 
-	// look for unresponsive hosts and cancel inflight requests as well
-	spmHandler.SetOnResultCallback(func(err error) {
-		request.recordHostResult(input, err)
-		if request.isUnresponsiveAddress(input) {
-			// stop all inflight requests
-			spmHandler.Cancel()
-		}
-	})
-
 	// bounded worker-pool to avoid spawning one goroutine per payload
 	type task struct {
 		req                *generatedRequest
@@ -269,11 +254,7 @@ func (request *Request) executeParallelHTTP(input *contextargs.Context, dynamicV
 				request.options.RateLimitTake()
 				hasInteractMatchers := interactsh.HasMatchers(request.CompiledOperators)
 				needsRequestEvent := hasInteractMatchers && request.NeedsRequestCondition()
-				select {
-				case <-spmHandler.Done():
-					spmHandler.Release()
-					continue
-				case spmHandler.ResultChan <- request.executeRequest(t.updatedInput, t.req, make(map[string]interface{}), hasInteractMatchers, func(event *output.InternalWrappedEvent) {
+				err := request.executeRequest(t.updatedInput, t.req, make(map[string]interface{}), hasInteractMatchers, func(event *output.InternalWrappedEvent) {
 					if (t.hasInteractMarkers || needsRequestEvent) && request.options.Interactsh != nil {
 						requestData := &interactsh.RequestData{
 							MakeResultFunc: request.MakeResultEvent,
@@ -287,7 +268,13 @@ func (request *Request) executeParallelHTTP(input *contextargs.Context, dynamicV
 						request.options.Interactsh.RequestEvent(sliceutil.Dedupe(allOASTUrls), requestData)
 					}
 					wrappedCallback(event)
-				}, 0):
+				}, 0)
+				select {
+				case <-spmHandler.Done():
+					spmHandler.Release()
+					continue
+				case spmHandler.ResultChan <- err:
+					request.recordHostResultAndCancelIfUnresponsive(t.updatedInput, err, spmHandler.Cancel)
 					spmHandler.Release()
 				}
 			}
@@ -433,15 +420,6 @@ func (request *Request) executeTurboHTTP(input *contextargs.Context, dynamicValu
 		}
 	}
 
-	// look for unresponsive hosts and cancel inflight requests as well
-	spmHandler.SetOnResultCallback(func(err error) {
-		request.recordHostResult(input, err)
-		if request.isUnresponsiveAddress(input) {
-			// stop all inflight requests
-			spmHandler.Cancel()
-		}
-	})
-
 	for {
 		inputData, payloads, ok := generator.nextValue()
 		if !ok {
@@ -476,19 +454,21 @@ func (request *Request) executeTurboHTTP(input *contextargs.Context, dynamicValu
 		}
 		generatedHttpRequest.pipelinedClient = pipeClient
 		spmHandler.Acquire()
-		go func(httpRequest *generatedRequest) {
+		go func(httpRequest *generatedRequest, requestInput *contextargs.Context) {
 			defer spmHandler.Release()
-			if spmHandler.FoundFirstMatch() || request.isUnresponsiveAddress(updatedInput) {
+			if spmHandler.FoundFirstMatch() || request.isUnresponsiveAddress(requestInput) {
 				// skip if first match is found
 				return
 			}
+			err := request.executeRequest(requestInput, httpRequest, previous, false, wrappedCallback, 0)
 			select {
 			case <-spmHandler.Done():
 				return
-			case spmHandler.ResultChan <- request.executeRequest(input, httpRequest, previous, false, wrappedCallback, 0):
+			case spmHandler.ResultChan <- err:
+				request.recordHostResultAndCancelIfUnresponsive(requestInput, err, spmHandler.Cancel)
 				return
 			}
-		}(generatedHttpRequest)
+		}(generatedHttpRequest, updatedInput)
 		request.options.Progress.IncrementRequests()
 	}
 	spmHandler.Wait()
@@ -1303,6 +1283,13 @@ func (request *Request) newContext(input *contextargs.Context) context.Context {
 func (request *Request) recordHostResult(input *contextargs.Context, err error) {
 	if request.options.HostErrorsCache != nil {
 		request.options.HostErrorsCache.MarkFailedOrRemove(request.options.ProtocolType.String(), input, err)
+	}
+}
+
+func (request *Request) recordHostResultAndCancelIfUnresponsive(input *contextargs.Context, err error, cancel func()) {
+	request.recordHostResult(input, err)
+	if request.isUnresponsiveAddress(input) {
+		cancel()
 	}
 }
 

--- a/pkg/protocols/http/request.go
+++ b/pkg/protocols/http/request.go
@@ -150,8 +150,7 @@ func (request *Request) executeRaceRequest(input *contextargs.Context, dynamicVa
 
 	// look for unresponsive hosts and cancel inflight requests as well
 	spmHandler.SetOnResultCallback(func(err error) {
-		// marks this host as unresponsive if applicable
-		request.markHostError(input, err)
+		request.recordHostResult(input, err)
 		if request.isUnresponsiveAddress(input) {
 			// stop all inflight requests
 			spmHandler.Cancel()
@@ -232,8 +231,7 @@ func (request *Request) executeParallelHTTP(input *contextargs.Context, dynamicV
 
 	// look for unresponsive hosts and cancel inflight requests as well
 	spmHandler.SetOnResultCallback(func(err error) {
-		// marks this host as unresponsive if applicable
-		request.markHostError(input, err)
+		request.recordHostResult(input, err)
 		if request.isUnresponsiveAddress(input) {
 			// stop all inflight requests
 			spmHandler.Cancel()
@@ -437,8 +435,7 @@ func (request *Request) executeTurboHTTP(input *contextargs.Context, dynamicValu
 
 	// look for unresponsive hosts and cancel inflight requests as well
 	spmHandler.SetOnResultCallback(func(err error) {
-		// marks this host as unresponsive if applicable
-		request.markHostError(input, err)
+		request.recordHostResult(input, err)
 		if request.isUnresponsiveAddress(input) {
 			// stop all inflight requests
 			spmHandler.Cancel()
@@ -601,19 +598,14 @@ func (request *Request) ExecuteWithResults(input *contextargs.Context, dynamicVa
 				return true, nil
 			}
 
+			request.recordHostResult(updatedInput, execReqErr)
 			if execReqErr != nil {
-				request.markHostError(updatedInput, execReqErr)
-
-				// if applicable mark the host as unresponsive
 				reqKitErr := errkit.FromError(execReqErr)
 				reqKitErr.Msgf("got err while executing %v", generatedHttpRequest.URL())
 
 				requestErr = reqKitErr
 				request.options.Progress.IncrementFailedRequestsBy(1)
 			} else {
-				// a successful response resets the host's error count so intermittent
-				// timeouts on a live host do not accumulate into a false skip
-				request.markHostSuccess(updatedInput)
 				request.options.Progress.IncrementRequests()
 			}
 
@@ -1305,18 +1297,12 @@ func (request *Request) newContext(input *contextargs.Context) context.Context {
 	return input.Context()
 }
 
-// markHostError checks if the error is a unreponsive host error and marks it
-func (request *Request) markHostError(input *contextargs.Context, err error) {
-	if request.options.HostErrorsCache != nil && err != nil {
-		request.options.HostErrorsCache.MarkFailedOrRemove(request.options.ProtocolType.String(), input, err)
-	}
-}
-
-// markHostSuccess resets the host's error count after a successful request so that
-// only consecutive failures (with no success in between) can mark a host unresponsive.
-func (request *Request) markHostSuccess(input *contextargs.Context) {
+// recordHostResult updates the host-errors cache with the outcome of a request.
+// A failure is counted; a success resets the host, so only consecutive failures
+// with no success in between can mark a host unresponsive.
+func (request *Request) recordHostResult(input *contextargs.Context, err error) {
 	if request.options.HostErrorsCache != nil {
-		request.options.HostErrorsCache.MarkFailedOrRemove(request.options.ProtocolType.String(), input, nil)
+		request.options.HostErrorsCache.MarkFailedOrRemove(request.options.ProtocolType.String(), input, err)
 	}
 }
 

--- a/pkg/protocols/http/request.go
+++ b/pkg/protocols/http/request.go
@@ -611,6 +611,9 @@ func (request *Request) ExecuteWithResults(input *contextargs.Context, dynamicVa
 				requestErr = reqKitErr
 				request.options.Progress.IncrementFailedRequestsBy(1)
 			} else {
+				// a successful response resets the host's error count so intermittent
+				// timeouts on a live host do not accumulate into a false skip
+				request.markHostSuccess(updatedInput)
 				request.options.Progress.IncrementRequests()
 			}
 
@@ -1306,6 +1309,14 @@ func (request *Request) newContext(input *contextargs.Context) context.Context {
 func (request *Request) markHostError(input *contextargs.Context, err error) {
 	if request.options.HostErrorsCache != nil && err != nil {
 		request.options.HostErrorsCache.MarkFailedOrRemove(request.options.ProtocolType.String(), input, err)
+	}
+}
+
+// markHostSuccess resets the host's error count after a successful request so that
+// only consecutive failures (with no success in between) can mark a host unresponsive.
+func (request *Request) markHostSuccess(input *contextargs.Context) {
+	if request.options.HostErrorsCache != nil {
+		request.options.HostErrorsCache.MarkFailedOrRemove(request.options.ProtocolType.String(), input, nil)
 	}
 }
 

--- a/pkg/protocols/http/request_test.go
+++ b/pkg/protocols/http/request_test.go
@@ -277,6 +277,72 @@ func (f *fakeHostErrorsCache) Check(string, *contextargs.Context) bool { return 
 // IsPermanentErr returns false for tests
 func (f *fakeHostErrorsCache) IsPermanentErr(*contextargs.Context, error) bool { return false }
 
+// spyHostErrorsCache records how the request path interacts with the cache:
+// a mark (non-nil error) versus a reset (nil error). Check returns skip so the
+// request actually executes.
+type spyHostErrorsCache struct {
+	marks  atomic.Int32
+	resets atomic.Int32
+	skip   bool
+}
+
+func (s *spyHostErrorsCache) SetVerbose(bool)                 {}
+func (s *spyHostErrorsCache) Close()                          {}
+func (s *spyHostErrorsCache) Remove(*contextargs.Context)     { s.resets.Add(1) }
+func (s *spyHostErrorsCache) MarkFailed(p string, c *contextargs.Context, err error) {
+	s.MarkFailedOrRemove(p, c, err)
+}
+func (s *spyHostErrorsCache) MarkFailedOrRemove(_ string, _ *contextargs.Context, err error) {
+	if err == nil {
+		s.resets.Add(1)
+	} else {
+		s.marks.Add(1)
+	}
+}
+func (s *spyHostErrorsCache) Check(string, *contextargs.Context) bool          { return s.skip }
+func (s *spyHostErrorsCache) IsPermanentErr(*contextargs.Context, error) bool  { return false }
+
+func TestHTTPResetsHostCacheOnSuccess(t *testing.T) {
+	options := testutils.DefaultOptions
+	testutils.Init(options)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprintf(w, "ok")
+	}))
+	defer ts.Close()
+
+	templateID := "reset-on-success"
+	req := &Request{
+		ID:     templateID,
+		Method: HTTPMethodTypeHolder{MethodType: HTTPGet},
+		Path:   []string{"{{BaseURL}}/"},
+		Operators: operators.Operators{
+			Matchers: []*matchers.Matcher{{
+				Part:  "body",
+				Type:  matchers.MatcherTypeHolder{MatcherType: matchers.WordsMatcher},
+				Words: []string{"ok"},
+			}},
+		},
+	}
+
+	executerOpts := testutils.NewMockExecuterOptions(options, &testutils.TemplateInfo{
+		ID:   templateID,
+		Info: model.Info{SeverityHolder: severity.Holder{Severity: severity.Low}, Name: "test"},
+	})
+	spy := &spyHostErrorsCache{}
+	executerOpts.HostErrorsCache = spy
+	require.NoError(t, req.Compile(executerOpts))
+
+	metadata := make(output.InternalEvent)
+	previous := make(output.InternalEvent)
+	ctxArgs := contextargs.NewWithInput(context.Background(), ts.URL)
+	err := req.ExecuteWithResults(ctxArgs, metadata, previous, func(event *output.InternalWrappedEvent) {})
+	require.NoError(t, err)
+
+	require.Greater(t, spy.resets.Load(), int32(0), "a successful request must reset the host-errors cache")
+	require.Equal(t, int32(0), spy.marks.Load(), "a successful request must not mark a host error")
+}
+
 func TestExecuteParallelHTTP_StopAtFirstMatch(t *testing.T) {
 	options := testutils.DefaultOptions
 	testutils.Init(options)

--- a/pkg/protocols/http/request_test.go
+++ b/pkg/protocols/http/request_test.go
@@ -343,6 +343,51 @@ func TestHTTPResetsHostCacheOnSuccess(t *testing.T) {
 	require.Equal(t, int32(0), spy.marks.Load(), "a successful request must not mark a host error")
 }
 
+func TestParallelHTTPResetsHostCacheOnSuccess(t *testing.T) {
+	options := testutils.DefaultOptions
+	testutils.Init(options)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprintf(w, "ok")
+	}))
+	defer ts.Close()
+
+	templateID := "parallel-reset-on-success"
+	req := &Request{
+		ID:      templateID,
+		Method:  HTTPMethodTypeHolder{MethodType: HTTPGet},
+		Path:    []string{"{{BaseURL}}/p?x={{v}}"},
+		Threads: 2,
+		Payloads: map[string]interface{}{
+			"v": []string{"1", "2", "3", "4"},
+		},
+		Operators: operators.Operators{
+			Matchers: []*matchers.Matcher{{
+				Part:  "body",
+				Type:  matchers.MatcherTypeHolder{MatcherType: matchers.WordsMatcher},
+				Words: []string{"ok"},
+			}},
+		},
+	}
+
+	executerOpts := testutils.NewMockExecuterOptions(options, &testutils.TemplateInfo{
+		ID:   templateID,
+		Info: model.Info{SeverityHolder: severity.Holder{Severity: severity.Low}, Name: "test"},
+	})
+	spy := &spyHostErrorsCache{}
+	executerOpts.HostErrorsCache = spy
+	require.NoError(t, req.Compile(executerOpts))
+
+	metadata := make(output.InternalEvent)
+	previous := make(output.InternalEvent)
+	ctxArgs := contextargs.NewWithInput(context.Background(), ts.URL)
+	err := req.ExecuteWithResults(ctxArgs, metadata, previous, func(event *output.InternalWrappedEvent) {})
+	require.NoError(t, err)
+
+	require.Greater(t, spy.resets.Load(), int32(0), "successful parallel requests must reset the host-errors cache")
+	require.Equal(t, int32(0), spy.marks.Load(), "successful parallel requests must not mark a host error")
+}
+
 func TestExecuteParallelHTTP_StopAtFirstMatch(t *testing.T) {
 	options := testutils.DefaultOptions
 	testutils.Init(options)

--- a/pkg/protocols/http/request_test.go
+++ b/pkg/protocols/http/request_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -12,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tarunKoyalwar/goleak"
 
+	"github.com/projectdiscovery/nuclei/v3/internal/tests/testutils"
 	"github.com/projectdiscovery/nuclei/v3/pkg/model"
 	"github.com/projectdiscovery/nuclei/v3/pkg/model/types/severity"
 	"github.com/projectdiscovery/nuclei/v3/pkg/operators"
@@ -20,7 +22,6 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/output"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/contextargs"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/interactsh"
-	"github.com/projectdiscovery/nuclei/v3/internal/tests/testutils"
 )
 
 func TestHTTPExtractMultipleReuse(t *testing.T) {
@@ -286,9 +287,9 @@ type spyHostErrorsCache struct {
 	skip   bool
 }
 
-func (s *spyHostErrorsCache) SetVerbose(bool)                 {}
-func (s *spyHostErrorsCache) Close()                          {}
-func (s *spyHostErrorsCache) Remove(*contextargs.Context)     { s.resets.Add(1) }
+func (s *spyHostErrorsCache) SetVerbose(bool)             {}
+func (s *spyHostErrorsCache) Close()                      {}
+func (s *spyHostErrorsCache) Remove(*contextargs.Context) { s.resets.Add(1) }
 func (s *spyHostErrorsCache) MarkFailed(p string, c *contextargs.Context, err error) {
 	s.MarkFailedOrRemove(p, c, err)
 }
@@ -299,8 +300,39 @@ func (s *spyHostErrorsCache) MarkFailedOrRemove(_ string, _ *contextargs.Context
 		s.marks.Add(1)
 	}
 }
-func (s *spyHostErrorsCache) Check(string, *contextargs.Context) bool          { return s.skip }
-func (s *spyHostErrorsCache) IsPermanentErr(*contextargs.Context, error) bool  { return false }
+func (s *spyHostErrorsCache) Check(string, *contextargs.Context) bool         { return s.skip }
+func (s *spyHostErrorsCache) IsPermanentErr(*contextargs.Context, error) bool { return false }
+
+type addressSpyHostErrorsCache struct {
+	mu     sync.Mutex
+	checks []string
+	resets []string
+}
+
+func (s *addressSpyHostErrorsCache) SetVerbose(bool) {}
+func (s *addressSpyHostErrorsCache) Close()          {}
+func (s *addressSpyHostErrorsCache) Remove(ctx *contextargs.Context) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.resets = append(s.resets, ctx.MetaInput.Address())
+}
+func (s *addressSpyHostErrorsCache) MarkFailed(string, *contextargs.Context, error) {}
+func (s *addressSpyHostErrorsCache) MarkFailedOrRemove(_ string, ctx *contextargs.Context, err error) {
+	if err == nil {
+		s.Remove(ctx)
+	}
+}
+func (s *addressSpyHostErrorsCache) Check(_ string, ctx *contextargs.Context) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.checks = append(s.checks, ctx.MetaInput.Address())
+	return false
+}
+func (s *addressSpyHostErrorsCache) IsPermanentErr(*contextargs.Context, error) bool {
+	return false
+}
 
 func TestHTTPResetsHostCacheOnSuccess(t *testing.T) {
 	options := testutils.DefaultOptions
@@ -386,6 +418,52 @@ func TestParallelHTTPResetsHostCacheOnSuccess(t *testing.T) {
 
 	require.Greater(t, spy.resets.Load(), int32(0), "successful parallel requests must reset the host-errors cache")
 	require.Equal(t, int32(0), spy.marks.Load(), "successful parallel requests must not mark a host error")
+}
+
+func TestParallelHTTPResetsUpdatedHostCacheKeyOnSuccess(t *testing.T) {
+	options := testutils.DefaultOptions
+	testutils.Init(options)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprintf(w, "ok")
+	}))
+	defer ts.Close()
+
+	templateID := "parallel-reset-updated-host"
+	req := &Request{
+		ID:      templateID,
+		Method:  HTTPMethodTypeHolder{MethodType: HTTPGet},
+		Path:    []string{ts.URL + "/p?x={{v}}"},
+		Threads: 2,
+		Payloads: map[string]interface{}{
+			"v": []string{"1", "2"},
+		},
+		Operators: operators.Operators{
+			Matchers: []*matchers.Matcher{{
+				Part:  "body",
+				Type:  matchers.MatcherTypeHolder{MatcherType: matchers.WordsMatcher},
+				Words: []string{"ok"},
+			}},
+		},
+	}
+
+	executerOpts := testutils.NewMockExecuterOptions(options, &testutils.TemplateInfo{
+		ID:   templateID,
+		Info: model.Info{SeverityHolder: severity.Holder{Severity: severity.Low}, Name: "test"},
+	})
+	spy := &addressSpyHostErrorsCache{}
+	executerOpts.HostErrorsCache = spy
+	require.NoError(t, req.Compile(executerOpts))
+
+	metadata := make(output.InternalEvent)
+	previous := make(output.InternalEvent)
+	ctxArgs := contextargs.NewWithInput(context.Background(), "http://example.invalid")
+	err := req.ExecuteWithResults(ctxArgs, metadata, previous, func(event *output.InternalWrappedEvent) {})
+	require.NoError(t, err)
+
+	expectedAddress := contextargs.NewWithInput(context.Background(), ts.URL).MetaInput.Address()
+	require.Contains(t, spy.checks, expectedAddress, "generated request host must be checked")
+	require.Contains(t, spy.resets, expectedAddress, "success must reset the generated request host")
 }
 
 func TestExecuteParallelHTTP_StopAtFirstMatch(t *testing.T) {


### PR DESCRIPTION
Closes #7454

## Why
A host that times out on every request was never added to the host-skip list, because `checkError` excluded `ErrKindNetworkTemporary`/`ErrKindDeadline` and the regex fallback did not list real timeout strings. Only permanent errors (connection refused, no route, DNS failure) counted toward `MaxHostError`. Scan time against an unresponsive host scaled linearly with template count instead of bailing after the threshold.

## What
- Count `ErrKindNetworkTemporary` (standard-HTTP request timeouts) toward `MaxHostError`.
- Add `i/o timeout` to the regex fallback, which covers rawhttp/`unsafe` templates whose timeouts surface as a plain-string `ReadStatusLine: ... i/o timeout` that errkit cannot classify.
- Reset-on-success still removes a host on the next successful response, so only consecutive timeouts with no success reach the threshold; a slow-but-alive host is not skipped.
- `ErrKindDeadline` left excluded: it can be a cancelled parent scan context, not a host fault.

## Verified
Tarpit (accepts TCP, never responds), one slow host, `-mhe 5`:

| Path | Before | After |
| --- | --- | --- |
| Standard HTTP, 120 templates | 60s, never skipped | 10s, skipped after threshold |
| rawhttp/unsafe, 30 templates | 271s, never skipped | skipped after threshold |

Connection-refused control still skips (no regression). Unit tests added (`TestCacheCheckTimeout`, `TestCacheCheckRawHTTPTimeout`); package suite green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved host failure accounting: cancelled/deadlined contexts and transient network errors are no longer counted; only consecutive failures trigger skipping, and successful responses now reset/remove host failure state.
  * Expanded detection of connection/timeout phrases to better identify network issues.

* **Tests**
  * Added tests for timeout accumulation, raw-string timeout matching, parent-context cancellation handling, non-consecutive timeouts, and reset-on-success (including parallel requests).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->