### PR TITLE
Add DNSSEC DNS record types

### DIFF
--- a/SYNTAX-REFERENCE.md
+++ b/SYNTAX-REFERENCE.md
@@ -2898,6 +2898,16 @@ Enum Values:
   - <code>ANY</code>
 
   - <code>SRV</code>
+
+  - <code>RRSIG</code>
+
+  - <code>NSEC</code>
+
+  - <code>DNSKEY</code>
+
+  - <code>NSEC3</code>
+
+  - <code>NSEC3PARAM</code>
 </div>
 
 <hr />

--- a/pkg/protocols/dns/dns.go
+++ b/pkg/protocols/dns/dns.go
@@ -36,7 +36,7 @@ type Request struct {
 	Name string `yaml:"name,omitempty" json:"name,omitempty" jsonschema:"title=hostname to make dns request for,description=Name is the Hostname to make DNS request for"`
 	// description: |
 	//   RequestType is the type of DNS request to make.
-	RequestType DNSRequestTypeHolder `yaml:"type,omitempty" json:"type,omitempty" jsonschema:"title=type of dns request to make,description=Type is the type of DNS request to make,enum=A,enum=NS,enum=DS,enum=CNAME,enum=SOA,enum=PTR,enum=MX,enum=TXT,enum=AAAA"`
+	RequestType DNSRequestTypeHolder `yaml:"type,omitempty" json:"type,omitempty" jsonschema:"title=type of dns request to make,description=Type is the type of DNS request to make,enum=A,enum=NS,enum=DS,enum=CNAME,enum=SOA,enum=PTR,enum=MX,enum=TXT,enum=AAAA,enum=CAA,enum=TLSA,enum=ANY,enum=SRV,enum=RRSIG,enum=NSEC,enum=DNSKEY,enum=NSEC3,enum=NSEC3PARAM"`
 	// description: |
 	//   Class is the class of the DNS request.
 	//
@@ -309,6 +309,16 @@ func questionTypeToInt(questionType string) uint16 {
 		question = dns.TypeANY
 	case "SRV":
 		question = dns.TypeSRV
+	case "RRSIG":
+		question = dns.TypeRRSIG
+	case "NSEC":
+		question = dns.TypeNSEC
+	case "DNSKEY":
+		question = dns.TypeDNSKEY
+	case "NSEC3":
+		question = dns.TypeNSEC3
+	case "NSEC3PARAM":
+		question = dns.TypeNSEC3PARAM
 	}
 	return question
 }

--- a/pkg/protocols/dns/dns_types.go
+++ b/pkg/protocols/dns/dns_types.go
@@ -39,24 +39,39 @@ const (
 	ANY
 	// name:SRV
 	SRV
+	// name:RRSIG
+	RRSIG
+	// name:NSEC
+	NSEC
+	// name:DNSKEY
+	DNSKEY
+	// name:NSEC3
+	NSEC3
+	// name:NSEC3PARAM
+	NSEC3PARAM
 	limit
 )
 
 // DNSRequestTypeMapping is a table for conversion of method from string.
 var DNSRequestTypeMapping = map[DNSRequestType]string{
-	A:     "A",
-	NS:    "NS",
-	DS:    "DS",
-	CNAME: "CNAME",
-	SOA:   "SOA",
-	PTR:   "PTR",
-	MX:    "MX",
-	TXT:   "TXT",
-	AAAA:  "AAAA",
-	CAA:   "CAA",
-	TLSA:  "TLSA",
-	ANY:   "ANY",
-	SRV:   "SRV",
+	A:          "A",
+	NS:         "NS",
+	DS:         "DS",
+	CNAME:      "CNAME",
+	SOA:        "SOA",
+	PTR:        "PTR",
+	MX:         "MX",
+	TXT:        "TXT",
+	AAAA:       "AAAA",
+	CAA:        "CAA",
+	TLSA:       "TLSA",
+	ANY:        "ANY",
+	SRV:        "SRV",
+	RRSIG:      "RRSIG",
+	NSEC:       "NSEC",
+	DNSKEY:     "DNSKEY",
+	NSEC3:      "NSEC3",
+	NSEC3PARAM: "NSEC3PARAM",
 }
 
 // GetSupportedDNSRequestTypes returns list of supported types

--- a/pkg/protocols/dns/dns_types_test.go
+++ b/pkg/protocols/dns/dns_types_test.go
@@ -1,0 +1,92 @@
+package dns
+
+import (
+	"testing"
+
+	"github.com/miekg/dns"
+	"github.com/stretchr/testify/require"
+)
+
+func TestToDNSRequestTypesDNSSEC(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected DNSRequestType
+	}{
+		{"NSEC", NSEC},
+		{"nsec", NSEC},
+		{"NSEC3", NSEC3},
+		{"NSEC3PARAM", NSEC3PARAM},
+		{"DNSKEY", DNSKEY},
+		{"RRSIG", RRSIG},
+		{"rrsig", RRSIG},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := toDNSRequestTypes(tt.input)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, got)
+			require.Equal(t, normalizeValue(tt.expected.String()), normalizeValue(tt.input))
+		})
+	}
+}
+
+func TestToDNSRequestTypesInvalid(t *testing.T) {
+	_, err := toDNSRequestTypes("NOTAREALTYPE")
+	require.Error(t, err)
+}
+
+func TestQuestionTypeToIntDNSSEC(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected uint16
+	}{
+		{"NSEC", dns.TypeNSEC},
+		{"NSEC3", dns.TypeNSEC3},
+		{"NSEC3PARAM", dns.TypeNSEC3PARAM},
+		{"DNSKEY", dns.TypeDNSKEY},
+		{"RRSIG", dns.TypeRRSIG},
+		{"A", dns.TypeA},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			require.Equal(t, tt.expected, questionTypeToInt(tt.input))
+		})
+	}
+}
+
+func TestGetSupportedDNSRequestTypesIncludesDNSSEC(t *testing.T) {
+	supported := GetSupportedDNSRequestTypes()
+	require.Contains(t, supported, NSEC)
+	require.Contains(t, supported, NSEC3)
+	require.Contains(t, supported, NSEC3PARAM)
+	require.Contains(t, supported, DNSKEY)
+	require.Contains(t, supported, RRSIG)
+}
+
+func TestMakeDNSRequestNSECQuestion(t *testing.T) {
+	recursion := false
+	request := &Request{
+		RequestType: DNSRequestTypeHolder{DNSRequestType: NSEC},
+		Name:        "{{FQDN}}",
+		Class:       "inet",
+		Recursion:   &recursion,
+	}
+	request.question = questionTypeToInt(request.RequestType.String())
+	request.class = classToInt(request.Class)
+
+	msg, err := request.Make("example.com", map[string]interface{}{"FQDN": "example.com"})
+	require.NoError(t, err)
+	require.Len(t, msg.Question, 1)
+	require.Equal(t, dns.TypeNSEC, msg.Question[0].Qtype)
+	require.Equal(t, "example.com.", msg.Question[0].Name)
+}
+
+func TestDNSRequestTypeHolderUnmarshalYAMLDNSSEC(t *testing.T) {
+	var holder DNSRequestTypeHolder
+	err := holder.UnmarshalYAML(func(v interface{}) error {
+		*v.(*string) = "NSEC3"
+		return nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, NSEC3, holder.DNSRequestType)
+}

--- a/pkg/templates/templates_doc.go
+++ b/pkg/templates/templates_doc.go
@@ -1225,6 +1225,11 @@ func init() {
 		"TLSA",
 		"ANY",
 		"SRV",
+		"RRSIG",
+		"NSEC",
+		"DNSKEY",
+		"NSEC3",
+		"NSEC3PARAM",
 	}
 
 	FILERequestDoc.Type = "file.Request"


### PR DESCRIPTION
Closes #5693

The DNS protocol type whitelist did not include DNSSEC records, so templates could not query NSEC/NSEC3 for zonewalking-style checks.

Adds NSEC, NSEC3, NSEC3PARAM, DNSKEY, and RRSIG to the DNS type enum and question mapping. Response extraction already handles these via miekg/dns. Unit tests cover parsing, Make(), and YAML unmarshal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for DNSSEC record query types: `RRSIG`, `NSEC`, `DNSKEY`, `NSEC3`, and `NSEC3PARAM`.
  * These types are now available in DNS request configuration and schema validation.

* **Documentation**
  * Updated syntax and generated documentation to list the newly supported DNSSEC types.

* **Tests**
  * Added coverage for DNSSEC type parsing, conversion, validation, and request generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->