### PR TITLE
fix(yaml): reject recursive include chains

### DIFF
--- a/pkg/utils/yaml/preprocess.go
+++ b/pkg/utils/yaml/preprocess.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"strings"
 
 	"github.com/projectdiscovery/nuclei/v3/pkg/templates/extensions"
 	fileutil "github.com/projectdiscovery/utils/file"
@@ -28,55 +27,66 @@ func PreProcess(data []byte) ([]byte, error) {
 
 func preProcess(data []byte, includeStack map[string]struct{}, depth int) ([]byte, error) {
 	// find all matches like !include:path\n
-	importMatches := reImportsPattern.FindAllSubmatch(data, -1)
+	// FindAllSubmatchIndex is used (instead of FindAllSubmatch) so each match
+	// carries its own offset; relying on bytes.Index would always resolve to the
+	// first occurrence and mis-pad repeated include directives.
+	importMatches := reImportsPattern.FindAllSubmatchIndex(data, -1)
 	hasImportDirectives := len(importMatches) > 0
 
 	if hasImportDirectives && StrictSyntax {
 		return data, errors.New("include directive preprocessing is disabled")
 	}
 
-	var replaceItems []string
+	if !hasImportDirectives {
+		return data, nil
+	}
+
+	// Expand each directive in place using its own offset. A strings.Replacer
+	// cannot be used here because it collapses identical directive lines onto a
+	// single replacement, which would reuse the first occurrence's indentation
+	// for every later occurrence.
+	var out bytes.Buffer
+	lastEnd := 0
 
 	for _, match := range importMatches {
-		var (
-			matchString     string
-			includeFileName string
-		)
-		matchBytes := match[0]
-		matchString = string(matchBytes)
-		if len(match) > 1 {
-			includeFileName = string(match[1])
+		matchStart, matchEnd := match[0], match[1]
+
+		var includeFileName string
+		if len(match) > 3 && match[2] >= 0 {
+			includeFileName = string(data[match[2]:match[3]])
+		}
+
+		// check if the file exists; otherwise leave the directive untouched
+		if !fileutil.FileExists(includeFileName) {
+			continue
+		}
+
+		includeFileContent, err := readIncludedFile(includeFileName, includeStack, depth)
+		if err != nil {
+			return nil, err
 		}
 
 		// Preserve the newline and indentation that should prefix included content lines.
-		matchIndex := bytes.Index(data, matchBytes)
-		lastNewLineIndex := bytes.LastIndex(data[:matchIndex], []byte("\n"))
+		lastNewLineIndex := bytes.LastIndex(data[:matchStart], []byte("\n"))
 		var padBytes []byte
 		if lastNewLineIndex < 0 {
-			padBytes = append([]byte("\n"), data[:matchIndex]...)
+			padBytes = append([]byte("\n"), data[:matchStart]...)
 		} else {
-			padBytes = data[lastNewLineIndex:matchIndex]
+			padBytes = data[lastNewLineIndex:matchStart]
 		}
 
-		// check if the file exists
-		if fileutil.FileExists(includeFileName) {
-			// and in case replace the comment with it
-			includeFileContent, err := readIncludedFile(includeFileName, includeStack, depth)
-			if err != nil {
-				return nil, err
-			}
+		// pad each line of file content with padBytes
+		includeFileContent = bytes.ReplaceAll(includeFileContent, []byte("\n"), padBytes)
 
-			// pad each line of file content with padBytes
-			includeFileContent = bytes.ReplaceAll(includeFileContent, []byte("\n"), padBytes)
-
-			replaceItems = append(replaceItems, matchString)
-			replaceItems = append(replaceItems, string(includeFileContent))
-		}
+		// copy everything up to the directive (including its indentation), then
+		// the expanded content, and resume after the directive.
+		out.Write(data[lastEnd:matchStart])
+		out.Write(includeFileContent)
+		lastEnd = matchEnd
 	}
+	out.Write(data[lastEnd:])
 
-	replacer := strings.NewReplacer(replaceItems...)
-
-	return []byte(replacer.Replace(string(data))), nil
+	return out.Bytes(), nil
 }
 
 func readIncludedFile(includeFileName string, includeStack map[string]struct{}, depth int) ([]byte, error) {

--- a/pkg/utils/yaml/preprocess.go
+++ b/pkg/utils/yaml/preprocess.go
@@ -3,7 +3,9 @@ package yaml
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -14,11 +16,17 @@ import (
 
 var reImportsPattern = regexp.MustCompile(`(?m)# !include:(.+.yaml)`)
 
+const maxIncludeDepth = 32
+
 // StrictSyntax determines if pre-processing directives should be observed
 var StrictSyntax bool
 
 // PreProcess all include directives
 func PreProcess(data []byte) ([]byte, error) {
+	return preProcess(data, make(map[string]struct{}), 0)
+}
+
+func preProcess(data []byte, includeStack map[string]struct{}, depth int) ([]byte, error) {
 	// find all matches like !include:path\n
 	importMatches := reImportsPattern.FindAllSubmatch(data, -1)
 	hasImportDirectives := len(importMatches) > 0
@@ -36,29 +44,26 @@ func PreProcess(data []byte) ([]byte, error) {
 		)
 		matchBytes := match[0]
 		matchString = string(matchBytes)
-		if len(match) > 0 {
+		if len(match) > 1 {
 			includeFileName = string(match[1])
 		}
 
-		// gets the number of tabs/spaces between the last \n and the beginning of the match
+		// Preserve the newline and indentation that should prefix included content lines.
 		matchIndex := bytes.Index(data, matchBytes)
 		lastNewLineIndex := bytes.LastIndex(data[:matchIndex], []byte("\n"))
-		padBytes := data[lastNewLineIndex:matchIndex]
+		var padBytes []byte
+		if lastNewLineIndex < 0 {
+			padBytes = append([]byte("\n"), data[:matchIndex]...)
+		} else {
+			padBytes = data[lastNewLineIndex:matchIndex]
+		}
 
 		// check if the file exists
 		if fileutil.FileExists(includeFileName) {
 			// and in case replace the comment with it
-			includeFileContent, err := os.ReadFile(includeFileName)
+			includeFileContent, err := readIncludedFile(includeFileName, includeStack, depth)
 			if err != nil {
 				return nil, err
-			}
-			// if it's yaml, tries to preprocess that too recursively
-			if stringsutil.HasSuffixAny(includeFileName, extensions.YAML) {
-				if subIncludedFileContent, err := PreProcess(includeFileContent); err == nil {
-					includeFileContent = subIncludedFileContent
-				} else {
-					return nil, err
-				}
 			}
 
 			// pad each line of file content with padBytes
@@ -72,4 +77,43 @@ func PreProcess(data []byte) ([]byte, error) {
 	replacer := strings.NewReplacer(replaceItems...)
 
 	return []byte(replacer.Replace(string(data))), nil
+}
+
+func readIncludedFile(includeFileName string, includeStack map[string]struct{}, depth int) ([]byte, error) {
+	includePath := includePathKey(includeFileName)
+	if _, ok := includeStack[includePath]; ok {
+		return nil, fmt.Errorf("circular include directive detected: %s", includeFileName)
+	}
+
+	includeStack[includePath] = struct{}{}
+	defer delete(includeStack, includePath)
+
+	includeFileContent, err := os.ReadFile(includeFileName)
+	if err != nil {
+		return nil, err
+	}
+
+	// if it's yaml, tries to preprocess that too recursively
+	if stringsutil.HasSuffixAny(includeFileName, extensions.YAML) {
+		if depth >= maxIncludeDepth {
+			return nil, fmt.Errorf("include directive exceeded maximum include depth of %d", maxIncludeDepth)
+		}
+		includeFileContent, err = preProcess(includeFileContent, includeStack, depth+1)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return includeFileContent, nil
+}
+
+func includePathKey(includeFileName string) string {
+	includePath, err := filepath.Abs(includeFileName)
+	if err != nil {
+		return filepath.Clean(includeFileName)
+	}
+	if evaluatedPath, err := filepath.EvalSymlinks(includePath); err == nil {
+		return evaluatedPath
+	}
+	return includePath
 }

--- a/pkg/utils/yaml/preprocess.go
+++ b/pkg/utils/yaml/preprocess.go
@@ -29,7 +29,7 @@ func preProcess(data []byte, includeStack map[string]struct{}, depth int) ([]byt
 	// find all matches like !include:path\n
 	// FindAllSubmatchIndex is used (instead of FindAllSubmatch) so each match
 	// carries its own offset; relying on bytes.Index would always resolve to the
-	// first occurrence and mis-pad repeated include directives.
+	// first occurrence and incorrectly pad repeated include directives.
 	importMatches := reImportsPattern.FindAllSubmatchIndex(data, -1)
 	hasImportDirectives := len(importMatches) > 0
 

--- a/pkg/utils/yaml/preprocess_test.go
+++ b/pkg/utils/yaml/preprocess_test.go
@@ -1,0 +1,77 @@
+package yaml
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPreProcessIncludesFileAtStartOfData(t *testing.T) {
+	restoreStrictSyntax(t)
+
+	dir := t.TempDir()
+	includedPath := filepath.Join(dir, "included.yaml")
+	require.NoError(t, os.WriteFile(includedPath, []byte("alpha: one\nbeta: two"), 0o600))
+
+	var (
+		output []byte
+		err    error
+	)
+	require.NotPanics(t, func() {
+		output, err = PreProcess([]byte(fmt.Sprintf("# !include:%s\nroot: true\n", includedPath)))
+	})
+	require.NoError(t, err)
+	require.NotContains(t, string(output), "# !include:")
+	require.Contains(t, string(output), "alpha: one\nbeta: two")
+	require.Contains(t, string(output), "root: true")
+}
+
+func TestPreProcessRejectsCircularInclude(t *testing.T) {
+	restoreStrictSyntax(t)
+
+	dir := t.TempDir()
+	templatePath := filepath.Join(dir, "self.yaml")
+	template := []byte(fmt.Sprintf("# !include:%s\nid: self\n", templatePath))
+	require.NoError(t, os.WriteFile(templatePath, template, 0o600))
+
+	var err error
+	require.NotPanics(t, func() {
+		_, err = PreProcess(template)
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "circular include")
+}
+
+func TestPreProcessRejectsExcessiveIncludeDepth(t *testing.T) {
+	restoreStrictSyntax(t)
+
+	dir := t.TempDir()
+	paths := make([]string, 40)
+	for i := range paths {
+		paths[i] = filepath.Join(dir, fmt.Sprintf("include-%02d.yaml", i))
+	}
+	for i, path := range paths {
+		content := fmt.Sprintf("id: include-%02d\n", i)
+		if i < len(paths)-1 {
+			content = fmt.Sprintf("# !include:%s\n%s", paths[i+1], content)
+		}
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	}
+
+	_, err := PreProcess([]byte(fmt.Sprintf("# !include:%s\nid: root\n", paths[0])))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "maximum include depth")
+}
+
+func restoreStrictSyntax(t *testing.T) {
+	t.Helper()
+
+	previous := StrictSyntax
+	StrictSyntax = false
+	t.Cleanup(func() {
+		StrictSyntax = previous
+	})
+}

--- a/pkg/utils/yaml/preprocess_test.go
+++ b/pkg/utils/yaml/preprocess_test.go
@@ -29,6 +29,32 @@ func TestPreProcessIncludesFileAtStartOfData(t *testing.T) {
 	require.Contains(t, string(output), "root: true")
 }
 
+func TestPreProcessExpandsRepeatedIncludeWithPerOccurrenceIndentation(t *testing.T) {
+	restoreStrictSyntax(t)
+
+	dir := t.TempDir()
+	childPath := filepath.Join(dir, "child.yaml")
+	require.NoError(t, os.WriteFile(childPath, []byte("key: value\nnested: true"), 0o600))
+
+	// The same include directive appears twice at different indentation levels.
+	// Each occurrence must be expanded using its own offset/indentation.
+	data := []byte(fmt.Sprintf("root:\n  # !include:%s\nother:\n      # !include:%s\n", childPath, childPath))
+
+	var (
+		output []byte
+		err    error
+	)
+	require.NotPanics(t, func() {
+		output, err = PreProcess(data)
+	})
+	require.NoError(t, err)
+
+	got := string(output)
+	require.NotContains(t, got, "# !include:")
+	require.Contains(t, got, "root:\n  key: value\n  nested: true")
+	require.Contains(t, got, "other:\n      key: value\n      nested: true")
+}
+
 func TestPreProcessRejectsCircularInclude(t *testing.T) {
 	restoreStrictSyntax(t)
 


### PR DESCRIPTION
## Proposed changes

Track the include stack while expanding YAML
includes and fail when a file is seen again or the
nesting limit is reached, keeping circular
includes from recursing until the process panics.

Also handle includes at the start of the buffer,
where the old padding lookup could slice from -1.

### Proof

<!-- How has this been tested? Please describe the tests that you ran to verify your changes. -->

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced YAML `# !include:` processing with recursive includes and improved handling of nested include chains
  * Added detection to prevent circular include loops
  * Enforced a maximum include nesting depth to avoid overly deep expansions
* **Bug Fixes**
  * Improved indentation/whitespace handling around include directives to preserve formatting more reliably
* **Tests**
  * Expanded coverage for include expansion, indentation behavior, circular include errors, and maximum-depth validation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->