### PR TITLE
fix(fuzz): preserve form parameters with shared prefixes

### DIFF
--- a/pkg/fuzz/component/query_test.go
+++ b/pkg/fuzz/component/query_test.go
@@ -44,3 +44,24 @@ func TestQueryComponent(t *testing.T) {
 	require.Equal(t, "foo=baz", rebuilt.RawQuery, "unexpected query string")
 	require.Equal(t, "https://example.com?foo=baz", rebuilt.String(), "unexpected url")
 }
+
+func TestQueryComponentDoesNotMergePrefixParameterNames(t *testing.T) {
+	req, err := retryablehttp.NewRequest(http.MethodGet, "https://example.com?foo=a&foobar=b&foobar=c", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	query := NewQuery()
+	_, err = query.Parse(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rebuilt, err := query.Rebuild()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	require.Equal(t, "foo=a&foobar=b&foobar=c", rebuilt.RawQuery, "unexpected query string")
+	require.Equal(t, "https://example.com?foo=a&foobar=b&foobar=c", rebuilt.String(), "unexpected url")
+}

--- a/pkg/fuzz/dataformat/form.go
+++ b/pkg/fuzz/dataformat/form.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
-	"strings"
 
 	"github.com/projectdiscovery/gologger"
 	mapsutil "github.com/projectdiscovery/utils/maps"
@@ -60,7 +59,7 @@ func (f *Form) Encode(data KV) (string, error) {
 		// here origKey is base key without _1, _2 etc.
 		if origKey != "" && !reNormalized.MatchString(origKey) {
 			params.Iterate(func(key string, value []string) bool {
-				if strings.HasPrefix(key, origKey) && reNormalized.MatchString(key) {
+				if baseKey, ok := normalizedKeyBase(key); ok && baseKey == origKey {
 					m := map[string]string{}
 					if normalized[origKey] != nil {
 						m = normalized[origKey]
@@ -126,6 +125,14 @@ func (f *Form) Encode(data KV) (string, error) {
 
 	encoded := params.Encode()
 	return encoded, nil
+}
+
+func normalizedKeyBase(key string) (string, bool) {
+	match := reNormalized.FindStringIndex(key)
+	if match == nil {
+		return "", false
+	}
+	return key[:match[0]], true
 }
 
 // Decode decodes the data from Form format

--- a/pkg/fuzz/dataformat/form_test.go
+++ b/pkg/fuzz/dataformat/form_test.go
@@ -1,0 +1,35 @@
+package dataformat
+
+import "testing"
+
+func TestFormDecodeEncode_DuplicateParameters(t *testing.T) {
+	form := NewForm()
+	decoded, err := form.Decode("foo=a&foo=b&foo=c")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	encoded, err := form.Encode(decoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if encoded != "foo=a&foo=b&foo=c" {
+		t.Fatalf("unexpected form encoding: %q", encoded)
+	}
+}
+
+func TestFormDecodeEncode_DoesNotMergePrefixParameterNames(t *testing.T) {
+	form := NewForm()
+	decoded, err := form.Decode("foo=a&foobar=b&foobar=c")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	encoded, err := form.Encode(decoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if encoded != "foo=a&foobar=b&foobar=c" {
+		t.Fatalf("unexpected form encoding: %q", encoded)
+	}
+}


### PR DESCRIPTION
## Proposed changes

Fixes incorrect reconstruction of form/query parameters when different parameter names share a prefix.

Before this change, decoding and re-encoding a query like:

```text
foo=a&foobar=b&foobar=c
```

could incorrectly treat `foobar_1` as if it belonged to `foo`, producing:

```text
foobar=c&foo=b&foo=a
```

This PR makes normalized duplicate-parameter handling match the exact base parameter name before merging values. It preserves the existing duplicate-parameter behavior for cases like `foo=a&foo=b&foo=c`, while avoiding accidental merges for prefix-sharing names such as `foo` and `foobar`.

### Proof

Tested with:

```sh
go test ./pkg/fuzz/dataformat -run 'TestFormDecodeEncode' -count=1
go test ./pkg/fuzz/component -run 'TestQueryComponent' -count=1
go test ./pkg/fuzz/dataformat ./pkg/fuzz/component
go test -race ./pkg/fuzz/dataformat ./pkg/fuzz/component
go test ./pkg/fuzz/...
```

## Checklist

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of form and query parameters so names with shared prefixes stay separate.
  * Preserved duplicate parameters and their original order when decoding and re-encoding form data.

* **Tests**
  * Added coverage for duplicate parameter handling.
  * Added coverage to ensure prefix-matching parameter names are not incorrectly merged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->