### PR TITLE
fix: stop busy-spinning hang monitor

### DIFF
--- a/internal/tests/integration/http_test.go
+++ b/internal/tests/integration/http_test.go
@@ -62,7 +62,7 @@ var httpTestcases = []integrationCase{
 	{Path: "protocols/http/get-case-insensitive.yaml", TestCase: &httpGetCaseInsensitive{}},
 	{Path: "protocols/http/get.yaml,protocols/http/get-case-insensitive.yaml", TestCase: &httpGetCaseInsensitiveCluster{}},
 	{Path: "protocols/http/get-redirects-chain-headers.yaml", TestCase: &httpGetRedirectsChainHeaders{}},
-	{Path: "protocols/http/dsl-matcher-variable.yaml", TestCase: &httpDSLVariable{}},
+	{Path: "protocols/http/dsl-matcher-variable.yaml", TestCase: &httpDSLVariable{}, Serial: true},
 	{Path: "protocols/http/dsl-functions.yaml", TestCase: &httpDSLFunctions{}},
 	{Path: "protocols/http/race-simple.yaml", TestCase: &httpRaceSimple{}},
 	{Path: "protocols/http/race-multiple.yaml", TestCase: &httpRaceMultiple{}},

--- a/internal/tests/integration/http_test.go
+++ b/internal/tests/integration/http_test.go
@@ -62,7 +62,7 @@ var httpTestcases = []integrationCase{
 	{Path: "protocols/http/get-case-insensitive.yaml", TestCase: &httpGetCaseInsensitive{}},
 	{Path: "protocols/http/get.yaml,protocols/http/get-case-insensitive.yaml", TestCase: &httpGetCaseInsensitiveCluster{}},
 	{Path: "protocols/http/get-redirects-chain-headers.yaml", TestCase: &httpGetRedirectsChainHeaders{}},
-	{Path: "protocols/http/dsl-matcher-variable.yaml", TestCase: &httpDSLVariable{}, Serial: true},
+	{Path: "protocols/http/dsl-matcher-variable.yaml", TestCase: &httpDSLVariable{}},
 	{Path: "protocols/http/dsl-functions.yaml", TestCase: &httpDSLFunctions{}},
 	{Path: "protocols/http/race-simple.yaml", TestCase: &httpRaceSimple{}},
 	{Path: "protocols/http/race-multiple.yaml", TestCase: &httpRaceMultiple{}},

--- a/pkg/utils/monitor/monitor.go
+++ b/pkg/utils/monitor/monitor.go
@@ -53,19 +53,20 @@ func (s *Agent) Start(interval time.Duration) context.CancelFunc {
 	ctx, cancel := context.WithCancel(context.Background())
 	ticker := time.NewTicker(interval)
 
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				ticker.Stop()
-			case <-ticker.C:
-				s.monitorWorker(cancel)
-			default:
-				continue
-			}
-		}
-	}()
+	go s.run(ctx, ticker, cancel)
 	return cancel
+}
+
+func (s *Agent) run(ctx context.Context, ticker *time.Ticker, cancel context.CancelFunc) {
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.monitorWorker(cancel)
+		}
+	}
 }
 
 // monitorWorker is a worker for monitoring running goroutines

--- a/pkg/utils/monitor/monitor_test.go
+++ b/pkg/utils/monitor/monitor_test.go
@@ -1,7 +1,9 @@
 package monitor
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -12,4 +14,27 @@ func TestMonitorCompareStringSliceEqual(t *testing.T) {
 
 	value = compareStringSliceEqual([]string{"a", "c"}, []string{"b", "a"})
 	require.False(t, value, "could get incorrect value")
+}
+
+func TestAgentRunExitsWhenCancelled(t *testing.T) {
+	// Given
+	monitor := NewStackMonitor()
+	ctx, cancel := context.WithCancel(context.Background())
+	ticker := time.NewTicker(time.Hour)
+	t.Cleanup(cancel)
+	done := make(chan struct{})
+
+	// When
+	go func() {
+		monitor.run(ctx, ticker, func() {})
+		close(done)
+	}()
+	cancel()
+
+	// Then
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		require.Fail(t, "monitor goroutine did not exit after cancellation")
+	}
 }


### PR DESCRIPTION
## Proposed changes

Fixes #7558.

`-hang-monitor` used a non-blocking `select` loop. While waiting for its 10-second ticker, the `default: continue` branch consumed CPU continuously. Calling the cancel function stopped the ticker but left the goroutine running, where it continued to spin.

This PR removes the non-blocking branch, defers ticker cleanup, and returns when the monitor context is cancelled. It keeps the existing `Agent.Start` API and `-hang-monitor` flag unchanged.

### Before / after

Before, a scan such as:

```console
nuclei -hm -t pkg/templates/tests/match-1.yaml -u http://127.0.0.1:18080 -timeout 5
```

would keep the monitor goroutine busy-spinning during the pending request and after cancellation. After this change, it blocks until the next tick or cancellation, and exits on cancellation.

### Proof

- Added `TestAgentRunExitsWhenCancelled`; it fails against the previous loop and passes with this fix.
- `go test -count=20 ./pkg/utils/monitor`
- `go test -race ./pkg/utils/monitor`
- `go vet ./pkg/utils/monitor`
- `make vet`
- `make build`
- Built the CLI and ran `-hm` against a local listener; the scan sent a GET request and exited successfully.
- `make test` was run. The changed monitor package passed, while the repository-wide command failed only in the pre-existing DNS integration-style test `pkg/protocols/dns:TestDNSExecuteWithResults` because this environment could not resolve DNS (`could not resolve, max retries exceeded`).

## Checklist

- [x] Pull request targets `dev`
- [x] Focused regression test added
- [x] Required vet and build checks passed
- [x] No documentation changes required (no user-facing API or flag changed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved monitoring reliability by removing unnecessary idle background activity.
  * Ensured the monitoring loop stops promptly and cleanly when cancellation is requested.

* **Tests**
  * Added a unit test to confirm the monitoring routine exits after context cancellation.
  * Updated integration test scheduling to run a specific HTTP DSL matcher test serially.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->