### PR TITLE
chore(deps): bump govaluate to fix slice-bounds panic on invalid UTF-8 input

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -104,7 +104,7 @@ require (
 	github.com/projectdiscovery/goflags v0.1.74
 	github.com/projectdiscovery/gologger v1.1.70
 	github.com/projectdiscovery/gostruct v0.0.2
-	github.com/projectdiscovery/govaluate v0.0.0-20260504230327-80320480bb6e
+	github.com/projectdiscovery/govaluate v0.0.0-20260615100919-5ee2581bbf7e
 	github.com/projectdiscovery/gozero v0.1.1-0.20260530071156-fa1dad563d76
 	github.com/projectdiscovery/httpx v1.9.0
 	github.com/projectdiscovery/mapcidr v1.1.97

--- a/go.sum
+++ b/go.sum
@@ -870,8 +870,8 @@ github.com/projectdiscovery/gologger v1.1.70 h1:A1ZAsUJfRUXO6qqwTwyTWXLVlBrVu/Gp
 github.com/projectdiscovery/gologger v1.1.70/go.mod h1:kpLKNafZWRN9P7WpJYtIOY/XvY/v41GDdU9NzICdKmo=
 github.com/projectdiscovery/gostruct v0.0.2 h1:s8gP8ApugGM4go1pA+sVlPDXaWqNP5BBDDSv7VEdG1M=
 github.com/projectdiscovery/gostruct v0.0.2/go.mod h1:H86peL4HKwMXcQQtEa6lmC8FuD9XFt6gkNR0B/Mu5PE=
-github.com/projectdiscovery/govaluate v0.0.0-20260504230327-80320480bb6e h1:o+ulEIaC2+9V2Ezr6mI5xEhKWsf0V/+FUQIS723Aj6U=
-github.com/projectdiscovery/govaluate v0.0.0-20260504230327-80320480bb6e/go.mod h1:xH7bPwHxUlz1yx9UlVeTF+UVCUaKhTnZgaxHb5z362E=
+github.com/projectdiscovery/govaluate v0.0.0-20260615100919-5ee2581bbf7e h1:vxzgQlz2Cy/YvizYDQx9OhucBcmBotfDhbQ4yCY2vfA=
+github.com/projectdiscovery/govaluate v0.0.0-20260615100919-5ee2581bbf7e/go.mod h1:xH7bPwHxUlz1yx9UlVeTF+UVCUaKhTnZgaxHb5z362E=
 github.com/projectdiscovery/gozero v0.1.1-0.20260530071156-fa1dad563d76 h1:AN70bbi6BBs7KpIM9w0LxygUN7uzT/oH+owDIQ+Fz/k=
 github.com/projectdiscovery/gozero v0.1.1-0.20260530071156-fa1dad563d76/go.mod h1:cWHYnRXoYWHtTpOYyAp5laGYX8GH8ITUhgQaP8G/8FA=
 github.com/projectdiscovery/hmap v0.0.101 h1:zXM6YtLmsn8Q0CUUw8QavhqWmiQYwaw+/U679Rr00pc=


### PR DESCRIPTION
## Summary

Bump `github.com/projectdiscovery/govaluate` to `v0.0.0-20260615100919-5ee2581bbf7e` to pull in the fix for the slice-bounds panic on invalid UTF-8 input.

## Related Issue

Fixes #7462

## Root Cause

The govaluate lexer advanced `strPosition` by `utf8.RuneLen(utf8.RuneError) == 3` when it encountered an invalid UTF-8 byte, even though only 1 byte was consumed. This caused the offset to drift past the actual string length, triggering a `slice bounds out of range` panic in `readUntilFalse`.

Since `expressions.Evaluate` only caught govaluate *errors* (not panics), a target returning invalid UTF-8 bytes in response data could crash the entire nuclei process.

## Fix

The upstream fix was merged in projectdiscovery/govaluate#4 (today, 2026-06-15). This PR updates nuclei's dependency to consume it.

**Changes:**
- `go.mod`: bump govaluate `v0.0.0-20260504230327-80320480bb6e` → `v0.0.0-20260615100919-5ee2581bbf7e`
- `go.sum`: updated checksums

## Testing

- `go build ./...` passes cleanly
- Existing unit tests pass
- The crash path (invalid UTF-8 in evaluated expressions) is now handled gracefully at the govaluate lexer level

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated govaluate dependency to the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->