### PR TITLE
fix(progress): avoid panic for disabled stats interval

### DIFF
--- a/pkg/progress/progress.go
+++ b/pkg/progress/progress.go
@@ -98,13 +98,15 @@ func (p *StatsTicker) Init(hostCount int64, rulesCount int, requestCount int64) 
 			gologger.Warning().Msgf("Couldn't start statistics: %s", err)
 		}
 
-		// Note: this is needed and is responsible for the tick event
-		p.stats.GetStatResponse(p.tickDuration, func(s string, err error) error {
-			if err != nil {
-				gologger.Warning().Msgf("Could not read statistics: %s\n", err)
-			}
-			return nil
-		})
+		if p.tickDuration > 0 {
+			// Note: this is needed and is responsible for the tick event
+			p.stats.GetStatResponse(p.tickDuration, func(s string, err error) error {
+				if err != nil {
+					gologger.Warning().Msgf("Could not read statistics: %s\n", err)
+				}
+				return nil
+			})
+		}
 	}
 }
 

--- a/pkg/progress/progress_test.go
+++ b/pkg/progress/progress_test.go
@@ -1,0 +1,85 @@
+package progress
+
+import (
+	"testing"
+	"time"
+
+	"github.com/projectdiscovery/clistats"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStatsTickerInit_registersPeriodicStatsOnly_whenIntervalIsPositive(t *testing.T) {
+	tests := []struct {
+		name              string
+		tickDuration      time.Duration
+		wantPeriodicStats bool
+	}{
+		{
+			name:              "interval is disabled",
+			tickDuration:      -1,
+			wantPeriodicStats: false,
+		},
+		{
+			name:              "interval is positive",
+			tickDuration:      time.Second,
+			wantPeriodicStats: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Given
+			stats := &statsClientSpy{}
+			ticker := &StatsTicker{
+				active:       true,
+				stats:        stats,
+				tickDuration: test.tickDuration,
+			}
+
+			// When
+			ticker.Init(1, 1, 1)
+
+			// Then
+			require.True(t, stats.started)
+			require.Equal(t, test.wantPeriodicStats, stats.periodicStatsRequested)
+		})
+	}
+}
+
+type statsClientSpy struct {
+	periodicStatsRequested bool
+	started                bool
+}
+
+func (s *statsClientSpy) Start() error {
+	s.started = true
+	return nil
+}
+
+func (s *statsClientSpy) Stop() error {
+	return nil
+}
+
+func (s *statsClientSpy) AddCounter(string, uint64) {}
+
+func (s *statsClientSpy) GetCounter(string) (uint64, bool) {
+	return 0, false
+}
+
+func (s *statsClientSpy) IncrementCounter(string, int) {}
+
+func (s *statsClientSpy) AddStatic(string, interface{}) {}
+
+func (s *statsClientSpy) GetStatic(string) (interface{}, bool) {
+	return nil, false
+}
+
+func (s *statsClientSpy) AddDynamic(string, clistats.DynamicCallback) {}
+
+func (s *statsClientSpy) GetDynamic(string) (clistats.DynamicCallback, bool) {
+	return nil, false
+}
+
+func (s *statsClientSpy) GetStatResponse(time.Duration, func(string, error) error) {
+	s.periodicStatsRequested = true
+}


### PR DESCRIPTION
## Summary

Fixes #7556.

- Do not register clistats periodic updates when the stats interval is disabled or non-positive.
- Keep the metrics server active and preserve periodic output for positive intervals.
- Add a focused regression test for both disabled and positive intervals.

## Reproduction

The SDK panicked when active stats were initialized with the disabled sentinel:

```go
ticker, err := progress.NewStatsTicker(-1, true, false, false, 0)
if err != nil {
    panic(err)
}
ticker.Init(1, 1, 1)
```

The previous implementation passed the non-positive duration to `time.NewTicker` through clistats. The new guard skips the periodic callback instead.

## Validation

- `go test -race -shuffle=on -count=1 ./pkg/progress`
- `go vet ./pkg/progress`
- `make vet`
- `make build`
- SDK smoke test using `NewStatsTicker(-1, true, false, false, 0)`

`make test` reached an unrelated pre-existing DNS-network failure in `pkg/protocols/dns` (`could not resolve, max retries exceeded`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled periodic statistics updates when no positive update interval is configured.
  * Continued to start the statistics client without scheduling unnecessary update requests.

* **Tests**
  * Added coverage verifying periodic statistics behavior for enabled and disabled intervals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->