### PR TITLE
check code template signature before dast load

### DIFF
--- a/internal/tests/integration/code_test.go
+++ b/internal/tests/integration/code_test.go
@@ -34,6 +34,7 @@ var codeTestCases = []integrationCase{
 	{Path: "protocols/code/py-file.yaml", TestCase: &codeFile{}, DisableOn: isCodeDisabled},
 	{Path: "protocols/code/py-env-var.yaml", TestCase: &codeEnvVar{}, DisableOn: isCodeDisabled},
 	{Path: "protocols/code/unsigned.yaml", TestCase: &unsignedCode{}, DisableOn: isCodeDisabled},
+	{Path: "protocols/code/dast-unsigned.yaml", TestCase: &dastUnsignedCode{}, DisableOn: isCodeDisabled},
 	{Path: "protocols/code/py-nosig.yaml", TestCase: &codePyNoSig{}, DisableOn: isCodeDisabled},
 	{Path: "protocols/code/py-interactsh.yaml", TestCase: &codeSnippet{}, DisableOn: isCodeDisabled},
 	{Path: "protocols/code/ps1-snippet.yaml", TestCase: &codeSnippet{}, DisableOn: func() bool { return !osutils.IsWindows() || isCodeDisabled() }},
@@ -94,6 +95,9 @@ func ensureSignedCodeTemplates() error {
 				continue
 			}
 			if _, ok := v.TestCase.(*codePyNoSig); ok {
+				continue
+			}
+			if _, ok := v.TestCase.(*dastUnsignedCode); ok {
 				continue
 			}
 			templatesToSign = append(templatesToSign, v.Path)
@@ -168,6 +172,22 @@ type unsignedCode struct{}
 // Execute executes a test case and returns an error if occurred
 func (h *unsignedCode) Execute(filePath string) error {
 	results, err := testutils.RunNucleiArgsWithEnvAndGetResults(debug, getEnvValues(), "-t", filePath, "-u", "input", "-code")
+
+	// should error out
+	if err != nil {
+		return nil
+	}
+
+	// this point should never be reached
+	return errors.Join(expectResultsCount(results, 1), errors.New("unsigned template was executed"))
+}
+
+type dastUnsignedCode struct{}
+
+// Execute runs an unsigned template that pairs a fuzzable request with a code
+// block under -dast, which must not bypass the code-signing check.
+func (h *dastUnsignedCode) Execute(filePath string) error {
+	results, err := testutils.RunNucleiArgsWithEnvAndGetResults(debug, getEnvValues(), "-t", filePath, "-u", "input", "-dast")
 
 	// should error out
 	if err != nil {

--- a/internal/tests/integration/testdata/protocols/code/dast-unsigned.yaml
+++ b/internal/tests/integration/testdata/protocols/code/dast-unsigned.yaml
@@ -1,0 +1,33 @@
+id: dast-unsigned-code
+
+info:
+  name: dast-unsigned-code
+  author: pdteam
+  severity: info
+  tags: dast,code
+  description: |
+    unsigned code paired with a fuzzable request must not execute under -dast
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/?x=1"
+    fuzzing:
+      - part: query
+        type: replace
+        mode: single
+        keys: ["x"]
+        fuzz:
+          - "test"
+
+code:
+  - engine:
+      - py
+      - python3
+    source: |
+      print("unsigned code")
+
+    matchers:
+      - type: word
+        words:
+          - "unsigned code"

--- a/pkg/catalog/loader/loader.go
+++ b/pkg/catalog/loader/loader.go
@@ -897,6 +897,20 @@ func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) ([]*temp
 						stats.Increment(templates.SkippedRequestSignatureStats)
 						return
 					}
+
+					// 'Code' protocol templates run arbitrary commands, so an
+					// unsigned one must never load regardless of the loading path
+					// (e.g. the DAST branch below) that follows.
+					if parsed.HasCodeRequest() && !parsed.Verified && !parsed.HasWorkflows() {
+						stats.Increment(templates.SkippedCodeTmplTamperedStats)
+						// these will be skipped so increment skip counter
+						stats.Increment(templates.SkippedUnsignedStats)
+						if config.DefaultConfig.LogAllEvents {
+							store.logger.Print().Msgf("[%v] Tampered/Unsigned template at %v.\n", aurora.Yellow("WRN").String(), templatePath)
+						}
+						return
+					}
+
 					// DAST only templates
 					// Skip DAST filter when loading auth templates
 					if store.ID() != AuthStoreId && typesOpts.DAST {
@@ -923,14 +937,6 @@ func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) ([]*temp
 						stats.Increment(templates.ExcludedCodeTmplStats)
 						if config.DefaultConfig.LogAllEvents {
 							store.logger.Print().Msgf("[%v] Code flag is required for code protocol template '%s'.\n", aurora.Yellow("WRN").String(), templatePath)
-						}
-					} else if parsed.HasCodeRequest() && !parsed.Verified && !parsed.HasWorkflows() {
-						// donot include unverified 'Code' protocol custom template in final list
-						stats.Increment(templates.SkippedCodeTmplTamperedStats)
-						// these will be skipped so increment skip counter
-						stats.Increment(templates.SkippedUnsignedStats)
-						if config.DefaultConfig.LogAllEvents {
-							store.logger.Print().Msgf("[%v] Tampered/Unsigned template at %v.\n", aurora.Yellow("WRN").String(), templatePath)
 						}
 					} else if parsed.IsFuzzableRequest() && !typesOpts.DAST {
 						stats.Increment(templates.ExcludedDastTmplStats)


### PR DESCRIPTION
Hoists the unsigned code-template guard ahead of the dast branch so it applies on every load path.

Fixes #7470

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Unsigned Code protocol templates are now prevented from being loaded and executed regardless of execution mode.

* **Tests**
  * Added test coverage for unsigned template handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->