### PR TITLE
fix(sarif): export empty report schema instead of exiting early on zero results

### DIFF
--- a/pkg/reporting/exporters/sarif/sarif.go
+++ b/pkg/reporting/exporters/sarif/sarif.go
@@ -169,7 +169,6 @@ func (exporter *Exporter) Export(event *output.ResultEvent) error {
 	exporter.sarif.RegisterResult(*result)
 
 	return nil
-
 }
 
 // Close Writes data and closes the exporter after operation
@@ -177,11 +176,7 @@ func (exporter *Exporter) Close() error {
 	exporter.mutex.Lock()
 	defer exporter.mutex.Unlock()
 
-	if len(exporter.rules) == 0 {
-		// no output if there are no results
-		return nil
-	}
-	// links results and rules/templates
+	// Always append tool schema details so empty scans produce valid structural validation tracking files
 	exporter.addToolDetails()
 
 	bin, err := exporter.sarif.Export()


### PR DESCRIPTION
### Description
This PR addresses issue #7313 where SARIF validation fails when running scans that return zero vulnerability findings. 

### Root Cause
Previously, the `Close()` method inside the SARIF exporter checked if `len(exporter.rules) == 0` and executed an early return. This resulted in either a completely blank file or a missing structure, which breaks strict compliance with Microsoft and GitHub Advanced Security SARIF schema validators expecting a valid tool run block.

### Changes
- Removed the early conditional return statement in the `Close()` function.
- Ensured `addToolDetails()` and the internal exporter execution run regardless of the result count, allowing a valid, empty SARIF JSON structure `[]` to be cleanly written out.

Fixes #7313

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SARIF exports are now generated consistently even when a scan finds no rules or results, so “empty scans” still produce an output file with the expected tool and schema details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->