### PR TITLE
fix(helpers): escape literal `.` in ASCII-section regex

### DIFF
--- a/pkg/protocols/common/helpers/responsehighlighter/hexdump.go
+++ b/pkg/protocols/common/helpers/responsehighlighter/hexdump.go
@@ -82,7 +82,7 @@ func highlightAsciiSection(hexDump HighlightableHexDump, snippetToColor string) 
 		if IsASCIIPrintable(v) {
 			value = regexp.QuoteMeta(string(v))
 		} else {
-			value = "."
+			value = `\.`
 		}
 		snippetCharactersMatchPattern += fmt.Sprintf(`(%s\n*)`, value)
 	}

--- a/pkg/protocols/common/helpers/responsehighlighter/response_highlighter_test.go
+++ b/pkg/protocols/common/helpers/responsehighlighter/response_highlighter_test.go
@@ -3,6 +3,7 @@ package responsehighlighter
 import (
 	"encoding/hex"
 	"testing"
+	"time"
 
 	"github.com/projectdiscovery/nuclei/v3/pkg/operators"
 	"github.com/stretchr/testify/require"
@@ -107,4 +108,30 @@ start ValueToMatch-2.1 end
 			"start \x1b[32mV\x1b[0m\x1b[32ma\x1b[0m\x1b[32ml\x1b[0m\x1b[32mu\x1b[0m\x1b[32me\x1b[0m\x1b[32mT\x1b[0m\x1b[32mo\x1b[0m\x1b[32mM\x1b[0m\x1b[32ma\x1b[0m\x1b[32mt\x1b[0m\x1b[32mc\x1b[0m\x1b[32mh\x1b[0m\x1b[32m-\x1b[0m\x1b[32m2\x1b[0m\x1b[32m.\x1b[0m\x1b[32m1\x1b[0m end \n"
 	result := Highlight(&operatorResult, input, false, false)
 	require.Equal(t, expected, result)
+}
+
+func TestHexDumpHighlightDoesNotExplode(t *testing.T) {
+	// Two binary matchers of different lengths,
+	// both consisting entirely of non-printable bytes
+	op := &operators.Result{
+		Matches: map[string][]string{
+			"long":  {"\x05\x00\x00\x01"},
+			"short": {"\x05\x00"},
+		},
+	}
+	response := []byte{0x05, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00}
+	dump := hex.Dump(response)
+
+	done := make(chan int, 1)
+	go func() { done <- len(Highlight(op, dump, false, true)) }()
+	select {
+	case n := <-done:
+		// Sanity: output should stay within a few KB for a single-row
+		// hex dump; before the fix it grew past 1 GB in <100 ms.
+		if n > 10_000 {
+			t.Fatalf("Highlight output suspiciously large: %d bytes", n)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Highlight hung — exponential ReplaceAll regression")
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/projectdiscovery/nuclei/issues/7475.

Fixes an exponential-blowup bug in `responsehighlighter.highlightAsciiSection` that hangs nuclei and OOMs the process within seconds whenever debug output is enabled for a network template whose matched response contains non-printable bytes, AND ≥2 matched binary fragments end up in `OperatorsResult.Matches`.

### Proof

Steps to reproduce from https://github.com/projectdiscovery/nuclei/issues/7475 don't longer result in `nuclei` entering an infinite loop.

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed hexdump response highlighting behavior for non-ASCII-printable characters.

* **Tests**
  * Added test to detect potential performance regressions in hexdump response highlighting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->