### PR TITLE
fix(js): escape mssql database name in conn URL

### DIFF
--- a/pkg/js/libs/mssql/mssql.go
+++ b/pkg/js/libs/mssql/mssql.go
@@ -68,11 +68,7 @@ func connect(ctx context.Context, executionId string, host string, port int, use
 
 	target := net.JoinHostPort(host, fmt.Sprintf("%d", port))
 
-	connString := fmt.Sprintf("sqlserver://%s:%s@%s?database=%s&connection+timeout=30",
-		url.PathEscape(username),
-		url.PathEscape(password),
-		target,
-		dbName)
+	connString := mssqlConnString(target, username, password, dbName)
 
 	db, err := sql.Open("sqlserver", connString)
 	if err != nil {
@@ -165,8 +161,6 @@ func (c *MSSQLClient) ExecuteQuery(ctx context.Context, host string, port int, u
 		return nil, protocolstate.ErrHostDenied.Msgf(host)
 	}
 
-	target := net.JoinHostPort(host, fmt.Sprintf("%d", port))
-
 	ok, err := c.IsMssql(ctx, host, port)
 	if err != nil {
 		return nil, err
@@ -175,11 +169,8 @@ func (c *MSSQLClient) ExecuteQuery(ctx context.Context, host string, port int, u
 		return nil, fmt.Errorf("not a mssql service")
 	}
 
-	connString := fmt.Sprintf("sqlserver://%s:%s@%s?database=%s&connection+timeout=30",
-		url.PathEscape(username),
-		url.PathEscape(password),
-		target,
-		dbName)
+	target := net.JoinHostPort(host, fmt.Sprintf("%d", port))
+	connString := mssqlConnString(target, username, password, dbName)
 
 	db, err := sql.Open("sqlserver", connString)
 	if err != nil {
@@ -205,4 +196,12 @@ func (c *MSSQLClient) ExecuteQuery(ctx context.Context, host string, port int, u
 		return nil, err
 	}
 	return data, nil
+}
+
+func mssqlConnString(target, username, password, dbName string) string {
+	return fmt.Sprintf("sqlserver://%s:%s@%s?database=%s&connection+timeout=30",
+		url.PathEscape(username),
+		url.PathEscape(password),
+		target,
+		url.QueryEscape(dbName))
 }

--- a/pkg/js/libs/mssql/mssql_test.go
+++ b/pkg/js/libs/mssql/mssql_test.go
@@ -1,0 +1,35 @@
+package mssql
+
+import (
+	"testing"
+
+	"github.com/microsoft/go-mssqldb/msdsn"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConnectionStringDoesNotTreatDatabaseNameAsDriverOptions(t *testing.T) {
+	dbName := "master&encrypt=true&certificate=/tmp/nuclei-mssql-test.pem" +
+		"&authenticator=krb5" +
+		"&krb5-configfile=/tmp/krb5.conf" +
+		"&krb5-keytabfile=/tmp/krb5.keytab" +
+		"&krb5-credcachefile=/tmp/krb5.ccache"
+
+	cfg, err := msdsn.Parse(mssqlConnString("127.0.0.1:1433", "user", "password", dbName))
+	require.NoError(t, err)
+
+	require.Equal(t, dbName, cfg.Database)
+	require.Equal(t, "30", cfg.Parameters["connection timeout"])
+	require.NotContains(t, cfg.Parameters, "encrypt")
+	require.NotContains(t, cfg.Parameters, "certificate")
+	require.NotContains(t, cfg.Parameters, "authenticator")
+	require.NotContains(t, cfg.Parameters, "krb5-configfile")
+	require.NotContains(t, cfg.Parameters, "krb5-keytabfile")
+	require.NotContains(t, cfg.Parameters, "krb5-credcachefile")
+}
+
+func TestConnectionStringKeepsPlainDatabaseName(t *testing.T) {
+	cfg, err := msdsn.Parse(mssqlConnString("127.0.0.1:1433", "user", "password", "master"))
+	require.NoError(t, err)
+
+	require.Equal(t, "master", cfg.Database)
+}


### PR DESCRIPTION
## Proposed changes

The MSSQL helpers put `dbName` directly in the URL
query as the database parameter. A template could
include '&' in the database name and append driver
options such as certificate/Kerberos file paths.

Build the URL through a shared helper and query-
escape the database value so it stays part of the
database parameter.

### Proof

<!-- How has this been tested? Please describe the tests that you ran to verify your changes. -->

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved MS SQL database connection code organization and consistency

* **Tests**
  * Added tests to verify MS SQL database connections function correctly with various database name formats, including those with special characters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->