### PR TITLE
Fix raw HTTP parser panic on single-LF request body

### DIFF
--- a/pkg/input/types/http.go
+++ b/pkg/input/types/http.go
@@ -279,10 +279,10 @@ func ParseRawRequest(raw string) (rr *RequestResponse, err error) {
 		// yaml may include trailing newlines
 		// remove them if present
 		bin := buff.Bytes()
-		if bin[len(bin)-1] == '\n' {
+		if len(bin) > 0 && bin[len(bin)-1] == '\n' {
 			bin = bin[:len(bin)-1]
 		}
-		if bin[len(bin)-1] == '\r' || bin[len(bin)-1] == '\n' {
+		if len(bin) > 0 && (bin[len(bin)-1] == '\r' || bin[len(bin)-1] == '\n') {
 			bin = bin[:len(bin)-1]
 		}
 		rr.Request.Body = conversion.String(bin)

--- a/pkg/input/types/http_test.go
+++ b/pkg/input/types/http_test.go
@@ -66,6 +66,61 @@ func TestParseHttpRequest(t *testing.T) {
 	}
 }
 
+func TestParseRawRequestBodyTrailingNewlines(t *testing.T) {
+	tests := []struct {
+		name         string
+		raw          string
+		expectedBody string
+	}{
+		{
+			name:         "single lf body",
+			raw:          "POST / HTTP/1.1\r\nHost: example.com\r\nContent-Length: 1\r\n\r\n\n",
+			expectedBody: "",
+		},
+		{
+			name:         "crlf body",
+			raw:          "POST / HTTP/1.1\r\nHost: example.com\r\nContent-Length: 2\r\n\r\n\r\n",
+			expectedBody: "",
+		},
+		{
+			name:         "empty body",
+			raw:          "POST / HTTP/1.1\r\nHost: example.com\r\nContent-Length: 0\r\n\r\n",
+			expectedBody: "",
+		},
+		{
+			name:         "body ending in lf",
+			raw:          "POST / HTTP/1.1\r\nHost: example.com\r\nContent-Length: 2\r\n\r\nA\n",
+			expectedBody: "A",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Run("ParseRawRequest", func(t *testing.T) {
+				var rr *RequestResponse
+				var err error
+				require.NotPanics(t, func() {
+					rr, err = ParseRawRequest(tt.raw)
+				})
+				require.NoError(t, err)
+				require.NotNil(t, rr)
+				require.Equal(t, tt.expectedBody, rr.Request.Body)
+			})
+
+			t.Run("ParseRawRequestWithURL", func(t *testing.T) {
+				var rr *RequestResponse
+				var err error
+				require.NotPanics(t, func() {
+					rr, err = ParseRawRequestWithURL(tt.raw, "http://example.com/")
+				})
+				require.NoError(t, err)
+				require.NotNil(t, rr)
+				require.Equal(t, tt.expectedBody, rr.Request.Body)
+			})
+		})
+	}
+}
+
 func TestUnmarshalJSON(t *testing.T) {
 	tests := []struct {
 		name           string


### PR DESCRIPTION
## Summary

Fixes a panic in the raw HTTP request parser when the request body is empty or contains only newline characters.

`ParseRawRequest` trimmed a trailing newline and then immediately accessed the final byte again. For a body containing only `"\n"`, the first trim left an empty slice and the next access could panic with:

```text
panic: runtime error: index out of range [-1]
````

## Changes

* Add length guards around raw request body trailing-newline trimming.
* Preserve the existing parsing behavior for normal bodies.
* Add regression coverage for:

  * `"\n"`
  * `"\r\n"`
  * `""`
  * `"A\n"`
* Cover both `ParseRawRequest` and `ParseRawRequestWithURL`.

## Tests

```text
go test ./pkg/input/types
```

Closes #7524.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of request bodies with trailing newline characters, including empty bodies, to prevent crashes and ensure parsing succeeds.
  * Request parsing now trims ending line breaks more reliably, returning the expected body content in edge cases.
* **Tests**
  * Added coverage for raw HTTP request parsing with different trailing newline and empty-body scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->