### PR TITLE
Add katana input

### DIFF
--- a/pkg/input/formats/README.md
+++ b/pkg/input/formats/README.md
@@ -6,6 +6,7 @@ Currently the following formats are implemented -
 
 - Burp Suite XML Request/Response file
 - Proxify JSONL output file
+- Katana JSONL crawl output file
 - OpenAPI Specification file
 - Postman Collection file
 - Swagger Specification file
@@ -88,3 +89,14 @@ Swagger specification file is converted from OpenAPI 2.0 format to OpenAPI 3.0 f
 ## Burp XML / Proxify JSONL
 
 These modules are generic and parse raw requests from these respective tools.
+
+## Katana JSONL
+
+This module ingests the JSONL crawl output of the [katana](https://github.com/projectdiscovery/katana) crawler (`katana -jsonl -o crawl.jsonl`), bridging crawling and DAST so a live crawl of a target can directly drive fuzzing (`nuclei -im katana -l crawl.jsonl -dast ...`).
+
+For each crawled endpoint it produces a fuzzable request:
+
+- When katana captured the raw request (the common case, including authenticated and non-GET requests), the raw request is parsed as-is, preserving method, headers, body, and all parameters.
+- When only discrete fields are present (method, endpoint, headers, body), a raw request is synthesized from them and parsed back, so the result has the same shape as every other input format.
+
+The parser is tolerant of mixed input: blank and malformed lines are skipped with a warning, and a bare URL line (katana's default non-JSONL output) is treated as a `GET` request.

--- a/pkg/input/formats/katana/katana.go
+++ b/pkg/input/formats/katana/katana.go
@@ -1,0 +1,193 @@
+// Package katana implements an input format that ingests the JSONL output of
+// the katana crawler (`katana -jsonl`) and turns each crawled endpoint into a
+// fuzzable nuclei request. This bridges crawling and DAST: instead of fuzzing
+// only a proxy-fed list of requests, nuclei can consume a crawl of the target
+// directly, preserving method, headers, body and parameters discovered on the
+// wire (including non-GET requests, which a bare URL list cannot express).
+package katana
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+
+	"github.com/projectdiscovery/gologger"
+	"github.com/projectdiscovery/nuclei/v3/pkg/input/formats"
+	"github.com/projectdiscovery/nuclei/v3/pkg/input/types"
+	"github.com/projectdiscovery/nuclei/v3/pkg/utils/json"
+)
+
+// maxTokenSize is the maximum size of a single JSONL line. Crawled requests can
+// carry large bodies / raw dumps, so we raise the scanner buffer well above the
+// default 64KB.
+const maxTokenSize = 10 * 1024 * 1024
+
+// KatanaFormat is a parser for katana JSONL crawl output.
+type KatanaFormat struct {
+	opts formats.InputFormatOptions
+}
+
+// New creates a new katana JSONL format parser.
+func New() *KatanaFormat {
+	return &KatanaFormat{}
+}
+
+var _ formats.Format = &KatanaFormat{}
+
+// katanaResult mirrors the relevant subset of katana's output.Result JSON.
+type katanaResult struct {
+	Request *katanaRequest `json:"request"`
+	Error   string         `json:"error"`
+}
+
+// katanaRequest mirrors the relevant subset of katana's navigation.Request JSON.
+type katanaRequest struct {
+	Method   string            `json:"method"`
+	Endpoint string            `json:"endpoint"`
+	Body     string            `json:"body"`
+	Headers  map[string]string `json:"headers"`
+	Raw      string            `json:"raw"`
+}
+
+// Name returns the name of the format.
+func (k *KatanaFormat) Name() string {
+	return "katana"
+}
+
+// SetOptions sets the options for the input format.
+func (k *KatanaFormat) SetOptions(options formats.InputFormatOptions) {
+	k.opts = options
+}
+
+// Parse parses katana JSONL output and calls the provided callback for each
+// request it discovers. It is tolerant of mixed input: blank lines are skipped,
+// and a bare URL line (katana's default non-JSONL output) is treated as a GET.
+func (k *KatanaFormat) Parse(input io.Reader, resultsCb formats.ParseReqRespCallback, filePath string) error {
+	scanner := bufio.NewScanner(input)
+	scanner.Buffer(make([]byte, 0, 64*1024), maxTokenSize)
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+
+		// Bare URL line (katana default output without -jsonl): treat as GET.
+		if !strings.HasPrefix(line, "{") {
+			if isAbsoluteURL(line) {
+				rr, err := k.buildFromComponents(http.MethodGet, line, nil, "")
+				if err != nil {
+					gologger.Warning().Msgf("katana: could not parse url %s: %s\n", line, err)
+					continue
+				}
+				if resultsCb(rr) {
+					return nil
+				}
+			}
+			continue
+		}
+
+		var result katanaResult
+		if err := json.Unmarshal([]byte(line), &result); err != nil {
+			gologger.Warning().Msgf("katana: could not decode jsonl line: %s\n", err)
+			continue
+		}
+		if result.Request == nil || result.Request.Endpoint == "" {
+			continue
+		}
+
+		rr, err := k.toRequestResponse(result.Request)
+		if err != nil {
+			gologger.Warning().Msgf("katana: could not parse request %s: %s\n", result.Request.Endpoint, err)
+			continue
+		}
+		if resultsCb(rr) {
+			return nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("could not read katana jsonl input: %w", err)
+	}
+	return nil
+}
+
+// toRequestResponse converts a katana request into nuclei's standard
+// RequestResponse. It prefers the captured raw request when available and falls
+// back to synthesizing one from the discovered components otherwise.
+func (k *KatanaFormat) toRequestResponse(req *katanaRequest) (*types.RequestResponse, error) {
+	if strings.TrimSpace(req.Raw) != "" {
+		return types.ParseRawRequestWithURL(req.Raw, req.Endpoint)
+	}
+	method := req.Method
+	if method == "" {
+		method = http.MethodGet
+	}
+	return k.buildFromComponents(method, req.Endpoint, req.Headers, req.Body)
+}
+
+// buildFromComponents synthesizes a raw HTTP request from discrete fields and
+// parses it back into a RequestResponse, reusing the well-tested raw parser so
+// the resulting object is identical in shape to the other input formats.
+func (k *KatanaFormat) buildFromComponents(method, endpoint string, headers map[string]string, body string) (*types.RequestResponse, error) {
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("invalid endpoint: %w", err)
+	}
+	if parsed.Host == "" {
+		return nil, fmt.Errorf("endpoint %q has no host", endpoint)
+	}
+
+	requestURI := parsed.RequestURI()
+	if requestURI == "" {
+		requestURI = "/"
+	}
+
+	var sb strings.Builder
+	sb.WriteString(method)
+	sb.WriteString(" ")
+	sb.WriteString(requestURI)
+	sb.WriteString(" HTTP/1.1\r\n")
+	sb.WriteString("Host: ")
+	sb.WriteString(parsed.Host)
+	sb.WriteString("\r\n")
+
+	// Emit headers in a deterministic order, skipping Host (already written).
+	for _, key := range sortedHeaderKeys(headers) {
+		if strings.EqualFold(key, "Host") {
+			continue
+		}
+		sb.WriteString(key)
+		sb.WriteString(": ")
+		sb.WriteString(headers[key])
+		sb.WriteString("\r\n")
+	}
+	sb.WriteString("\r\n")
+	if body != "" {
+		sb.WriteString(body)
+	}
+
+	return types.ParseRawRequestWithURL(sb.String(), endpoint)
+}
+
+// sortedHeaderKeys returns the header keys in deterministic (sorted) order.
+func sortedHeaderKeys(headers map[string]string) []string {
+	if len(headers) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(headers))
+	for k := range headers {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// isAbsoluteURL reports whether the line is an absolute http(s) URL.
+func isAbsoluteURL(line string) bool {
+	u, err := url.Parse(line)
+	return err == nil && u.IsAbs() && u.Host != "" && (u.Scheme == "http" || u.Scheme == "https")
+}

--- a/pkg/input/formats/katana/katana_test.go
+++ b/pkg/input/formats/katana/katana_test.go
@@ -1,0 +1,117 @@
+package katana
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/input/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKatanaFormatName(t *testing.T) {
+	require.Equal(t, "katana", New().Name())
+}
+
+func TestKatanaFormatParse(t *testing.T) {
+	inputFile := "../testdata/katana.jsonl"
+
+	file, err := os.Open(inputFile)
+	require.Nilf(t, err, "error opening katana input file: %v", err)
+	defer func() { _ = file.Close() }()
+
+	var got []*types.RequestResponse
+	err = New().Parse(file, func(rr *types.RequestResponse) bool {
+		got = append(got, rr)
+		return false
+	}, inputFile)
+	require.NoError(t, err)
+
+	// 3 JSONL records + 1 bare URL line; malformed and blank lines skipped.
+	require.Len(t, got, 4)
+
+	urls := make([]string, 0, len(got))
+	for _, rr := range got {
+		urls = append(urls, rr.URL.String())
+	}
+	require.ElementsMatch(t, []string{
+		"https://ginandjuice.shop/catalog/product?productId=1",
+		"https://ginandjuice.shop/catalog/subscribe",
+		"https://ginandjuice.shop/login",
+		"https://ginandjuice.shop/about",
+	}, urls)
+}
+
+func TestKatanaFormatRawRequestPreserved(t *testing.T) {
+	// A POST with a captured raw request must preserve method and body.
+	rr := parseSingle(t, `{"request":{"method":"POST","endpoint":"https://example.com/sub","raw":"POST /sub HTTP/1.1\r\nHost: example.com\r\nContent-Type: application/x-www-form-urlencoded\r\n\r\nemail=a%40b.com"}}`)
+	require.Equal(t, "POST", rr.Request.Method)
+	require.Equal(t, "email=a%40b.com", rr.Request.Body)
+	require.Equal(t, "https://example.com/sub", rr.URL.String())
+}
+
+func TestKatanaFormatComponentSynthesis(t *testing.T) {
+	// No raw request: it must be synthesized from method/endpoint/headers/body.
+	rr := parseSingle(t, `{"request":{"method":"POST","endpoint":"https://example.com/login","headers":{"Content-Type":"application/json"},"body":"{\"u\":\"admin\"}"}}`)
+	require.Equal(t, "POST", rr.Request.Method)
+	require.Equal(t, `{"u":"admin"}`, rr.Request.Body)
+	require.Equal(t, "https://example.com/login", rr.URL.String())
+
+	built, err := rr.BuildRequest()
+	require.NoError(t, err)
+	require.Equal(t, "application/json", built.Header.Get("Content-Type"))
+	require.Equal(t, "example.com", built.Host)
+}
+
+func TestKatanaFormatQueryParamsRetained(t *testing.T) {
+	// Parameter variants must survive so the fuzzer can target them.
+	rr := parseSingle(t, `{"request":{"method":"GET","endpoint":"https://example.com/p?id=1&q=2"}}`)
+	require.Equal(t, "https://example.com/p?id=1&q=2", rr.URL.String())
+	require.Equal(t, "GET", rr.Request.Method)
+}
+
+func TestKatanaFormatGracefulSkips(t *testing.T) {
+	input := strings.Join([]string{
+		"",
+		"garbage",
+		`{"request":null}`,
+		`{"request":{"endpoint":""}}`,
+		`{"request":{"method":"GET","endpoint":"https://example.com/ok"}}`,
+	}, "\n")
+
+	var got []*types.RequestResponse
+	err := New().Parse(strings.NewReader(input), func(rr *types.RequestResponse) bool {
+		got = append(got, rr)
+		return false
+	}, "test")
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, "https://example.com/ok", got[0].URL.String())
+}
+
+func TestKatanaFormatCallbackStops(t *testing.T) {
+	input := strings.Join([]string{
+		`{"request":{"method":"GET","endpoint":"https://example.com/1"}}`,
+		`{"request":{"method":"GET","endpoint":"https://example.com/2"}}`,
+	}, "\n")
+
+	var count int
+	err := New().Parse(strings.NewReader(input), func(_ *types.RequestResponse) bool {
+		count++
+		return true // request to stop after the first
+	}, "test")
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+}
+
+func parseSingle(t *testing.T, line string) *types.RequestResponse {
+	t.Helper()
+	var got *types.RequestResponse
+	err := New().Parse(strings.NewReader(line), func(rr *types.RequestResponse) bool {
+		got = rr
+		return false
+	}, "test")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	return got
+}

--- a/pkg/input/formats/testdata/katana.jsonl
+++ b/pkg/input/formats/testdata/katana.jsonl
@@ -1,0 +1,6 @@
+{"timestamp":"2024-01-01T00:00:00Z","request":{"method":"GET","endpoint":"https://ginandjuice.shop/catalog/product?productId=1","tag":"a","source":"https://ginandjuice.shop/","raw":"GET /catalog/product?productId=1 HTTP/1.1\r\nHost: ginandjuice.shop\r\nUser-Agent: katana\r\n\r\n"}}
+{"timestamp":"2024-01-01T00:00:01Z","request":{"method":"POST","endpoint":"https://ginandjuice.shop/catalog/subscribe","body":"email=test%40test.com","raw":"POST /catalog/subscribe HTTP/1.1\r\nHost: ginandjuice.shop\r\nContent-Type: application/x-www-form-urlencoded\r\nContent-Length: 21\r\n\r\nemail=test%40test.com"}}
+{"timestamp":"2024-01-01T00:00:02Z","request":{"method":"POST","endpoint":"https://ginandjuice.shop/login","headers":{"Content-Type":"application/json"},"body":"{\"username\":\"admin\",\"password\":\"x\"}"}}
+
+not-json-should-be-skipped
+https://ginandjuice.shop/about

--- a/pkg/input/provider/http/multiformat.go
+++ b/pkg/input/provider/http/multiformat.go
@@ -11,6 +11,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/input/formats"
 	"github.com/projectdiscovery/nuclei/v3/pkg/input/formats/burp"
 	"github.com/projectdiscovery/nuclei/v3/pkg/input/formats/json"
+	"github.com/projectdiscovery/nuclei/v3/pkg/input/formats/katana"
 	"github.com/projectdiscovery/nuclei/v3/pkg/input/formats/openapi"
 	"github.com/projectdiscovery/nuclei/v3/pkg/input/formats/swagger"
 	"github.com/projectdiscovery/nuclei/v3/pkg/input/formats/yaml"
@@ -145,6 +146,7 @@ var providersList = []formats.Format{
 	yaml.New(),
 	openapi.New(),
 	swagger.New(),
+	katana.New(),
 }
 
 // SupportedFormats returns the list of supported formats in comma-separated


### PR DESCRIPTION
Parse katana JSONL crawl output as nuclei input for DAST scanning. Closes #7548.