### PR TITLE
chore(deps): bump rawhttp to fix duplicate HTTP status line parsing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/projectdiscovery/fastdialer v0.5.13
 	github.com/projectdiscovery/hmap v0.0.101
 	github.com/projectdiscovery/interactsh v1.3.1
-	github.com/projectdiscovery/rawhttp v0.1.90
+	github.com/projectdiscovery/rawhttp v0.1.91-0.20260616205543-c41b464d9bad
 	github.com/projectdiscovery/retryabledns v1.0.115
 	github.com/projectdiscovery/retryablehttp-go v1.3.19
 	github.com/projectdiscovery/yamldoc-go v1.0.6

--- a/go.sum
+++ b/go.sum
@@ -888,8 +888,8 @@ github.com/projectdiscovery/networkpolicy v0.1.42 h1:/d5vriH8fDMoEaFCSD1nuCWs/ki
 github.com/projectdiscovery/networkpolicy v0.1.42/go.mod h1:9ULLaMbdv9UnT0C5rmuK4nIwYs0o776xMnkPUb8TtaE=
 github.com/projectdiscovery/ratelimit v0.0.88 h1:AcurW9aLRzlEyPe9kSjnOpr3XzLMWTpiWAlW/w73ALU=
 github.com/projectdiscovery/ratelimit v0.0.88/go.mod h1:CU1s+68UUG2mctSl2wi32/DHLJA6TMg+4rxgP59LfVk=
-github.com/projectdiscovery/rawhttp v0.1.90 h1:LOSZ6PUH08tnKmWsIwvwv1Z/4zkiYKYOSZ6n+8RFKtw=
-github.com/projectdiscovery/rawhttp v0.1.90/go.mod h1:VZYAM25UI/wVB3URZ95ZaftgOnsbphxyAw/XnQRRz4Y=
+github.com/projectdiscovery/rawhttp v0.1.91-0.20260616205543-c41b464d9bad h1:R7Y88pYjte4eIZ80C2K544fNda+gSU7ZvopcTJBZST4=
+github.com/projectdiscovery/rawhttp v0.1.91-0.20260616205543-c41b464d9bad/go.mod h1:VZYAM25UI/wVB3URZ95ZaftgOnsbphxyAw/XnQRRz4Y=
 github.com/projectdiscovery/rdap v0.9.0 h1:wPhHx5pQ2QI+WGhyNb2PjhTl0NtB39Nk7YFZ9cp8ZGA=
 github.com/projectdiscovery/rdap v0.9.0/go.mod h1:zk4yrJFQ2Hy36Aqk+DvotYQxYAeALaCJ5ORySkff36Q=
 github.com/projectdiscovery/retryabledns v1.0.115 h1:RKV63FNIznFHUoawg/1hs53pVH3wqPtFhwstCuxVSoA=


### PR DESCRIPTION
## Proposed changes

Bumps `github.com/projectdiscovery/rawhttp` from `v0.1.90` to `v0.1.91-0.20260616205543-c41b464d9bad` to pull in the fix for parsing responses with duplicate HTTP status lines.

Fixes #7363

Targets that emit a malformed response with a repeated status line before the headers (e.g. a Grandstream HT801 responding with `HTTP/1.0 200 OK` twice) fail with a header parse error even under `unsafe: true`, so matchers never run and the response body is unreachable. As discussed in #7363, the root cause is in `rawhttp`: its header reader rejects any line without a colon, and a repeated status line has none. The fix was merged upstream in projectdiscovery/rawhttp#542 (commit `c41b464`), which skips leading duplicate status lines in `ReadResponse` before header parsing, bounded at 8 lines, with regression tests (`TestReadResponseDuplicateStatusLines`, `TestReadResponseTripleStatusLines`).

No new `rawhttp` tag has been cut past `v0.1.90` yet, so this pins the pseudo-version at the fix merge commit, which is also the current `rawhttp` main HEAD (the only commits between `v0.1.90` and main are the fix PR itself). Same shape as #7464, the govaluate bump pinned to an untagged upstream fix commit.

### Proof

Standalone repro calling rawhttp's `client.ReadResponse` on the response bytes from the issue (`"HTTP/1.0 200 OK\r\nHTTP/1.0 200 OK\r\nContent-Type: text/html\r\nContent-Length: 5\r\n\r\nhello"`):

Before, pinned at `v0.1.90`:

```
ERROR: invalid header line: "HTTP/1.0 200 OK\r\n"
```

After, pinned at `v0.1.91-0.20260616205543-c41b464d9bad`:

```
OK status=200 headers=2 body="hello"
```

Also verified end to end with a local nuclei build at this commit against a mock server replaying the device's response under an `unsafe: true` raw template: the response now parses (`-debug` shows the 200, headers, and body) and a word matcher on the body fires.

Local checks on the changed module graph:

- `go build ./cmd/nuclei` passes
- `go vet ./pkg/protocols/http/... ./pkg/protocols/common/protocolstate/...` (the packages importing rawhttp) passes
- `go test ./pkg/protocols/http/...` passes with the bump
- `go mod tidy` produced no changes beyond the bump

Note: `TestExecuteParallelHTTP_GoroutineLeaks` is flaky under load on my machine on a clean `dev` checkout as well (fastdialer `closeAfterTimeout` goroutine caught by the leak detector), unrelated to this change.

## Checklist

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (regression tests live upstream in rawhttp#542)
- [ ] I have added necessary documentation (if appropriate)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal networking dependency to a newer development version.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->