### PR TITLE
fix(js): normalize & reject trace file DSN opts in oracle

### DIFF
--- a/pkg/js/libs/oracle/oracle.go
+++ b/pkg/js/libs/oracle/oracle.go
@@ -5,7 +5,9 @@ import (
 	"database/sql"
 	"fmt"
 	"net"
+	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/praetorian-inc/fingerprintx/pkg/plugins"
@@ -84,6 +86,11 @@ func isOracle(ctx context.Context, executionId string, host string, port int) (I
 }
 
 func (c *OracleClient) oracleDbInstance(ctx context.Context, connStr string, executionId string) (*goora.OracleConnector, error) {
+	connStr, err := sandboxDSN(executionId, connStr)
+	if err != nil {
+		return nil, err
+	}
+
 	if c.connector == nil {
 		connector := goora.NewConnector(connStr)
 		oraConnector, ok := connector.(*goora.OracleConnector)
@@ -98,6 +105,48 @@ func (c *OracleClient) oracleDbInstance(ctx context.Context, connStr string, exe
 	c.connector.Dialer(&oracleCustomDialer{executionId: executionId, ctx: ctx})
 
 	return c.connector, nil
+}
+
+func sandboxDSN(executionId string, dsn string) (string, error) {
+	parsed, err := url.Parse(dsn)
+	if err != nil {
+		return "", err
+	}
+
+	query := parsed.Query()
+	changed := false
+	for key, values := range query {
+		if !isOracleTracePathOption(key) {
+			continue
+		}
+		for i, value := range values {
+			if value == "" {
+				continue
+			}
+			normalized, err := protocolstate.NormalizePathWithExecutionId(executionId, value)
+			if err != nil {
+				return "", fmt.Errorf("oracle %s %q: %w", key, value, err)
+			}
+			values[i] = normalized
+		}
+		query[key] = values
+		changed = true
+	}
+	if !changed {
+		return dsn, nil
+	}
+
+	parsed.RawQuery = query.Encode()
+	return parsed.String(), nil
+}
+
+func isOracleTracePathOption(key string) bool {
+	switch strings.ToUpper(strings.TrimSpace(key)) {
+	case "TRACE FILE", "TRACE DIR", "TRACE FOLDER", "TRACE DIRECTORY":
+		return true
+	default:
+		return false
+	}
 }
 
 // Connect connects to an Oracle database

--- a/pkg/js/libs/oracle/oracle_test.go
+++ b/pkg/js/libs/oracle/oracle_test.go
@@ -1,0 +1,102 @@
+package oracle
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/config"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
+	"github.com/projectdiscovery/nuclei/v3/pkg/types"
+	go_ora "github.com/sijms/go-ora/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSandboxDSNRejectsTraceFileOutsideTemplatesWithoutLFA(t *testing.T) {
+	templatesDir := t.TempDir()
+	restoreOracleTemplatesDir(t, templatesDir)
+
+	executionID := t.Name()
+	protocolstate.SetLfaAllowed(&types.Options{ExecutionId: executionID, AllowLocalFileAccess: false})
+
+	traceFile := filepath.Join(t.TempDir(), "trace.log")
+	dsn := go_ora.BuildUrl("127.0.0.1", 1521, "XE", "user", "pass", map[string]string{
+		"TRACE FILE": traceFile,
+	})
+
+	_, err := sandboxDSN(executionID, dsn)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "-lfa is not enabled")
+}
+
+func TestConnectWithDSNRejectsTraceFileBeforeOracleOpen(t *testing.T) {
+	templatesDir := t.TempDir()
+	restoreOracleTemplatesDir(t, templatesDir)
+
+	executionID := t.Name()
+	protocolstate.SetLfaAllowed(&types.Options{ExecutionId: executionID, AllowLocalFileAccess: false})
+
+	traceFile := filepath.Join(t.TempDir(), "trace.log")
+	dsn := go_ora.BuildUrl("127.0.0.1", 1521, "XE", "user", "pass", map[string]string{
+		"TRACE FILE": traceFile,
+	})
+
+	ctx := context.WithValue(context.Background(), "executionId", executionID) // nolint:staticcheck
+	_, err := (&OracleClient{}).ConnectWithDSN(ctx, dsn)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "-lfa is not enabled")
+	require.NoFileExists(t, traceFile)
+}
+
+func TestSandboxDSNNormalizesTraceOptionsWithinTemplatesWithoutLFA(t *testing.T) {
+	templatesDir := t.TempDir()
+	restoreOracleTemplatesDir(t, templatesDir)
+
+	executionID := t.Name()
+	protocolstate.SetLfaAllowed(&types.Options{ExecutionId: executionID, AllowLocalFileAccess: false})
+
+	traceFile := filepath.Join(templatesDir, "trace.log")
+	traceDir := filepath.Join(templatesDir, "trace-dir")
+	dsn := go_ora.BuildUrl("127.0.0.1", 1521, "XE", "user", "pass", map[string]string{
+		"TRACE FILE":      traceFile,
+		"TRACE DIRECTORY": traceDir,
+	})
+
+	got, err := sandboxDSN(executionID, dsn)
+	require.NoError(t, err)
+
+	cfg, err := go_ora.ParseConfig(got)
+	require.NoError(t, err)
+	require.Equal(t, traceFile, cfg.TraceFilePath)
+	require.Equal(t, traceDir, cfg.TraceDir)
+}
+
+func TestSandboxDSNAllowsTraceFileOutsideTemplatesWithLFA(t *testing.T) {
+	templatesDir := t.TempDir()
+	restoreOracleTemplatesDir(t, templatesDir)
+
+	executionID := t.Name()
+	protocolstate.SetLfaAllowed(&types.Options{ExecutionId: executionID, AllowLocalFileAccess: true})
+
+	traceFile := filepath.Join(t.TempDir(), "trace.log")
+	dsn := go_ora.BuildUrl("127.0.0.1", 1521, "XE", "user", "pass", map[string]string{
+		"TRACE FILE": traceFile,
+	})
+
+	got, err := sandboxDSN(executionID, dsn)
+	require.NoError(t, err)
+
+	cfg, err := go_ora.ParseConfig(got)
+	require.NoError(t, err)
+	require.Equal(t, traceFile, cfg.TraceFilePath)
+}
+
+func restoreOracleTemplatesDir(t *testing.T, templatesDir string) {
+	t.Helper()
+
+	oldTemplatesDir := config.DefaultConfig.TemplatesDirectory
+	config.DefaultConfig.SetTemplatesDir(templatesDir)
+	t.Cleanup(func() {
+		config.DefaultConfig.SetTemplatesDir(oldTemplatesDir)
+	})
+}


### PR DESCRIPTION
## Proposed changes

go-ora accepts `TRACE {FILE,DIR}`-style DSN options
and may create those files while opening the conn. 
Normalize those paths and reject outside paths
unless `-allow-local-file-access` is enabled.

### Proof

<!-- How has this been tested? Please describe the tests that you ran to verify your changes. -->

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Oracle connection string handling by validating DSN trace options during initialization.
  * Normalize Oracle trace file/directory paths within allowed templates to ensure consistent behavior.
  * Reject Oracle DSN trace paths when local file access is not permitted.

* **Tests**
  * Added coverage for Oracle DSN sandboxing and trace option validation, including cases with and without local file access enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->