### PR TITLE
fix(http): reject request-condition(s) in fuzzing

### DIFF
--- a/pkg/protocols/http/validate.go
+++ b/pkg/protocols/http/validate.go
@@ -7,6 +7,10 @@ func (request *Request) validate() error {
 		return errors.New("'race' and 'req-condition' can't be used together")
 	}
 
+	if len(request.Fuzzing) > 0 && request.NeedsRequestCondition() {
+		return errors.New("'fuzzing' and 'request-condition' can't be used together")
+	}
+
 	if request.Redirects && request.HostRedirects {
 		return errors.New("'redirects' and 'host-redirects' can't be used together")
 	}

--- a/pkg/protocols/http/validate_test.go
+++ b/pkg/protocols/http/validate_test.go
@@ -4,6 +4,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz"
+	"github.com/projectdiscovery/nuclei/v3/pkg/operators"
+	"github.com/projectdiscovery/nuclei/v3/pkg/operators/extractors"
+	"github.com/projectdiscovery/nuclei/v3/pkg/operators/matchers"
 )
 
 func TestValidateRedirectsCombinations(t *testing.T) {
@@ -49,5 +54,35 @@ func TestValidateRedirectsCombinations(t *testing.T) {
 		req := &Request{}
 		err := req.validate()
 		require.NoError(t, err)
+	})
+}
+
+func TestValidateFuzzingWithRequestCondition(t *testing.T) {
+	t.Run("matcher dsl", func(t *testing.T) {
+		req := &Request{
+			Fuzzing: []*fuzz.Rule{{}},
+			Operators: operators.Operators{
+				Matchers: []*matchers.Matcher{
+					{DSL: []string{"duration_1 > 18"}},
+				},
+			},
+		}
+		err := req.validate()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "'fuzzing' and 'request-condition' can't be used together")
+	})
+
+	t.Run("extractor part", func(t *testing.T) {
+		req := &Request{
+			Fuzzing: []*fuzz.Rule{{}},
+			Operators: operators.Operators{
+				Extractors: []*extractors.Extractor{
+					{Part: "body_1"},
+				},
+			},
+		}
+		err := req.validate()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "'fuzzing' and 'request-condition' can't be used together")
 	})
 }


### PR DESCRIPTION
## Proposed changes

HTTP fuzzing does not maintain the ordered request
history used by request-condition fields. Reject
fuzzing templates that reference those fields at
validation time instead of letting them eval with
an invalid request count.

Fixes #4891

### Proof

<!-- How has this been tested? Please describe the tests that you ran to verify your changes. -->

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added HTTP request validation to prevent enabling fuzzing alongside request-condition matchers, ensuring conflicting configurations are rejected with clear error messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->