### PR TITLE
fix: preserve explicit target port in network templates (fixes #7323)

### DIFF
--- a/internal/tests/integration/network_test.go
+++ b/internal/tests/integration/network_test.go
@@ -6,7 +6,6 @@ package integration_test
 import (
 	"fmt"
 	"net"
-	"strings"
 	"testing"
 	"time"
 
@@ -213,9 +212,24 @@ func TestNetwork(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		results, err = testutils.RunNucleiTemplateAndGetResults("protocols/network/network-port.yaml", strings.ReplaceAll(server.URL, "23846", "443"), suite.debug)
+		// An explicitly specified reserved port (e.g. host:8081) must be preserved
+		// and not overridden by the template port (regression test for #7323).
+		// 8081 is a reserved port but is used here on an unprivileged port so the
+		// listener binds without root. The server is started on 8081 and the
+		// template (port 23846) must dial the operator-specified 8081 to match.
+		serverReserved := testutils.NewTCPServer(nil, 8081, func(conn net.Conn) {
+			defer func() { _ = conn.Close() }()
+
+			data, err := reader.ConnReadNWithTimeout(conn, 4, 5*time.Second)
+			if err == nil && string(data) == "PING" {
+				_, _ = conn.Write([]byte("PONG"))
+			}
+		})
+		defer serverReserved.Close()
+
+		results, err = testutils.RunNucleiTemplateAndGetResults("protocols/network/network-port.yaml", serverReserved.URL, suite.debug)
 		if err != nil {
-			t.Fatalf("network-port template failed with overridden input port: %v", err)
+			t.Fatalf("network-port template failed with explicit reserved input port: %v", err)
 		}
 		if err := expectResultsCount(results, 1); err != nil {
 			t.Fatal(err)

--- a/pkg/protocols/common/contextargs/contextargs.go
+++ b/pkg/protocols/common/contextargs/contextargs.go
@@ -108,8 +108,15 @@ func (ctx *Context) Add(key string, v interface{}) {
 	}
 }
 
-// UseNetworkPort updates input with required/default network port for that template
-// but is ignored if input/target contains non-http ports like 80,8080,8081 etc
+// UseNetworkPort updates input with required/default network port for that template.
+// The template port is used when:
+//   - the input has no port at all, OR
+//   - the input port is a reserved HTTP/DNS port AND the port was not explicitly
+//     specified by the user (i.e. the input contains a URL scheme, meaning the
+//     port was implied by the scheme, not typed by the operator).
+//
+// When the operator explicitly writes "target:80" (no scheme), that port is
+// intentional (e.g. an SSH service running on port 80) and must not be replaced.
 func (ctx *Context) UseNetworkPort(port string, excludePorts string) error {
 	ignorePorts := reservedPorts
 	if excludePorts != "" {
@@ -125,8 +132,19 @@ func (ctx *Context) UseNetworkPort(port string, excludePorts string) error {
 		return err
 	}
 	inputPort := target.Port()
-	if inputPort == "" || stringsutil.EqualFoldAny(inputPort, ignorePorts...) {
-		// replace port with networkPort
+	if inputPort == "" {
+		// No port in input at all — use the template port.
+		target.UpdatePort(port)
+		ctx.MetaInput.Input = target.Host
+		return nil
+	}
+	// The input has an explicit port. Only override a reserved port when the
+	// input included a URL scheme (http:// / https://), which means the port was
+	// implied by the scheme rather than deliberately typed by the operator.
+	// A bare "host:port" form (no scheme) means the operator chose that port
+	// on purpose and we must not overwrite it.
+	hasScheme := strings.Contains(ctx.MetaInput.Input, "://")
+	if hasScheme && stringsutil.EqualFoldAny(inputPort, ignorePorts...) {
 		target.UpdatePort(port)
 		ctx.MetaInput.Input = target.Host
 	}

--- a/pkg/protocols/common/contextargs/contextargs_test.go
+++ b/pkg/protocols/common/contextargs/contextargs_test.go
@@ -1,0 +1,79 @@
+package contextargs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUseNetworkPort(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        string
+		templatePort string
+		excludePorts string
+		wantInput    string
+	}{
+		{
+			// No port in input → use template port (existing behaviour).
+			name:         "no port in input uses template port",
+			input:        "example.com",
+			templatePort: "22",
+			wantInput:    "example.com:22",
+		},
+		{
+			// Input has a non-reserved port explicitly → must NOT be replaced.
+			// This is the core of issue #7323: SSH on a non-standard port.
+			name:         "explicit non-reserved port is preserved",
+			input:        "example.com:2222",
+			templatePort: "22",
+			wantInput:    "example.com:2222",
+		},
+		{
+			// Key regression: bare host:80 form — operator explicitly wants port 80
+			// (e.g. SSH/other service listening on port 80). Must NOT be replaced.
+			name:         "bare host:80 explicit port preserved (issue #7323)",
+			input:        "example.com:80",
+			templatePort: "22",
+			wantInput:    "example.com:80",
+		},
+		{
+			// http://host:80 — port 80 is scheme-implied, replacement is fine.
+			name:         "scheme-implied port 80 is replaced",
+			input:        "http://example.com:80",
+			templatePort: "22",
+			wantInput:    "example.com:22",
+		},
+		{
+			// http://host (no port) — template port used.
+			name:         "http scheme no port uses template port",
+			input:        "http://example.com",
+			templatePort: "8888",
+			wantInput:    "example.com:8888",
+		},
+		{
+			// Empty template port → no change.
+			name:         "empty template port is noop",
+			input:        "example.com:9999",
+			templatePort: "",
+			wantInput:    "example.com:9999",
+		},
+		{
+			// Explicit port that equals template port → unchanged.
+			name:         "explicit port matching template port unchanged",
+			input:        "example.com:22",
+			templatePort: "22",
+			wantInput:    "example.com:22",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := NewWithInput(context.Background(), tt.input)
+			err := ctx.UseNetworkPort(tt.templatePort, tt.excludePorts)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantInput, ctx.MetaInput.Input)
+		})
+	}
+}

--- a/pkg/protocols/common/contextargs/contextargs_test.go
+++ b/pkg/protocols/common/contextargs/contextargs_test.go
@@ -7,6 +7,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestUseNetworkPort is the behavior matrix for UseNetworkPort.
+//
+// The contract (see issue #7323):
+//   - empty template port            -> no-op, input untouched
+//   - input with no port             -> input gets the template port
+//   - bare "host:port" (no scheme)   -> operator-chosen port, always preserved
+//   - "scheme://host:port"           -> port is scheme-implied; a reserved
+//     (or excluded) port is replaced by the template port, otherwise preserved
 func TestUseNetworkPort(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -15,56 +23,155 @@ func TestUseNetworkPort(t *testing.T) {
 		excludePorts string
 		wantInput    string
 	}{
+		// --- empty template port: always a no-op ---
 		{
-			// No port in input → use template port (existing behaviour).
-			name:         "no port in input uses template port",
-			input:        "example.com",
-			templatePort: "22",
-			wantInput:    "example.com:22",
-		},
-		{
-			// Input has a non-reserved port explicitly → must NOT be replaced.
-			// This is the core of issue #7323: SSH on a non-standard port.
-			name:         "explicit non-reserved port is preserved",
-			input:        "example.com:2222",
-			templatePort: "22",
-			wantInput:    "example.com:2222",
-		},
-		{
-			// Key regression: bare host:80 form — operator explicitly wants port 80
-			// (e.g. SSH/other service listening on port 80). Must NOT be replaced.
-			name:         "bare host:80 explicit port preserved (issue #7323)",
-			input:        "example.com:80",
-			templatePort: "22",
-			wantInput:    "example.com:80",
-		},
-		{
-			// http://host:80 — port 80 is scheme-implied, replacement is fine.
-			name:         "scheme-implied port 80 is replaced",
-			input:        "http://example.com:80",
-			templatePort: "22",
-			wantInput:    "example.com:22",
-		},
-		{
-			// http://host (no port) — template port used.
-			name:         "http scheme no port uses template port",
-			input:        "http://example.com",
-			templatePort: "8888",
-			wantInput:    "example.com:8888",
-		},
-		{
-			// Empty template port → no change.
-			name:         "empty template port is noop",
+			name:         "empty template port leaves bare host:port untouched",
 			input:        "example.com:9999",
 			templatePort: "",
 			wantInput:    "example.com:9999",
 		},
 		{
-			// Explicit port that equals template port → unchanged.
-			name:         "explicit port matching template port unchanged",
+			name:         "empty template port leaves no-port input untouched",
+			input:        "example.com",
+			templatePort: "",
+			wantInput:    "example.com",
+		},
+
+		// --- no port in input: template port is applied ---
+		{
+			name:         "bare host without port uses template port",
+			input:        "example.com",
+			templatePort: "22",
+			wantInput:    "example.com:22",
+		},
+		{
+			name:         "http scheme without port uses template port",
+			input:        "http://example.com",
+			templatePort: "8888",
+			wantInput:    "example.com:8888",
+		},
+		{
+			name:         "https scheme without port uses template port",
+			input:        "https://example.com",
+			templatePort: "9090",
+			wantInput:    "example.com:9090",
+		},
+		{
+			name:         "http scheme with path and no port uses template port",
+			input:        "http://example.com/some/path",
+			templatePort: "8888",
+			wantInput:    "example.com:8888",
+		},
+
+		// --- bare host:port (no scheme): operator intent, never replaced ---
+		{
+			// core of issue #7323: SSH (or anything) on port 80.
+			name:         "bare host with reserved port 80 is preserved",
+			input:        "example.com:80",
+			templatePort: "22",
+			wantInput:    "example.com:80",
+		},
+		{
+			name:         "bare host with reserved port 443 is preserved",
+			input:        "example.com:443",
+			templatePort: "22",
+			wantInput:    "example.com:443",
+		},
+		{
+			name:         "bare host with reserved port 8080 is preserved",
+			input:        "example.com:8080",
+			templatePort: "22",
+			wantInput:    "example.com:8080",
+		},
+		{
+			name:         "bare host with reserved port 53 is preserved",
+			input:        "example.com:53",
+			templatePort: "22",
+			wantInput:    "example.com:53",
+		},
+		{
+			name:         "bare host with non-reserved port is preserved",
+			input:        "example.com:2222",
+			templatePort: "22",
+			wantInput:    "example.com:2222",
+		},
+		{
+			name:         "bare host with port equal to template port is preserved",
 			input:        "example.com:22",
 			templatePort: "22",
 			wantInput:    "example.com:22",
+		},
+
+		// --- scheme + reserved port: scheme-implied, replaced ---
+		{
+			name:         "http scheme with reserved port 80 is replaced",
+			input:        "http://example.com:80",
+			templatePort: "22",
+			wantInput:    "example.com:22",
+		},
+		{
+			name:         "https scheme with reserved port 443 is replaced",
+			input:        "https://example.com:443",
+			templatePort: "22",
+			wantInput:    "example.com:22",
+		},
+		{
+			name:         "http scheme with reserved port 8080 is replaced",
+			input:        "http://example.com:8080",
+			templatePort: "22",
+			wantInput:    "example.com:22",
+		},
+
+		// --- scheme + non-reserved port: preserved ---
+		// Note: when the port is preserved the input is left exactly as-is (the
+		// scheme is kept). Only the replace path rewrites to bare "host:port".
+		// getAddress() strips the scheme before dialing, so both forms dial the
+		// same address.
+		{
+			name:         "http scheme with non-reserved port is preserved verbatim",
+			input:        "http://example.com:9999",
+			templatePort: "22",
+			wantInput:    "http://example.com:9999",
+		},
+
+		// --- excludePorts: replaces the default reserved set ---
+		{
+			name:         "scheme port in excludePorts is replaced",
+			input:        "http://example.com:9090",
+			templatePort: "22",
+			excludePorts: "9090",
+			wantInput:    "example.com:22",
+		},
+		{
+			name:         "scheme port not in excludePorts is preserved verbatim",
+			input:        "http://example.com:9091",
+			templatePort: "22",
+			excludePorts: "9090",
+			wantInput:    "http://example.com:9091",
+		},
+		{
+			// excludePorts replaces the reserved list, so 80 is no longer ignored
+			// and the scheme-prefixed input is preserved verbatim.
+			name:         "scheme reserved port not in custom excludePorts is preserved verbatim",
+			input:        "http://example.com:80",
+			templatePort: "22",
+			excludePorts: "9090",
+			wantInput:    "http://example.com:80",
+		},
+		{
+			name:         "scheme multiple excludePorts replaces matching",
+			input:        "http://example.com:8443",
+			templatePort: "22",
+			excludePorts: "9090,8443",
+			wantInput:    "example.com:22",
+		},
+		{
+			// bare host:port is preserved even when the port is in excludePorts.
+			name:         "bare host port in excludePorts is still preserved",
+			input:        "example.com:9090",
+			templatePort: "22",
+			excludePorts: "9090",
+			wantInput:    "example.com:9090",
 		},
 	}
 
@@ -75,5 +182,70 @@ func TestUseNetworkPort(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, tt.wantInput, ctx.MetaInput.Input)
 		})
+	}
+}
+
+// TestUseNetworkPortIPv6 keeps IPv6 handling honest: bracketed literals must be
+// preserved and the reserved/scheme rules apply the same way as for hostnames.
+func TestUseNetworkPortIPv6(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        string
+		templatePort string
+		wantInput    string
+	}{
+		{
+			name:         "bare IPv6 with reserved port is preserved",
+			input:        "[::1]:80",
+			templatePort: "22",
+			wantInput:    "[::1]:80",
+		},
+		{
+			name:         "bare IPv6 with non-reserved port is preserved",
+			input:        "[2001:db8::1]:2222",
+			templatePort: "22",
+			wantInput:    "[2001:db8::1]:2222",
+		},
+		{
+			name:         "scheme IPv6 with reserved port is replaced",
+			input:        "http://[::1]:80",
+			templatePort: "22",
+			wantInput:    "[::1]:22",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := NewWithInput(context.Background(), tt.input)
+			err := ctx.UseNetworkPort(tt.templatePort, "")
+			require.NoError(t, err)
+			require.Equal(t, tt.wantInput, ctx.MetaInput.Input)
+		})
+	}
+}
+
+// TestUseNetworkPortServiceNameExclude verifies excludePorts accepts service
+// names (resolved via portutil), e.g. "http" -> "80".
+func TestUseNetworkPortServiceNameExclude(t *testing.T) {
+	ctx := NewWithInput(context.Background(), "http://example.com:80")
+	err := ctx.UseNetworkPort("22", "http")
+	require.NoError(t, err)
+	require.Equal(t, "example.com:22", ctx.MetaInput.Input)
+}
+
+// TestUseNetworkPortIdempotent ensures repeated application is stable and does
+// not keep mutating the input.
+func TestUseNetworkPortIdempotent(t *testing.T) {
+	ctx := NewWithInput(context.Background(), "example.com")
+	for i := 0; i < 3; i++ {
+		require.NoError(t, ctx.UseNetworkPort("22", ""))
+		require.Equal(t, "example.com:22", ctx.MetaInput.Input)
+	}
+
+	// A preserved bare explicit port must stay stable too.
+	ctx = NewWithInput(context.Background(), "example.com:80")
+	for i := 0; i < 3; i++ {
+		require.NoError(t, ctx.UseNetworkPort("22", ""))
+		require.Equal(t, "example.com:80", ctx.MetaInput.Input)
 	}
 }


### PR DESCRIPTION
## Problem

When a user explicitly specifies a port on the CLI:

```
nuclei -target TARGET:80 -t network/cves/2001/CVE-2001-1473.yaml
```

Nuclei ignores the user's port and connects to the template's port (e.g. 22) instead:

```
[WRN] [CVE-2001-1473] Could not make network request for (TARGET:22): could not connect...
```

This makes it **impossible to scan services running on non-standard ports** — SSH on 80, FTP on 443, etc. The target is silently scanned on the wrong port.

## Root Cause

`UseNetworkPort()` in `contextargs.go` unconditionally replaces any port in `reservedPorts` (`80, 443, 8080, …`) with the template port, even when the operator **deliberately typed** `TARGET:80`.

The function cannot distinguish between:
- `http://TARGET:80` — port 80 is **scheme-implied**, replacing it is correct
- `TARGET:80` — port 80 is **explicitly chosen**, replacing it is wrong

## Fix

Only replace a reserved port when the input contains a URL scheme (`://`), which means the port was implied by the scheme rather than typed by the operator.

A bare `host:port` form means the operator chose that port on purpose — it is preserved unchanged.

**Change in `contextargs.go` is ~15 lines.**

## Tests

Seven table-driven cases added to `contextargs_test.go` (new file):

| Case | Input | Template port | Expected |
|---|---|---|---|
| No port in input | `example.com` | 22 | `example.com:22` |
| Explicit non-reserved port | `example.com:2222` | 22 | `example.com:2222` ✓ |
| **Bare host:80 (regression #7323)** | `example.com:80` | 22 | `example.com:80` ✓ |
| Scheme-implied port 80 | `http://example.com:80` | 22 | `example.com:22` |
| HTTP scheme no port | `http://example.com` | 8888 | `example.com:8888` |
| Empty template port | `example.com:9999` | (empty) | `example.com:9999` |
| Explicit port == template port | `example.com:22` | 22 | `example.com:22` |

All pass.

## Related

Fixes #7323

---

Would it be possible to add a `💎 Bounty` label to this issue/PR? The bug completely silences scanning of services on non-standard ports, which is a meaningful impact for anyone doing custom port scanning with nuclei.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network port handling to respect explicitly provided `host:port` inputs.
  * Reserved HTTP/DNS ports are replaced only when the input includes a URL scheme (`http://`/`https://`); scheme-less `host:port` values are preserved.
  * Added a regression test to ensure operator-specified ports aren’t overridden by templates.
* **Tests**
  * Expanded coverage for IPv6 handling, service-name-to-port exclusions, and idempotent behavior on repeated runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->