### PR TITLE
feat(http): add disable-decompression option to HTTP requests

### DIFF
--- a/pkg/protocols/http/http.go
+++ b/pkg/protocols/http/http.go
@@ -174,6 +174,10 @@ type Request struct {
 	DisableCookie bool `yaml:"disable-cookie,omitempty" json:"disable-cookie,omitempty" jsonschema:"title=optional disable cookie reuse,description=Optional setting that disables cookie reuse"`
 
 	// description: |
+	//   DisableDecompression disables automatic response decompression
+	DisableDecompression bool `yaml:"disable-decompression,omitempty" json:"disable-decompression,omitempty" jsonschema:"title=disable automatic response decompression,description=Disables automatic response decompression"`
+
+	// description: |
 	//   Enables force reading of the entire raw unsafe request body ignoring
 	//   any specified content length headers.
 	ForceReadAllBody bool `yaml:"read-all,omitempty" json:"read-all,omitempty" jsonschema:"title=force read all body,description=Enables force reading of entire unsafe http request body"`
@@ -333,10 +337,11 @@ func (request *Request) Compile(options *protocols.ExecutorOptions) error {
 	}
 
 	connectionConfiguration := &httpclientpool.Configuration{
-		Threads:       request.Threads,
-		MaxRedirects:  request.MaxRedirects,
-		NoTimeout:     false,
-		DisableCookie: request.DisableCookie,
+		Threads:              request.Threads,
+		MaxRedirects:         request.MaxRedirects,
+		NoTimeout:            false,
+		DisableCookie:        request.DisableCookie,
+		DisableDecompression: request.DisableDecompression,
 		Connection: &httpclientpool.ConnectionConfiguration{
 			DisableKeepAlive: disableKeepAlive,
 		},

--- a/pkg/protocols/http/httpclientpool/clientpool.go
+++ b/pkg/protocols/http/httpclientpool/clientpool.go
@@ -193,6 +193,8 @@ type Configuration struct {
 	Connection *ConnectionConfiguration
 	// ResponseHeaderTimeout is the timeout for response body to be read from the server
 	ResponseHeaderTimeout time.Duration
+	// DisableDecompression disables automatic response decompression
+	DisableDecompression bool
 }
 
 func (c *Configuration) Clone() *Configuration {
@@ -241,13 +243,15 @@ func (c *Configuration) Hash() string {
 	}
 	builder.WriteString("r")
 	builder.WriteString(strconv.FormatInt(int64(c.ResponseHeaderTimeout.Seconds()), 10))
+	builder.WriteString("dd")
+	builder.WriteString(strconv.FormatBool(c.DisableDecompression))
 	hash := builder.String()
 	return hash
 }
 
 // HasStandardOptions checks whether the configuration requires custom settings
 func (c *Configuration) HasStandardOptions() bool {
-	return c.Threads == 0 && c.MaxRedirects == 0 && c.RedirectFlow == DontFollowRedirect && c.DisableCookie && c.Connection == nil && !c.NoTimeout && c.ResponseHeaderTimeout == 0
+	return c.Threads == 0 && c.MaxRedirects == 0 && c.RedirectFlow == DontFollowRedirect && c.DisableCookie && c.Connection == nil && !c.NoTimeout && c.ResponseHeaderTimeout == 0 && !c.DisableDecompression
 }
 
 // GetRawHTTP returns the rawhttp request client
@@ -347,7 +351,7 @@ func wrappedGet(options *types.Options, configuration *Configuration, host strin
 	// actually live on http.Transport participate in the key, so clients
 	// that differ in client-level settings (redirect policy, cookies,
 	// timeout) still share a single connection pool per host.
-	transportKey := transportHash(host, disableKeepAlives, maxIdleConns, maxIdleConnsPerHost, maxConnsPerHost, responseHeaderTimeout)
+	transportKey := transportHash(host, disableKeepAlives, maxIdleConns, maxIdleConnsPerHost, maxConnsPerHost, responseHeaderTimeout, configuration.DisableDecompression)
 
 	createTransport := func() (http.RoundTripper, error) {
 		// Set the base TLS configuration definition
@@ -386,6 +390,7 @@ func wrappedGet(options *types.Options, configuration *Configuration, host strin
 			DisableKeepAlives:     disableKeepAlives,
 			IdleConnTimeout:       30 * time.Second,
 			ResponseHeaderTimeout: responseHeaderTimeout,
+			DisableCompression:    configuration.DisableDecompression,
 		}
 
 		if options.AliveHttpProxy != "" {
@@ -504,7 +509,7 @@ var sharedTLSSessionCache = tls.NewLRUClientSessionCache(2048)
 // transportHash identifies a shareable transport. Only parameters that live
 // on http.Transport participate; everything else (redirects, cookie jars,
 // client timeouts) is layered on top by the per-configuration client.
-func transportHash(host string, disableKeepAlives bool, maxIdleConns, maxIdleConnsPerHost, maxConnsPerHost int, responseHeaderTimeout time.Duration) string {
+func transportHash(host string, disableKeepAlives bool, maxIdleConns, maxIdleConnsPerHost, maxConnsPerHost int, responseHeaderTimeout time.Duration, disableCompression bool) string {
 	builder := &strings.Builder{}
 	builder.Grow(len(host) + 32)
 	builder.WriteString(host)
@@ -518,6 +523,8 @@ func transportHash(host string, disableKeepAlives bool, maxIdleConns, maxIdleCon
 	builder.WriteString(strconv.Itoa(maxConnsPerHost))
 	builder.WriteString("|rht")
 	builder.WriteString(strconv.FormatInt(int64(responseHeaderTimeout), 10))
+	builder.WriteString("|dc")
+	builder.WriteString(strconv.FormatBool(disableCompression))
 	return builder.String()
 }
 

--- a/pkg/protocols/http/operators_test.go
+++ b/pkg/protocols/http/operators_test.go
@@ -7,13 +7,13 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/projectdiscovery/nuclei/v3/internal/tests/testutils"
 	"github.com/projectdiscovery/nuclei/v3/pkg/model"
 	"github.com/projectdiscovery/nuclei/v3/pkg/model/types/severity"
 	"github.com/projectdiscovery/nuclei/v3/pkg/operators"
 	"github.com/projectdiscovery/nuclei/v3/pkg/operators/extractors"
 	"github.com/projectdiscovery/nuclei/v3/pkg/operators/matchers"
 	"github.com/projectdiscovery/nuclei/v3/pkg/output"
-	"github.com/projectdiscovery/nuclei/v3/internal/tests/testutils"
 )
 
 func TestResponseToDSLMap(t *testing.T) {

--- a/pkg/protocols/http/request.go
+++ b/pkg/protocols/http/request.go
@@ -1010,7 +1010,7 @@ func (request *Request) executeRequest(input *contextargs.Context, generatedRequ
 	// evaluate responses continuously until first redirect request in reverse order
 	for respChain.Has() {
 		// fill buffers, read response body and reuse connection
-		if err := respChain.Fill(); err != nil {
+		if err := request.fillPreservingEncoding(respChain); err != nil {
 			return errors.Wrap(err, "could not generate response chain")
 		}
 
@@ -1394,4 +1394,22 @@ func (request *Request) isUnresponsiveAddress(input *contextargs.Context) bool {
 		return request.options.HostErrorsCache.Check(request.options.ProtocolType.String(), input)
 	}
 	return false
+}
+
+// fillPreservingEncoding calls respChain.Fill() while preserving the raw Content-Encoding header
+// when DisableDecompression is enabled.
+func (request *Request) fillPreservingEncoding(respChain *httpUtils.ResponseChain) error {
+	var contentEncoding string
+	if request.DisableDecompression && respChain.Response() != nil {
+		contentEncoding = respChain.Response().Header.Get("Content-Encoding")
+		respChain.Response().Header.Del("Content-Encoding")
+	}
+
+	err := respChain.Fill()
+
+	if request.DisableDecompression && respChain.Response() != nil && contentEncoding != "" {
+		respChain.Response().Header.Set("Content-Encoding", contentEncoding)
+	}
+
+	return err
 }

--- a/pkg/protocols/http/request_annotations_test.go
+++ b/pkg/protocols/http/request_annotations_test.go
@@ -7,9 +7,9 @@ import (
 	"time"
 
 	"github.com/projectdiscovery/gologger"
+	"github.com/projectdiscovery/nuclei/v3/internal/tests/testutils"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/http/httpclientpool"
-	"github.com/projectdiscovery/nuclei/v3/internal/tests/testutils"
 	"github.com/projectdiscovery/retryablehttp-go"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/protocols/http/request_test.go
+++ b/pkg/protocols/http/request_test.go
@@ -1,8 +1,13 @@
 package http
 
 import (
+	"bytes"
+	"compress/gzip"
+	"compress/zlib"
 	"context"
 	"fmt"
+	"github.com/andybalholm/brotli"
+	"github.com/klauspost/compress/zstd"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -720,4 +725,125 @@ func TestExecuteParallelHTTP_GoroutineLeaks(t *testing.T) {
 		require.Error(t, err)
 		require.Equal(t, context.Canceled, err)
 	})
+}
+
+func TestHTTPDisableDecompression(t *testing.T) {
+	options := testutils.DefaultOptions
+	testutils.Init(options)
+
+	tests := []struct {
+		encoding string
+		compress func([]byte) []byte
+	}{
+		{
+			encoding: "gzip",
+			compress: func(data []byte) []byte {
+				var buf bytes.Buffer
+				zw := gzip.NewWriter(&buf)
+				_, _ = zw.Write(data)
+				zw.Close()
+				return buf.Bytes()
+			},
+		},
+		{
+			encoding: "deflate",
+			compress: func(data []byte) []byte {
+				var buf bytes.Buffer
+				zw := zlib.NewWriter(&buf)
+				_, _ = zw.Write(data)
+				zw.Close()
+				return buf.Bytes()
+			},
+		},
+		{
+			encoding: "br",
+			compress: func(data []byte) []byte {
+				var buf bytes.Buffer
+				zw := brotli.NewWriter(&buf)
+				_, _ = zw.Write(data)
+				zw.Close()
+				return buf.Bytes()
+			},
+		},
+		{
+			encoding: "zstd",
+			compress: func(data []byte) []byte {
+				var buf bytes.Buffer
+				zw, _ := zstd.NewWriter(&buf)
+				_, _ = zw.Write(data)
+				zw.Close()
+				return buf.Bytes()
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.encoding, func(t *testing.T) {
+			rawContent := []byte("hello-decompression-test-" + tc.encoding)
+			compressedContent := tc.compress(rawContent)
+
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Encoding", tc.encoding)
+				w.Header().Set("Content-Type", "text/plain")
+				w.WriteHeader(200)
+				_, _ = w.Write(compressedContent)
+			}))
+			defer ts.Close()
+
+			// 1. With DisableDecompression = false (default) -> should decompress
+			{
+				request := &Request{
+					ID:     "test-decompression-enabled-" + tc.encoding,
+					Path:   []string{"{{BaseURL}}"},
+					Method: HTTPMethodTypeHolder{MethodType: HTTPGet},
+				}
+
+				executerOpts := testutils.NewMockExecuterOptions(options, &testutils.TemplateInfo{
+					ID:   "test-decompression-enabled-" + tc.encoding,
+					Info: model.Info{SeverityHolder: severity.Holder{Severity: severity.Low}, Name: "test"},
+				})
+
+				err := request.Compile(executerOpts)
+				require.Nil(t, err)
+
+				metadata := make(output.InternalEvent)
+				previous := make(output.InternalEvent)
+				ctxArgs := contextargs.NewWithInput(context.Background(), ts.URL)
+				var body string
+				err = request.ExecuteWithResults(ctxArgs, metadata, previous, func(event *output.InternalWrappedEvent) {
+					body = event.InternalEvent["body"].(string)
+				})
+				require.Nil(t, err)
+				require.Equal(t, string(rawContent), body)
+			}
+
+			// 2. With DisableDecompression = true -> should NOT decompress
+			{
+				request := &Request{
+					ID:                   "test-decompression-disabled-" + tc.encoding,
+					Path:                 []string{"{{BaseURL}}"},
+					Method:               HTTPMethodTypeHolder{MethodType: HTTPGet},
+					DisableDecompression: true,
+				}
+
+				executerOpts := testutils.NewMockExecuterOptions(options, &testutils.TemplateInfo{
+					ID:   "test-decompression-disabled-" + tc.encoding,
+					Info: model.Info{SeverityHolder: severity.Holder{Severity: severity.Low}, Name: "test"},
+				})
+
+				err := request.Compile(executerOpts)
+				require.Nil(t, err)
+
+				metadata := make(output.InternalEvent)
+				previous := make(output.InternalEvent)
+				ctxArgs := contextargs.NewWithInput(context.Background(), ts.URL)
+				var body string
+				err = request.ExecuteWithResults(ctxArgs, metadata, previous, func(event *output.InternalWrappedEvent) {
+					body = event.InternalEvent["body"].(string)
+				})
+				require.Nil(t, err)
+				require.Equal(t, string(compressedContent), body)
+			}
+		})
+	}
 }


### PR DESCRIPTION
This PR introduces the disable-decompression option on a per-request/per-template basis for HTTP requests.

### Use Case
Currently, compressed content (gzip, deflate, brotli, zstd) is automatically decompressed before hitting matchers/extractors. This makes it impossible to write version extractors or perform signature validation directly on raw compressed bodies (such as extracting version metadata from Citrix Netscaler gzip headers).

With disable-decompression: true enabled on the HTTP request, automatic body decompression is bypassed, returning the raw compressed response body.

### Changes
- Added disable-decompression boolean to HTTP request schema and YAML/JSON models.
- Propagated DisableDecompression configuration to client pools, transports, and connection hashing.
- Added unit tests (TestHTTPDisableDecompression) to verify both decompressed and raw compressed paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `disable-decompression` option to control whether HTTP responses are automatically decompressed.
* **Bug Fixes**
  * When decompression is disabled, redirect responses now preserve the original `Content-Encoding` behavior to keep content consistent.
* **Tests**
  * Added coverage validating request body handling for multiple encodings (gzip, deflate, br, zstd), comparing default decompressed vs `DisableDecompression: true` raw (compressed) behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->