### PR TITLE
fuzz: add parser harnesses for raw requests & templates

### DIFF
--- a/pkg/input/types/fuzz.go
+++ b/pkg/input/types/fuzz.go
@@ -1,0 +1,18 @@
+//go:build gofuzz
+// +build gofuzz
+
+package types
+
+// Fuzz exercises raw HTTP request parsing used by input format ingestion.
+func Fuzz(data []byte) int {
+	if len(data) == 0 {
+		return 0
+	}
+	if len(data) > fuzzMaxInputSize {
+		return -1
+	}
+	if !fuzzRawRequestParsing(data) {
+		return 0
+	}
+	return 1
+}

--- a/pkg/input/types/fuzz_harness.go
+++ b/pkg/input/types/fuzz_harness.go
@@ -1,0 +1,288 @@
+package types
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	fuzzMaxInputSize  = 16 << 10
+	fuzzMaxHeaders    = 8
+	fuzzMaxValueBytes = 256
+)
+
+var (
+	fuzzMethods = []string{"GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"}
+	fuzzPaths   = []string{"/", "/api/v1/users", "/login", "/search?q=nuclei", "?debug=true"}
+	fuzzHosts   = []string{"example.com", "scanme.sh", "127.0.0.1", "example.com:8080"}
+)
+
+type fuzzHeader struct {
+	key   string
+	value string
+}
+
+type fuzzRawRequestCandidate struct {
+	method    string
+	path      string
+	host      string
+	targetURL string
+	headers   []fuzzHeader
+	body      string
+}
+
+func fuzzRawRequestParsing(data []byte) bool {
+	raw, targetURL, ok := rawRequestFromFuzzData(data)
+	if !ok {
+		return false
+	}
+
+	parsed := false
+	if rr, err := ParseRawRequest(raw); err == nil {
+		exerciseFuzzRequestResponse(rr)
+		parsed = true
+	}
+	if rr, err := ParseRawRequestWithURL(raw, targetURL); err == nil {
+		exerciseFuzzRequestResponse(rr)
+		parsed = true
+	}
+	if rr, err := ParseRawRequest(string(data)); err == nil {
+		exerciseFuzzRequestResponse(rr)
+		parsed = true
+	}
+	if rr, err := ParseRawRequestWithURL(string(data), targetURL); err == nil {
+		exerciseFuzzRequestResponse(rr)
+		parsed = true
+	}
+
+	return parsed
+}
+
+func rawRequestFromFuzzData(data []byte) (string, string, bool) {
+	if len(data) == 0 || len(data) > fuzzMaxInputSize {
+		return "", "", false
+	}
+
+	candidate := newFuzzRawRequestCandidate(data)
+	candidate.applyLines(splitFuzzLines(data))
+	return candidate.build(), candidate.targetURL, true
+}
+
+func newFuzzRawRequestCandidate(data []byte) *fuzzRawRequestCandidate {
+	method := fuzzMethods[int(fuzzByteAt(data, 0))%len(fuzzMethods)]
+	path := fuzzPaths[int(fuzzByteAt(data, 1))%len(fuzzPaths)]
+	host := fuzzHosts[int(fuzzByteAt(data, 2))%len(fuzzHosts)]
+
+	return &fuzzRawRequestCandidate{
+		method:    method,
+		path:      path,
+		host:      host,
+		targetURL: "https://" + host + path,
+		headers: []fuzzHeader{
+			{key: "User-Agent", value: "nuclei-fuzz"},
+		},
+		body: fuzzBody(string(data)),
+	}
+}
+
+func (candidate *fuzzRawRequestCandidate) applyLines(lines []string) {
+	for _, line := range lines {
+		key, value, ok := cutFuzzKV(line)
+		if !ok {
+			candidate.body = fuzzBody(line)
+			continue
+		}
+
+		switch key {
+		case "method":
+			candidate.method = fuzzMethod(value, candidate.method)
+		case "path":
+			candidate.path = fuzzRelativePath(value, candidate.path)
+		case "host":
+			candidate.host = fuzzHost(value, candidate.host)
+		case "url", "target-url":
+			candidate.targetURL = fuzzAbsoluteURL(value, candidate.targetURL)
+		case "header":
+			candidate.addHeader(value)
+		case "body":
+			candidate.body = fuzzBody(value)
+		}
+	}
+}
+
+func (candidate *fuzzRawRequestCandidate) addHeader(value string) {
+	key, headerValue, ok := strings.Cut(value, ":")
+	if !ok {
+		key, headerValue, ok = strings.Cut(value, "=")
+	}
+	if !ok {
+		return
+	}
+
+	key = fuzzHeaderKey(key)
+	if key == "" || strings.EqualFold(key, "Host") || len(candidate.headers) >= fuzzMaxHeaders {
+		return
+	}
+	candidate.headers = append(candidate.headers, fuzzHeader{key: key, value: fuzzHeaderValue(headerValue)})
+}
+
+func (candidate *fuzzRawRequestCandidate) build() string {
+	var builder strings.Builder
+	fmt.Fprintf(&builder, "%s %s HTTP/1.1\r\n", candidate.method, candidate.path)
+	fmt.Fprintf(&builder, "Host: %s\r\n", candidate.host)
+	for _, header := range candidate.headers {
+		fmt.Fprintf(&builder, "%s: %s\r\n", header.key, header.value)
+	}
+	builder.WriteString("\r\n")
+	builder.WriteString(candidate.body)
+	return builder.String()
+}
+
+func exerciseFuzzRequestResponse(rr *RequestResponse) {
+	if rr == nil {
+		panic("nil request response")
+	}
+	if rr.Request == nil {
+		panic("nil parsed request")
+	}
+	_ = rr.Clone()
+	_ = rr.ID()
+	_, _ = rr.MarshalJSON()
+}
+
+func splitFuzzLines(data []byte) []string {
+	fields := strings.FieldsFunc(string(data), func(r rune) bool {
+		return r == '\n' || r == '\r' || r == ';'
+	})
+	if len(fields) > fuzzMaxHeaders*4 {
+		fields = fields[:fuzzMaxHeaders*4]
+	}
+
+	lines := make([]string, 0, len(fields))
+	for _, field := range fields {
+		field = fuzzTrim(field)
+		if field != "" {
+			lines = append(lines, field)
+		}
+	}
+	return lines
+}
+
+func cutFuzzKV(line string) (string, string, bool) {
+	key, value, ok := strings.Cut(line, "=")
+	if !ok {
+		key, value, ok = strings.Cut(line, ":")
+	}
+	if !ok {
+		return "", "", false
+	}
+	return strings.ToLower(fuzzTrim(key)), fuzzTrim(value), true
+}
+
+func fuzzByteAt(data []byte, index int) byte {
+	if len(data) == 0 {
+		return 0
+	}
+	return data[index%len(data)]
+}
+
+func fuzzMethod(value, fallback string) string {
+	value = strings.ToUpper(fuzzToken(value, 16))
+	if value == "" {
+		return fallback
+	}
+	return value
+}
+
+func fuzzRelativePath(value, fallback string) string {
+	value = fuzzTrim(value)
+	if value == "" {
+		return fallback
+	}
+	if len(value) > fuzzMaxValueBytes {
+		value = value[:fuzzMaxValueBytes]
+	}
+	if strings.HasPrefix(value, "?") || strings.HasPrefix(value, "/") {
+		return value
+	}
+	return "/" + value
+}
+
+func fuzzAbsoluteURL(value, fallback string) string {
+	value = fuzzTrim(value)
+	if strings.HasPrefix(value, "http://") || strings.HasPrefix(value, "https://") {
+		return value
+	}
+	host := fuzzHost(value, "")
+	if host == "" {
+		return fallback
+	}
+	return "https://" + host + "/"
+}
+
+func fuzzHost(value, fallback string) string {
+	value = strings.ToLower(fuzzTrim(value))
+	var builder strings.Builder
+	for _, r := range value {
+		switch {
+		case r >= 'a' && r <= 'z':
+			builder.WriteRune(r)
+		case r >= '0' && r <= '9':
+			builder.WriteRune(r)
+		case r == '.' || r == '-' || r == ':':
+			builder.WriteRune(r)
+		}
+		if builder.Len() >= 128 {
+			break
+		}
+	}
+	if builder.Len() == 0 {
+		return fallback
+	}
+	return builder.String()
+}
+
+func fuzzHeaderKey(value string) string {
+	return fuzzToken(value, 64)
+}
+
+func fuzzHeaderValue(value string) string {
+	return fuzzTrim(value)
+}
+
+func fuzzBody(value string) string {
+	value = strings.ReplaceAll(value, "\x00", "")
+	if len(value) > fuzzMaxValueBytes {
+		value = value[:fuzzMaxValueBytes]
+	}
+	return value
+}
+
+func fuzzToken(value string, limit int) string {
+	value = fuzzTrim(value)
+	var builder strings.Builder
+	for _, r := range value {
+		switch {
+		case r >= 'a' && r <= 'z':
+			builder.WriteRune(r - 'a' + 'A')
+		case r >= 'A' && r <= 'Z':
+			builder.WriteRune(r)
+		case r >= '0' && r <= '9':
+			builder.WriteRune(r)
+		case r == '-':
+			builder.WriteRune(r)
+		}
+		if builder.Len() >= limit {
+			break
+		}
+	}
+	return builder.String()
+}
+
+func fuzzTrim(value string) string {
+	value = strings.TrimSpace(strings.NewReplacer("\x00", "", "\r", " ", "\n", " ").Replace(value))
+	if len(value) > fuzzMaxValueBytes {
+		value = value[:fuzzMaxValueBytes]
+	}
+	return value
+}

--- a/pkg/input/types/fuzz_harness_test.go
+++ b/pkg/input/types/fuzz_harness_test.go
@@ -22,6 +22,8 @@ func TestRawRequestFromFuzzDataSeedCorpus(t *testing.T) {
 		data, err := os.ReadFile(path)
 		require.NoError(t, err)
 
+		require.Truef(t, fuzzRawRequestParsing(data), "seed %s should exercise the raw request parser fuzz path", entry.Name())
+
 		raw, targetURL, ok := rawRequestFromFuzzData(data)
 		require.Truef(t, ok, "seed %s should decode into a raw request", entry.Name())
 		require.NotEmpty(t, raw)

--- a/pkg/input/types/fuzz_harness_test.go
+++ b/pkg/input/types/fuzz_harness_test.go
@@ -1,0 +1,46 @@
+package types
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRawRequestFromFuzzDataSeedCorpus(t *testing.T) {
+	entries, err := os.ReadDir("testdata/gofuzz-corpus")
+	require.NoError(t, err)
+	require.NotEmpty(t, entries)
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		path := filepath.Join("testdata/gofuzz-corpus", entry.Name())
+		data, err := os.ReadFile(path)
+		require.NoError(t, err)
+
+		raw, targetURL, ok := rawRequestFromFuzzData(data)
+		require.Truef(t, ok, "seed %s should decode into a raw request", entry.Name())
+		require.NotEmpty(t, raw)
+		require.NotEmpty(t, targetURL)
+
+		rr, err := ParseRawRequest(raw)
+		require.NoErrorf(t, err, "seed %s generated raw request should parse", entry.Name())
+		exerciseFuzzRequestResponse(rr)
+
+		rr, err = ParseRawRequestWithURL(raw, targetURL)
+		require.NoErrorf(t, err, "seed %s generated raw request should parse with URL", entry.Name())
+		exerciseFuzzRequestResponse(rr)
+	}
+}
+
+func TestRawRequestFromFuzzDataRejectsOversizeInput(t *testing.T) {
+	data := make([]byte, fuzzMaxInputSize+1)
+	raw, targetURL, ok := rawRequestFromFuzzData(data)
+	require.False(t, ok)
+	require.Empty(t, raw)
+	require.Empty(t, targetURL)
+}

--- a/pkg/input/types/testdata/gofuzz-corpus/burp-post.seed
+++ b/pkg/input/types/testdata/gofuzz-corpus/burp-post.seed
@@ -1,0 +1,6 @@
+method=POST
+path=/submit?debug=true
+host=127.0.0.1:8080
+header=Origin: https://example.com
+header=Content-Type: application/x-www-form-urlencoded
+body=username=admin&password=login

--- a/pkg/input/types/testdata/gofuzz-corpus/get.seed
+++ b/pkg/input/types/testdata/gofuzz-corpus/get.seed
@@ -1,0 +1,4 @@
+method=GET
+path=/api/v1/users?id=1
+host=example.com
+header=Accept: application/json

--- a/pkg/input/types/testdata/gofuzz-corpus/json-body.seed
+++ b/pkg/input/types/testdata/gofuzz-corpus/json-body.seed
@@ -1,0 +1,5 @@
+method=POST
+path=/api/v1/login
+host=scanme.sh
+header=Content-Type: application/json
+body={"username":"admin","password":"admin"}

--- a/pkg/input/types/testdata/gofuzz-corpus/url-override.seed
+++ b/pkg/input/types/testdata/gofuzz-corpus/url-override.seed
@@ -1,0 +1,6 @@
+method=PUT
+path=/openapi/generated
+host=api.example.com
+url=https://target.example.org/base
+header=X-Request-ID: fuzz
+body={"ok":true}

--- a/pkg/protocols/http/raw/fuzz.go
+++ b/pkg/protocols/http/raw/fuzz.go
@@ -1,0 +1,19 @@
+//go:build gofuzz
+// +build gofuzz
+
+package raw
+
+// Fuzz exercises raw HTTP request parsing in safe, unsafe, self-contained, and
+// path-automerge modes.
+func Fuzz(data []byte) int {
+	if len(data) == 0 {
+		return 0
+	}
+	if len(data) > fuzzMaxInputSize {
+		return -1
+	}
+	if !fuzzRawHTTPParsing(data) {
+		return 0
+	}
+	return 1
+}

--- a/pkg/protocols/http/raw/fuzz_harness.go
+++ b/pkg/protocols/http/raw/fuzz_harness.go
@@ -1,0 +1,355 @@
+package raw
+
+import (
+	"fmt"
+	"strings"
+
+	urlutil "github.com/projectdiscovery/utils/url"
+)
+
+const (
+	fuzzMaxInputSize  = 16 << 10
+	fuzzMaxHeaders    = 8
+	fuzzMaxValueBytes = 256
+)
+
+var (
+	fuzzRawMethods = []string{"GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"}
+	fuzzRawPaths   = []string{"/", "", "/admin/login", "/api/v1/users?id=1", "1337?with=param", "http://127.0.0.1/foo?id=1"}
+	fuzzRawHosts   = []string{"example.com", "{{Hostname}}", "127.0.0.1", "example.com:8080"}
+	fuzzInputURLs  = []string{"https://example.com", "https://example.com/base", "http://target.local:8080/root?x=1", "http://httpbin.org/bar"}
+)
+
+type fuzzRawHeader struct {
+	key   string
+	value string
+}
+
+type fuzzRawHTTPCandidate struct {
+	method               string
+	path                 string
+	host                 string
+	inputURL             string
+	unsafe               bool
+	disablePathAutomerge bool
+	headers              []fuzzRawHeader
+	body                 string
+}
+
+func fuzzRawHTTPParsing(data []byte) bool {
+	rawRequest, inputURL, unsafe, disablePathAutomerge, ok := rawHTTPRequestFromFuzzData(data)
+	if !ok {
+		return false
+	}
+
+	parsedURL, err := urlutil.Parse(inputURL)
+	if err != nil {
+		return false
+	}
+
+	parsed := false
+	for _, unsafeMode := range fuzzBoolCases(unsafe) {
+		for _, disableAutomerge := range fuzzBoolCases(disablePathAutomerge) {
+			request, parseErr := Parse(rawRequest, parsedURL.Clone(), unsafeMode, disableAutomerge)
+			if parseErr == nil {
+				exerciseFuzzRawRequest(request)
+				parsed = true
+			}
+		}
+
+		request, parseErr := ParseRawRequest(rawRequest, unsafeMode)
+		if parseErr == nil {
+			exerciseFuzzRawRequest(request)
+			parsed = true
+		}
+	}
+
+	if looksLikeRawHTTPRequest(data) {
+		rawInput := string(data)
+		for _, unsafeMode := range []bool{false, true} {
+			request, parseErr := Parse(rawInput, parsedURL.Clone(), unsafeMode, disablePathAutomerge)
+			if parseErr == nil {
+				exerciseFuzzRawRequest(request)
+				parsed = true
+			}
+
+			request, parseErr = ParseRawRequest(rawInput, unsafeMode)
+			if parseErr == nil {
+				exerciseFuzzRawRequest(request)
+				parsed = true
+			}
+		}
+	}
+
+	return parsed
+}
+
+func rawHTTPRequestFromFuzzData(data []byte) (string, string, bool, bool, bool) {
+	if len(data) == 0 || len(data) > fuzzMaxInputSize {
+		return "", "", false, false, false
+	}
+
+	candidate := newFuzzRawHTTPCandidate(data)
+	candidate.applyLines(splitFuzzLines(data))
+	return candidate.build(), candidate.inputURL, candidate.unsafe, candidate.disablePathAutomerge, true
+}
+
+func newFuzzRawHTTPCandidate(data []byte) *fuzzRawHTTPCandidate {
+	flags := fuzzByteAt(data, 1)
+	return &fuzzRawHTTPCandidate{
+		method:               fuzzRawMethods[int(fuzzByteAt(data, 0))%len(fuzzRawMethods)],
+		path:                 fuzzRawPaths[int(fuzzByteAt(data, 2))%len(fuzzRawPaths)],
+		host:                 fuzzRawHosts[int(fuzzByteAt(data, 3))%len(fuzzRawHosts)],
+		inputURL:             fuzzInputURLs[int(fuzzByteAt(data, 4))%len(fuzzInputURLs)],
+		unsafe:               flags&0x01 != 0,
+		disablePathAutomerge: flags&0x02 != 0,
+		headers: []fuzzRawHeader{
+			{key: "User-Agent", value: "nuclei-fuzz"},
+		},
+		body: fuzzRawBody(string(data)),
+	}
+}
+
+func (candidate *fuzzRawHTTPCandidate) applyLines(lines []string) {
+	for _, line := range lines {
+		key, value, ok := cutFuzzKV(line)
+		if !ok {
+			candidate.body = fuzzRawBody(line)
+			continue
+		}
+
+		switch key {
+		case "method":
+			candidate.method = fuzzRawMethod(value, candidate.method)
+		case "path":
+			if value == "" {
+				candidate.path = ""
+			} else {
+				candidate.path = fuzzRawPath(value, candidate.path)
+			}
+		case "host":
+			candidate.host = fuzzRawHost(value, candidate.host)
+		case "input-url", "url":
+			candidate.inputURL = fuzzRawInputURL(value, candidate.inputURL)
+		case "unsafe":
+			candidate.unsafe = fuzzRawBool(value, candidate.unsafe)
+		case "disable-automerge", "disable-path-automerge":
+			candidate.disablePathAutomerge = fuzzRawBool(value, candidate.disablePathAutomerge)
+		case "header":
+			candidate.addHeader(value)
+		case "body":
+			candidate.body = fuzzRawBody(value)
+		}
+	}
+}
+
+func (candidate *fuzzRawHTTPCandidate) addHeader(value string) {
+	key, headerValue, ok := strings.Cut(value, ":")
+	if !ok {
+		key, headerValue, ok = strings.Cut(value, "=")
+	}
+	if !ok {
+		return
+	}
+
+	key = fuzzRawHeaderKey(key)
+	if key == "" || strings.EqualFold(key, "Host") || len(candidate.headers) >= fuzzMaxHeaders {
+		return
+	}
+	candidate.headers = append(candidate.headers, fuzzRawHeader{key: key, value: fuzzRawHeaderValue(headerValue)})
+}
+
+func (candidate *fuzzRawHTTPCandidate) build() string {
+	var builder strings.Builder
+	if candidate.path == "" {
+		fmt.Fprintf(&builder, "%s HTTP/1.1\r\n", candidate.method)
+	} else {
+		fmt.Fprintf(&builder, "%s %s HTTP/1.1\r\n", candidate.method, candidate.path)
+	}
+	fmt.Fprintf(&builder, "Host: %s\r\n", candidate.host)
+	for _, header := range candidate.headers {
+		fmt.Fprintf(&builder, "%s: %s\r\n", header.key, header.value)
+	}
+	builder.WriteString("\r\n")
+	builder.WriteString(candidate.body)
+	return builder.String()
+}
+
+func exerciseFuzzRawRequest(request *Request) {
+	if request == nil {
+		panic("nil raw request")
+	}
+	_ = request.FullURL
+	_ = request.Method
+	_ = request.Path
+	_ = request.Data
+	if len(request.UnsafeRawBytes) > 0 {
+		_ = request.TryFillCustomHeaders([]string{"X-Fuzz: 1"})
+	}
+}
+
+func looksLikeRawHTTPRequest(data []byte) bool {
+	line := string(data)
+	if index := strings.IndexAny(line, "\r\n"); index >= 0 {
+		line = line[:index]
+	}
+	parts := strings.Fields(line)
+	return len(parts) >= 3 && strings.HasPrefix(parts[2], "HTTP/")
+}
+
+func fuzzBoolCases(value bool) []bool {
+	if value {
+		return []bool{true, false}
+	}
+	return []bool{false, true}
+}
+
+func splitFuzzLines(data []byte) []string {
+	fields := strings.FieldsFunc(string(data), func(r rune) bool {
+		return r == '\n' || r == '\r' || r == ';'
+	})
+	if len(fields) > fuzzMaxHeaders*4 {
+		fields = fields[:fuzzMaxHeaders*4]
+	}
+
+	lines := make([]string, 0, len(fields))
+	for _, field := range fields {
+		field = fuzzTrim(field)
+		if field != "" {
+			lines = append(lines, field)
+		}
+	}
+	return lines
+}
+
+func cutFuzzKV(line string) (string, string, bool) {
+	key, value, ok := strings.Cut(line, "=")
+	if !ok {
+		key, value, ok = strings.Cut(line, ":")
+	}
+	if !ok {
+		return "", "", false
+	}
+	return strings.ToLower(fuzzTrim(key)), fuzzTrim(value), true
+}
+
+func fuzzByteAt(data []byte, index int) byte {
+	if len(data) == 0 {
+		return 0
+	}
+	return data[index%len(data)]
+}
+
+func fuzzRawMethod(value, fallback string) string {
+	value = strings.ToUpper(fuzzRawToken(value, 16))
+	if value == "" {
+		return fallback
+	}
+	return value
+}
+
+func fuzzRawPath(value, fallback string) string {
+	value = fuzzTrim(value)
+	if value == "" {
+		return fallback
+	}
+	if len(value) > fuzzMaxValueBytes {
+		value = value[:fuzzMaxValueBytes]
+	}
+	return value
+}
+
+func fuzzRawInputURL(value, fallback string) string {
+	value = fuzzTrim(value)
+	if strings.HasPrefix(value, "http://") || strings.HasPrefix(value, "https://") {
+		return value
+	}
+	host := fuzzRawHost(value, "")
+	if host == "" {
+		return fallback
+	}
+	return "https://" + host + "/"
+}
+
+func fuzzRawHost(value, fallback string) string {
+	value = strings.TrimSpace(strings.NewReplacer("\x00", "", "\r", "", "\n", "", "/", "", "\\", "").Replace(value))
+	if value == "{{Hostname}}" || value == "{{BaseURL}}" {
+		return value
+	}
+
+	value = strings.ToLower(value)
+	var builder strings.Builder
+	for _, r := range value {
+		switch {
+		case r >= 'a' && r <= 'z':
+			builder.WriteRune(r)
+		case r >= '0' && r <= '9':
+			builder.WriteRune(r)
+		case r == '.' || r == '-' || r == ':':
+			builder.WriteRune(r)
+		}
+		if builder.Len() >= 128 {
+			break
+		}
+	}
+	if builder.Len() == 0 {
+		return fallback
+	}
+	return builder.String()
+}
+
+func fuzzRawHeaderKey(value string) string {
+	return fuzzRawToken(value, 64)
+}
+
+func fuzzRawHeaderValue(value string) string {
+	return fuzzTrim(value)
+}
+
+func fuzzRawBody(value string) string {
+	value = strings.ReplaceAll(value, "\x00", "")
+	if len(value) > fuzzMaxValueBytes {
+		value = value[:fuzzMaxValueBytes]
+	}
+	return value
+}
+
+func fuzzRawBool(value string, fallback bool) bool {
+	switch strings.ToLower(fuzzTrim(value)) {
+	case "1", "t", "true", "yes", "y", "on":
+		return true
+	case "0", "f", "false", "no", "n", "off":
+		return false
+	default:
+		return fallback
+	}
+}
+
+func fuzzRawToken(value string, limit int) string {
+	value = fuzzTrim(value)
+	var builder strings.Builder
+	for _, r := range value {
+		switch {
+		case r >= 'a' && r <= 'z':
+			builder.WriteRune(r - 'a' + 'A')
+		case r >= 'A' && r <= 'Z':
+			builder.WriteRune(r)
+		case r >= '0' && r <= '9':
+			builder.WriteRune(r)
+		case r == '-':
+			builder.WriteRune(r)
+		}
+		if builder.Len() >= limit {
+			break
+		}
+	}
+	return builder.String()
+}
+
+func fuzzTrim(value string) string {
+	value = strings.TrimSpace(strings.NewReplacer("\x00", "", "\r", " ", "\n", " ").Replace(value))
+	if len(value) > fuzzMaxValueBytes {
+		value = value[:fuzzMaxValueBytes]
+	}
+	return value
+}

--- a/pkg/protocols/http/raw/fuzz_harness_test.go
+++ b/pkg/protocols/http/raw/fuzz_harness_test.go
@@ -1,0 +1,53 @@
+package raw
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	urlutil "github.com/projectdiscovery/utils/url"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRawHTTPRequestFromFuzzDataSeedCorpus(t *testing.T) {
+	entries, err := os.ReadDir("testdata/gofuzz-corpus")
+	require.NoError(t, err)
+	require.NotEmpty(t, entries)
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		path := filepath.Join("testdata/gofuzz-corpus", entry.Name())
+		data, err := os.ReadFile(path)
+		require.NoError(t, err)
+
+		rawRequest, inputURL, unsafe, disablePathAutomerge, ok := rawHTTPRequestFromFuzzData(data)
+		require.Truef(t, ok, "seed %s should decode into a raw request", entry.Name())
+		require.NotEmpty(t, rawRequest)
+		require.NotEmpty(t, inputURL)
+
+		parsedURL, err := urlutil.Parse(inputURL)
+		require.NoErrorf(t, err, "seed %s should generate a valid input URL", entry.Name())
+
+		request, err := Parse(rawRequest, parsedURL, unsafe, disablePathAutomerge)
+		require.NoErrorf(t, err, "seed %s generated raw request should parse", entry.Name())
+		exerciseFuzzRawRequest(request)
+
+		request, err = ParseRawRequest(rawRequest, unsafe)
+		if err == nil {
+			exerciseFuzzRawRequest(request)
+		}
+	}
+}
+
+func TestRawHTTPRequestFromFuzzDataRejectsOversizeInput(t *testing.T) {
+	data := make([]byte, fuzzMaxInputSize+1)
+	rawRequest, inputURL, unsafe, disablePathAutomerge, ok := rawHTTPRequestFromFuzzData(data)
+	require.False(t, ok)
+	require.Empty(t, rawRequest)
+	require.Empty(t, inputURL)
+	require.False(t, unsafe)
+	require.False(t, disablePathAutomerge)
+}

--- a/pkg/protocols/http/raw/fuzz_harness_test.go
+++ b/pkg/protocols/http/raw/fuzz_harness_test.go
@@ -23,6 +23,8 @@ func TestRawHTTPRequestFromFuzzDataSeedCorpus(t *testing.T) {
 		data, err := os.ReadFile(path)
 		require.NoError(t, err)
 
+		require.Truef(t, fuzzRawHTTPParsing(data), "seed %s should exercise the raw HTTP parser fuzz path", entry.Name())
+
 		rawRequest, inputURL, unsafe, disablePathAutomerge, ok := rawHTTPRequestFromFuzzData(data)
 		require.Truef(t, ok, "seed %s should decode into a raw request", entry.Name())
 		require.NotEmpty(t, rawRequest)

--- a/pkg/protocols/http/raw/testdata/gofuzz-corpus/empty-path.seed
+++ b/pkg/protocols/http/raw/testdata/gofuzz-corpus/empty-path.seed
@@ -1,0 +1,7 @@
+method=GET
+path=
+host={{Hostname}}
+input-url=https://example.com/base?debug=true
+unsafe=false
+disable-automerge=false
+header=Accept: */*

--- a/pkg/protocols/http/raw/testdata/gofuzz-corpus/host-reconstruct.seed
+++ b/pkg/protocols/http/raw/testdata/gofuzz-corpus/host-reconstruct.seed
@@ -1,0 +1,7 @@
+method=GET
+path=/manager/html
+host=example.com:8080
+input-url=https://target.example/base
+unsafe=false
+disable-automerge=false
+header=Authorization: Basic dXNlcjpwYXNz

--- a/pkg/protocols/http/raw/testdata/gofuzz-corpus/path-automerge.seed
+++ b/pkg/protocols/http/raw/testdata/gofuzz-corpus/path-automerge.seed
@@ -1,0 +1,8 @@
+method=POST
+path=/login
+host={{Hostname}}
+input-url=https://example.com/app
+unsafe=false
+disable-automerge=false
+header=Content-Type: application/x-www-form-urlencoded
+body=username=admin&password=login

--- a/pkg/protocols/http/raw/testdata/gofuzz-corpus/unsafe-full-url.seed
+++ b/pkg/protocols/http/raw/testdata/gofuzz-corpus/unsafe-full-url.seed
@@ -1,0 +1,7 @@
+method=GET
+path=http://127.0.0.1/foo?id=123&name=test
+host={{Hostname}}
+input-url=http://httpbin.org/bar
+unsafe=true
+disable-automerge=true
+header=Connection: close

--- a/pkg/protocols/http/raw/testdata/gofuzz-corpus/unsafe-relative-query.seed
+++ b/pkg/protocols/http/raw/testdata/gofuzz-corpus/unsafe-relative-query.seed
@@ -1,0 +1,6 @@
+method=GET
+path=1337?with=param
+host={{Hostname}}
+input-url=https://example.com/test.js?x=1
+unsafe=true
+disable-automerge=false

--- a/pkg/templates/fuzz.go
+++ b/pkg/templates/fuzz.go
@@ -1,0 +1,19 @@
+//go:build gofuzz
+// +build gofuzz
+
+package templates
+
+// Fuzz exercises YAML and JSON template parsing plus compile-time validation
+// without executing any protocol requests.
+func Fuzz(data []byte) int {
+	if len(data) == 0 {
+		return 0
+	}
+	if len(data) > fuzzMaxInputSize {
+		return -1
+	}
+	if !fuzzTemplateParsing(data) {
+		return 0
+	}
+	return 1
+}

--- a/pkg/templates/fuzz_harness.go
+++ b/pkg/templates/fuzz_harness.go
@@ -54,10 +54,7 @@ func fuzzTemplateParsing(data []byte) bool {
 	candidate := newFuzzTemplateCandidate(data)
 	candidate.applyLines(splitFuzzLines(data))
 
-	parsed := false
-	if exerciseFuzzYAMLTemplate(candidate.yaml()) {
-		parsed = true
-	}
+	parsed := exerciseFuzzYAMLTemplate(candidate.yaml())
 	if exerciseFuzzJSONTemplate(candidate.json()) {
 		parsed = true
 	}

--- a/pkg/templates/fuzz_harness.go
+++ b/pkg/templates/fuzz_harness.go
@@ -1,0 +1,426 @@
+package templates
+
+import (
+	"bytes"
+	"context"
+	stdjson "encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/catalog"
+	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/disk"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolinit"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
+	nucleiTypes "github.com/projectdiscovery/nuclei/v3/pkg/types"
+	"github.com/projectdiscovery/ratelimit"
+	"gopkg.in/yaml.v2"
+)
+
+const (
+	fuzzMaxInputSize  = 16 << 10
+	fuzzMaxValueBytes = 256
+)
+
+var (
+	fuzzTemplateSeverities = []string{"info", "low", "medium", "high", "critical", "unknown"}
+	fuzzTemplateMethods    = []string{"GET", "POST", "PUT", "DELETE", "PATCH", "HEAD"}
+	fuzzTemplatePaths      = []string{"/", "/login", "/api/v1/users", "/search?q=nuclei", "/admin/{{id}}"}
+	fuzzTemplateWords      = []string{"nuclei", "Example Domain", "HTTP", "success", "admin"}
+	errFuzzHelperDisabled  = errors.New("fuzz template helper file loading disabled")
+	fuzzProtocolInit       sync.Once
+)
+
+type fuzzTemplateCandidate struct {
+	id            string
+	name          string
+	author        string
+	severity      string
+	method        string
+	path          string
+	matcherWord   string
+	useRawRequest bool
+}
+
+func fuzzTemplateParsing(data []byte) bool {
+	if len(data) == 0 || len(data) > fuzzMaxInputSize {
+		return false
+	}
+
+	candidate := newFuzzTemplateCandidate(data)
+	candidate.applyLines(splitFuzzLines(data))
+
+	parsed := false
+	if exerciseFuzzYAMLTemplate(candidate.yaml()) {
+		parsed = true
+	}
+	if exerciseFuzzJSONTemplate(candidate.json()) {
+		parsed = true
+	}
+
+	exerciseFuzzDirectTemplateParsers(data)
+	return parsed
+}
+
+func exerciseFuzzYAMLTemplate(data []byte) bool {
+	return exerciseFuzzYAMLTemplateErr(data) == nil
+}
+
+func exerciseFuzzYAMLTemplateErr(data []byte) error {
+	template, err := parseFuzzYAMLTemplate(data)
+	if err != nil {
+		return err
+	}
+	exerciseFuzzParsedTemplate(template)
+	if _, err = compileFuzzTemplate(data); err != nil {
+		return err
+	}
+	return nil
+}
+
+func exerciseFuzzJSONTemplate(data []byte) bool {
+	return exerciseFuzzJSONTemplateErr(data) == nil
+}
+
+func exerciseFuzzJSONTemplateErr(data []byte) error {
+	template, err := parseFuzzJSONTemplate(data)
+	if err != nil {
+		return err
+	}
+	exerciseFuzzParsedTemplate(template)
+	if _, err = compileFuzzTemplate(data); err != nil {
+		return err
+	}
+	return nil
+}
+
+func exerciseFuzzDirectTemplateParsers(data []byte) {
+	if len(bytes.TrimSpace(data)) == 0 {
+		return
+	}
+
+	if template, err := parseFuzzYAMLTemplate(data); err == nil {
+		exerciseFuzzParsedTemplate(template)
+	}
+	if stdjson.Valid(data) {
+		if template, err := parseFuzzJSONTemplate(data); err == nil {
+			exerciseFuzzParsedTemplate(template)
+		}
+	}
+}
+
+func parseFuzzYAMLTemplate(data []byte) (*Template, error) {
+	template := &Template{}
+	if err := yaml.UnmarshalStrict(data, template); err != nil {
+		return nil, err
+	}
+	if err := validateTemplateMandatoryFields(template); err != nil {
+		return nil, err
+	}
+	return template, nil
+}
+
+func parseFuzzJSONTemplate(data []byte) (*Template, error) {
+	template := &Template{}
+	if err := template.unmarshalJSONStrict(data); err != nil {
+		return nil, err
+	}
+	if err := validateTemplateMandatoryFields(template); err != nil {
+		return nil, err
+	}
+	return template, nil
+}
+
+func compileFuzzTemplate(data []byte) (*Template, error) {
+	template, err := parseTemplateNoVerify(data, newFuzzExecutorOptions())
+	if err != nil {
+		return nil, err
+	}
+	if template == nil {
+		return nil, errors.New("nil compiled template")
+	}
+	exerciseFuzzParsedTemplate(template)
+	return template, nil
+}
+
+func exerciseFuzzParsedTemplate(template *Template) {
+	if template == nil {
+		panic("nil template")
+	}
+	_ = template.Type()
+	_ = template.Requests()
+	template.validateAllRequestIDs()
+	template.parseSelfContainedRequests()
+}
+
+func newFuzzExecutorOptions() *protocols.ExecutorOptions {
+	options := nucleiTypes.DefaultOptions()
+	options.NoColor = true
+	options.RateLimit = 1
+	options.RateLimitDuration = time.Second
+	options.BulkSize = 1
+	options.TemplateThreads = 1
+	options.PayloadConcurrency = 1
+	options.TemplateLoadingConcurrency = 1
+	options.ExecutionId = "fuzz-template"
+	options.LoadHelperFileFunction = func(string, string, catalog.Catalog) (io.ReadCloser, error) {
+		return nil, errFuzzHelperDisabled
+	}
+	fuzzProtocolInit.Do(func() {
+		_ = protocolstate.Init(options)
+		_ = protocolinit.Init(options)
+	})
+
+	executorOptions := &protocols.ExecutorOptions{
+		Options:      options,
+		Catalog:      disk.NewCatalog(""),
+		RateLimiter:  ratelimit.New(context.Background(), 1, time.Second),
+		Parser:       NewParser(),
+		DoNotCache:   true,
+		TemplatePath: "fuzz-template.yaml",
+	}
+	executorOptions.CreateTemplateCtxStore()
+	return executorOptions
+}
+
+func newFuzzTemplateCandidate(data []byte) *fuzzTemplateCandidate {
+	flags := fuzzByteAt(data, 1)
+	return &fuzzTemplateCandidate{
+		id:            fuzzTemplateID(string(data)),
+		name:          "fuzz template",
+		author:        "nuclei-fuzzer",
+		severity:      fuzzTemplateSeverities[int(fuzzByteAt(data, 0))%len(fuzzTemplateSeverities)],
+		method:        fuzzTemplateMethods[int(fuzzByteAt(data, 2))%len(fuzzTemplateMethods)],
+		path:          fuzzTemplatePaths[int(fuzzByteAt(data, 3))%len(fuzzTemplatePaths)],
+		matcherWord:   fuzzTemplateWords[int(fuzzByteAt(data, 4))%len(fuzzTemplateWords)],
+		useRawRequest: flags&0x01 != 0,
+	}
+}
+
+func (candidate *fuzzTemplateCandidate) applyLines(lines []string) {
+	for _, line := range lines {
+		key, value, ok := cutFuzzKV(line)
+		if !ok {
+			candidate.matcherWord = fuzzTemplateText(line, candidate.matcherWord)
+			continue
+		}
+
+		switch key {
+		case "id":
+			candidate.id = fuzzTemplateID(value)
+		case "name":
+			candidate.name = fuzzTemplateText(value, candidate.name)
+		case "author":
+			candidate.author = fuzzTemplateID(value)
+		case "severity":
+			candidate.severity = fuzzSeverity(value, candidate.severity)
+		case "method":
+			candidate.method = fuzzMethod(value, candidate.method)
+		case "path":
+			candidate.path = fuzzPath(value, candidate.path)
+		case "matcher", "word":
+			candidate.matcherWord = fuzzTemplateText(value, candidate.matcherWord)
+		case "raw", "use-raw":
+			candidate.useRawRequest = fuzzBool(value, candidate.useRawRequest)
+		}
+	}
+}
+
+func (candidate *fuzzTemplateCandidate) yaml() []byte {
+	var builder strings.Builder
+	fmt.Fprintf(&builder, "id: %s\n", yamlQuote(candidate.id))
+	fmt.Fprintf(&builder, "info:\n  name: %s\n  author: %s\n  severity: %s\n", yamlQuote(candidate.name), yamlQuote(candidate.author), yamlQuote(candidate.severity))
+	builder.WriteString("http:\n  - ")
+	if candidate.useRawRequest {
+		builder.WriteString("raw:\n      - |\n")
+		for _, line := range strings.Split(candidate.rawRequest(), "\r\n") {
+			if line == "" {
+				builder.WriteString("        \n")
+				continue
+			}
+			fmt.Fprintf(&builder, "        %s\n", line)
+		}
+	} else {
+		fmt.Fprintf(&builder, "method: %s\n    path:\n      - %s\n", yamlQuote(candidate.method), yamlQuote("{{BaseURL}}"+candidate.path))
+	}
+	builder.WriteString("    matchers:\n      - type: word\n        part: body\n        words:\n")
+	fmt.Fprintf(&builder, "          - %s\n", yamlQuote(candidate.matcherWord))
+	return []byte(builder.String())
+}
+
+func (candidate *fuzzTemplateCandidate) json() []byte {
+	request := map[string]interface{}{
+		"matchers": []map[string]interface{}{
+			{
+				"type":  "word",
+				"part":  "body",
+				"words": []string{candidate.matcherWord},
+			},
+		},
+	}
+	if candidate.useRawRequest {
+		request["raw"] = []string{candidate.rawRequest()}
+	} else {
+		request["method"] = candidate.method
+		request["path"] = []string{"{{BaseURL}}" + candidate.path}
+	}
+
+	template := map[string]interface{}{
+		"id": candidate.id,
+		"info": map[string]interface{}{
+			"name":     candidate.name,
+			"author":   candidate.author,
+			"severity": candidate.severity,
+		},
+		"http": []map[string]interface{}{request},
+	}
+	data, err := stdjson.Marshal(template)
+	if err != nil {
+		panic(err)
+	}
+	return data
+}
+
+func (candidate *fuzzTemplateCandidate) rawRequest() string {
+	path := candidate.path
+	if path == "" {
+		path = "/"
+	}
+	return fmt.Sprintf("%s %s HTTP/1.1\r\nHost: {{Hostname}}\r\nUser-Agent: nuclei-fuzz\r\n\r\n", candidate.method, path)
+}
+
+func splitFuzzLines(data []byte) []string {
+	fields := strings.FieldsFunc(string(data), func(r rune) bool {
+		return r == '\n' || r == '\r' || r == ';'
+	})
+	if len(fields) > 32 {
+		fields = fields[:32]
+	}
+
+	lines := make([]string, 0, len(fields))
+	for _, field := range fields {
+		field = fuzzTrim(field)
+		if field != "" {
+			lines = append(lines, field)
+		}
+	}
+	return lines
+}
+
+func cutFuzzKV(line string) (string, string, bool) {
+	key, value, ok := strings.Cut(line, "=")
+	if !ok {
+		key, value, ok = strings.Cut(line, ":")
+	}
+	if !ok {
+		return "", "", false
+	}
+	return strings.ToLower(fuzzTrim(key)), fuzzTrim(value), true
+}
+
+func yamlQuote(value string) string {
+	data, err := stdjson.Marshal(value)
+	if err != nil {
+		panic(err)
+	}
+	return string(data)
+}
+
+func fuzzByteAt(data []byte, index int) byte {
+	if len(data) == 0 {
+		return 0
+	}
+	return data[index%len(data)]
+}
+
+func fuzzTemplateID(value string) string {
+	value = strings.ToLower(fuzzToken(value, 48))
+	value = strings.Trim(value, "-_")
+	value = strings.ReplaceAll(value, "_-", "-")
+	value = strings.ReplaceAll(value, "-_", "-")
+	if value == "" {
+		return "fuzz-template"
+	}
+	return value
+}
+
+func fuzzTemplateText(value, fallback string) string {
+	value = fuzzTrim(value)
+	if value == "" {
+		return fallback
+	}
+	return value
+}
+
+func fuzzSeverity(value, fallback string) string {
+	value = strings.ToLower(fuzzTrim(value))
+	for _, severity := range fuzzTemplateSeverities {
+		if value == severity {
+			return value
+		}
+	}
+	return fallback
+}
+
+func fuzzMethod(value, fallback string) string {
+	value = strings.ToUpper(fuzzToken(value, 16))
+	if value == "" {
+		return fallback
+	}
+	return value
+}
+
+func fuzzPath(value, fallback string) string {
+	value = fuzzTrim(value)
+	if value == "" {
+		return fallback
+	}
+	if !strings.HasPrefix(value, "/") && !strings.HasPrefix(value, "?") {
+		value = "/" + value
+	}
+	return value
+}
+
+func fuzzBool(value string, fallback bool) bool {
+	switch strings.ToLower(fuzzTrim(value)) {
+	case "1", "t", "true", "yes", "y", "on":
+		return true
+	case "0", "f", "false", "no", "n", "off":
+		return false
+	default:
+		return fallback
+	}
+}
+
+func fuzzToken(value string, limit int) string {
+	value = fuzzTrim(value)
+	var builder strings.Builder
+	for _, r := range value {
+		switch {
+		case r >= 'a' && r <= 'z':
+			builder.WriteRune(r)
+		case r >= 'A' && r <= 'Z':
+			builder.WriteRune(r - 'A' + 'a')
+		case r >= '0' && r <= '9':
+			builder.WriteRune(r)
+		case r == '-' || r == '_':
+			builder.WriteRune(r)
+		}
+		if builder.Len() >= limit {
+			break
+		}
+	}
+	return builder.String()
+}
+
+func fuzzTrim(value string) string {
+	value = strings.TrimSpace(strings.NewReplacer("\x00", "", "\r", " ", "\n", " ").Replace(value))
+	if len(value) > fuzzMaxValueBytes {
+		value = value[:fuzzMaxValueBytes]
+	}
+	return value
+}

--- a/pkg/templates/fuzz_harness_test.go
+++ b/pkg/templates/fuzz_harness_test.go
@@ -1,0 +1,43 @@
+package templates
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTemplateFromFuzzDataSeedCorpus(t *testing.T) {
+	entries, err := os.ReadDir("testdata/gofuzz-corpus")
+	require.NoError(t, err)
+	require.NotEmpty(t, entries)
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		path := filepath.Join("testdata/gofuzz-corpus", entry.Name())
+		data, err := os.ReadFile(path)
+		require.NoError(t, err)
+
+		candidate := newFuzzTemplateCandidate(data)
+		candidate.applyLines(splitFuzzLines(data))
+
+		require.NoErrorf(t, exerciseFuzzYAMLTemplateErr(candidate.yaml()), "seed %s generated YAML should parse and compile", entry.Name())
+		require.NoErrorf(t, exerciseFuzzJSONTemplateErr(candidate.json()), "seed %s generated JSON should parse and compile", entry.Name())
+	}
+}
+
+func TestTemplateFromFuzzDataRejectsOversizeInput(t *testing.T) {
+	data := make([]byte, fuzzMaxInputSize+1)
+	require.False(t, fuzzTemplateParsing(data))
+}
+
+func TestFuzzTemplateHelperFileLoadingDisabled(t *testing.T) {
+	options := newFuzzExecutorOptions()
+	reader, err := options.Options.LoadHelperFile("anything.js", "fuzz-template.yaml", options.Catalog)
+	require.Nil(t, reader)
+	require.ErrorIs(t, err, errFuzzHelperDisabled)
+}

--- a/pkg/templates/testdata/gofuzz-corpus/http-json.seed
+++ b/pkg/templates/testdata/gofuzz-corpus/http-json.seed
@@ -1,0 +1,7 @@
+id=http-json-fuzz
+name=HTTP JSON fuzz template
+author=nuclei-fuzzer
+severity=medium
+method=POST
+path=/api/v1/login
+matcher=success

--- a/pkg/templates/testdata/gofuzz-corpus/http-yaml.seed
+++ b/pkg/templates/testdata/gofuzz-corpus/http-yaml.seed
@@ -1,0 +1,7 @@
+id=http-yaml-fuzz
+name=HTTP YAML fuzz template
+author=nuclei-fuzzer
+severity=info
+method=GET
+path=/status
+matcher=HTTP

--- a/pkg/templates/testdata/gofuzz-corpus/raw-http.seed
+++ b/pkg/templates/testdata/gofuzz-corpus/raw-http.seed
@@ -1,0 +1,8 @@
+id=raw-http-fuzz
+name=Raw HTTP fuzz template
+author=nuclei-fuzzer
+severity=low
+method=GET
+path=/admin
+raw=true
+matcher=admin

--- a/pkg/templates/testdata/gofuzz-corpus/template-path-vars.seed
+++ b/pkg/templates/testdata/gofuzz-corpus/template-path-vars.seed
@@ -1,0 +1,7 @@
+id=template-path-vars
+name=Template path vars
+author=nuclei-fuzzer
+severity=high
+method=PUT
+path=/admin/{{id}}
+matcher=Example Domain


### PR DESCRIPTION
## Proposed changes

Add go-fuzz harnesses for raw request and template
parsing.

The new coverage exercises input raw request
parsing, HTTP raw request parsing across safe and
unsafe modes, and YAML/JSON template parsing with
lightweight compile-time validation. Seed corpora
cover common ingestion shapes, host reconstruction,
full URL paths, empty path automerge, relative
query paths, and raw HTTP template requests.

Part of #7312

### Proof

<!-- How has this been tested? Please describe the tests that you ran to verify your changes. -->

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added fuzzing entrypoints to exercise parsing across templates, HTTP raw handling, and input types.

* **Tests**
  * Added comprehensive fuzz-harness test suites validating parsing, oversize-rejection, and seed-corpus coverage.
  * Added multiple fuzz seed corpus entries covering GET/POST/PUT, JSON/form bodies, headers, and URL variations.

* **Chores**
  * Introduced fuzzing harnesses and infrastructure across core modules to improve input-validation testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->