### PR TITLE
fix(js): respect network policy before dialing ldap

### DIFF
--- a/pkg/js/libs/ldap/ldap.go
+++ b/pkg/js/libs/ldap/ldap.go
@@ -7,8 +7,8 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/projectdiscovery/goja"
 	"github.com/go-ldap/ldap/v3"
+	"github.com/projectdiscovery/goja"
 	"github.com/projectdiscovery/nuclei/v3/pkg/js/utils"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
 )
@@ -84,6 +84,10 @@ func NewClient(call goja.ConstructorCall, runtime *goja.Runtime) *goja.Object {
 
 	u, err := url.Parse(ldapUrl)
 	c.nj.HandleError(err, "invalid ldap url supported schemas are ldap://, ldaps://, ldapi://, and cldap://")
+	if u.Scheme == "" {
+		// default to ldap
+		u.Scheme = "ldap"
+	}
 
 	executionId := c.nj.ExecutionId()
 	dialers := protocolstate.GetDialersWithId(executionId)
@@ -94,44 +98,43 @@ func NewClient(call goja.ConstructorCall, runtime *goja.Runtime) *goja.Object {
 	dialCtx := c.nj.Context()
 	var conn net.Conn
 	if u.Scheme == "ldapi" {
+		const ldapiPolicyHost = "127.0.0.1"
+
+		c.nj.Require(protocolstate.IsHostAllowed(executionId, ldapiPolicyHost), protocolstate.ErrHostDenied.Msgf(ldapiPolicyHost).Error())
 		if u.Path == "" || u.Path == "/" {
 			u.Path = "/var/run/slapd/ldapi"
 		}
 		conn, err = dialers.Fastdialer.Dial(dialCtx, "unix", u.Path)
 		c.nj.HandleError(err, "failed to connect to ldap server")
 	} else {
-		host, port, err := net.SplitHostPort(u.Host)
-		if err != nil {
-			// we assume that error is due to missing port
-			host = u.Host
-			port = ""
-		}
-		if u.Scheme == "" {
-			// default to ldap
-			u.Scheme = "ldap"
-		}
-
 		switch u.Scheme {
-		case "cldap":
-			if port == "" {
-				port = ldap.DefaultLdapPort
+		case "cldap", "ldap", "ldaps":
+			host, port := u.Hostname(), u.Port()
+			c.nj.Require(host != "", "ldap host cannot be empty")
+			c.nj.Require(protocolstate.IsHostAllowed(executionId, host), protocolstate.ErrHostDenied.Msgf(host).Error())
+
+			switch u.Scheme {
+			case "cldap":
+				if port == "" {
+					port = ldap.DefaultLdapPort
+				}
+				conn, err = dialers.Fastdialer.Dial(dialCtx, "udp", net.JoinHostPort(host, port))
+			case "ldap":
+				if port == "" {
+					port = ldap.DefaultLdapPort
+				}
+				conn, err = dialers.Fastdialer.Dial(dialCtx, "tcp", net.JoinHostPort(host, port))
+			case "ldaps":
+				if port == "" {
+					port = ldap.DefaultLdapsPort
+				}
+				serverName := host
+				if c.cfg.ServerName != "" {
+					serverName = c.cfg.ServerName
+				}
+				conn, err = dialers.Fastdialer.DialTLSWithConfig(dialCtx, "tcp", net.JoinHostPort(host, port),
+					&tls.Config{InsecureSkipVerify: true, MinVersion: tls.VersionTLS10, ServerName: serverName})
 			}
-			conn, err = dialers.Fastdialer.Dial(dialCtx, "udp", net.JoinHostPort(host, port))
-		case "ldap":
-			if port == "" {
-				port = ldap.DefaultLdapPort
-			}
-			conn, err = dialers.Fastdialer.Dial(dialCtx, "tcp", net.JoinHostPort(host, port))
-		case "ldaps":
-			if port == "" {
-				port = ldap.DefaultLdapsPort
-			}
-			serverName := host
-			if c.cfg.ServerName != "" {
-				serverName = c.cfg.ServerName
-			}
-			conn, err = dialers.Fastdialer.DialTLSWithConfig(dialCtx, "tcp", net.JoinHostPort(host, port),
-				&tls.Config{InsecureSkipVerify: true, MinVersion: tls.VersionTLS10, ServerName: serverName})
 		default:
 			err = fmt.Errorf("unsupported ldap url schema %v", u.Scheme)
 		}

--- a/pkg/js/libs/ldap/ldap_test.go
+++ b/pkg/js/libs/ldap/ldap_test.go
@@ -1,0 +1,116 @@
+package ldap
+
+import (
+	"context"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/projectdiscovery/goja"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
+	"github.com/projectdiscovery/nuclei/v3/pkg/types"
+)
+
+func TestNewClientDeniesRestrictedLocalTCPBeforeDial(t *testing.T) {
+	_, err := newLDAPClientForTest(t, &types.Options{
+		RestrictLocalNetworkAccess: true,
+	}, "ldap://127.0.0.1")
+
+	requireNetworkPolicyError(t, err, "127.0.0.1")
+	requireRejectedBeforeDial(t, err)
+}
+
+func TestNewClientDeniesLDAPIAsLocalNetworkAccess(t *testing.T) {
+	_, err := newLDAPClientForTest(t, &types.Options{
+		RestrictLocalNetworkAccess: true,
+	}, "ldapi:///var/run/slapd/ldapi")
+
+	requireNetworkPolicyError(t, err, "127.0.0.1")
+	requireRejectedBeforeDial(t, err)
+}
+
+func requireRejectedBeforeDial(t *testing.T, err error) {
+	t.Helper()
+
+	if strings.Contains(err.Error(), "failed to connect to ldap server") {
+		t.Fatalf("ldap target should be rejected by policy before dialing, got %q", err)
+	}
+}
+
+func TestNewClientAllowsTCPWhenNetworkPolicyAllows(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = listener.Close()
+	}()
+
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err == nil {
+			accepted <- conn
+			return
+		}
+		accepted <- nil
+	}()
+
+	client, err := newLDAPClientForTest(t, &types.Options{}, "ldap://"+listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = client.conn.Close()
+	})
+
+	select {
+	case conn := <-accepted:
+		if conn == nil {
+			t.Fatal("listener closed before accepting ldap connection")
+		}
+		_ = conn.Close()
+	case <-time.After(time.Second):
+		t.Fatal("ldap constructor did not connect to allowed listener")
+	}
+}
+
+func newLDAPClientForTest(t *testing.T, options *types.Options, ldapURL string) (*Client, error) {
+	t.Helper()
+
+	executionID := "ldap-" + strings.NewReplacer("/", "-", " ", "-").Replace(t.Name())
+	options.ExecutionId = executionID
+	if err := protocolstate.Init(options); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		protocolstate.Close(executionID)
+	})
+
+	runtime := goja.New()
+	runtime.SetContextValue("executionId", executionID)
+	runtime.SetContextValue("ctx", context.Background())
+
+	obj, err := runtime.New(runtime.ToValue(NewClient), runtime.ToValue(ldapURL), runtime.ToValue("corp.internal"))
+	if err != nil {
+		return nil, err
+	}
+
+	client, ok := obj.Export().(*Client)
+	if !ok {
+		t.Fatalf("expected *Client export, got %T", obj.Export())
+	}
+	return client, nil
+}
+
+func requireNetworkPolicyError(t *testing.T, err error, target string) {
+	t.Helper()
+
+	if err == nil {
+		t.Fatal("expected network-policy denial, got nil")
+	}
+	if !strings.Contains(err.Error(), "network policy") || !strings.Contains(err.Error(), target) {
+		t.Fatalf("expected network-policy denial for %q, got %q", target, err)
+	}
+}


### PR DESCRIPTION
## Proposed changes

LDAP was the only JS protocol client that reached
the dialer without an `IsHostAllowed` check.
Validate ldap, ldaps, and cldap hosts before
connecting, and treat ldapi as loopback so
restricted local network access rejects Unix
socket LDAP before the socket path is opened.

### Proof

<!-- How has this been tested? Please describe the tests that you ran to verify your changes. -->

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced network policy enforcement for LDAP connections, ensuring restricted local network access is properly validated before connection attempts are made.

* **Tests**
  * Added comprehensive test coverage for network policy validation in LDAP connection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->