### PR TITLE
fix(engine): resolve memory and goroutine leaks in embedded engine usage (#7503)

### DIFF
--- a/lib/sdk.go
+++ b/lib/sdk.go
@@ -244,6 +244,12 @@ func (e *NucleiEngine) closeInternal() {
 	if e.opts != nil {
 		generators.ClearOptionsPayloadMap(e.opts)
 	}
+	if e.parser != nil {
+		e.parser.Purge()
+	}
+	if purger, ok := e.executerOpts.Parser.(interface{ Purge() }); ok && purger != nil {
+		purger.Purge()
+	}
 }
 
 // Close all resources used by nuclei engine

--- a/pkg/protocols/common/protocolstate/state.go
+++ b/pkg/protocols/common/protocolstate/state.go
@@ -282,7 +282,7 @@ func interfaceAddresses(interfaceName string) ([]net.Addr, error) {
 	return addrs, nil
 }
 
-// Close closes the global shared fastdialer
+// Close closes the global shared fastdialer and associated protocol state resources
 func Close(executionId string) {
 	dialersInstance, ok := dialers.Get(executionId)
 	if !ok {
@@ -293,8 +293,18 @@ func Close(executionId string) {
 		// Drop all cached HTTP clients/transports and close their idle
 		// keep-alive connections to avoid lingering transport goroutines
 		// after shutdown.
-		dialersInstance.HTTPClientPool.Close()
-		dialersInstance.Fastdialer.Close()
+		if dialersInstance.HTTPClientPool != nil {
+			dialersInstance.HTTPClientPool.Close()
+		}
+		if dialersInstance.Fastdialer != nil {
+			dialersInstance.Fastdialer.Close()
+		}
+		if pool, ok := dialersInstance.PerHostRateLimitPool.(interface{ Close() }); ok && pool != nil {
+			pool.Close()
+		}
+		if tracker, ok := dialersInstance.HTTPToHTTPSPortTracker.(interface{ Purge() }); ok && tracker != nil {
+			tracker.Purge()
+		}
 	}
 
 	dialers.Delete(executionId)

--- a/pkg/protocols/http/httpclientpool/http_to_https_tracker.go
+++ b/pkg/protocols/http/httpclientpool/http_to_https_tracker.go
@@ -1,6 +1,7 @@
 package httpclientpool
 
 import (
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 // NOTE: detection and correction apply to the standard net/http (retryablehttp)
 // request path only. Unsafe/raw (rawhttp) requests bypass this scheme rewrite.
 type HTTPToHTTPSPortTracker struct {
+	mu sync.Mutex
 	// ports is an LRU discovery cache bounded to prevent memory leaks in long-running engines
 	ports *expirable.LRU[string, struct{}]
 
@@ -40,6 +42,9 @@ func (t *HTTPToHTTPSPortTracker) RecordHTTPToHTTPSPort(hostPort string) {
 	if normalizedHostPort == "" {
 		return
 	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
 
 	if t.ports.Contains(normalizedHostPort) {
 		return // Already recorded, no need to log again
@@ -85,7 +90,11 @@ func (t *HTTPToHTTPSPortTracker) Evict(hostPort string) {
 		return
 	}
 
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
 	if t.ports.Remove(normalizedHostPort) {
+		t.totalCorrections.Add(1)
 		gologger.Debug().Msgf("[http-to-https-tracker] Reverted HTTP-to-HTTPS for %s (https attempt failed, falling back to http)", normalizedHostPort)
 	}
 }

--- a/pkg/protocols/http/httpclientpool/http_to_https_tracker.go
+++ b/pkg/protocols/http/httpclientpool/http_to_https_tracker.go
@@ -1,9 +1,10 @@
 package httpclientpool
 
 import (
-	"sync"
 	"sync/atomic"
+	"time"
 
+	"github.com/hashicorp/golang-lru/v2/expirable"
 	"github.com/projectdiscovery/gologger"
 )
 
@@ -14,8 +15,8 @@ import (
 // NOTE: detection and correction apply to the standard net/http (retryablehttp)
 // request path only. Unsafe/raw (rawhttp) requests bypass this scheme rewrite.
 type HTTPToHTTPSPortTracker struct {
-	// ports is a grow-only discovery cache, sync.Map gives lock-free reads
-	ports sync.Map // map[string]struct{}
+	// ports is an LRU discovery cache bounded to prevent memory leaks in long-running engines
+	ports *expirable.LRU[string, struct{}]
 
 	// Statistics
 	totalDetections  atomic.Uint64
@@ -24,12 +25,14 @@ type HTTPToHTTPSPortTracker struct {
 
 // NewHTTPToHTTPSPortTracker creates a new HTTP-to-HTTPS port tracker
 func NewHTTPToHTTPSPortTracker() *HTTPToHTTPSPortTracker {
-	return &HTTPToHTTPSPortTracker{}
+	return &HTTPToHTTPSPortTracker{
+		ports: expirable.NewLRU[string, struct{}](4096, nil, 24*time.Hour),
+	}
 }
 
 // RecordHTTPToHTTPSPort records that a host:port requires HTTPS
 func (t *HTTPToHTTPSPortTracker) RecordHTTPToHTTPSPort(hostPort string) {
-	if hostPort == "" {
+	if hostPort == "" || t.ports == nil {
 		return
 	}
 
@@ -38,9 +41,10 @@ func (t *HTTPToHTTPSPortTracker) RecordHTTPToHTTPSPort(hostPort string) {
 		return
 	}
 
-	if _, loaded := t.ports.LoadOrStore(normalizedHostPort, struct{}{}); loaded {
+	if t.ports.Contains(normalizedHostPort) {
 		return // Already recorded, no need to log again
 	}
+	t.ports.Add(normalizedHostPort, struct{}{})
 	t.totalDetections.Add(1)
 
 	gologger.Debug().Msgf("[http-to-https-tracker] Detected HTTP-to-HTTPS port mismatch for %s", normalizedHostPort)
@@ -48,7 +52,7 @@ func (t *HTTPToHTTPSPortTracker) RecordHTTPToHTTPSPort(hostPort string) {
 
 // RequiresHTTPS checks if a host:port requires HTTPS
 func (t *HTTPToHTTPSPortTracker) RequiresHTTPS(hostPort string) bool {
-	if hostPort == "" {
+	if hostPort == "" || t.ports == nil {
 		return false
 	}
 
@@ -57,7 +61,7 @@ func (t *HTTPToHTTPSPortTracker) RequiresHTTPS(hostPort string) bool {
 		return false
 	}
 
-	_, ok := t.ports.Load(normalizedHostPort)
+	_, ok := t.ports.Get(normalizedHostPort)
 	return ok
 }
 
@@ -72,7 +76,7 @@ func (t *HTTPToHTTPSPortTracker) RecordCorrection() {
 // evicted so subsequent requests (including those from unrelated templates)
 // against the same host:port are not silently broken.
 func (t *HTTPToHTTPSPortTracker) Evict(hostPort string) {
-	if hostPort == "" {
+	if hostPort == "" || t.ports == nil {
 		return
 	}
 
@@ -81,18 +85,28 @@ func (t *HTTPToHTTPSPortTracker) Evict(hostPort string) {
 		return
 	}
 
-	if _, loaded := t.ports.LoadAndDelete(normalizedHostPort); loaded {
+	if t.ports.Remove(normalizedHostPort) {
 		gologger.Debug().Msgf("[http-to-https-tracker] Reverted HTTP-to-HTTPS for %s (https attempt failed, falling back to http)", normalizedHostPort)
+	}
+}
+
+// Purge removes all tracked entries from the tracker
+func (t *HTTPToHTTPSPortTracker) Purge() {
+	if t.ports != nil {
+		t.ports.Purge()
 	}
 }
 
 // Stats returns statistics about the tracker
 func (t *HTTPToHTTPSPortTracker) Stats() HTTPToHTTPSPortStats {
+	tracked := 0
+	if t.ports != nil {
+		tracked = t.ports.Len()
+	}
 	return HTTPToHTTPSPortStats{
 		TotalDetections:  t.totalDetections.Load(),
 		TotalCorrections: t.totalCorrections.Load(),
-		// detections are incremented once per unique host:port, so this is exact
-		TrackedPorts: int(t.totalDetections.Load()),
+		TrackedPorts:     tracked,
 	}
 }
 

--- a/pkg/templates/parser.go
+++ b/pkg/templates/parser.go
@@ -61,6 +61,16 @@ func (p *Parser) CompiledCache() *Cache {
 	return p.compiledTemplatesCache
 }
 
+// Purge purges both parsed and compiled template caches
+func (p *Parser) Purge() {
+	if p.parsedTemplatesCache != nil {
+		p.parsedTemplatesCache.Purge()
+	}
+	if p.compiledTemplatesCache != nil {
+		p.compiledTemplatesCache.Purge()
+	}
+}
+
 func (p *Parser) ParsedCount() int {
 	p.Lock()
 	defer p.Unlock()


### PR DESCRIPTION
### Summary
Fixes #7503 by addressing architectural memory and goroutine leaks when embedding `NucleiEngine` in long-running applications.

### Key Changes
1. **Bounded HTTPToHTTPSPortTracker:** Replaced unbounded `sync.Map` with an expirable LRU cache (4096 capacity, 24h TTL) in `pkg/protocols/http/httpclientpool/http_to_https_tracker.go`.
2. **Protocol State Teardown:** Updated `protocolstate.Close()` in `pkg/protocols/common/protocolstate/state.go` to release per-host rate limiter pools and purge port trackers.
3. **Template Parser Cache Purging:** Added thread-safe `Purge()` method to template parser and invoked it during `NucleiEngine.Close()` in `lib/sdk.go`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown cleanup to purge template parser state and reduce leftover cached memory after scans.
  * Updated HTTPS detection tracking to use a bounded, expiring cache, so stale host/port entries are automatically removed.
  * Refined protocol shutdown to more safely close shared networking resources and purge HTTP→HTTPS port tracking when applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->