### PR TITLE
refactor(templates): centralize opt-in capability gates

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -709,7 +709,7 @@ func (r *Runner) RunEnumeration() error {
 		if err := store.ValidateTemplates(); err != nil {
 			return err
 		}
-		if stats.GetValue(templates.SyntaxErrorStats) == 0 && stats.GetValue(templates.SyntaxWarningStats) == 0 && stats.GetValue(templates.RuntimeWarningsStats) == 0 {
+		if stats.GetValue(templates.TemplateSyntaxErrorStats) == 0 && stats.GetValue(templates.TemplateSyntaxWarningStats) == 0 && stats.GetValue(templates.TemplateRuntimeWarningStats) == 0 {
 			r.Logger.Info().Msgf("All templates validated successfully")
 		} else {
 			return errors.New("encountered errors while performing template validation")
@@ -930,36 +930,36 @@ func (r *Runner) executeTemplatesInput(store *loader.Store, engine *core.Engine)
 	return results, nil
 }
 
-// displayExecutionInfo displays misc info about the nuclei engine execution
+// displayExecutionInfo prints parser stats, version info, and scan counts.
 func (r *Runner) displayExecutionInfo(store *loader.Store) {
-	// Display stats for any loaded templates' syntax warnings or errors
-	stats.Display(templates.SyntaxWarningStats)
-	stats.Display(templates.SyntaxErrorStats)
-	stats.Display(templates.RuntimeWarningsStats)
+	// Display parser stats for templates loaded into the store.
+	stats.Display(templates.TemplateSyntaxWarningStats)
+	stats.Display(templates.TemplateSyntaxErrorStats)
+	stats.Display(templates.TemplateRuntimeWarningStats)
+
 	tmplCount := len(store.Templates())
 	workflowCount := len(store.Workflows())
 	if r.options.Verbose || (tmplCount == 0 && workflowCount == 0) {
-		// only print these stats in verbose mode
-		stats.ForceDisplayWarning(templates.ExcludedHeadlessTmplStats)
-		stats.ForceDisplayWarning(templates.ExcludedCodeTmplStats)
-		stats.ForceDisplayWarning(templates.ExcludedDastTmplStats)
-		stats.ForceDisplayWarning(templates.TemplatesExcludedStats)
-		stats.ForceDisplayWarning(templates.ExcludedFileStats)
-		stats.ForceDisplayWarning(templates.ExcludedSelfContainedStats)
+		// Excluded-template stats are noisy during normal scans, but useful in verbose mode
+		// and when no runnable templates remain.
+		for _, capability := range templates.AllCapabilities() {
+			stats.ForceDisplayWarning(capability.Stat())
+		}
+		stats.ForceDisplayWarning(templates.ExcludedWeakMatcherTemplateStats)
 	}
 
 	if tmplCount == 0 && workflowCount == 0 {
-		// if dast flag is used print explicit warning
 		if r.options.DAST {
 			r.Logger.Warning().Msg("No DAST templates found")
 		}
-		stats.ForceDisplayWarning(templates.SkippedCodeTmplTamperedStats)
+		stats.ForceDisplayWarning(templates.SkippedUnverifiedCodeTemplateStats)
 	} else {
-		stats.DisplayAsWarning(templates.SkippedCodeTmplTamperedStats)
+		stats.DisplayAsWarning(templates.SkippedUnverifiedCodeTemplateStats)
 	}
+
 	stats.DisplayAsWarning(httpProtocol.SetThreadToCountZero)
-	stats.ForceDisplayWarning(templates.SkippedUnsignedStats)
-	stats.ForceDisplayWarning(templates.SkippedRequestSignatureStats)
+	stats.ForceDisplayWarning(templates.SkippedUnverifiedTemplateStats)
+	stats.ForceDisplayWarning(templates.SkippedRequestSignatureTemplateStats)
 
 	cfg := config.DefaultConfig
 

--- a/pkg/catalog/disk/find.go
+++ b/pkg/catalog/disk/find.go
@@ -193,6 +193,9 @@ func (c *DiskCatalog) findFileMatches(absPath string, processed map[string]struc
 	if err != nil {
 		return "", false, err
 	}
+	defer func() {
+		_ = info.Close()
+	}()
 	stat, err := info.Stat()
 	if err != nil {
 		return "", false, err

--- a/pkg/catalog/loader/loader.go
+++ b/pkg/catalog/loader/loader.go
@@ -431,7 +431,7 @@ func (store *Store) LoadTemplateTags() (map[string]int, error) {
 		loaded, err := store.config.ExecutorOptions.Parser.LoadTemplate(templatePath, store.tagFilter, nil, store.config.Catalog)
 		if err != nil {
 			if strings.Contains(err.Error(), templates.ErrExcluded.Error()) {
-				stats.Increment(templates.TemplatesExcludedStats)
+				stats.Increment(templates.ExcludedWeakMatcherTemplateStats)
 				if config.DefaultConfig.LogAllEvents {
 					store.logger.Print().Msgf("[%v] %v\n", aurora.Yellow("WRN").String(), err.Error())
 				}
@@ -491,7 +491,7 @@ func (store *Store) LoadTemplatesOnlyMetadata() error {
 					loaded, err := store.config.ExecutorOptions.Parser.LoadTemplate(templatePath, store.tagFilter, nil, store.config.Catalog)
 					if !loaded {
 						if err != nil && strings.Contains(err.Error(), templates.ErrExcluded.Error()) {
-							stats.Increment(templates.TemplatesExcludedStats)
+							stats.Increment(templates.ExcludedWeakMatcherTemplateStats)
 							if config.DefaultConfig.LogAllEvents {
 								store.logger.Print().Msgf("[%v] %v\n", aurora.Yellow("WRN").String(), err.Error())
 							}
@@ -532,7 +532,7 @@ func (store *Store) LoadTemplatesOnlyMetadata() error {
 
 		if err != nil {
 			if strings.Contains(err.Error(), templates.ErrExcluded.Error()) {
-				stats.Increment(templates.TemplatesExcludedStats)
+				stats.Increment(templates.ExcludedWeakMatcherTemplateStats)
 				if config.DefaultConfig.LogAllEvents {
 					store.logger.Print().Msgf("[%v] %v\n", aurora.Yellow("WRN").String(), err.Error())
 				}
@@ -549,13 +549,7 @@ func (store *Store) LoadTemplatesOnlyMetadata() error {
 	}
 
 	loadedTemplateIDs := mapsutil.NewSyncLockMap[string, struct{}]()
-	caps := templates.Capabilities{
-		Headless:      store.config.ExecutorOptions.Options.Headless,
-		Code:          store.config.ExecutorOptions.Options.EnableCodeTemplates,
-		DAST:          store.config.ExecutorOptions.Options.DAST,
-		SelfContained: store.config.ExecutorOptions.Options.EnableSelfContainedTemplates,
-		File:          store.config.ExecutorOptions.Options.EnableFileTemplates,
-	}
+	caps := templates.CapabilitiesFromOptions(store.config.ExecutorOptions.Options)
 	isListOrDisplay := store.config.ExecutorOptions.Options.TemplateList ||
 		store.config.ExecutorOptions.Options.TemplateDisplay
 
@@ -565,8 +559,11 @@ func (store *Store) LoadTemplatesOnlyMetadata() error {
 			continue
 		}
 
-		if !isListOrDisplay && !template.IsEnabledFor(caps) {
-			continue
+		if !isListOrDisplay {
+			if missingCaps := template.MissingLoadCapabilities(caps); len(missingCaps) > 0 {
+				store.noteMissingCapabilities(templatePath, missingCaps)
+				continue
+			}
 		}
 
 		if loadedTemplateIDs.Has(template.ID) {
@@ -580,6 +577,15 @@ func (store *Store) LoadTemplatesOnlyMetadata() error {
 	}
 
 	return nil
+}
+
+func (store *Store) noteMissingCapabilities(templatePath string, missingCaps []templates.Capability) {
+	for _, capability := range missingCaps {
+		stats.Increment(capability.Stat())
+		if config.DefaultConfig.LogAllEvents {
+			store.logger.Warning().Msg(capability.MissingFlagMessage(templatePath))
+		}
+	}
 }
 
 // ValidateTemplates takes a list of templates and validates them
@@ -801,13 +807,15 @@ func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) ([]*temp
 			return
 		}
 
-		stats.Increment(templates.TemplatesExcludedStats)
+		stats.Increment(templates.ExcludedWeakMatcherTemplateStats)
 		if config.DefaultConfig.LogAllEvents {
-			store.logger.Print().Msgf("[%v] %v excluded from default run using .nuclei-ignore\n", aurora.Yellow("WRN").String(), templatePath)
+			store.logger.Warning().Msgf("%v excluded from default run using .nuclei-ignore", templatePath)
 		}
 	}
 
 	typesOpts := store.config.ExecutorOptions.Options
+	caps := templates.CapabilitiesFromOptions(typesOpts)
+
 	concurrency := typesOpts.TemplateLoadingConcurrency
 	if concurrency <= 0 {
 		concurrency = types.DefaultTemplateLoadingConcurrency
@@ -872,42 +880,36 @@ func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) ([]*temp
 				if err != nil {
 					// exclude templates not compatible with offline matching from total runtime warning stats
 					if !errors.Is(err, templates.ErrIncompatibleWithOfflineMatching) {
-						stats.Increment(templates.RuntimeWarningsStats)
+						stats.Increment(templates.TemplateRuntimeWarningStats)
 					}
 					store.logger.Warning().Msgf("Could not parse template %s: %s\n", templatePath, err)
 				} else if parsed != nil {
 					if !parsed.Verified && typesOpts.DisableUnsignedTemplates {
 						// skip unverified templates when prompted to
-						stats.Increment(templates.SkippedUnsignedStats)
+						stats.Increment(templates.SkippedUnverifiedTemplateStats)
 						return
 					}
 
-					if parsed.SelfContained && !typesOpts.EnableSelfContainedTemplates {
-						stats.Increment(templates.ExcludedSelfContainedStats)
+					// code-protocol-based templates run arbitrary commands, so an
+					// unsigned one must be reported as an unverified code template
+					// before the generic missing-capability gate can classify it as
+					// just missing -code.
+					if parsed.HasCodeRequest() && !parsed.Verified && !parsed.HasWorkflows() {
+						stats.Increment(templates.SkippedUnverifiedCodeTemplateStats)
+						if config.DefaultConfig.LogAllEvents {
+							store.logger.Warning().Msgf("Unverified code template at %q", templatePath)
+						}
 						return
 					}
 
-					if parsed.HasFileRequest() && !typesOpts.EnableFileTemplates {
-						stats.Increment(templates.ExcludedFileStats)
+					if missingCaps := parsed.MissingLoadCapabilities(caps); len(missingCaps) > 0 {
+						store.noteMissingCapabilities(templatePath, missingCaps)
 						return
 					}
 
 					// if template has request signature like aws then only signed and verified templates are allowed
 					if parsed.UsesRequestSignature() && !parsed.Verified {
-						stats.Increment(templates.SkippedRequestSignatureStats)
-						return
-					}
-
-					// 'Code' protocol templates run arbitrary commands, so an
-					// unsigned one must never load regardless of the loading path
-					// (e.g. the DAST branch below) that follows.
-					if parsed.HasCodeRequest() && !parsed.Verified && !parsed.HasWorkflows() {
-						stats.Increment(templates.SkippedCodeTmplTamperedStats)
-						// these will be skipped so increment skip counter
-						stats.Increment(templates.SkippedUnsignedStats)
-						if config.DefaultConfig.LogAllEvents {
-							store.logger.Print().Msgf("[%v] Tampered/Unsigned template at %v.\n", aurora.Yellow("WRN").String(), templatePath)
-						}
+						stats.Increment(templates.SkippedRequestSignatureTemplateStats)
 						return
 					}
 
@@ -917,31 +919,7 @@ func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) ([]*temp
 						// check if the template is a DAST template
 						// also allow global matchers template to be loaded
 						if parsed.IsFuzzableRequest() || parsed.IsGlobalMatchersTemplate() {
-							if parsed.HasHeadlessRequest() && !typesOpts.Headless {
-								stats.Increment(templates.ExcludedHeadlessTmplStats)
-								if config.DefaultConfig.LogAllEvents {
-									store.logger.Print().Msgf("[%v] Headless flag is required for headless template '%s'.\n", aurora.Yellow("WRN").String(), templatePath)
-								}
-							} else {
-								loadTemplate(parsed)
-							}
-						}
-					} else if parsed.HasHeadlessRequest() && !typesOpts.Headless {
-						// donot include headless template in final list if headless flag is not set
-						stats.Increment(templates.ExcludedHeadlessTmplStats)
-						if config.DefaultConfig.LogAllEvents {
-							store.logger.Print().Msgf("[%v] Headless flag is required for headless template '%s'.\n", aurora.Yellow("WRN").String(), templatePath)
-						}
-					} else if parsed.HasCodeRequest() && !typesOpts.EnableCodeTemplates {
-						// donot include 'Code' protocol custom template in final list if code flag is not set
-						stats.Increment(templates.ExcludedCodeTmplStats)
-						if config.DefaultConfig.LogAllEvents {
-							store.logger.Print().Msgf("[%v] Code flag is required for code protocol template '%s'.\n", aurora.Yellow("WRN").String(), templatePath)
-						}
-					} else if parsed.IsFuzzableRequest() && !typesOpts.DAST {
-						stats.Increment(templates.ExcludedDastTmplStats)
-						if config.DefaultConfig.LogAllEvents {
-							store.logger.Print().Msgf("[%v] -dast flag is required for DAST template '%s'.\n", aurora.Yellow("WRN").String(), templatePath)
+							loadTemplate(parsed)
 						}
 					} else {
 						loadTemplate(parsed)
@@ -950,9 +928,9 @@ func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) ([]*temp
 			}
 			if err != nil {
 				if strings.Contains(err.Error(), templates.ErrExcluded.Error()) {
-					stats.Increment(templates.TemplatesExcludedStats)
+					stats.Increment(templates.ExcludedWeakMatcherTemplateStats)
 					if config.DefaultConfig.LogAllEvents {
-						store.logger.Print().Msgf("[%v] %v\n", aurora.Yellow("WRN").String(), err.Error())
+						store.logger.Warning().Msg(err.Error())
 					}
 					return
 				}

--- a/pkg/catalog/loader/loader_test.go
+++ b/pkg/catalog/loader/loader_test.go
@@ -1,11 +1,18 @@
 package loader
 
 import (
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 
+	"github.com/projectdiscovery/gologger"
+	"github.com/projectdiscovery/nuclei/v3/internal/tests/testutils"
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/config"
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/disk"
+	"github.com/projectdiscovery/nuclei/v3/pkg/loader/workflow"
+	"github.com/projectdiscovery/nuclei/v3/pkg/templates"
+	"github.com/projectdiscovery/nuclei/v3/pkg/utils/stats"
 	"github.com/stretchr/testify/require"
 )
 
@@ -100,4 +107,102 @@ func TestRemoteTemplates(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestLoadTemplatesRecordsUnsignedCodeTemplateOnlyAsCodeSkip(t *testing.T) {
+	templatePath := filepath.Join(t.TempDir(), "unsigned-code.yaml")
+	err := os.WriteFile(templatePath, []byte(`id: unsigned-code-template
+
+info:
+  name: Unsigned Code Template
+  author: pdteam
+  severity: info
+
+code:
+  - engine:
+      - sh
+    source: |
+      echo unsigned-code-template
+`), 0o600)
+	require.NoError(t, err)
+
+	options := testutils.DefaultOptions.Copy()
+	options.Logger = &gologger.Logger{}
+	options.ExecutionId = "loader-unsigned-code-template"
+	options.EnableCodeTemplates = false
+	options.DisableUnsignedTemplates = false
+	options.TemplateLoadingConcurrency = 1
+	testutils.Init(options)
+	t.Cleanup(func() {
+		testutils.Cleanup(options)
+	})
+
+	catalog := disk.NewCatalog("")
+	executerOpts := testutils.NewMockExecuterOptions(options, nil)
+	executerOpts.Catalog = catalog
+	executerOpts.Parser = templates.NewParser()
+	executerOpts.Logger = options.Logger
+
+	workflowLoader, err := workflow.NewLoader(executerOpts)
+	require.NoError(t, err)
+	executerOpts.WorkflowLoader = workflowLoader
+
+	store, err := New(NewConfig(options, catalog, executerOpts))
+	require.NoError(t, err)
+
+	initialUnverifiedCode := stats.GetValue(templates.SkippedUnverifiedCodeTemplateStats)
+	initialUnverified := stats.GetValue(templates.SkippedUnverifiedTemplateStats)
+
+	loaded, err := store.LoadTemplates([]string{templatePath})
+	require.NoError(t, err)
+	require.Empty(t, loaded)
+	require.Equal(t, initialUnverifiedCode+1, stats.GetValue(templates.SkippedUnverifiedCodeTemplateStats))
+	require.Equal(t, initialUnverified, stats.GetValue(templates.SkippedUnverifiedTemplateStats))
+}
+
+func TestLoadTemplatesDoesNotRequireGlobalMatchersFlagToLoadTemplate(t *testing.T) {
+	templatePath := filepath.Join(t.TempDir(), "global-matchers.yaml")
+	err := os.WriteFile(templatePath, []byte(`id: global-matchers-template
+
+info:
+  name: Global Matchers Template
+  author: pdteam
+  severity: info
+
+http:
+  - global-matchers: true
+    matchers:
+      - type: word
+        words:
+          - global-matchers-template
+`), 0o600)
+	require.NoError(t, err)
+
+	options := testutils.DefaultOptions.Copy()
+	options.Logger = &gologger.Logger{}
+	options.ExecutionId = "loader-global-matchers-template"
+	options.EnableGlobalMatchersTemplates = false
+	options.TemplateLoadingConcurrency = 1
+	testutils.Init(options)
+	t.Cleanup(func() {
+		testutils.Cleanup(options)
+	})
+
+	catalog := disk.NewCatalog("")
+	executerOpts := testutils.NewMockExecuterOptions(options, nil)
+	executerOpts.Catalog = catalog
+	executerOpts.Parser = templates.NewParser()
+	executerOpts.Logger = options.Logger
+
+	workflowLoader, err := workflow.NewLoader(executerOpts)
+	require.NoError(t, err)
+	executerOpts.WorkflowLoader = workflowLoader
+
+	store, err := New(NewConfig(options, catalog, executerOpts))
+	require.NoError(t, err)
+
+	loaded, err := store.LoadTemplates([]string{templatePath})
+	require.NoError(t, err)
+	require.Len(t, loaded, 1)
+	require.Equal(t, "global-matchers-template", loaded[0].ID)
 }

--- a/pkg/templates/capability.go
+++ b/pkg/templates/capability.go
@@ -1,0 +1,256 @@
+package templates
+
+import (
+	"fmt"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/types"
+)
+
+// Capability identifies an opt-in capability a template may require.
+type Capability string
+
+const (
+	// CapabilityHeadless requires the -headless flag.
+	CapabilityHeadless Capability = "headless"
+	// CapabilityCode requires the -code flag.
+	CapabilityCode Capability = "code"
+	// CapabilityDAST requires the -dast flag.
+	CapabilityDAST Capability = "dast"
+	// CapabilitySelfContained requires the -enable-self-contained flag.
+	CapabilitySelfContained Capability = "self-contained"
+	// CapabilityGlobalMatchers requires the -enable-global-matchers flag.
+	CapabilityGlobalMatchers Capability = "global-matchers"
+	// CapabilityFile requires the -file flag.
+	CapabilityFile Capability = "file"
+)
+
+type capabilityDefinition struct {
+	capability   Capability
+	stat         string
+	flag         string
+	templateKind string
+	loadBlocking bool
+	enabled      func(*types.Options) bool
+	required     func(*Template) bool
+}
+
+var capabilityDefinitions = []capabilityDefinition{
+	{
+		capability:   CapabilityHeadless,
+		stat:         ExcludedHeadlessTemplateStats,
+		flag:         "-headless",
+		templateKind: "headless",
+		loadBlocking: true,
+		enabled: func(options *types.Options) bool {
+			return options.Headless
+		},
+		required: func(template *Template) bool {
+			return template.HasHeadlessRequest()
+		},
+	},
+	{
+		capability:   CapabilityCode,
+		stat:         ExcludedCodeTemplateStats,
+		flag:         "-code",
+		templateKind: "code protocol",
+		loadBlocking: true,
+		enabled: func(options *types.Options) bool {
+			return options.EnableCodeTemplates
+		},
+		required: func(template *Template) bool {
+			return template.HasCodeRequest()
+		},
+	},
+	{
+		capability:   CapabilityDAST,
+		stat:         ExcludedDASTTemplateStats,
+		flag:         "-dast",
+		templateKind: "DAST",
+		loadBlocking: true,
+		enabled: func(options *types.Options) bool {
+			return options.DAST
+		},
+		required: func(template *Template) bool {
+			return template.IsFuzzableRequest()
+		},
+	},
+	{
+		capability:   CapabilitySelfContained,
+		stat:         ExcludedSelfContainedTemplateStats,
+		flag:         "-enable-self-contained",
+		templateKind: "self-contained",
+		loadBlocking: true,
+		enabled: func(options *types.Options) bool {
+			return options.EnableSelfContainedTemplates
+		},
+		required: func(template *Template) bool {
+			return template.requiresSelfContained()
+		},
+	},
+	{
+		capability:   CapabilityGlobalMatchers,
+		stat:         ExcludedGlobalMatchersTemplateStats,
+		flag:         "-enable-global-matchers",
+		templateKind: "global matchers",
+		loadBlocking: false,
+		enabled: func(options *types.Options) bool {
+			return options.EnableGlobalMatchersTemplates
+		},
+		required: func(template *Template) bool {
+			return template.requiresGlobalMatchers()
+		},
+	},
+	{
+		capability:   CapabilityFile,
+		stat:         ExcludedFileTemplateStats,
+		flag:         "-file",
+		templateKind: "file",
+		loadBlocking: true,
+		enabled: func(options *types.Options) bool {
+			return options.EnableFileTemplates
+		},
+		required: func(template *Template) bool {
+			return template.HasFileRequest()
+		},
+	},
+}
+
+// AllCapabilities returns all template execution capabilities in evaluation order.
+func AllCapabilities() []Capability {
+	capabilities := make([]Capability, 0, len(capabilityDefinitions))
+	for _, definition := range capabilityDefinitions {
+		capabilities = append(capabilities, definition.capability)
+	}
+
+	return capabilities
+}
+
+// Stat returns the stats key for a missing capability.
+func (capability Capability) Stat() string {
+	definition, _ := capability.definition()
+
+	return definition.stat
+}
+
+// Flag returns the CLI flag enabling the capability.
+func (capability Capability) Flag() string {
+	definition, _ := capability.definition()
+
+	return definition.flag
+}
+
+// TemplateKind returns the template kind label used in missing-flag messages.
+func (capability Capability) TemplateKind() string {
+	definition, found := capability.definition()
+	if !found {
+		return string(capability)
+	}
+
+	return definition.templateKind
+}
+
+func (capability Capability) definition() (capabilityDefinition, bool) {
+	for _, definition := range capabilityDefinitions {
+		if definition.capability == capability {
+			return definition, true
+		}
+	}
+
+	return capabilityDefinition{}, false
+}
+
+// MissingFlagMessage returns a per-template message for a missing capability.
+func (capability Capability) MissingFlagMessage(templatePath string) string {
+	return fmt.Sprintf("%s flag is required for %s template %q.", capability.Flag(), capability.TemplateKind(), templatePath)
+}
+
+// CapabilitySet represents enabled template execution capabilities.
+type CapabilitySet map[Capability]bool
+
+// CapabilitiesFromOptions returns the template capabilities enabled by options.
+func CapabilitiesFromOptions(options *types.Options) CapabilitySet {
+	capabilities := make(CapabilitySet, len(capabilityDefinitions))
+	for _, definition := range capabilityDefinitions {
+		capabilities[definition.capability] = definition.enabled(options)
+	}
+
+	return capabilities
+}
+
+// Has returns true when a capability is enabled.
+func (caps CapabilitySet) Has(capability Capability) bool {
+	return caps[capability]
+}
+
+// RequiredCapabilities returns the opt-in capabilities required by the template.
+func (template *Template) RequiredCapabilities() []Capability {
+	var required []Capability
+
+	for _, definition := range capabilityDefinitions {
+		if definition.required(template) {
+			required = append(required, definition.capability)
+		}
+	}
+
+	return required
+}
+
+func (template *Template) requiresSelfContained() bool {
+	if template.SelfContained {
+		return true
+	}
+
+	for _, request := range template.RequestsHTTP {
+		if request != nil && request.SelfContained {
+			return true
+		}
+	}
+	for _, request := range template.RequestsNetwork {
+		if request != nil && request.SelfContained {
+			return true
+		}
+	}
+	for _, request := range template.RequestsHeadless {
+		if request != nil && request.SelfContained {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (template *Template) requiresGlobalMatchers() bool {
+	for _, request := range template.RequestsHTTP {
+		if request != nil && request.GlobalMatchers {
+			return true
+		}
+	}
+
+	return false
+}
+
+// MissingCapabilities returns all disabled capabilities required by the template.
+func (template *Template) MissingCapabilities(caps CapabilitySet) []Capability {
+	return template.missingCapabilities(caps, false)
+}
+
+// MissingLoadCapabilities returns disabled capabilities that prevent a template
+// from being loaded into the execution store.
+func (template *Template) MissingLoadCapabilities(caps CapabilitySet) []Capability {
+	return template.missingCapabilities(caps, true)
+}
+
+func (template *Template) missingCapabilities(caps CapabilitySet, loadOnly bool) []Capability {
+	var missing []Capability
+
+	for _, definition := range capabilityDefinitions {
+		if loadOnly && !definition.loadBlocking {
+			continue
+		}
+		if definition.required(template) && !caps.Has(definition.capability) {
+			missing = append(missing, definition.capability)
+		}
+	}
+
+	return missing
+}

--- a/pkg/templates/compile.go
+++ b/pkg/templates/compile.go
@@ -250,16 +250,12 @@ func Parse(filePath string, preprocessor Preprocessor, options *protocols.Execut
 //
 // TODO: support all protocols.
 func (template *Template) isGlobalMatchersEnabled() bool {
-	if !template.Options.Options.EnableGlobalMatchersTemplates {
+	caps := CapabilitiesFromOptions(template.Options.Options)
+	if !caps.Has(CapabilityGlobalMatchers) {
 		return false
 	}
 
-	for _, request := range template.RequestsHTTP {
-		if request.GlobalMatchers {
-			return true
-		}
-	}
-	return false
+	return template.requiresGlobalMatchers()
 }
 
 // parseSelfContainedRequests parses the self contained template requests.
@@ -311,6 +307,7 @@ func (template *Template) compileProtocolRequests(options *protocols.ExecutorOpt
 	}
 
 	var requests []protocols.Request
+	caps := CapabilitiesFromOptions(options.Options)
 
 	if template.hasMultipleRequests() {
 		// when multiple requests are present preserve the order of requests and protocols
@@ -332,7 +329,7 @@ func (template *Template) compileProtocolRequests(options *protocols.ExecutorOpt
 		if template.HasHTTPRequest() {
 			requests = append(requests, template.convertRequestToProtocolsRequest(template.RequestsHTTP)...)
 		}
-		if template.HasHeadlessRequest() && options.Options.Headless {
+		if template.HasHeadlessRequest() && caps.Has(CapabilityHeadless) {
 			requests = append(requests, template.convertRequestToProtocolsRequest(template.RequestsHeadless)...)
 		}
 		if template.HasSSLRequest() {
@@ -344,7 +341,7 @@ func (template *Template) compileProtocolRequests(options *protocols.ExecutorOpt
 		if template.HasWHOISRequest() {
 			requests = append(requests, template.convertRequestToProtocolsRequest(template.RequestsWHOIS)...)
 		}
-		if template.HasCodeRequest() && options.Options.EnableCodeTemplates {
+		if template.HasCodeRequest() && caps.Has(CapabilityCode) {
 			requests = append(requests, template.convertRequestToProtocolsRequest(template.RequestsCode)...)
 		}
 		if template.HasJavascriptRequest() {

--- a/pkg/templates/compile_test.go
+++ b/pkg/templates/compile_test.go
@@ -7,10 +7,12 @@ import (
 	netHttp "net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/julienschmidt/httprouter"
+	"github.com/projectdiscovery/nuclei/v3/internal/tests/testutils"
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/config"
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/disk"
 	"github.com/projectdiscovery/nuclei/v3/pkg/loader/workflow"
@@ -26,7 +28,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/variables"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/http"
 	"github.com/projectdiscovery/nuclei/v3/pkg/templates"
-	"github.com/projectdiscovery/nuclei/v3/internal/tests/testutils"
+	"github.com/projectdiscovery/nuclei/v3/pkg/utils/stats"
 	"github.com/projectdiscovery/nuclei/v3/pkg/workflows"
 	"github.com/projectdiscovery/ratelimit"
 	"github.com/stretchr/testify/require"
@@ -203,6 +205,83 @@ func Test_ParseWorkflowWithGlobalMatchers(t *testing.T) {
 	require.Len(t, got.CompiledWorkflow.Workflows, 2)
 	require.Len(t, got.CompiledWorkflow.Workflows[0].Executers, 1)
 	require.Len(t, got.CompiledWorkflow.Workflows[1].Executers, 0)
+}
+
+func Test_ParseWorkflowAllowsFileAndSelfContainedSubtemplatesWhenEnabled(t *testing.T) {
+	setup()
+	previousFileTemplates := executerOpts.Options.EnableFileTemplates
+	previousSelfContainedTemplates := executerOpts.Options.EnableSelfContainedTemplates
+	defer func() {
+		executerOpts.Options.EnableFileTemplates = previousFileTemplates
+		executerOpts.Options.EnableSelfContainedTemplates = previousSelfContainedTemplates
+	}()
+
+	executerOpts.Options.EnableFileTemplates = true
+	executerOpts.Options.EnableSelfContainedTemplates = true
+
+	got, err := templates.Parse("tests/workflow-capability-gates.yaml", nil, executerOpts)
+	require.NoError(t, err, "could not parse workflow template")
+	require.NotNil(t, got.CompiledWorkflow, "compiled workflow should not be nil")
+	require.Len(t, got.CompiledWorkflow.Workflows, 1)
+
+	workflow := got.CompiledWorkflow.Workflows[0]
+	require.Len(t, workflow.Executers, 1)
+	require.Len(t, workflow.Subtemplates, 1)
+	require.Len(t, workflow.Subtemplates[0].Executers, 1)
+}
+
+func Test_ParseWorkflowRecordsUnsignedCodeSubtemplateOnlyAsCodeSkip(t *testing.T) {
+	setup()
+	previousCodeTemplates := executerOpts.Options.EnableCodeTemplates
+	previousDisableUnsigned := executerOpts.Options.DisableUnsignedTemplates
+	defer func() {
+		executerOpts.Options.EnableCodeTemplates = previousCodeTemplates
+		executerOpts.Options.DisableUnsignedTemplates = previousDisableUnsigned
+	}()
+
+	executerOpts.Options.EnableCodeTemplates = false
+	executerOpts.Options.DisableUnsignedTemplates = false
+
+	dir := t.TempDir()
+	codeTemplatePath := filepath.Join(dir, "unsigned-code.yaml")
+	err := os.WriteFile(codeTemplatePath, []byte(`id: workflow-unsigned-code
+
+info:
+  name: Workflow Unsigned Code
+  author: pdteam
+  severity: info
+
+code:
+  - engine:
+      - sh
+    source: |
+      echo workflow-unsigned-code
+`), 0o600)
+	require.NoError(t, err)
+
+	workflowPath := filepath.Join(dir, "workflow.yaml")
+	err = os.WriteFile(workflowPath, []byte(fmt.Sprintf(`id: workflow-unsigned-code-gate
+
+info:
+  name: Workflow Unsigned Code Gate
+  author: pdteam
+  severity: info
+
+workflows:
+  - template: %q
+`, codeTemplatePath)), 0o600)
+	require.NoError(t, err)
+
+	initialUnverifiedCode := stats.GetValue(templates.SkippedUnverifiedCodeTemplateStats)
+	initialUnverified := stats.GetValue(templates.SkippedUnverifiedTemplateStats)
+
+	got, err := templates.Parse(workflowPath, nil, executerOpts)
+	require.NoError(t, err)
+	require.NotNil(t, got.CompiledWorkflow)
+	require.Len(t, got.CompiledWorkflow.Workflows, 1)
+	require.Empty(t, got.CompiledWorkflow.Workflows[0].Executers)
+	require.Equal(t, initialUnverifiedCode+1, stats.GetValue(templates.SkippedUnverifiedCodeTemplateStats))
+	require.Equal(t, initialUnverified, stats.GetValue(templates.SkippedUnverifiedTemplateStats))
 }
 
 func Test_WrongTemplate(t *testing.T) {

--- a/pkg/templates/parser.go
+++ b/pkg/templates/parser.go
@@ -102,7 +102,7 @@ func (p *Parser) LoadTemplate(templatePath string, t any, extraTags []string, ca
 
 	validationError := validateTemplateMandatoryFields(template)
 	if validationError != nil {
-		stats.Increment(SyntaxErrorStats)
+		stats.Increment(TemplateSyntaxErrorStats)
 		return false, errkit.Newf("Could not load template %s: %s", templatePath, validationError)
 	}
 
@@ -115,7 +115,7 @@ func (p *Parser) LoadTemplate(templatePath string, t any, extraTags []string, ca
 	if ret {
 		validationWarning := validateTemplateOptionalFields(template)
 		if validationWarning != nil {
-			stats.Increment(SyntaxWarningStats)
+			stats.Increment(TemplateSyntaxWarningStats)
 			checkOpenFileError(validationWarning)
 			return ret, errkit.Newf("Could not load template %s: %s", templatePath, validationWarning)
 		}
@@ -208,7 +208,7 @@ func (p *Parser) LoadWorkflow(templatePath string, catalog catalog.Catalog) (boo
 
 	if len(template.Workflows) > 0 {
 		if validationError := validateTemplateMandatoryFields(template); validationError != nil {
-			stats.Increment(SyntaxErrorStats)
+			stats.Increment(TemplateSyntaxErrorStats)
 			return false, validationError
 		}
 		return true, nil

--- a/pkg/templates/parser_stats.go
+++ b/pkg/templates/parser_stats.go
@@ -1,18 +1,48 @@
 package templates
 
 const (
-	SyntaxWarningStats           = "syntax-warnings"
-	SyntaxErrorStats             = "syntax-errors"
-	RuntimeWarningsStats         = "runtime-warnings"
-	SkippedCodeTmplTamperedStats = "unsigned-warnings"
-	ExcludedHeadlessTmplStats    = "headless-flag-missing-warnings"
-	TemplatesExcludedStats       = "templates-executed"
-	ExcludedCodeTmplStats        = "code-flag-missing-warnings"
-	ExcludedDastTmplStats        = "fuzz-flag-missing-warnings"
-	SkippedUnsignedStats         = "skipped-unsigned-stats" // tracks loading of unsigned templates
-	ExcludedSelfContainedStats   = "excluded-self-contained-stats"
-	ExcludedFileStats            = "excluded-file-stats"
-	SkippedRequestSignatureStats = "skipped-request-signature-stats"
+	TemplateRuntimeWarningStats = "template-runtime-warnings"
+	TemplateSyntaxErrorStats    = "template-syntax-errors"
+	TemplateSyntaxWarningStats  = "template-syntax-warnings"
+
+	SkippedRequestSignatureTemplateStats = "skipped-request-signature-templates"
+	SkippedUnverifiedCodeTemplateStats   = "skipped-unverified-code-templates"
+	SkippedUnverifiedTemplateStats       = "skipped-unverified-templates"
+
+	ExcludedCodeTemplateStats           = "excluded-code-templates"
+	ExcludedDASTTemplateStats           = "excluded-dast-templates"
+	ExcludedFileTemplateStats           = "excluded-file-templates"
+	ExcludedGlobalMatchersTemplateStats = "excluded-global-matcher-templates"
+	ExcludedHeadlessTemplateStats       = "excluded-headless-templates"
+	ExcludedSelfContainedTemplateStats  = "excluded-self-contained-templates"
+	ExcludedWeakMatcherTemplateStats    = "excluded-weak-matcher-templates"
+)
+
+const (
+	// Deprecated: Use TemplateSyntaxWarningStats instead.
+	SyntaxWarningStats = TemplateSyntaxWarningStats
+	// Deprecated: Use TemplateSyntaxErrorStats instead.
+	SyntaxErrorStats = TemplateSyntaxErrorStats
+	// Deprecated: Use TemplateRuntimeWarningStats instead.
+	RuntimeWarningsStats = TemplateRuntimeWarningStats
+	// Deprecated: Use SkippedUnverifiedCodeTemplateStats instead.
+	SkippedCodeTmplTamperedStats = SkippedUnverifiedCodeTemplateStats
+	// Deprecated: Use ExcludedHeadlessTemplateStats instead.
+	ExcludedHeadlessTmplStats = ExcludedHeadlessTemplateStats
+	// Deprecated: Use ExcludedWeakMatcherTemplateStats instead.
+	TemplatesExcludedStats = ExcludedWeakMatcherTemplateStats
+	// Deprecated: Use ExcludedCodeTemplateStats instead.
+	ExcludedCodeTmplStats = ExcludedCodeTemplateStats
+	// Deprecated: Use ExcludedDASTTemplateStats instead.
+	ExcludedDastTmplStats = ExcludedDASTTemplateStats
+	// Deprecated: Use SkippedUnverifiedTemplateStats instead.
+	SkippedUnsignedStats = SkippedUnverifiedTemplateStats
+	// Deprecated: Use ExcludedSelfContainedTemplateStats instead.
+	ExcludedSelfContainedStats = ExcludedSelfContainedTemplateStats
+	// Deprecated: Use ExcludedFileTemplateStats instead.
+	ExcludedFileStats = ExcludedFileTemplateStats
+	// Deprecated: Use SkippedRequestSignatureTemplateStats instead.
+	SkippedRequestSignatureStats = SkippedRequestSignatureTemplateStats
 )
 
 // Deprecated: Use ExcludedDastTmplStats instead.

--- a/pkg/templates/stats.go
+++ b/pkg/templates/stats.go
@@ -2,17 +2,68 @@ package templates
 
 import "github.com/projectdiscovery/nuclei/v3/pkg/utils/stats"
 
+type templateStatEntry struct {
+	name        string
+	description string
+}
+
+var templateStatEntries = []templateStatEntry{
+	{
+		name:        TemplateSyntaxWarningStats,
+		description: "Found %d templates with syntax warning (use -validate flag for further examination)",
+	},
+	{
+		name:        TemplateSyntaxErrorStats,
+		description: "Found %d templates with syntax error (use -validate flag for further examination)",
+	},
+	{
+		name:        TemplateRuntimeWarningStats,
+		description: "Found %d templates with runtime error (use -validate flag for further examination)",
+	},
+	{
+		name:        SkippedUnverifiedCodeTemplateStats,
+		description: "Found %d unsigned or tampered code template (carefully examine before using it & use -sign flag to sign them)",
+	},
+	{
+		name:        ExcludedHeadlessTemplateStats,
+		description: "Excluded %d headless template[s] (disabled as default), use -headless option to run headless templates.",
+	},
+	{
+		name:        ExcludedCodeTemplateStats,
+		description: "Excluded %d code template[s] (disabled as default), use -code option to run code templates.",
+	},
+	{
+		name:        ExcludedSelfContainedTemplateStats,
+		description: "Excluded %d self-contained template[s] (disabled as default), use -esc option to run self-contained templates.",
+	},
+	{
+		name:        ExcludedGlobalMatchersTemplateStats,
+		description: "Excluded %d global matcher template[s] (disabled as default), use -enable-global-matchers option to run global matcher templates.",
+	},
+	{
+		name:        ExcludedFileTemplateStats,
+		description: "Excluded %d file template[s] (disabled as default), use -file option to run file templates.",
+	},
+	{
+		name:        ExcludedWeakMatcherTemplateStats,
+		description: "Excluded %d template[s] with known weak matchers / tags excluded from default run using .nuclei-ignore",
+	},
+	{
+		name:        ExcludedDASTTemplateStats,
+		description: "Excluded %d dast template[s] (disabled as default), use -dast option to run dast templates.",
+	},
+	{
+		name:        SkippedUnverifiedTemplateStats,
+		description: "Skipping %d unsigned template[s]",
+	},
+	{
+		name:        SkippedRequestSignatureTemplateStats,
+		description: "Skipping %d templates, HTTP Request signatures can only be used in Signed & Verified templates.",
+	},
+}
+
 func init() {
-	stats.NewEntry(SyntaxWarningStats, "Found %d templates with syntax warning (use -validate flag for further examination)")
-	stats.NewEntry(SyntaxErrorStats, "Found %d templates with syntax error (use -validate flag for further examination)")
-	stats.NewEntry(RuntimeWarningsStats, "Found %d templates with runtime error (use -validate flag for further examination)")
-	stats.NewEntry(SkippedCodeTmplTamperedStats, "Found %d unsigned or tampered code template (carefully examine before using it & use -sign flag to sign them)")
-	stats.NewEntry(ExcludedHeadlessTmplStats, "Excluded %d headless template[s] (disabled as default), use -headless option to run headless templates.")
-	stats.NewEntry(ExcludedCodeTmplStats, "Excluded %d code template[s] (disabled as default), use -code option to run code templates.")
-	stats.NewEntry(ExcludedSelfContainedStats, "Excluded %d self-contained template[s] (disabled as default), use -esc option to run self-contained templates.")
-	stats.NewEntry(ExcludedFileStats, "Excluded %d file template[s] (disabled as default), use -file option to run file templates.")
-	stats.NewEntry(TemplatesExcludedStats, "Excluded %d template[s] with known weak matchers / tags excluded from default run using .nuclei-ignore")
-	stats.NewEntry(ExcludedDastTmplStats, "Excluded %d dast template[s] (disabled as default), use -dast option to run dast templates.")
-	stats.NewEntry(SkippedUnsignedStats, "Skipping %d unsigned template[s]")
-	stats.NewEntry(SkippedRequestSignatureStats, "Skipping %d templates, HTTP Request signatures can only be used in Signed & Verified templates.")
+	for _, entry := range templateStatEntries {
+		stats.NewEntry(entry.name, entry.description)
+	}
 }

--- a/pkg/templates/templates.go
+++ b/pkg/templates/templates.go
@@ -633,6 +633,8 @@ func (template *Template) finalizeFromJSON(data []byte) error {
 }
 
 // Requirements holds the required options for a template to be enabled.
+//
+// Deprecated: use [Template.RequiredCapabilities] instead.
 type Requirements struct {
 	Headless      bool
 	Code          bool
@@ -642,6 +644,8 @@ type Requirements struct {
 }
 
 // Requirements returns what options must be enabled for the template to run.
+//
+// Deprecated: use [Template.RequiredCapabilities] instead.
 func (template *Template) Requirements() Requirements {
 	return Requirements{
 		Headless:      template.HasHeadlessRequest(),
@@ -653,6 +657,8 @@ func (template *Template) Requirements() Requirements {
 }
 
 // Capabilities represents the enabled options/capabilities.
+//
+// Deprecated: use [CapabilitySet] and [CapabilitiesFromOptions] instead.
 type Capabilities struct {
 	Headless      bool
 	Code          bool
@@ -663,28 +669,18 @@ type Capabilities struct {
 
 // IsEnabledFor checks if all template requirements are satisfied by the given
 // capabilities.
+//
+// Deprecated: use [Template.MissingCapabilities] instead.
 func (template *Template) IsEnabledFor(caps Capabilities) bool {
-	reqs := template.Requirements()
+	return len(template.MissingCapabilities(caps.toCapabilitySet())) == 0
+}
 
-	if reqs.Headless && !caps.Headless {
-		return false
+func (caps Capabilities) toCapabilitySet() CapabilitySet {
+	return CapabilitySet{
+		CapabilityHeadless:      caps.Headless,
+		CapabilityCode:          caps.Code,
+		CapabilityDAST:          caps.DAST,
+		CapabilitySelfContained: caps.SelfContained,
+		CapabilityFile:          caps.File,
 	}
-
-	if reqs.Code && !caps.Code {
-		return false
-	}
-
-	if reqs.DAST && !caps.DAST {
-		return false
-	}
-
-	if reqs.SelfContained && !caps.SelfContained {
-		return false
-	}
-
-	if reqs.File && !caps.File {
-		return false
-	}
-
-	return true
 }

--- a/pkg/templates/templates_test.go
+++ b/pkg/templates/templates_test.go
@@ -4,6 +4,12 @@ import (
 	"os"
 	"testing"
 
+	"github.com/projectdiscovery/nuclei/v3/pkg/fuzz"
+	codeProtocol "github.com/projectdiscovery/nuclei/v3/pkg/protocols/code"
+	fileProtocol "github.com/projectdiscovery/nuclei/v3/pkg/protocols/file"
+	headlessProtocol "github.com/projectdiscovery/nuclei/v3/pkg/protocols/headless"
+	httpProtocol "github.com/projectdiscovery/nuclei/v3/pkg/protocols/http"
+	"github.com/projectdiscovery/nuclei/v3/pkg/types"
 	"github.com/projectdiscovery/nuclei/v3/pkg/utils/json"
 	"github.com/projectdiscovery/nuclei/v3/pkg/utils/yaml"
 	"github.com/stretchr/testify/require"
@@ -59,4 +65,194 @@ func TestTemplateStruct(t *testing.T) {
 	yamlTemplate = Template{}
 	err = yaml.Unmarshal(yamlBin, &yamlTemplate)
 	require.Nil(t, err, "failed to unmarshal yaml template")
+}
+
+func TestCapabilitiesFromOptions(t *testing.T) {
+	options := &types.Options{
+		Headless:                      true,
+		EnableCodeTemplates:           true,
+		DAST:                          true,
+		EnableSelfContainedTemplates:  true,
+		EnableGlobalMatchersTemplates: true,
+		EnableFileTemplates:           true,
+	}
+
+	require.Equal(t, CapabilitySet{
+		CapabilityHeadless:       true,
+		CapabilityCode:           true,
+		CapabilityDAST:           true,
+		CapabilitySelfContained:  true,
+		CapabilityGlobalMatchers: true,
+		CapabilityFile:           true,
+	}, CapabilitiesFromOptions(options))
+}
+
+func TestDeprecatedStatAliases(t *testing.T) {
+	require.Equal(t, TemplateSyntaxWarningStats, SyntaxWarningStats)
+	require.Equal(t, TemplateSyntaxErrorStats, SyntaxErrorStats)
+	require.Equal(t, TemplateRuntimeWarningStats, RuntimeWarningsStats)
+	require.Equal(t, SkippedUnverifiedCodeTemplateStats, SkippedCodeTmplTamperedStats)
+	require.Equal(t, ExcludedHeadlessTemplateStats, ExcludedHeadlessTmplStats)
+	require.Equal(t, ExcludedWeakMatcherTemplateStats, TemplatesExcludedStats)
+	require.Equal(t, ExcludedCodeTemplateStats, ExcludedCodeTmplStats)
+	require.Equal(t, ExcludedDASTTemplateStats, ExcludedDastTmplStats)
+	require.Equal(t, ExcludedDastTmplStats, ExludedDastTmplStats)
+	require.Equal(t, SkippedUnverifiedTemplateStats, SkippedUnsignedStats)
+	require.Equal(t, ExcludedSelfContainedTemplateStats, ExcludedSelfContainedStats)
+	require.Equal(t, ExcludedFileTemplateStats, ExcludedFileStats)
+	require.Equal(t, SkippedRequestSignatureTemplateStats, SkippedRequestSignatureStats)
+}
+
+func TestAllCapabilities(t *testing.T) {
+	require.Equal(t, []Capability{
+		CapabilityHeadless,
+		CapabilityCode,
+		CapabilityDAST,
+		CapabilitySelfContained,
+		CapabilityGlobalMatchers,
+		CapabilityFile,
+	}, AllCapabilities())
+}
+
+func TestCapabilityMetadata(t *testing.T) {
+	tests := []struct {
+		capability   Capability
+		expectedStat string
+		expectedFlag string
+		expectedKind string
+	}{
+		{
+			capability:   CapabilityHeadless,
+			expectedStat: ExcludedHeadlessTemplateStats,
+			expectedFlag: "-headless",
+			expectedKind: "headless",
+		},
+		{
+			capability:   CapabilityCode,
+			expectedStat: ExcludedCodeTemplateStats,
+			expectedFlag: "-code",
+			expectedKind: "code protocol",
+		},
+		{
+			capability:   CapabilityDAST,
+			expectedStat: ExcludedDASTTemplateStats,
+			expectedFlag: "-dast",
+			expectedKind: "DAST",
+		},
+		{
+			capability:   CapabilitySelfContained,
+			expectedStat: ExcludedSelfContainedTemplateStats,
+			expectedFlag: "-enable-self-contained",
+			expectedKind: "self-contained",
+		},
+		{
+			capability:   CapabilityGlobalMatchers,
+			expectedStat: ExcludedGlobalMatchersTemplateStats,
+			expectedFlag: "-enable-global-matchers",
+			expectedKind: "global matchers",
+		},
+		{
+			capability:   CapabilityFile,
+			expectedStat: ExcludedFileTemplateStats,
+			expectedFlag: "-file",
+			expectedKind: "file",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(string(test.capability), func(t *testing.T) {
+			require.Equal(t, test.expectedStat, test.capability.Stat())
+			require.Equal(t, test.expectedFlag, test.capability.Flag())
+			require.Equal(t, test.expectedKind, test.capability.TemplateKind())
+			require.Equal(t,
+				test.expectedFlag+" flag is required for "+test.expectedKind+" template \"template.yaml\".",
+				test.capability.MissingFlagMessage("template.yaml"),
+			)
+		})
+	}
+}
+
+func TestTemplateMissingCapabilitiesReturnsAllMissingCapabilities(t *testing.T) {
+	template := &Template{
+		SelfContained:    true,
+		RequestsFile:     []*fileProtocol.Request{{}},
+		RequestsHeadless: []*headlessProtocol.Request{{Fuzzing: []*fuzz.Rule{{}}}},
+		RequestsCode:     []*codeProtocol.Request{{}},
+		RequestsHTTP: []*httpProtocol.Request{{
+			GlobalMatchers: true,
+		}},
+	}
+
+	require.Equal(t, []Capability{
+		CapabilityHeadless,
+		CapabilityCode,
+		CapabilityDAST,
+		CapabilitySelfContained,
+		CapabilityGlobalMatchers,
+		CapabilityFile,
+	}, template.MissingCapabilities(CapabilitySet{}))
+	require.Empty(t, template.MissingCapabilities(CapabilitySet{
+		CapabilityHeadless:       true,
+		CapabilityCode:           true,
+		CapabilityDAST:           true,
+		CapabilitySelfContained:  true,
+		CapabilityGlobalMatchers: true,
+		CapabilityFile:           true,
+	}))
+}
+
+func TestTemplateMissingLoadCapabilitiesAllowsGlobalMatchers(t *testing.T) {
+	template := &Template{
+		RequestsHTTP: []*httpProtocol.Request{{
+			GlobalMatchers: true,
+		}},
+	}
+
+	require.Equal(t, []Capability{CapabilityGlobalMatchers}, template.MissingCapabilities(CapabilitySet{}))
+	require.Empty(t, template.MissingLoadCapabilities(CapabilitySet{}))
+}
+
+func TestDeprecatedRequirementsAndIsEnabledForWrappers(t *testing.T) {
+	template := &Template{
+		SelfContained: true,
+		RequestsFile:  []*fileProtocol.Request{{}},
+	}
+
+	require.Equal(t, Requirements{
+		SelfContained: true,
+		File:          true,
+	}, template.Requirements())
+	require.False(t, template.IsEnabledFor(Capabilities{File: true}))
+	require.True(t, template.IsEnabledFor(Capabilities{
+		SelfContained: true,
+		File:          true,
+	}))
+}
+
+func TestTemplateMissingCapabilitiesDetectsRequestSelfContained(t *testing.T) {
+	template := &Template{
+		RequestsHTTP: []*httpProtocol.Request{{
+			SelfContained: true,
+		}},
+	}
+
+	require.Equal(t, []Capability{CapabilitySelfContained}, template.MissingCapabilities(CapabilitySet{}))
+	require.Empty(t, template.MissingCapabilities(CapabilitySet{CapabilitySelfContained: true}))
+}
+
+func TestTemplateMissingCapabilitiesIgnoresNilHTTPRequests(t *testing.T) {
+	template := &Template{
+		RequestsHTTP: []*httpProtocol.Request{nil},
+	}
+
+	require.Empty(t, template.MissingCapabilities(CapabilitySet{}))
+}
+
+func TestIsFuzzableRequestIgnoresNilRequests(t *testing.T) {
+	template := &Template{
+		RequestsHTTP:     []*httpProtocol.Request{nil},
+		RequestsHeadless: []*headlessProtocol.Request{nil},
+	}
+
+	require.False(t, template.IsFuzzableRequest())
 }

--- a/pkg/templates/templates_utils.go
+++ b/pkg/templates/templates_utils.go
@@ -109,7 +109,7 @@ func (t *Template) HasWorkflows() bool {
 func (t *Template) IsFuzzableRequest() bool {
 	if t.HasHTTPRequest() {
 		for _, request := range t.RequestsHTTP {
-			if request.HasFuzzing() {
+			if request != nil && request.HasFuzzing() {
 				return true
 			}
 		}
@@ -117,7 +117,7 @@ func (t *Template) IsFuzzableRequest() bool {
 
 	if t.HasHeadlessRequest() {
 		for _, request := range t.RequestsHeadless {
-			if request.HasFuzzing() {
+			if request != nil && request.HasFuzzing() {
 				return true
 			}
 		}

--- a/pkg/templates/tests/workflow-capability-gates.yaml
+++ b/pkg/templates/tests/workflow-capability-gates.yaml
@@ -1,0 +1,11 @@
+id: workflow-capability-gates
+
+info:
+  name: Workflow Capability Gates
+  author: pdteam
+  severity: info
+
+workflows:
+  - template: tests/workflow-file-template.yaml
+    subtemplates:
+      - template: tests/workflow-self-contained-template.yaml

--- a/pkg/templates/tests/workflow-file-template.yaml
+++ b/pkg/templates/tests/workflow-file-template.yaml
@@ -1,0 +1,14 @@
+id: workflow-file-template
+
+info:
+  name: Workflow File Template
+  author: pdteam
+  severity: info
+
+file:
+  - extensions:
+      - all
+    matchers:
+      - type: word
+        words:
+          - "db_password"

--- a/pkg/templates/tests/workflow-self-contained-template.yaml
+++ b/pkg/templates/tests/workflow-self-contained-template.yaml
@@ -1,0 +1,17 @@
+id: workflow-self-contained-template
+
+info:
+  name: Workflow Self Contained Template
+  author: pdteam
+  severity: info
+
+self-contained: true
+
+http:
+  - method: GET
+    path:
+      - "http://127.0.0.1:9999/"
+    matchers:
+      - type: dsl
+        dsl:
+          - "true"

--- a/pkg/templates/workflows.go
+++ b/pkg/templates/workflows.go
@@ -71,15 +71,19 @@ func parseWorkflowTemplate(workflow *workflows.WorkflowTemplate, preprocessor Pr
 	}
 
 	var workflowTemplates []*Template
+
+	caps := CapabilitiesFromOptions(options.Options)
 	for _, path := range paths {
 		template, err := Parse(path, preprocessor, options.Copy())
 		if err != nil {
 			gologger.Warning().Msgf("Could not parse workflow template %s: %v\n", path, err)
 			continue
 		}
+
 		if template == nil {
 			continue
 		}
+
 		if template.Executer == nil {
 			gologger.Warning().Msgf("Could not parse workflow template %s: no executer found\n", path)
 			continue
@@ -87,30 +91,28 @@ func parseWorkflowTemplate(workflow *workflows.WorkflowTemplate, preprocessor Pr
 
 		if options.Options.DisableUnsignedTemplates && !template.Verified {
 			// skip unverified templates when prompted to do so
-			stats.Increment(SkippedUnsignedStats)
-			continue
-		}
-		if template.UsesRequestSignature() && !template.Verified {
-			stats.Increment(SkippedRequestSignatureStats)
+			stats.Increment(SkippedUnverifiedTemplateStats)
 			continue
 		}
 
-		if template.HasCodeRequest() {
-			if !options.Options.EnableCodeTemplates {
-				// NOTE(dwisiswant0): It is safe to continue here during
-				// validation mode, because the template has already been parsed
-				// and syntax-validated by templates.Parse() above. It only
-				// prevents adding to workflow's executer list and suppresses
-				// warning messages.
-				if !options.Options.Validate {
-					gologger.Warning().Msgf("`-code` flag not found, skipping code template from workflow: %v\n", path)
-				}
-				continue
-			} else if !template.Verified {
-				// unverified code templates are not allowed in workflows
-				gologger.Warning().Msgf("skipping unverified code template from workflow: %v\n", path)
-				continue
+		if template.HasCodeRequest() && !template.Verified {
+			// unverified code templates are not allowed in workflows
+			stats.Increment(SkippedUnverifiedCodeTemplateStats)
+			gologger.Warning().Msgf("Skipping unverified code template(s) from workflow: %v\n", path)
+			continue
+		}
+
+		if missingCaps := template.MissingLoadCapabilities(caps); len(missingCaps) > 0 {
+			for _, capability := range missingCaps {
+				stats.Increment(capability.Stat())
+				gologger.Warning().Msgf("Skipping workflow subtemplate: %s", capability.MissingFlagMessage(path))
 			}
+			continue
+		}
+
+		if template.UsesRequestSignature() && !template.Verified {
+			stats.Increment(SkippedRequestSignatureTemplateStats)
+			continue
 		}
 
 		// increment signed/unsigned counters


### PR DESCRIPTION
## Proposed changes

Move template execution requirements into a shared
capability table that maps each capability to its
flag, stats key, and template predicate. Use the
shared model from template loading, workflow
parsing, request compilation, and runner stats
display so file, self-contained, headless, code,
DAST, and global matcher gates stay in sync.

----

Prev. unverified code templates were being counted in overlapping and/or inconsistent ways. Sometimes the top-level loader would increment both the generic unverified counter and the code-template counter for the same skip, and workflow subtemplates did their own thing. The numbers were basically meaningless. Here, that the counters are mutually exclusive now, they actually mean something clear, much easier to reason about.

A few things are worth calling out when I'm working on this:

We have got a vocab mess. The actual terms we use in the code & docs like signed vs. tampered vs. verified, skipped vs. excluded, and similar labels. These words are not interchangeable, but we have been treating them like they are. That's how we end up with confusing stats, contradictory comments, and weird behavior down the line. We should probably just write down clear definitions once (a tiny `GLOSSARY dot md` would do it) and then actually stick to them.

The user-facing messages are a separate concern. A lot of them feel like they were added randomly over time, slightly different wording, tone, and even spelling for basically the same situation, making the whole thing feel sloppy, even when the logic underneath is solid. We should clean those up and make them consistent, calm, and predictable.

Hence, anything shown to users should use the full, long flag name instead of short flags. I mean they are great for typing a command, but they are terrible for doc or error messages. If the error tells user to do something, it should spell out exactly what they need to do. Users be like "wtf is -duc? -esc?" and then they have to go look it up, which is a bad experience. If it says "you need to enable [INSERT SOME LONG FLAG NAME]" then they know exactly what to do.

I also don't think we should twist ourselves into knots to keep compatibility for internal names that are not part of official lib SDK-facing API. If no external user is supposed to be consuming it, hanging onto the old name just weighs the code down. Compatibility should protect real users, not preserve technical debt forever.

And, currently, [I'm still not sure about this but, for the shake of future-proofing,] a capability needs a certain flag, the capability definition should be the single source of truth for that flag name. So hardcoding the same flag string in messages, stats, checks, everywhere else is just begging for things to get out of sync. The next time we rename a flag or add a new type, we shouldn't have to go on a `grep` hunt.

### Proof

<!-- How has this been tested? Please describe the tests that you ran to verify your changes. -->

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added capability-based template execution gating (headless, code, DAST, self-contained, global matchers, file).

- **Improvements**
  - Standardized template metrics with more granular syntax/runtime warning and skip/exclusion counters.
  - Updated workflow subtemplate filtering and unsigned/unverified skipping behavior to align with capabilities.
  - Improved missing-capability reporting and event-logging behavior.

- **Bug Fixes**
  - Fixed a potential file-handle leak during disk matching.
  - Made fuzzing detection resilient to nil request entries.

- **Tests**
  - Added/expanded tests for capability gating, workflow parsing, and skip-stat correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->