### PR TITLE
fix(index): limit include-tags to matching tag exclusions

### DIFF
--- a/internal/tests/functional/testdata/testcases.txt
+++ b/internal/tests/functional/testdata/testcases.txt
@@ -24,7 +24,10 @@
 {{binary}} -tags cve -exclude-templates http/cves/2020/
 {{binary}} -tags cve -exclude-templates http/cves/2020/CVE-2020-9757.yaml
 {{binary}} -tags cve -exclude-templates http/cves/2020/CVE-2020-9757.yaml -exclude-templates http/cves/2021/
-{{binary}} -tags cve -include-tags dos,fuzz
+# Skipped until the next nuclei release ships #7536: release still force-includes
+# via -include-tags (bypassing -tags), so release/current load counts diverge by design.
+# Covered by pkg/catalog/index filter unit tests in the meantime.
+# {{binary}} -tags cve -include-tags dos,fuzz
 {{binary}} -tags cve -ntv 8.8.8,8.8.9
 {{binary}} -tags cve -severity high
 {{binary}} -tags cve,dos,fuzz

--- a/pkg/catalog/index/filter.go
+++ b/pkg/catalog/index/filter.go
@@ -15,9 +15,10 @@ import (
 // Inclusion fields (e.g., Authors, Tags, IDs, Severities, ProtocolTypes) use
 // AND logic across different filter types and OR logic within each type.
 // Exclusion fields (e.g., ExcludeTags, ExcludeIDs, ExcludeSeverities,
-// ExcludeProtocolTypes) take precedence over inclusion fields. Additionally,
-// IncludeTemplates and IncludeTags can force inclusion of templates even if
-// they match exclusion criteria.
+// ExcludeProtocolTypes) take precedence over normal inclusion fields.
+// IncludeTags can force inclusion only for the same excluded tag; other
+// exclusion criteria and unrelated excluded tags still apply. IncludeTemplates
+// remains an explicit template override.
 type Filter struct {
 	// once ensures that IDs and ExcludedIDs are compiled the first time Matches is called.
 	once sync.Once
@@ -31,7 +32,7 @@ type Filter struct {
 	// ExcludeTags to exclude (takes precedence over Tags).
 	ExcludeTags []string
 
-	// IncludeTags to force include even if excluded.
+	// IncludeTags to force include matching tag exclusions.
 	IncludeTags []string
 
 	// IDs to include (supports wildcards).
@@ -75,7 +76,7 @@ type Filter struct {
 func (f *Filter) Matches(m *Metadata) bool {
 	f.once.Do(f.Compile)
 
-	if f.isForcedInclude(m) {
+	if f.matchesIncludeTemplate(m) {
 		return true
 	}
 
@@ -90,19 +91,13 @@ func (f *Filter) Matches(m *Metadata) bool {
 	return true
 }
 
-// isForcedInclude checks if template is forced to be included.
-func (f *Filter) isForcedInclude(m *Metadata) bool {
+// matchesIncludeTemplate checks if template is explicitly included by path.
+func (f *Filter) matchesIncludeTemplate(m *Metadata) bool {
 	if len(f.IncludeTemplates) > 0 {
 		for _, includePath := range f.IncludeTemplates {
 			if matchesPath(m.FilePath, includePath) {
 				return true
 			}
-		}
-	}
-
-	if len(f.IncludeTags) > 0 {
-		if slices.ContainsFunc(f.IncludeTags, m.HasTag) {
-			return true
 		}
 	}
 
@@ -120,8 +115,10 @@ func (f *Filter) isExcluded(m *Metadata) bool {
 	}
 
 	if len(f.ExcludeTags) > 0 {
-		if slices.ContainsFunc(f.ExcludeTags, m.HasTag) {
-			return true
+		for _, excludeTag := range f.ExcludeTags {
+			if m.HasTag(excludeTag) && !slices.Contains(f.IncludeTags, excludeTag) {
+				return true
+			}
 		}
 	}
 

--- a/pkg/catalog/index/filter_test.go
+++ b/pkg/catalog/index/filter_test.go
@@ -58,12 +58,111 @@ func TestFilterMatches(t *testing.T) {
 		require.False(t, filter.Matches(metadata))
 	})
 
-	t.Run("Include tags overrides exclude", func(t *testing.T) {
+	t.Run("Include tags overrides same exclude tag", func(t *testing.T) {
+		filter := &Filter{
+			ExcludeTags: []string{"cve"},
+			IncludeTags: []string{"cve"},
+		}
+		require.True(t, filter.Matches(metadata))
+	})
+
+	t.Run("Include tags does not override unrelated exclude tags", func(t *testing.T) {
 		filter := &Filter{
 			ExcludeTags: []string{"rce"},
 			IncludeTags: []string{"cve"},
 		}
-		require.True(t, filter.Matches(metadata))
+		require.False(t, filter.Matches(metadata))
+	})
+
+	t.Run("Include tags does not override other exclusions", func(t *testing.T) {
+		tests := []struct {
+			name   string
+			filter *Filter
+		}{
+			{
+				name: "exclude id",
+				filter: &Filter{
+					ExcludeIDs:  []string{"test-template-1"},
+					IncludeTags: []string{"cve"},
+				},
+			},
+			{
+				name: "exclude template",
+				filter: &Filter{
+					ExcludeTemplates: []string{"/templates/cves/"},
+					IncludeTags:      []string{"cve"},
+				},
+			},
+			{
+				name: "exclude severity",
+				filter: &Filter{
+					ExcludeSeverities: []severity.Severity{severity.Critical},
+					IncludeTags:       []string{"cve"},
+				},
+			},
+			{
+				name: "exclude protocol",
+				filter: &Filter{
+					ExcludeProtocolTypes: []types.ProtocolType{types.HTTPProtocol},
+					IncludeTags:          []string{"cve"},
+				},
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				require.False(t, tt.filter.Matches(metadata))
+			})
+		}
+	})
+
+	t.Run("Include tags does not override normal includes", func(t *testing.T) {
+		tests := []struct {
+			name   string
+			filter *Filter
+		}{
+			{
+				name: "author",
+				filter: &Filter{
+					Authors:     []string{"unknown"},
+					IncludeTags: []string{"cve"},
+				},
+			},
+			{
+				name: "tag",
+				filter: &Filter{
+					Tags:        []string{"xss"},
+					IncludeTags: []string{"cve"},
+				},
+			},
+			{
+				name: "id",
+				filter: &Filter{
+					IDs:         []string{"other-template"},
+					IncludeTags: []string{"cve"},
+				},
+			},
+			{
+				name: "severity",
+				filter: &Filter{
+					Severities:  []severity.Severity{severity.High},
+					IncludeTags: []string{"cve"},
+				},
+			},
+			{
+				name: "protocol",
+				filter: &Filter{
+					ProtocolTypes: []types.ProtocolType{types.DNSProtocol},
+					IncludeTags:   []string{"cve"},
+				},
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				require.False(t, tt.filter.Matches(metadata))
+			})
+		}
 	})
 
 	t.Run("ID filter - exact match", func(t *testing.T) {


### PR DESCRIPTION
## Proposed changes

IncludeTags in the metadata index was treated as
a forced include, so `-itags` could bypass
explicit ID/path filters and other include
criteria, while also let a template thru when it
had both an included tag and a different excluded
tag.

Match the parsed-template filter instead: an
included tag only cancels exclusion for that same
tag. Other exclusions and normal include filters
still apply, while IncludeTemplates remains the
explicit path override.

Fixes #7534

### Proof

```console
$ $ go test ./pkg/catalog/index -run 'TestFilterMatches/Include_tags' -count=1
ok  	github.com/projectdiscovery/nuclei/v3/pkg/catalog/index	0.127s
```

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated catalog template filtering so protocol/type-based exclusions take precedence over normal inclusion.
  * Refined “forced include” behavior: included tags can only restore an excluded tag when they reference the same tag; other exclusions (and unrelated include tags) no longer bypass rules.
  * Kept explicit template path overrides intact.
* **Tests**
  * Expanded unit test coverage for include/exclude tag interactions across other filtering dimensions.
  * Skipped a specific functional test case until the next nuclei release, citing intentional load-count differences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->