### PR TITLE
Fix case-insensitive `word` matcher missing dynamic (rendered) values

### DIFF
--- a/pkg/operators/matchers/match.go
+++ b/pkg/operators/matchers/match.go
@@ -73,6 +73,9 @@ func (matcher *Matcher) MatchWords(corpus string, data map[string]interface{}) (
 			}
 		} else {
 			word = result.Text
+			if matcher.CaseInsensitive {
+				word = strings.ToLower(word)
+			}
 		}
 		// Continue if the word doesn't match
 		if !strings.Contains(corpus, word) {

--- a/pkg/operators/matchers/match_test.go
+++ b/pkg/operators/matchers/match_test.go
@@ -427,6 +427,19 @@ func TestMatchRegex_LiteralPrefixShortCircuit(t *testing.T) {
 	require.Equal(t, []string{"12"}, matches)
 }
 
+func TestMatchWords_CaseInsensitive_DynamicValue(t *testing.T) {
+	m := &Matcher{
+		Type:            MatcherTypeHolder{MatcherType: WordsMatcher},
+		CaseInsensitive: true,
+		Words:           []string{"{{host}}"},
+	}
+	require.NoError(t, m.CompileMatchers())
+
+	isMatched, matched := m.MatchWords("visit example.com now", map[string]interface{}{"host": "Example.COM"})
+	require.True(t, isMatched, "Could not match case-insensitive dynamic word against lowercased corpus")
+	require.Equal(t, []string{"example.com"}, matched)
+}
+
 func TestMatcher_MatchDSL_ErrorHandling(t *testing.T) {
 	// First expression errors (division by zero), second is true
 	bad, err := govaluate.NewEvaluableExpression("1 / 0")


### PR DESCRIPTION
### Description

A `word` matcher with `case-insensitive: true` fails to match when a template word (e.g. `{{host}}`, or a value chained from a prior extractor) resolves to a value containing uppercase letters.

`MatchWords` lowercases the corpus, and compile lowercases the *literal* words, but the **rendered** dynamic word is never lowercased. So `strings.Contains(lowercasedCorpus, "Example.COM")` never matches — a missed detection / false negative for any case-insensitive `word` matcher backed by a dynamic value (extractor output, response headers like `Server:`/`Set-Cookie:`, tokens, etc.).

### Fix

Lowercase the rendered word when `CaseInsensitive` is set. The literal-word path is unchanged (already folded to lowercase at compile time).

```go
} else {
    word = result.Text
    if matcher.CaseInsensitive {
        word = strings.ToLower(word)
    }
}
```

### Test

Added `TestMatchWords_CaseInsensitive_DynamicValue` in `pkg/operators/matchers/match_test.go`. `go test ./pkg/operators/matchers/` passes (new test + existing).

Fixes #7560