### PR TITLE
fix leaks

### DIFF
--- a/lib/sdk.go
+++ b/lib/sdk.go
@@ -80,6 +80,7 @@ type NucleiEngine struct {
 	browserInstance  *engine.Browser
 	httpClient       *retryablehttp.Client
 	parser           *templates.Parser
+	ownsParser       bool // true when the engine created the parser and may purge it on Close
 	authprovider     authprovider.AuthProvider
 
 	// unexported meta options
@@ -243,6 +244,13 @@ func (e *NucleiEngine) closeInternal() {
 	}
 	if e.opts != nil {
 		generators.ClearOptionsPayloadMap(e.opts)
+	}
+	// Purge the template caches (compiled templates are heap-heavy) so a
+	// long-running embedder does not retain them for the process lifetime.
+	// Only do this when the engine created the parser; a caller-supplied
+	// parser is an opt-in shared cache the caller owns.
+	if e.ownsParser && e.parser != nil {
+		e.parser.Purge()
 	}
 }
 

--- a/lib/sdk_private.go
+++ b/lib/sdk_private.go
@@ -170,6 +170,7 @@ func (e *NucleiEngine) init(ctx context.Context) error {
 
 	if e.parser == nil {
 		e.parser = templates.NewParser()
+		e.ownsParser = true
 	}
 
 	if protocolstate.ShouldInit(e.opts.ExecutionId) {
@@ -314,6 +315,7 @@ func (e *NucleiEngine) init(ctx context.Context) error {
 	if e.parser == nil {
 		op := templates.NewParser()
 		e.parser = op
+		e.ownsParser = true
 		e.opts.Parser = op
 		e.executerOpts.Parser = op
 		e.executerOpts.Options.Parser = op

--- a/pkg/protocols/common/protocolstate/state.go
+++ b/pkg/protocols/common/protocolstate/state.go
@@ -294,6 +294,13 @@ func Close(executionId string) {
 		// keep-alive connections to avoid lingering transport goroutines
 		// after shutdown.
 		dialersInstance.HTTPClientPool.Close()
+		// Stop the per-host rate limit pool so its background limiters (one
+		// goroutine each, up to the pool capacity) are released instead of
+		// leaking on shutdown or engine recreate. Typed as any here to avoid
+		// an import cycle with the httpclientpool package.
+		if pool, ok := dialersInstance.PerHostRateLimitPool.(interface{ Close() }); ok && pool != nil {
+			pool.Close()
+		}
 		dialersInstance.Fastdialer.Close()
 	}
 

--- a/pkg/protocols/http/httpclientpool/http_to_https_tracker.go
+++ b/pkg/protocols/http/httpclientpool/http_to_https_tracker.go
@@ -1,6 +1,7 @@
 package httpclientpool
 
 import (
+	"sync"
 	"sync/atomic"
 
 	lru "github.com/hashicorp/golang-lru/v2"
@@ -22,6 +23,9 @@ const defaultHTTPToHTTPSTrackerSize = 50000
 // NOTE: detection and correction apply to the standard net/http (retryablehttp)
 // request path only. Unsafe/raw (rawhttp) requests bypass this scheme rewrite.
 type HTTPToHTTPSPortTracker struct {
+	// once guards lazy initialization of ports so a zero-value tracker
+	// (e.g. var t HTTPToHTTPSPortTracker) is safe to use directly.
+	once sync.Once
 	// ports is a bounded LRU of host:port that require HTTPS
 	ports *lru.Cache[string, struct{}]
 
@@ -44,6 +48,19 @@ func newHTTPToHTTPSPortTrackerWithSize(size int) *HTTPToHTTPSPortTracker {
 	return &HTTPToHTTPSPortTracker{ports: cache}
 }
 
+// cache returns the bounded LRU, lazily initializing it with the default size
+// when the tracker was constructed as a zero value rather than via
+// NewHTTPToHTTPSPortTracker. Since ports is a pointer, a nil cache would
+// otherwise panic on first use (unlike the previous zero-value-safe sync.Map).
+func (t *HTTPToHTTPSPortTracker) cache() *lru.Cache[string, struct{}] {
+	t.once.Do(func() {
+		if t.ports == nil {
+			t.ports, _ = lru.New[string, struct{}](defaultHTTPToHTTPSTrackerSize)
+		}
+	})
+	return t.ports
+}
+
 // RecordHTTPToHTTPSPort records that a host:port requires HTTPS
 func (t *HTTPToHTTPSPortTracker) RecordHTTPToHTTPSPort(hostPort string) {
 	if hostPort == "" {
@@ -55,7 +72,14 @@ func (t *HTTPToHTTPSPortTracker) RecordHTTPToHTTPSPort(hostPort string) {
 		return
 	}
 
-	if existed, _ := t.ports.ContainsOrAdd(normalizedHostPort, struct{}{}); existed {
+	// PeekOrAdd atomically inserts the entry only when absent, so a unique
+	// host:port is counted exactly once even under concurrent detections
+	// (ContainsOrAdd would do this too). On a hit we additionally issue a Get
+	// to refresh the LRU recency: neither Peek/PeekOrAdd nor ContainsOrAdd
+	// updates recent-ness, and an actively re-detected host:port must not be
+	// evicted while it is still in use.
+	if _, existed, _ := t.cache().PeekOrAdd(normalizedHostPort, struct{}{}); existed {
+		t.cache().Get(normalizedHostPort)
 		return // Already recorded, no need to log again
 	}
 	t.totalDetections.Add(1)
@@ -76,7 +100,7 @@ func (t *HTTPToHTTPSPortTracker) RequiresHTTPS(hostPort string) bool {
 
 	// Get (rather than Contains) so active host:ports refresh their LRU
 	// recency and are not evicted while still in use.
-	_, ok := t.ports.Get(normalizedHostPort)
+	_, ok := t.cache().Get(normalizedHostPort)
 	return ok
 }
 
@@ -100,7 +124,7 @@ func (t *HTTPToHTTPSPortTracker) Evict(hostPort string) {
 		return
 	}
 
-	if present := t.ports.Remove(normalizedHostPort); present {
+	if present := t.cache().Remove(normalizedHostPort); present {
 		gologger.Debug().Msgf("[http-to-https-tracker] Reverted HTTP-to-HTTPS for %s (https attempt failed, falling back to http)", normalizedHostPort)
 	}
 }
@@ -112,7 +136,7 @@ func (t *HTTPToHTTPSPortTracker) Stats() HTTPToHTTPSPortStats {
 		TotalCorrections: t.totalCorrections.Load(),
 		// TrackedPorts is the number of entries currently held in the bounded
 		// LRU (may be lower than TotalDetections once eviction kicks in).
-		TrackedPorts: t.ports.Len(),
+		TrackedPorts: t.cache().Len(),
 	}
 }
 

--- a/pkg/protocols/http/httpclientpool/http_to_https_tracker.go
+++ b/pkg/protocols/http/httpclientpool/http_to_https_tracker.go
@@ -1,11 +1,19 @@
 package httpclientpool
 
 import (
-	"sync"
 	"sync/atomic"
 
+	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/projectdiscovery/gologger"
 )
+
+// defaultHTTPToHTTPSTrackerSize bounds how many host:port entries the tracker
+// keeps in memory. It is an LRU rather than a grow-only map so a long-running
+// embedder (e.g. a scan service running for days) does not accumulate one entry
+// per unique host:port forever. Evicting the least-recently-used entry only
+// costs a single re-detection (one extra 400) if that host:port is scanned
+// again later, and the result is re-learned immediately.
+const defaultHTTPToHTTPSTrackerSize = 50000
 
 // HTTPToHTTPSPortTracker tracks host:port combinations that require HTTPS
 // This is used to automatically detect and correct cases where HTTP requests
@@ -14,8 +22,8 @@ import (
 // NOTE: detection and correction apply to the standard net/http (retryablehttp)
 // request path only. Unsafe/raw (rawhttp) requests bypass this scheme rewrite.
 type HTTPToHTTPSPortTracker struct {
-	// ports is a grow-only discovery cache, sync.Map gives lock-free reads
-	ports sync.Map // map[string]struct{}
+	// ports is a bounded LRU of host:port that require HTTPS
+	ports *lru.Cache[string, struct{}]
 
 	// Statistics
 	totalDetections  atomic.Uint64
@@ -24,7 +32,16 @@ type HTTPToHTTPSPortTracker struct {
 
 // NewHTTPToHTTPSPortTracker creates a new HTTP-to-HTTPS port tracker
 func NewHTTPToHTTPSPortTracker() *HTTPToHTTPSPortTracker {
-	return &HTTPToHTTPSPortTracker{}
+	return newHTTPToHTTPSPortTrackerWithSize(defaultHTTPToHTTPSTrackerSize)
+}
+
+func newHTTPToHTTPSPortTrackerWithSize(size int) *HTTPToHTTPSPortTracker {
+	if size <= 0 {
+		size = defaultHTTPToHTTPSTrackerSize
+	}
+	// lru.New only errors on a non-positive size, which is guarded above
+	cache, _ := lru.New[string, struct{}](size)
+	return &HTTPToHTTPSPortTracker{ports: cache}
 }
 
 // RecordHTTPToHTTPSPort records that a host:port requires HTTPS
@@ -38,7 +55,7 @@ func (t *HTTPToHTTPSPortTracker) RecordHTTPToHTTPSPort(hostPort string) {
 		return
 	}
 
-	if _, loaded := t.ports.LoadOrStore(normalizedHostPort, struct{}{}); loaded {
+	if existed, _ := t.ports.ContainsOrAdd(normalizedHostPort, struct{}{}); existed {
 		return // Already recorded, no need to log again
 	}
 	t.totalDetections.Add(1)
@@ -57,7 +74,9 @@ func (t *HTTPToHTTPSPortTracker) RequiresHTTPS(hostPort string) bool {
 		return false
 	}
 
-	_, ok := t.ports.Load(normalizedHostPort)
+	// Get (rather than Contains) so active host:ports refresh their LRU
+	// recency and are not evicted while still in use.
+	_, ok := t.ports.Get(normalizedHostPort)
 	return ok
 }
 
@@ -81,7 +100,7 @@ func (t *HTTPToHTTPSPortTracker) Evict(hostPort string) {
 		return
 	}
 
-	if _, loaded := t.ports.LoadAndDelete(normalizedHostPort); loaded {
+	if present := t.ports.Remove(normalizedHostPort); present {
 		gologger.Debug().Msgf("[http-to-https-tracker] Reverted HTTP-to-HTTPS for %s (https attempt failed, falling back to http)", normalizedHostPort)
 	}
 }
@@ -91,8 +110,9 @@ func (t *HTTPToHTTPSPortTracker) Stats() HTTPToHTTPSPortStats {
 	return HTTPToHTTPSPortStats{
 		TotalDetections:  t.totalDetections.Load(),
 		TotalCorrections: t.totalCorrections.Load(),
-		// detections are incremented once per unique host:port, so this is exact
-		TrackedPorts: int(t.totalDetections.Load()),
+		// TrackedPorts is the number of entries currently held in the bounded
+		// LRU (may be lower than TotalDetections once eviction kicks in).
+		TrackedPorts: t.ports.Len(),
 	}
 }
 

--- a/pkg/protocols/http/httpclientpool/http_to_https_tracker_test.go
+++ b/pkg/protocols/http/httpclientpool/http_to_https_tracker_test.go
@@ -2,6 +2,7 @@ package httpclientpool
 
 import (
 	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -56,4 +57,82 @@ func TestHTTPToHTTPSPortTracker_BoundedLRU(t *testing.T) {
 	// the oldest entry must have been evicted, the newest must remain
 	require.False(t, tr.RequiresHTTPS("http://host0.example.com:8443/"), "oldest entry should be evicted")
 	require.True(t, tr.RequiresHTTPS(fmt.Sprintf("http://host%d.example.com:8443/", size*3-1)), "newest entry should be retained")
+}
+
+// TestHTTPToHTTPSPortTracker_RequiresHTTPSRefreshesLRU guards the recency-refresh
+// contract: a lookup must mark the entry as recently used so that an actively
+// queried host:port survives eviction over an untouched one.
+func TestHTTPToHTTPSPortTracker_RequiresHTTPSRefreshesLRU(t *testing.T) {
+	tr := newHTTPToHTTPSPortTrackerWithSize(2)
+
+	tr.RecordHTTPToHTTPSPort("http://a.example.com:8443/")
+	tr.RecordHTTPToHTTPSPort("http://b.example.com:8443/")
+
+	require.True(t, tr.RequiresHTTPS("http://a.example.com:8443/"), "lookup should refresh recency")
+
+	tr.RecordHTTPToHTTPSPort("http://c.example.com:8443/")
+
+	require.True(t, tr.RequiresHTTPS("http://a.example.com:8443/"), "refreshed entry should be retained")
+	require.False(t, tr.RequiresHTTPS("http://b.example.com:8443/"), "untouched least-recently-used entry should be evicted")
+	require.True(t, tr.RequiresHTTPS("http://c.example.com:8443/"))
+}
+
+// TestHTTPToHTTPSPortTracker_RecordRefreshesLRU guards the recency-refresh
+// contract on the write path: re-recording an existing host:port must mark it
+// recently-used so an actively re-detected entry survives eviction over an
+// untouched one (a plain ContainsOrAdd would not refresh recency here).
+func TestHTTPToHTTPSPortTracker_RecordRefreshesLRU(t *testing.T) {
+	tr := newHTTPToHTTPSPortTrackerWithSize(2)
+
+	tr.RecordHTTPToHTTPSPort("http://a.example.com:8443/")
+	tr.RecordHTTPToHTTPSPort("http://b.example.com:8443/")
+
+	// re-recording "a" must refresh its recency, making "b" the LRU victim
+	tr.RecordHTTPToHTTPSPort("http://a.example.com:8443/")
+
+	tr.RecordHTTPToHTTPSPort("http://c.example.com:8443/")
+
+	require.True(t, tr.RequiresHTTPS("http://a.example.com:8443/"), "re-recorded entry should be retained")
+	require.False(t, tr.RequiresHTTPS("http://b.example.com:8443/"), "untouched least-recently-used entry should be evicted")
+	require.True(t, tr.RequiresHTTPS("http://c.example.com:8443/"))
+
+	// re-recording an existing host must not inflate the unique-detection count
+	require.EqualValues(t, 3, tr.Stats().TotalDetections, "re-recording an existing host:port must not double-count")
+}
+
+// TestHTTPToHTTPSPortTracker_ConcurrentRecordCountsOnce ensures that recording
+// the same host:port from many goroutines counts it as a single detection.
+// PeekOrAdd makes the insert+count atomic; a check-then-add (Get then Add)
+// implementation would over-count under the race detector.
+func TestHTTPToHTTPSPortTracker_ConcurrentRecordCountsOnce(t *testing.T) {
+	tr := NewHTTPToHTTPSPortTracker()
+
+	const goroutines = 64
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			tr.RecordHTTPToHTTPSPort("http://race.example.com:8443/")
+		}()
+	}
+	wg.Wait()
+
+	require.EqualValues(t, 1, tr.Stats().TotalDetections, "a unique host:port must be counted exactly once")
+	require.Equal(t, 1, tr.Stats().TrackedPorts, "a unique host:port must occupy a single LRU entry")
+}
+
+// TestHTTPToHTTPSPortTracker_ZeroValueSafe ensures a zero-value tracker
+// (constructed directly rather than via NewHTTPToHTTPSPortTracker) lazily
+// initializes its bounded LRU instead of panicking on a nil cache.
+func TestHTTPToHTTPSPortTracker_ZeroValueSafe(t *testing.T) {
+	var tr HTTPToHTTPSPortTracker
+
+	require.NotPanics(t, func() {
+		require.False(t, tr.RequiresHTTPS("http://example.com:8443/"))
+		tr.RecordHTTPToHTTPSPort("http://example.com:8443/")
+		require.True(t, tr.RequiresHTTPS("http://example.com:8443/"))
+		tr.Evict("http://example.com:8443/")
+		_ = tr.Stats()
+	})
 }

--- a/pkg/protocols/http/httpclientpool/http_to_https_tracker_test.go
+++ b/pkg/protocols/http/httpclientpool/http_to_https_tracker_test.go
@@ -1,6 +1,7 @@
 package httpclientpool
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -33,4 +34,26 @@ func TestHTTPToHTTPSPortTracker_Evict(t *testing.T) {
 	// Evicting unknown / empty values must be safe no-ops.
 	tr.Evict("")
 	tr.Evict("http://not-recorded.example:1234/")
+}
+
+// TestHTTPToHTTPSPortTracker_BoundedLRU guards against unbounded memory growth
+// in long-running embedders: the tracker must cap the number of host:port
+// entries it retains and evict the least-recently-used ones instead of growing
+// forever.
+func TestHTTPToHTTPSPortTracker_BoundedLRU(t *testing.T) {
+	const size = 100
+	tr := newHTTPToHTTPSPortTrackerWithSize(size)
+
+	for i := 0; i < size*3; i++ {
+		tr.RecordHTTPToHTTPSPort(fmt.Sprintf("http://host%d.example.com:8443/", i))
+	}
+
+	// cumulative detections counts every unique host:port ever recorded
+	require.EqualValues(t, size*3, tr.Stats().TotalDetections)
+	// but the in-memory set is bounded by the LRU capacity
+	require.Equal(t, size, tr.Stats().TrackedPorts, "tracker must not grow beyond its LRU capacity")
+
+	// the oldest entry must have been evicted, the newest must remain
+	require.False(t, tr.RequiresHTTPS("http://host0.example.com:8443/"), "oldest entry should be evicted")
+	require.True(t, tr.RequiresHTTPS(fmt.Sprintf("http://host%d.example.com:8443/", size*3-1)), "newest entry should be retained")
 }

--- a/pkg/protocols/http/httpclientpool/perhost_ratelimit_pool_close_test.go
+++ b/pkg/protocols/http/httpclientpool/perhost_ratelimit_pool_close_test.go
@@ -1,0 +1,40 @@
+package httpclientpool
+
+import (
+	"fmt"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPerHostRateLimitPool_CloseReleasesLimiters ensures Close() drains the pool
+// and releases the per-host rate limiter goroutines (one per host) instead of
+// leaking them. protocolstate.Close wires this in so a long-running embedder
+// that recreates engines does not accumulate limiter goroutines over time.
+func TestPerHostRateLimitPool_CloseReleasesLimiters(t *testing.T) {
+	opts := &types.Options{RateLimit: 100, RateLimitDuration: time.Second}
+	pool := NewPerHostRateLimitPool(1024, time.Hour, time.Hour, opts)
+
+	runtime.GC()
+	base := runtime.NumGoroutine()
+
+	const n = 50
+	for i := 0; i < n; i++ {
+		_, err := pool.GetOrCreate(fmt.Sprintf("http://host%d.example.com:443", i))
+		require.NoError(t, err)
+	}
+	require.Equal(t, n, pool.Size())
+	require.Greater(t, runtime.NumGoroutine(), base, "limiter goroutines should be running before Close")
+
+	pool.Close()
+	require.Equal(t, 0, pool.Size(), "Close must empty the pool")
+
+	// cancelled limiter goroutines exit asynchronously
+	require.Eventually(t, func() bool {
+		runtime.GC()
+		return runtime.NumGoroutine()-base <= n/5
+	}, 3*time.Second, 20*time.Millisecond, "limiter goroutines should be released after Close")
+}

--- a/pkg/protocols/http/httpclientpool/perhost_ratelimit_pool_close_test.go
+++ b/pkg/protocols/http/httpclientpool/perhost_ratelimit_pool_close_test.go
@@ -27,7 +27,9 @@ func TestPerHostRateLimitPool_CloseReleasesLimiters(t *testing.T) {
 		require.NoError(t, err)
 	}
 	require.Equal(t, n, pool.Size())
-	require.Greater(t, runtime.NumGoroutine(), base, "limiter goroutines should be running before Close")
+	require.Eventually(t, func() bool {
+		return runtime.NumGoroutine() > base
+	}, time.Second, 20*time.Millisecond, "limiter goroutines should be running before Close")
 
 	pool.Close()
 	require.Equal(t, 0, pool.Size(), "Close must empty the pool")

--- a/pkg/templates/parser.go
+++ b/pkg/templates/parser.go
@@ -51,6 +51,17 @@ func NewParserWithParsedCache(cache *Cache) *Parser {
 	}
 }
 
+// Purge clears the parsed and compiled template caches. It should be called
+// when the parser is no longer needed (e.g. on engine Close) so a long-running
+// embedder does not retain every compiled template (a heap-heavy object) for
+// the entire process lifetime.
+func (p *Parser) Purge() {
+	p.Lock()
+	defer p.Unlock()
+	p.parsedTemplatesCache.Purge()
+	p.compiledTemplatesCache.Purge()
+}
+
 // Cache returns the parsed templates cache
 func (p *Parser) Cache() *Cache {
 	return p.parsedTemplatesCache

--- a/pkg/templates/parser_purge_test.go
+++ b/pkg/templates/parser_purge_test.go
@@ -1,0 +1,24 @@
+package templates
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestParserPurgeClearsCaches ensures Purge drops both the parsed and compiled
+// template caches so a long-running embedder does not retain compiled templates
+// (heap-heavy objects) for the entire process lifetime.
+func TestParserPurgeClearsCaches(t *testing.T) {
+	p := NewParser()
+
+	p.Cache().Store("tpl-a", &Template{}, []byte("raw"), nil)
+	p.CompiledCache().Store("tpl-a", &Template{}, []byte("raw"), nil)
+	require.Equal(t, 1, p.ParsedCount(), "parsed cache should hold the stored template")
+	require.Equal(t, 1, p.CompiledCount(), "compiled cache should hold the stored template")
+
+	p.Purge()
+
+	require.Equal(t, 0, p.ParsedCount(), "parsed cache must be empty after Purge")
+	require.Equal(t, 0, p.CompiledCount(), "compiled cache must be empty after Purge")
+}


### PR DESCRIPTION
bound the HTTPToHTTPS tracker with an lru release the per host rate limit pool goroutines on close and purge the template caches on engine close so a long running embedder stops leaking memory and goroutines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public way to purge template parser caches (both parsed and compiled templates).
* **Bug Fixes**
  * Improved shutdown cleanup so shared template parsers and their caches are no longer cleared unexpectedly.
  * Ensured HTTP per-host rate limiting background work is fully stopped during shutdown.
  * Reworked HTTP-to-HTTPS tracking to use bounded memory with LRU eviction and refreshed recency for active entries.
* **Tests**
  * Added tests for parser cache purging, bounded LRU tracker behavior (including concurrency and zero-value safety), and per-host rate limiter shutdown cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->