### PR TITLE
fix(js): enforce network policy in net.Open/net.OpenTLS before dialing

### DIFF
--- a/pkg/js/libs/net/net.go
+++ b/pkg/js/libs/net/net.go
@@ -27,6 +27,11 @@ var (
 // ```
 func Open(ctx context.Context, protocol, address string) (*NetConn, error) {
 	executionId := ctx.Value("executionId").(string)
+	host, _, _ := net.SplitHostPort(address)
+	if host != "" && !protocolstate.IsHostAllowed(executionId, host) {
+		// host is not valid according to network policy
+		return nil, protocolstate.ErrHostDenied.Msgf(host)
+	}
 	dialer := protocolstate.GetDialersWithId(executionId)
 	if dialer == nil {
 		return nil, fmt.Errorf("dialers not initialized for %s", executionId)
@@ -54,6 +59,10 @@ func OpenTLS(ctx context.Context, protocol, address string) (*NetConn, error) {
 		config = c
 	}
 	executionId := ctx.Value("executionId").(string)
+	if host != "" && !protocolstate.IsHostAllowed(executionId, host) {
+		// host is not valid according to network policy
+		return nil, protocolstate.ErrHostDenied.Msgf(host)
+	}
 	dialer := protocolstate.GetDialersWithId(executionId)
 	if dialer == nil {
 		return nil, fmt.Errorf("dialers not initialized for %s", executionId)


### PR DESCRIPTION
### Summary
The generic `nuclei/net` JavaScript library dialed via the fastdialer without an explicit `protocolstate.IsHostAllowed` check, unlike sibling libraries (`redis`, `ldap`, `ssh`, ...) which validate the host against the configured network policy before connecting. This is the first item in #7526.

This adds the same pre-check to `net.Open` and `net.OpenTLS`.

### Changes
- `pkg/js/libs/net/net.go`: parse the host from the address and return `protocolstate.ErrHostDenied` before dialing when the host is denied by policy, mirroring `pkg/js/libs/redis/redis.go` and `pkg/js/libs/ldap/ldap.go`.

Purely additive — the fail-open default of `IsHostAllowed` is unchanged, and legitimate scan targets remain allowed. `pop3`, `rsync`, and `rdp` have the same gap and can follow in separate PRs.

Refs #7526

### Testing
`go build ./...` and `go test ./pkg/protocols/javascript/...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added network policy enforcement when establishing standard and secure connections.
  * Connections to denied hosts are now blocked with a clear error message before dialing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->