### PR TITLE
fix(network): record decoded bytes for debug dump

### DIFF
--- a/pkg/protocols/network/request.go
+++ b/pkg/protocols/network/request.go
@@ -336,8 +336,6 @@ func (request *Request) executeRequestWithPayloads(variables map[string]interfac
 			dataInBytes = []byte(data)
 		}
 
-		reqBuilder.Write(dataInBytes)
-
 		if err := expressions.ContainsUnresolvedVariables(data); err != nil {
 			gologger.Warning().Msgf("[%s] Could not make network request for %s: %v\n", request.options.TemplateID, actualAddress, err)
 			return nil
@@ -351,6 +349,8 @@ func (request *Request) executeRequestWithPayloads(variables map[string]interfac
 				return errors.Wrap(err, "could not write request to server")
 			}
 		}
+
+		reqBuilder.Write(dataInBytes)
 
 		if _, err := conn.Write(dataInBytes); err != nil {
 			request.options.Output.Request(request.options.TemplatePath, address, request.Type().String(), err)


### PR DESCRIPTION
Fixes https://github.com/projectdiscovery/nuclei/issues/7477.

## Proposed changes

Move the `reqBuilder.Write(dataInBytes)` call after the hex decode so the logged bytes match what is actually written to the connection.

### Proof

Using the "Steps to reproduce" from https://github.com/projectdiscovery/nuclei/issues/7477:

Before:
```

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.8.0

		projectdiscovery.io

[INF] Current nuclei version: v3.8.0 (outdated)
[INF] Current nuclei-templates version: v10.4.4 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 179
[INF] Templates loaded for current scan: 1
[INF] Executing 1 signed templates from projectdiscovery/nuclei-templates
[INF] Targets loaded for current scan: 1
[INF] [mikrotik-routeros-api] Dumped Network request for 127.0.0.1:1234
00000000  33 61 30 30 30 30 30 30  32 66 30 30 30 30 30 30  |3a0000002f000000|
00000010  30 32 30 30 30 30 34 30  30 32 30 66 30 30 30 31  |02000040020f0001|
00000020  30 30 33 64 30 35 30 30  30 30 30 30 30 30 30 30  |003d050000000000|
00000030  30 30 30 30 30 30 30 30  30 30 30 30 30 30 32 66  |000000000000002f|
00000040  30 30 30 30 30 30 30 30  30 30 30 30 30 30 30 30  |0000000000000000|
00000050  30 30 34 30 31 66 30 30  30 30 30 30 30 30 30 30  |00401f0000000000|
00000060  30 30 30 30 30 30 30 30  30 30 30 30 30 30 30 30  |0000000000000000|
00000070  30 30 30 30 30 30 30 30                           |00000000| address=127.0.0.1:1234
```

With this fix in place:
```

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v3.9.0

		projectdiscovery.io

[INF] Current nuclei version: v3.9.0 (latest)
[INF] Current nuclei-templates version: v10.4.4 (latest)
[WRN] Scan results upload to cloud is disabled.
[INF] New templates added in latest release: 179
[INF] Templates loaded for current scan: 1
[INF] Executing 1 signed templates from projectdiscovery/nuclei-templates
[INF] Targets loaded for current scan: 1
[INF] [mikrotik-routeros-api] Dumped Network request for 127.0.0.1:1234
00000000  3a 00 00 00 2f 00 00 00  02 00 00 40 02 0f 00 01  |:.../......@....|
00000010  00 3d 05 00 00 00 00 00  00 00 00 00 00 00 00 2f  |.=............./|
00000020  00 00 00 00 00 00 00 00  00 40 1f 00 00 00 00 00  |.........@......|
00000030  00 00 00 00 00 00 00 00  00 00 00 00              |............| address=127.0.0.1:1234
```

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect representation of hex-encoded network requests in output logging to accurately reflect the actual bytes sent over TCP connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->