### PR TITLE
Add error matcher for timeout and connection failures

### DIFF
--- a/pkg/operators/error_matchers_test.go
+++ b/pkg/operators/error_matchers_test.go
@@ -1,0 +1,79 @@
+package operators
+
+import (
+	"testing"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/operators/matchers"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHasErrorMatchers(t *testing.T) {
+	t.Run("error type", func(t *testing.T) {
+		ops := &Operators{Matchers: []*matchers.Matcher{{
+			Type:   matchers.MatcherTypeHolder{MatcherType: matchers.ErrorMatcher},
+			Errors: []string{"timeout"},
+		}}}
+		require.NoError(t, ops.Compile())
+		require.True(t, ops.HasErrorMatchers())
+	})
+
+	t.Run("dsl timeout var", func(t *testing.T) {
+		ops := &Operators{Matchers: []*matchers.Matcher{{
+			Type: matchers.MatcherTypeHolder{MatcherType: matchers.DSLMatcher},
+			DSL:  []string{"timeout == true"},
+		}}}
+		require.NoError(t, ops.Compile())
+		require.True(t, ops.HasErrorMatchers())
+	})
+
+	t.Run("dsl error_type var", func(t *testing.T) {
+		ops := &Operators{Matchers: []*matchers.Matcher{{
+			Type: matchers.MatcherTypeHolder{MatcherType: matchers.DSLMatcher},
+			DSL:  []string{`error_type == "timeout"`},
+		}}}
+		require.NoError(t, ops.Compile())
+		require.True(t, ops.HasErrorMatchers())
+	})
+
+	t.Run("dsl error var", func(t *testing.T) {
+		ops := &Operators{Matchers: []*matchers.Matcher{{
+			Type: matchers.MatcherTypeHolder{MatcherType: matchers.DSLMatcher},
+			DSL:  []string{`contains(error, "refused")`},
+		}}}
+		require.NoError(t, ops.Compile())
+		require.True(t, ops.HasErrorMatchers())
+	})
+
+	t.Run("dsl without error vars", func(t *testing.T) {
+		ops := &Operators{Matchers: []*matchers.Matcher{{
+			Type: matchers.MatcherTypeHolder{MatcherType: matchers.DSLMatcher},
+			DSL:  []string{"status_code == 200"},
+		}}}
+		require.NoError(t, ops.Compile())
+		require.False(t, ops.HasErrorMatchers())
+	})
+
+	t.Run("dsl timeout as identifier prefix does not match", func(t *testing.T) {
+		ops := &Operators{Matchers: []*matchers.Matcher{{
+			Type: matchers.MatcherTypeHolder{MatcherType: matchers.DSLMatcher},
+			DSL:  []string{"timeout_ms > 100"},
+		}}}
+		require.NoError(t, ops.Compile())
+		require.False(t, ops.HasErrorMatchers())
+	})
+
+	t.Run("word matcher only", func(t *testing.T) {
+		ops := &Operators{Matchers: []*matchers.Matcher{{
+			Type:  matchers.MatcherTypeHolder{MatcherType: matchers.WordsMatcher},
+			Words: []string{"ok"},
+			Part:  "body",
+		}}}
+		require.NoError(t, ops.Compile())
+		require.False(t, ops.HasErrorMatchers())
+	})
+
+	t.Run("nil operators", func(t *testing.T) {
+		var ops *Operators
+		require.False(t, ops.HasErrorMatchers())
+	})
+}

--- a/pkg/operators/matchers/compile.go
+++ b/pkg/operators/matchers/compile.go
@@ -38,7 +38,7 @@ func (matcher *Matcher) CompileMatchers() error {
 	}
 
 	// By default, match on body if user hasn't provided any specific items
-	if matcher.Part == "" && matcher.GetType() != DSLMatcher {
+	if matcher.Part == "" && matcher.GetType() != DSLMatcher && matcher.GetType() != ErrorMatcher {
 		matcher.Part = "body"
 	}
 
@@ -90,17 +90,31 @@ func (matcher *Matcher) CompileMatchers() error {
 	}
 
 	if matcher.CaseInsensitive {
-		if matcher.GetType() != WordsMatcher {
-			return fmt.Errorf("case-insensitive flag is supported only for 'word' matchers (not '%s')", matcher.Type)
-		}
-		for i := range matcher.Words {
-			matcher.Words[i] = strings.ToLower(matcher.Words[i])
+		switch matcher.GetType() {
+		case WordsMatcher:
+			for i := range matcher.Words {
+				matcher.Words[i] = strings.ToLower(matcher.Words[i])
+			}
+		case ErrorMatcher:
+			// Applied at MatchError time so reserved kinds (timeout/connection/any) stay intact.
+		default:
+			return fmt.Errorf("case-insensitive flag is supported only for 'word' and 'error' matchers (not '%s')", matcher.Type)
 		}
 	}
 	return nil
 }
 
-// GetType returns the condition type of the matcher
+// NeedsPart returns true when the matcher requires a response part corpus.
+func (matcher *Matcher) NeedsPart() bool {
+	switch matcher.GetType() {
+	case DSLMatcher, ErrorMatcher:
+		return false
+	default:
+		return true
+	}
+}
+
+// GetCondition returns the condition type of the matcher
 // todo: the field should be exposed natively
 func (matcher *Matcher) GetCondition() ConditionType {
 	return matcher.condition

--- a/pkg/operators/matchers/error_match_test.go
+++ b/pkg/operators/matchers/error_match_test.go
@@ -1,0 +1,152 @@
+package matchers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMatchError(t *testing.T) {
+	t.Run("any error when errors empty", func(t *testing.T) {
+		m := &Matcher{Type: MatcherTypeHolder{MatcherType: ErrorMatcher}}
+		require.NoError(t, m.CompileMatchers())
+		ok, snippets := m.MatchError(map[string]interface{}{"error": "boom", "error_type": "unknown", "timeout": false})
+		require.True(t, m.Result(ok))
+		require.Equal(t, []string{"boom"}, snippets)
+		ok, _ = m.MatchError(map[string]interface{}{})
+		require.False(t, m.Result(ok))
+	})
+
+	t.Run("empty error string does not match", func(t *testing.T) {
+		m := &Matcher{Type: MatcherTypeHolder{MatcherType: ErrorMatcher}, Errors: []string{"any"}}
+		require.NoError(t, m.CompileMatchers())
+		ok, _ := m.MatchError(map[string]interface{}{"error": "", "error_type": "unknown", "timeout": false})
+		require.False(t, m.Result(ok))
+		ok, _ = m.MatchError(map[string]interface{}{"error": nil})
+		require.False(t, m.Result(ok))
+	})
+
+	t.Run("timeout kind", func(t *testing.T) {
+		m := &Matcher{Type: MatcherTypeHolder{MatcherType: ErrorMatcher}, Errors: []string{"timeout"}}
+		require.NoError(t, m.CompileMatchers())
+		ok, _ := m.MatchError(map[string]interface{}{"error": "i/o timeout", "error_type": "timeout", "timeout": true})
+		require.True(t, m.Result(ok))
+		ok, _ = m.MatchError(map[string]interface{}{"error": "connection refused", "error_type": "connection", "timeout": false})
+		require.False(t, m.Result(ok))
+	})
+
+	t.Run("connection and connect kinds", func(t *testing.T) {
+		for _, kind := range []string{"connection", "connect"} {
+			m := &Matcher{Type: MatcherTypeHolder{MatcherType: ErrorMatcher}, Errors: []string{kind}}
+			require.NoError(t, m.CompileMatchers())
+			ok, _ := m.MatchError(map[string]interface{}{"error": "connection refused", "error_type": "connection", "timeout": false})
+			require.True(t, m.Result(ok), "kind %q", kind)
+			ok, _ = m.MatchError(map[string]interface{}{"error": "i/o timeout", "error_type": "timeout", "timeout": true})
+			require.False(t, m.Result(ok), "kind %q", kind)
+		}
+	})
+
+	t.Run("any and star kinds", func(t *testing.T) {
+		for _, kind := range []string{"any", "*"} {
+			m := &Matcher{Type: MatcherTypeHolder{MatcherType: ErrorMatcher}, Errors: []string{kind}}
+			require.NoError(t, m.CompileMatchers())
+			ok, snippets := m.MatchError(map[string]interface{}{"error": "something went wrong", "error_type": "unknown", "timeout": false})
+			require.True(t, m.Result(ok), "kind %q", kind)
+			require.Equal(t, []string{"something went wrong"}, snippets)
+		}
+	})
+
+	t.Run("substring in error message", func(t *testing.T) {
+		m := &Matcher{Type: MatcherTypeHolder{MatcherType: ErrorMatcher}, Errors: []string{"connection refused"}}
+		require.NoError(t, m.CompileMatchers())
+		ok, snippets := m.MatchError(map[string]interface{}{"error": "dial tcp 127.0.0.1:1: connection refused", "error_type": "connection", "timeout": false})
+		require.True(t, m.Result(ok))
+		require.Equal(t, []string{"connection refused"}, snippets)
+
+		ok, _ = m.MatchError(map[string]interface{}{"error": "i/o timeout", "error_type": "timeout", "timeout": true})
+		require.False(t, m.Result(ok))
+	})
+
+	t.Run("case insensitive substring", func(t *testing.T) {
+		m := &Matcher{
+			Type:            MatcherTypeHolder{MatcherType: ErrorMatcher},
+			Errors:          []string{"No Such Host"},
+			CaseInsensitive: true,
+		}
+		require.NoError(t, m.CompileMatchers())
+		ok, snippets := m.MatchError(map[string]interface{}{"error": "lookup example.invalid: no such host", "error_type": "connection", "timeout": false})
+		require.True(t, m.Result(ok))
+		require.Equal(t, []string{"No Such Host"}, snippets)
+	})
+
+	t.Run("case sensitive substring misses", func(t *testing.T) {
+		m := &Matcher{
+			Type:   MatcherTypeHolder{MatcherType: ErrorMatcher},
+			Errors: []string{"No Such Host"},
+		}
+		require.NoError(t, m.CompileMatchers())
+		ok, _ := m.MatchError(map[string]interface{}{"error": "lookup example.invalid: no such host", "error_type": "connection", "timeout": false})
+		require.False(t, m.Result(ok))
+	})
+
+	t.Run("or condition across kind and substring", func(t *testing.T) {
+		m := &Matcher{
+			Type:      MatcherTypeHolder{MatcherType: ErrorMatcher},
+			Errors:    []string{"timeout", "no such host"},
+			Condition: "or",
+		}
+		require.NoError(t, m.CompileMatchers())
+		ok, _ := m.MatchError(map[string]interface{}{"error": "lookup x: no such host", "error_type": "connection", "timeout": false})
+		require.True(t, m.Result(ok))
+		ok, _ = m.MatchError(map[string]interface{}{"error": "i/o timeout", "error_type": "timeout", "timeout": true})
+		require.True(t, m.Result(ok))
+		ok, _ = m.MatchError(map[string]interface{}{"error": "broken pipe", "error_type": "connection", "timeout": false})
+		require.False(t, m.Result(ok))
+	})
+
+	t.Run("and condition requires all", func(t *testing.T) {
+		m := &Matcher{
+			Type:      MatcherTypeHolder{MatcherType: ErrorMatcher},
+			Errors:    []string{"dial tcp", "connection refused"},
+			Condition: "and",
+		}
+		require.NoError(t, m.CompileMatchers())
+		ok, snippets := m.MatchError(map[string]interface{}{"error": "dial tcp 127.0.0.1:1: connection refused", "error_type": "connection", "timeout": false})
+		require.True(t, m.Result(ok))
+		require.Equal(t, []string{"dial tcp", "connection refused"}, snippets)
+
+		ok, _ = m.MatchError(map[string]interface{}{"error": "dial tcp: i/o timeout", "error_type": "timeout", "timeout": true})
+		require.False(t, m.Result(ok))
+	})
+
+	t.Run("match-all returns every matching snippet", func(t *testing.T) {
+		m := &Matcher{
+			Type:      MatcherTypeHolder{MatcherType: ErrorMatcher},
+			Errors:    []string{"dial tcp", "connection refused", "missing"},
+			Condition: "or",
+			MatchAll:  true,
+		}
+		require.NoError(t, m.CompileMatchers())
+		ok, snippets := m.MatchError(map[string]interface{}{"error": "dial tcp 127.0.0.1:1: connection refused", "error_type": "connection", "timeout": false})
+		require.True(t, m.Result(ok))
+		require.Equal(t, []string{"dial tcp", "connection refused"}, snippets)
+	})
+
+	t.Run("negative", func(t *testing.T) {
+		m := &Matcher{Type: MatcherTypeHolder{MatcherType: ErrorMatcher}, Errors: []string{"timeout"}, Negative: true}
+		require.NoError(t, m.CompileMatchers())
+		ok, snippets := m.MatchError(map[string]interface{}{"error": "i/o timeout", "error_type": "timeout", "timeout": true})
+		matched, out := m.ResultWithMatchedSnippet(ok, snippets)
+		require.False(t, matched)
+		require.Empty(t, out)
+		ok, _ = m.MatchError(map[string]interface{}{})
+		require.True(t, m.Result(ok))
+	})
+}
+
+func TestHasErrorMatchersViaOperatorsPackage(t *testing.T) {
+	m := &Matcher{Type: MatcherTypeHolder{MatcherType: ErrorMatcher}, Errors: []string{"timeout"}}
+	require.NoError(t, m.CompileMatchers())
+	require.Equal(t, ErrorMatcher, m.GetType())
+	require.False(t, m.NeedsPart())
+}

--- a/pkg/operators/matchers/fuzz_harness.go
+++ b/pkg/operators/matchers/fuzz_harness.go
@@ -13,7 +13,7 @@ const (
 )
 
 var (
-	fuzzMatcherTypes = []MatcherType{WordsMatcher, RegexMatcher, BinaryMatcher, StatusMatcher, SizeMatcher, DSLMatcher, XPathMatcher}
+	fuzzMatcherTypes = []MatcherType{WordsMatcher, RegexMatcher, BinaryMatcher, StatusMatcher, SizeMatcher, DSLMatcher, XPathMatcher, ErrorMatcher}
 	fuzzConditions   = []string{"", "and", "or"}
 	fuzzEncodings    = []string{"", "hex"}
 	fuzzParts        = []string{"", "body", "raw", "all_headers", "header", "response"}
@@ -193,10 +193,18 @@ func (candidate *fuzzMatcherCandidate) build() (*Matcher, bool) {
 		matcher.Status = append([]int(nil), candidate.status...)
 	case SizeMatcher:
 		matcher.Size = append([]int(nil), candidate.size...)
+	case ErrorMatcher:
+		matcher.Part = ""
+		matcher.Encoding = ""
+		matcher.CaseInsensitive = false
+		matcher.Errors = append([]string(nil), candidate.values...)
 	default:
 		matcher.Words = append([]string(nil), candidate.values...)
 	}
 
+	if matcher.GetType() == ErrorMatcher {
+		return matcher, true
+	}
 	if matcher.GetType() == StatusMatcher || matcher.GetType() == SizeMatcher {
 		return matcher, len(matcher.Status) > 0 || len(matcher.Size) > 0
 	}

--- a/pkg/operators/matchers/match.go
+++ b/pkg/operators/matchers/match.go
@@ -250,6 +250,93 @@ func (matcher *Matcher) MatchDSL(data map[string]interface{}) bool {
 	return false
 }
 
+// MatchError matches request execution errors exposed on the event map.
+//
+// Errors values may be:
+//   - kinds: timeout, connection, connect, any, * (classify via error_type / timeout)
+//   - any other string: substring match against the error message
+//
+// An empty Errors list matches any request error. Condition (and/or), MatchAll,
+// and CaseInsensitive apply the same way as word matchers.
+func (matcher *Matcher) MatchError(data map[string]interface{}) (bool, []string) {
+	errVal, ok := data["error"]
+	if !ok || errVal == nil {
+		return false, []string{}
+	}
+	errStr, _ := errVal.(string)
+	if errStr == "" {
+		return false, []string{}
+	}
+
+	if len(matcher.Errors) == 0 {
+		return true, []string{errStr}
+	}
+
+	corpus := errStr
+	if matcher.CaseInsensitive {
+		corpus = strings.ToLower(corpus)
+	}
+
+	errType, _ := data["error_type"].(string)
+	isTimeout, _ := data["timeout"].(bool)
+
+	var matched []string
+	for i, item := range matcher.Errors {
+		item = strings.TrimSpace(item)
+		if item == "" {
+			if matcher.condition == ANDCondition {
+				return false, []string{}
+			}
+			continue
+		}
+
+		okMatch, snippet := matcher.matchErrorItem(item, errStr, corpus, errType, isTimeout)
+		if !okMatch {
+			if matcher.condition == ANDCondition {
+				return false, []string{}
+			}
+			continue
+		}
+
+		if matcher.condition == ORCondition && !matcher.MatchAll {
+			return true, []string{snippet}
+		}
+		matched = append(matched, snippet)
+
+		if len(matcher.Errors)-1 == i && !matcher.MatchAll {
+			return true, matched
+		}
+	}
+	if len(matched) > 0 && matcher.MatchAll {
+		return true, matched
+	}
+	return false, []string{}
+}
+
+func (matcher *Matcher) matchErrorItem(item, errStr, corpus, errType string, isTimeout bool) (bool, string) {
+	switch strings.ToLower(item) {
+	case "timeout":
+		if isTimeout || errType == "timeout" {
+			return true, item
+		}
+	case "connection", "connect":
+		if errType == "connection" {
+			return true, item
+		}
+	case "any", "*":
+		return true, errStr
+	default:
+		needle := item
+		if matcher.CaseInsensitive {
+			needle = strings.ToLower(item)
+		}
+		if strings.Contains(corpus, needle) {
+			return true, item
+		}
+	}
+	return false, ""
+}
+
 // MatchXPath matches on a generic map result
 func (matcher *Matcher) MatchXPath(corpus string) bool {
 	if strings.HasPrefix(corpus, "<?xml") {

--- a/pkg/operators/matchers/matchers.go
+++ b/pkg/operators/matchers/matchers.go
@@ -10,7 +10,7 @@ import (
 type Matcher struct {
 	// description: |
 	//   Type is the type of the matcher.
-	Type MatcherTypeHolder `yaml:"type" json:"type" jsonschema:"title=type of matcher,description=Type of the matcher,enum=status,enum=size,enum=word,enum=regex,enum=binary,enum=dsl"`
+	Type MatcherTypeHolder `yaml:"type" json:"type" jsonschema:"title=type of matcher,description=Type of the matcher,enum=status,enum=size,enum=word,enum=regex,enum=binary,enum=dsl,enum=xpath,enum=error"`
 	// description: |
 	//   Condition is the optional condition between two matcher variables. By default,
 	//   the condition is assumed to be OR.
@@ -103,6 +103,20 @@ type Matcher struct {
 	//     value: >
 	//       []string{"//a[@target=\"_blank\"]"}
 	XPath []string `yaml:"xpath,omitempty" json:"xpath,omitempty" jsonschema:"title=xpath queries to match in response,description=xpath are the XPath queries that will be evaluated against the response part of nuclei matching rules"`
+	// description: |
+	//   Errors are patterns matched against a failed request (no successful response).
+	//
+	//   Reserved kinds (matched via error classification): timeout, connection, any.
+	//   Any other value is treated as a substring of the error message.
+	//   When empty, any request error matches.
+	// examples:
+	//   - name: Match request timeouts by kind
+	//     value: >
+	//       []string{"timeout"}
+	//   - name: Match a substring in the error message
+	//     value: >
+	//       []string{"connection refused"}
+	Errors []string `yaml:"errors,omitempty" json:"errors,omitempty" jsonschema:"title=error patterns to match,description=Error kinds (timeout, connection, any) or substrings of the error message"`
 	// description: |
 	//   Encoding specifies the encoding for the words field if any.
 	// values:

--- a/pkg/operators/matchers/matchers_types.go
+++ b/pkg/operators/matchers/matchers_types.go
@@ -27,6 +27,8 @@ const (
 	DSLMatcher
 	// name:xpath
 	XPathMatcher
+	// name:error
+	ErrorMatcher
 	limit
 )
 
@@ -39,6 +41,7 @@ var MatcherTypes = map[MatcherType]string{
 	BinaryMatcher: "binary",
 	DSLMatcher:    "dsl",
 	XPathMatcher:  "xpath",
+	ErrorMatcher:  "error",
 }
 
 // GetType returns the type of the matcher

--- a/pkg/operators/matchers/validate.go
+++ b/pkg/operators/matchers/validate.go
@@ -48,6 +48,8 @@ func (matcher *Matcher) Validate() error {
 		expectedFields = append(commonExpectedFields, "Regex", "Part", "Encoding", "CaseInsensitive")
 	case XPathMatcher:
 		expectedFields = append(commonExpectedFields, "XPath", "Part")
+	case ErrorMatcher:
+		expectedFields = append(commonExpectedFields, "Errors", "CaseInsensitive")
 	}
 
 	if err = checkFields(matcher, matcherMap, expectedFields...); err != nil {

--- a/pkg/operators/operators.go
+++ b/pkg/operators/operators.go
@@ -81,6 +81,56 @@ func (operators *Operators) HasDSL() bool {
 	return false
 }
 
+// HasErrorMatchers reports whether operators include an error matcher or a DSL
+// expression that references request-error fields (timeout / error / error_type).
+// When true, protocols should still run matchers on failed requests and should
+// not skip the template solely because the host is marked unresponsive.
+func (operators *Operators) HasErrorMatchers() bool {
+	if operators == nil {
+		return false
+	}
+	for _, matcher := range operators.Matchers {
+		if matcher.GetType() == matchers.ErrorMatcher {
+			return true
+		}
+		if matcher.GetType() == matchers.DSLMatcher {
+			for _, expr := range matcher.DSL {
+				if dslReferencesRequestError(expr) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func dslReferencesRequestError(expr string) bool {
+	lower := strings.ToLower(expr)
+	// word-ish checks so we don't treat unrelated identifiers as error matchers
+	for _, token := range []string{"timeout", "error_type", "error"} {
+		idx := 0
+		for {
+			i := strings.Index(lower[idx:], token)
+			if i < 0 {
+				break
+			}
+			i += idx
+			beforeOK := i == 0 || !isIdentByte(lower[i-1])
+			after := i + len(token)
+			afterOK := after >= len(lower) || !isIdentByte(lower[after])
+			if beforeOK && afterOK {
+				return true
+			}
+			idx = after
+		}
+	}
+	return false
+}
+
+func isIdentByte(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= '0' && b <= '9') || b == '_'
+}
+
 // GetMatchersCondition returns the condition for the matchers
 func (operators *Operators) GetMatchersCondition() matchers.ConditionType {
 	return operators.matchersCondition

--- a/pkg/protocols/code/code.go
+++ b/pkg/protocols/code/code.go
@@ -29,6 +29,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/interactsh"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/utils/vardump"
 	protocolutils "github.com/projectdiscovery/nuclei/v3/pkg/protocols/utils"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/utils/requesterr"
 	templateTypes "github.com/projectdiscovery/nuclei/v3/pkg/templates/types"
 	"github.com/projectdiscovery/nuclei/v3/pkg/types"
 	contextutil "github.com/projectdiscovery/utils/context"
@@ -332,6 +333,9 @@ func (request *Request) ExecuteWithResults(input *contextargs.Context, dynamicVa
 	data["template-info"] = request.options.TemplateInfo
 	if gOutput.Stderr.Len() > 0 {
 		data["stderr"] = fmtStdout(gOutput.Stderr.String())
+	}
+	if err != nil {
+		requesterr.Annotate(data, err, 0)
 	}
 
 	// expose response variables in proto_var format

--- a/pkg/protocols/dns/operators.go
+++ b/pkg/protocols/dns/operators.go
@@ -21,7 +21,7 @@ import (
 // Match matches a generic data response against a given matcher
 func (request *Request) Match(data map[string]interface{}, matcher *matchers.Matcher) (bool, []string) {
 	item, ok := request.getMatchPart(matcher.Part, data)
-	if !ok && matcher.Type.MatcherType != matchers.DSLMatcher {
+	if !ok && matcher.NeedsPart() {
 		return false, []string{}
 	}
 
@@ -44,6 +44,8 @@ func (request *Request) Match(data map[string]interface{}, matcher *matchers.Mat
 		return matcher.Result(matcher.MatchDSL(data)), []string{}
 	case matchers.XPathMatcher:
 		return matcher.Result(matcher.MatchXPath(types.ToString(item))), []string{}
+	case matchers.ErrorMatcher:
+		return matcher.ResultWithMatchedSnippet(matcher.MatchError(data))
 	}
 	return false, []string{}
 }

--- a/pkg/protocols/dns/request.go
+++ b/pkg/protocols/dns/request.go
@@ -22,6 +22,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/helpers/responsehighlighter"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/utils/vardump"
 	protocolutils "github.com/projectdiscovery/nuclei/v3/pkg/protocols/utils"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/utils/requesterr"
 	templateTypes "github.com/projectdiscovery/nuclei/v3/pkg/templates/types"
 	"github.com/projectdiscovery/retryabledns"
 	iputil "github.com/projectdiscovery/utils/ip"
@@ -175,6 +176,23 @@ func (request *Request) execute(input *contextargs.Context, domain string, metad
 		request.options.Progress.IncrementRequests()
 	}
 	if response == nil {
+		if err != nil && request.CompiledOperators != nil && request.CompiledOperators.HasErrorMatchers() {
+			outputEvent := output.InternalEvent{
+				"host":          domain,
+				"matched":       question,
+				"request":       requestString,
+				"duration":      duration.Seconds(),
+				"template-id":   request.options.TemplateID,
+				"template-info": request.options.TemplateInfo,
+				"template-path": request.options.TemplatePath,
+				"type":          request.Type().String(),
+			}
+			maps.Copy(outputEvent, previous)
+			maps.Copy(outputEvent, vars)
+			requesterr.Annotate(outputEvent, err, duration)
+			event := eventcreator.CreateEvent(request, outputEvent, request.options.Options.Debug || request.options.Options.DebugResponse)
+			callback(event)
+		}
 		return errors.Wrap(err, "could not send dns request")
 	}
 

--- a/pkg/protocols/file/operators.go
+++ b/pkg/protocols/file/operators.go
@@ -15,7 +15,7 @@ import (
 // Match matches a generic data response again a given matcher
 func (request *Request) Match(data map[string]interface{}, matcher *matchers.Matcher) (bool, []string) {
 	itemStr, ok := request.getMatchPart(matcher.Part, data)
-	if !ok && matcher.Type.MatcherType != matchers.DSLMatcher {
+	if !ok && matcher.NeedsPart() {
 		return false, []string{}
 	}
 
@@ -32,6 +32,8 @@ func (request *Request) Match(data map[string]interface{}, matcher *matchers.Mat
 		return matcher.Result(matcher.MatchDSL(data)), []string{}
 	case matchers.XPathMatcher:
 		return matcher.Result(matcher.MatchXPath(itemStr)), []string{}
+	case matchers.ErrorMatcher:
+		return matcher.ResultWithMatchedSnippet(matcher.MatchError(data))
 	}
 	return false, []string{}
 }

--- a/pkg/protocols/headless/operators.go
+++ b/pkg/protocols/headless/operators.go
@@ -17,7 +17,7 @@ import (
 // Match matches a generic data response again a given matcher
 func (request *Request) Match(data map[string]interface{}, matcher *matchers.Matcher) (bool, []string) {
 	itemStr, ok := request.getMatchPart(matcher.Part, data)
-	if !ok && matcher.Type.MatcherType != matchers.DSLMatcher {
+	if !ok && matcher.NeedsPart() {
 		return false, []string{}
 	}
 
@@ -40,6 +40,8 @@ func (request *Request) Match(data map[string]interface{}, matcher *matchers.Mat
 		return matcher.Result(matcher.MatchDSL(data)), []string{}
 	case matchers.XPathMatcher:
 		return matcher.Result(matcher.MatchXPath(itemStr)), []string{}
+	case matchers.ErrorMatcher:
+		return matcher.ResultWithMatchedSnippet(matcher.MatchError(data))
 	}
 	return false, []string{}
 }

--- a/pkg/protocols/headless/request.go
+++ b/pkg/protocols/headless/request.go
@@ -23,6 +23,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/render"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/headless/engine"
 	protocolutils "github.com/projectdiscovery/nuclei/v3/pkg/protocols/utils"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/utils/requesterr"
 	templateTypes "github.com/projectdiscovery/nuclei/v3/pkg/templates/types"
 	"github.com/projectdiscovery/nuclei/v3/pkg/types"
 	urlutil "github.com/projectdiscovery/utils/url"
@@ -165,6 +166,14 @@ func (request *Request) executeRequestWithPayloads(input *contextargs.Context, p
 	if err != nil {
 		request.options.Output.Request(request.options.TemplatePath, input.MetaInput.Input, request.Type().String(), err)
 		request.options.Progress.IncrementFailedRequestsBy(1)
+		if request.CompiledOperators != nil && request.CompiledOperators.HasErrorMatchers() {
+			outputEvent := request.responseToDSLMap("", "", "", "", input.MetaInput.Input, input.MetaInput.Input, "")
+			outputEvent["duration"] = runDuration.Seconds()
+			maps.Copy(outputEvent, payloads)
+			requesterr.Annotate(outputEvent, err, runDuration)
+			event := eventcreator.CreateEvent(request, outputEvent, request.options.Options.Debug || request.options.Options.DebugResponse)
+			callback(event)
+		}
 		return errors.Wrap(err, errCouldNotGetHtmlElement)
 	}
 	defer page.Close()

--- a/pkg/protocols/http/operators.go
+++ b/pkg/protocols/http/operators.go
@@ -21,7 +21,7 @@ import (
 // TODO: Try to consolidate this in protocols.MakeDefaultMatchFunc to avoid any inconsistencies
 func (request *Request) Match(data map[string]interface{}, matcher *matchers.Matcher) (bool, []string) {
 	item, ok := request.getMatchPart(matcher.Part, data)
-	if !ok && matcher.Type.MatcherType != matchers.DSLMatcher {
+	if !ok && matcher.NeedsPart() {
 		return false, []string{}
 	}
 
@@ -44,6 +44,8 @@ func (request *Request) Match(data map[string]interface{}, matcher *matchers.Mat
 		return matcher.Result(matcher.MatchDSL(data)), []string{}
 	case matchers.XPathMatcher:
 		return matcher.Result(matcher.MatchXPath(item)), []string{}
+	case matchers.ErrorMatcher:
+		return matcher.ResultWithMatchedSnippet(matcher.MatchError(data))
 	}
 	return false, []string{}
 }
@@ -127,6 +129,7 @@ func (request *Request) responseToDSLMap(resp *http.Response, host, matched, raw
 	request.setHashOrDefault(data, "all_headers", headers)
 	request.setHashOrDefault(data, "header", headers)
 	data["duration"] = duration.Seconds()
+	data["timeout"] = false
 	data["template-id"] = request.options.TemplateID
 	data["template-info"] = request.options.TemplateInfo
 	data["template-path"] = request.options.TemplatePath

--- a/pkg/protocols/http/operators_test.go
+++ b/pkg/protocols/http/operators_test.go
@@ -41,7 +41,7 @@ func TestResponseToDSLMap(t *testing.T) {
 	matched := "http://example.com/test/?test=1"
 
 	event := request.responseToDSLMap(resp, host, matched, exampleRawRequest, exampleRawResponse, exampleResponseBody, exampleResponseHeader, 1*time.Second, map[string]interface{}{})
-	require.Len(t, event, 15, "could not get correct number of items in dsl map")
+	require.Len(t, event, 16, "could not get correct number of items in dsl map")
 	require.Equal(t, exampleRawResponse, event["response"], "could not get correct resp")
 	require.Equal(t, "Test-Response", event["test"], "could not get correct resp for header")
 }
@@ -71,7 +71,7 @@ func TestHTTPOperatorMatch(t *testing.T) {
 	matched := "http://example.com/test/?test=1"
 
 	event := request.responseToDSLMap(resp, host, matched, exampleRawRequest, exampleRawResponse, exampleResponseBody, exampleResponseHeader, 1*time.Second, map[string]interface{}{})
-	require.Len(t, event, 15, "could not get correct number of items in dsl map")
+	require.Len(t, event, 16, "could not get correct number of items in dsl map")
 	require.Equal(t, exampleRawResponse, event["response"], "could not get correct resp")
 	require.Equal(t, "Test-Response", event["test"], "could not get correct resp for header")
 
@@ -159,7 +159,7 @@ func TestHTTPOperatorExtract(t *testing.T) {
 	matched := "http://example.com/test/?test=1"
 
 	event := request.responseToDSLMap(resp, host, matched, exampleRawRequest, exampleRawResponse, exampleResponseBody, exampleResponseHeader, 1*time.Second, map[string]interface{}{})
-	require.Len(t, event, 15, "could not get correct number of items in dsl map")
+	require.Len(t, event, 16, "could not get correct number of items in dsl map")
 	require.Equal(t, exampleRawResponse, event["response"], "could not get correct resp")
 	require.Equal(t, "Test-Response", event["test_header"], "could not get correct resp for header")
 
@@ -286,7 +286,7 @@ func TestHTTPMakeResult(t *testing.T) {
 	matched := "http://example.com/test/?test=1"
 
 	event := request.responseToDSLMap(resp, host, matched, exampleRawRequest, exampleRawResponse, exampleResponseBody, exampleResponseHeader, 1*time.Second, map[string]interface{}{})
-	require.Len(t, event, 15, "could not get correct number of items in dsl map")
+	require.Len(t, event, 16, "could not get correct number of items in dsl map")
 	require.Equal(t, exampleRawResponse, event["response"], "could not get correct resp")
 	require.Equal(t, "Test-Response", event["test"], "could not get correct resp for header")
 

--- a/pkg/protocols/http/request.go
+++ b/pkg/protocols/http/request.go
@@ -37,6 +37,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/http/httputils"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/http/signer"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/http/signerpool"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/utils/requesterr"
 	templateTypes "github.com/projectdiscovery/nuclei/v3/pkg/templates/types"
 	"github.com/projectdiscovery/nuclei/v3/pkg/types"
 	"github.com/projectdiscovery/nuclei/v3/pkg/types/nucleierr"
@@ -945,10 +946,9 @@ func (request *Request) executeRequest(input *contextargs.Context, generatedRequ
 		request.options.Output.Request(request.options.TemplatePath, formedURL, request.Type().String(), err)
 		request.options.Progress.IncrementErrorsBy(1)
 
-		// In case of interactsh markers and request times out, still send
-		// a callback event so in case we receive an interaction, correlation is possible.
-		// Also, to log failed use-cases.
-		outputEvent := request.responseToDSLMap(&http.Response{}, input.MetaInput.Input, formedURL, convUtil.String(dumpedRequest), "", "", "", 0, generatedRequest.meta)
+		duration := time.Since(timeStart)
+		outputEvent := request.responseToDSLMap(&http.Response{}, input.MetaInput.Input, formedURL, convUtil.String(dumpedRequest), "", "", "", duration, generatedRequest.meta)
+		requesterr.Annotate(outputEvent, err, duration)
 		if i := strings.LastIndex(hostname, ":"); i != -1 {
 			hostname = hostname[:i]
 		}
@@ -957,16 +957,23 @@ func (request *Request) executeRequest(input *contextargs.Context, generatedRequ
 			outputEvent["ip"] = input.MetaInput.CustomIP
 		} else {
 			outputEvent["ip"] = dialers.Fastdialer.GetDialedIP(hostname)
-			// try getting cname
 			request.addCNameIfAvailable(hostname, outputEvent)
 		}
+		if request.options.Interactsh != nil {
+			request.options.Interactsh.MakePlaceholders(generatedRequest.interactshURLs, outputEvent)
+		}
 
-		if len(generatedRequest.interactshURLs) > 0 {
-			// according to logic we only need to trigger a callback if interactsh was used
-			// and request failed in hope that later on oast interaction will be received
-			event := &output.InternalWrappedEvent{}
-			if request.CompiledOperators != nil && request.CompiledOperators.HasDSL() {
-				event.InternalEvent = outputEvent
+		hasErrorMatchers := request.CompiledOperators != nil && request.CompiledOperators.HasErrorMatchers()
+		if hasErrorMatchers || len(generatedRequest.interactshURLs) > 0 {
+			var event *output.InternalWrappedEvent
+			if hasErrorMatchers {
+				event = eventcreator.CreateEvent(request, outputEvent, request.options.Options.Debug || request.options.Options.DebugResponse)
+			} else {
+				// Interactsh-only failure path: keep a lightweight event for later OAST correlation.
+				event = &output.InternalWrappedEvent{}
+				if request.CompiledOperators != nil && request.CompiledOperators.HasDSL() {
+					event.InternalEvent = outputEvent
+				}
 			}
 			callback(event)
 		}
@@ -1397,8 +1404,13 @@ func (request *Request) recordHostResultAndCancelIfUnresponsive(input *contextar
 	}
 }
 
-// isUnresponsiveAddress checks if the error is a unreponsive based on its execution history
+// isUnresponsiveAddress checks if the host is marked unresponsive based on
+// execution history. Templates with error/timeout matchers intentionally bypass
+// this skip so they can still observe and match request failures.
 func (request *Request) isUnresponsiveAddress(input *contextargs.Context) bool {
+	if request.CompiledOperators != nil && request.CompiledOperators.HasErrorMatchers() {
+		return false
+	}
 	if request.options.HostErrorsCache != nil {
 		return request.options.HostErrorsCache.Check(request.options.ProtocolType.String(), input)
 	}

--- a/pkg/protocols/http/request_test.go
+++ b/pkg/protocols/http/request_test.go
@@ -727,3 +727,193 @@ func TestExecuteParallelHTTP_GoroutineLeaks(t *testing.T) {
 		require.Equal(t, context.Canceled, err)
 	})
 }
+
+func TestHTTPErrorMatcherOnConnectionFailure(t *testing.T) {
+	options := testutils.DefaultOptions
+	testutils.Init(options)
+
+	templateID := "http-error-matcher"
+	request := &Request{
+		ID:     templateID,
+		Method: HTTPMethodTypeHolder{MethodType: HTTPGet},
+		Path:   []string{"{{BaseURL}}/"},
+		Operators: operators.Operators{
+			Matchers: []*matchers.Matcher{{
+				Type:   matchers.MatcherTypeHolder{MatcherType: matchers.ErrorMatcher},
+				Errors: []string{"connection"},
+			}},
+		},
+	}
+
+	executerOpts := testutils.NewMockExecuterOptions(options, &testutils.TemplateInfo{
+		ID:   templateID,
+		Info: model.Info{SeverityHolder: severity.Holder{Severity: severity.Low}, Name: "test"},
+	})
+	err := request.Compile(executerOpts)
+	require.NoError(t, err)
+
+	var matched bool
+	var event *output.InternalWrappedEvent
+	ctxArgs := contextargs.NewWithInput(context.Background(), "http://127.0.0.1:1")
+	err = request.ExecuteWithResults(ctxArgs, nil, nil, func(e *output.InternalWrappedEvent) {
+		event = e
+		if e.OperatorsResult != nil && e.OperatorsResult.Matched {
+			matched = true
+		}
+	})
+	require.Error(t, err)
+	require.NotNil(t, event)
+	require.True(t, matched, "connection error should match type: error matcher")
+	require.Equal(t, "connection", event.InternalEvent["error_type"])
+	require.Equal(t, false, event.InternalEvent["timeout"])
+}
+
+func TestHTTPErrorMatcherSubstring(t *testing.T) {
+	options := testutils.DefaultOptions
+	testutils.Init(options)
+
+	templateID := "http-error-substring"
+	request := &Request{
+		ID:     templateID,
+		Method: HTTPMethodTypeHolder{MethodType: HTTPGet},
+		Path:   []string{"{{BaseURL}}/"},
+		Operators: operators.Operators{
+			Matchers: []*matchers.Matcher{{
+				Type:   matchers.MatcherTypeHolder{MatcherType: matchers.ErrorMatcher},
+				Errors: []string{"connection refused"},
+			}},
+		},
+	}
+	executerOpts := testutils.NewMockExecuterOptions(options, &testutils.TemplateInfo{
+		ID:   templateID,
+		Info: model.Info{SeverityHolder: severity.Holder{Severity: severity.Low}, Name: "test"},
+	})
+	require.NoError(t, request.Compile(executerOpts))
+
+	var matched bool
+	ctxArgs := contextargs.NewWithInput(context.Background(), "http://127.0.0.1:1")
+	err := request.ExecuteWithResults(ctxArgs, nil, nil, func(e *output.InternalWrappedEvent) {
+		if e.OperatorsResult != nil && e.OperatorsResult.Matched {
+			matched = true
+		}
+	})
+	require.Error(t, err)
+	require.True(t, matched)
+}
+
+func TestHTTPErrorMatcherDSL(t *testing.T) {
+	options := testutils.DefaultOptions
+	testutils.Init(options)
+
+	templateID := "http-error-dsl"
+	request := &Request{
+		ID:     templateID,
+		Method: HTTPMethodTypeHolder{MethodType: HTTPGet},
+		Path:   []string{"{{BaseURL}}/"},
+		Operators: operators.Operators{
+			Matchers: []*matchers.Matcher{{
+				Type: matchers.MatcherTypeHolder{MatcherType: matchers.DSLMatcher},
+				DSL:  []string{`error_type == "connection"`},
+			}},
+		},
+	}
+	executerOpts := testutils.NewMockExecuterOptions(options, &testutils.TemplateInfo{
+		ID:   templateID,
+		Info: model.Info{SeverityHolder: severity.Holder{Severity: severity.Low}, Name: "test"},
+	})
+	require.NoError(t, request.Compile(executerOpts))
+
+	var matched bool
+	ctxArgs := contextargs.NewWithInput(context.Background(), "http://127.0.0.1:1")
+	err := request.ExecuteWithResults(ctxArgs, nil, nil, func(e *output.InternalWrappedEvent) {
+		if e.OperatorsResult != nil && e.OperatorsResult.Matched {
+			matched = true
+		}
+	})
+	require.Error(t, err)
+	require.True(t, matched, "DSL error_type matcher should fire on connection failure")
+}
+
+func TestHTTPErrorMatcherBypassesHostErrorsCache(t *testing.T) {
+	options := testutils.DefaultOptions
+	testutils.Init(options)
+
+	templateID := "http-error-host-cache"
+	request := &Request{
+		ID:     templateID,
+		Method: HTTPMethodTypeHolder{MethodType: HTTPGet},
+		Path:   []string{"{{BaseURL}}/"},
+		Operators: operators.Operators{
+			Matchers: []*matchers.Matcher{{
+				Type:   matchers.MatcherTypeHolder{MatcherType: matchers.ErrorMatcher},
+				Errors: []string{"connection"},
+			}},
+		},
+	}
+	executerOpts := testutils.NewMockExecuterOptions(options, &testutils.TemplateInfo{
+		ID:   templateID,
+		Info: model.Info{SeverityHolder: severity.Holder{Severity: severity.Low}, Name: "test"},
+	})
+	// Host is marked unresponsive; without error matchers the request would be skipped.
+	executerOpts.HostErrorsCache = &spyHostErrorsCache{skip: true}
+	require.NoError(t, request.Compile(executerOpts))
+
+	var matched bool
+	var callbacks int
+	ctxArgs := contextargs.NewWithInput(context.Background(), "http://127.0.0.1:1")
+	err := request.ExecuteWithResults(ctxArgs, nil, nil, func(e *output.InternalWrappedEvent) {
+		callbacks++
+		if e.OperatorsResult != nil && e.OperatorsResult.Matched {
+			matched = true
+		}
+	})
+	require.Error(t, err)
+	require.Equal(t, 1, callbacks, "error matcher should bypass host-errors skip")
+	require.True(t, matched)
+}
+
+func TestHTTPErrorMatcherTimeout(t *testing.T) {
+	options := testutils.DefaultOptions.Copy()
+	options.Timeout = 1
+	testutils.Init(options)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(3 * time.Second)
+	}))
+	defer ts.Close()
+
+	templateID := "http-error-timeout"
+	request := &Request{
+		ID: templateID,
+		Raw: []string{`@timeout: 1s
+GET / HTTP/1.1
+Host: {{Hostname}}
+`},
+		Operators: operators.Operators{
+			Matchers: []*matchers.Matcher{{
+				Type:   matchers.MatcherTypeHolder{MatcherType: matchers.ErrorMatcher},
+				Errors: []string{"timeout"},
+			}},
+		},
+	}
+	executerOpts := testutils.NewMockExecuterOptions(options, &testutils.TemplateInfo{
+		ID:   templateID,
+		Info: model.Info{SeverityHolder: severity.Holder{Severity: severity.Low}, Name: "test"},
+	})
+	require.NoError(t, request.Compile(executerOpts))
+
+	var matched bool
+	var event *output.InternalWrappedEvent
+	ctxArgs := contextargs.NewWithInput(context.Background(), ts.URL)
+	err := request.ExecuteWithResults(ctxArgs, nil, nil, func(e *output.InternalWrappedEvent) {
+		event = e
+		if e.OperatorsResult != nil && e.OperatorsResult.Matched {
+			matched = true
+		}
+	})
+	require.Error(t, err)
+	require.NotNil(t, event)
+	require.True(t, matched, "timeout error should match type: error matcher")
+	require.Equal(t, true, event.InternalEvent["timeout"])
+	require.Equal(t, "timeout", event.InternalEvent["error_type"])
+}

--- a/pkg/protocols/javascript/js.go
+++ b/pkg/protocols/javascript/js.go
@@ -32,6 +32,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/render"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/utils/vardump"
 	protocolutils "github.com/projectdiscovery/nuclei/v3/pkg/protocols/utils"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/utils/requesterr"
 	templateTypes "github.com/projectdiscovery/nuclei/v3/pkg/templates/types"
 	"github.com/projectdiscovery/nuclei/v3/pkg/types"
 	"github.com/projectdiscovery/utils/errkit"
@@ -663,6 +664,9 @@ func (request *Request) executeRequestWithPayloads(
 	values := mapsutil.Merge(payloadValues, results)
 	// generate event data
 	data := request.generateEventData(input, values, hostPort)
+	if err != nil {
+		requesterr.Annotate(data, err, 0)
+	}
 
 	// add and get values from templatectx
 	request.options.AddTemplateVars(input.MetaInput, request.Type(), request.GetID(), data)

--- a/pkg/protocols/network/operators.go
+++ b/pkg/protocols/network/operators.go
@@ -16,7 +16,7 @@ import (
 // Match matches a generic data response again a given matcher
 func (request *Request) Match(data map[string]interface{}, matcher *matchers.Matcher) (bool, []string) {
 	itemStr, ok := request.getMatchPart(matcher.Part, data)
-	if !ok && matcher.Type.MatcherType != matchers.DSLMatcher {
+	if !ok && matcher.NeedsPart() {
 		return false, []string{}
 	}
 
@@ -33,6 +33,8 @@ func (request *Request) Match(data map[string]interface{}, matcher *matchers.Mat
 		return matcher.Result(matcher.MatchDSL(data)), []string{}
 	case matchers.XPathMatcher:
 		return matcher.Result(matcher.MatchXPath(itemStr)), []string{}
+	case matchers.ErrorMatcher:
+		return matcher.ResultWithMatchedSnippet(matcher.MatchError(data))
 	}
 	return false, []string{}
 }

--- a/pkg/protocols/network/request.go
+++ b/pkg/protocols/network/request.go
@@ -30,6 +30,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/utils/vardump"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/network/networkclientpool"
 	protocolutils "github.com/projectdiscovery/nuclei/v3/pkg/protocols/utils"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/utils/requesterr"
 	templateTypes "github.com/projectdiscovery/nuclei/v3/pkg/templates/types"
 	"github.com/projectdiscovery/utils/errkit"
 	mapsutil "github.com/projectdiscovery/utils/maps"
@@ -335,6 +336,7 @@ func (request *Request) executeRequestWithPayloads(variables map[string]interfac
 	if err != nil {
 		request.options.Output.Request(request.options.TemplatePath, address, request.Type().String(), err)
 		request.options.Progress.IncrementFailedRequestsBy(1)
+		request.emitErrorEvent(callback, err, address, actualAddress, payloads, hostname)
 		return errors.Wrap(err, "could not connect to server")
 	}
 	defer func() {
@@ -392,12 +394,14 @@ func (request *Request) executeRequestWithPayloads(variables map[string]interfac
 		if _, err := conn.Write(dataInBytes); err != nil {
 			request.options.Output.Request(request.options.TemplatePath, address, request.Type().String(), err)
 			request.options.Progress.IncrementFailedRequestsBy(1)
+			request.emitErrorEvent(callback, err, address, actualAddress, payloads, hostname)
 			return errors.Wrap(err, "could not write request to server")
 		}
 
 		if input.Read > 0 {
 			buffer, err := ConnReadNWithTimeout(conn, int64(input.Read), request.options.Options.GetTimeouts().TcpReadTimeout)
 			if err != nil {
+				request.emitErrorEvent(callback, err, address, actualAddress, payloads, hostname)
 				return errkit.Wrap(err, "could not read response from connection")
 			}
 			stepDurations = append(stepDurations, time.Since(timeStart))
@@ -456,6 +460,9 @@ func (request *Request) executeRequestWithPayloads(variables map[string]interfac
 
 	response := responseBuilder.String()
 	outputEvent := request.responseToDSLMap(reqBuilder.String(), string(final), response, input.MetaInput.Input, actualAddress)
+	if readErr != nil {
+		requesterr.Annotate(outputEvent, readErr, 0)
+	}
 	addDurationFields(outputEvent, stepDurations)
 	// add response fields to template context and merge templatectx variables to output event
 	request.options.AddTemplateVars(input.MetaInput, request.Type(), request.ID, outputEvent)
@@ -572,6 +579,22 @@ func ConnReadNWithTimeout(conn net.Conn, n int64, timeout time.Duration) ([]byte
 	return b[:count], nil
 }
 
+// emitErrorEvent creates a matcher event for a failed network I/O operation when
+// the template has error/timeout matchers.
+func (request *Request) emitErrorEvent(callback protocols.OutputEventCallback, err error, address, actualAddress string, payloads map[string]interface{}, hostname string) {
+	if request.CompiledOperators == nil || !request.CompiledOperators.HasErrorMatchers() {
+		return
+	}
+	outputEvent := request.responseToDSLMap("", "", "", address, actualAddress)
+	requesterr.Annotate(outputEvent, err, 0)
+	maps.Copy(outputEvent, payloads)
+	if hostname != "" {
+		outputEvent["ip"] = hostname
+	}
+	event := eventcreator.CreateEvent(request, outputEvent, request.options.Options.Debug || request.options.Options.DebugResponse)
+	callback(event)
+}
+
 // markHostError checks if the error is a unreponsive host error and marks it
 func (request *Request) markHostError(input *contextargs.Context, err error) {
 	if request.options.HostErrorsCache != nil {
@@ -579,8 +602,12 @@ func (request *Request) markHostError(input *contextargs.Context, err error) {
 	}
 }
 
-// isUnresponsiveAddress checks if the error is a unreponsive based on its execution history
+// isUnresponsiveAddress checks if the host is marked unresponsive based on
+// execution history. Templates with error/timeout matchers bypass this skip.
 func (request *Request) isUnresponsiveAddress(input *contextargs.Context) bool {
+	if request.CompiledOperators != nil && request.CompiledOperators.HasErrorMatchers() {
+		return false
+	}
 	if request.options.HostErrorsCache != nil {
 		return request.options.HostErrorsCache.Check(request.options.ProtocolType.String(), input)
 	}

--- a/pkg/protocols/offlinehttp/operators.go
+++ b/pkg/protocols/offlinehttp/operators.go
@@ -20,7 +20,7 @@ import (
 // Match matches a generic data response again a given matcher
 func (request *Request) Match(data map[string]interface{}, matcher *matchers.Matcher) (bool, []string) {
 	item, ok := getMatchPart(matcher.Part, data)
-	if !ok && matcher.Type.MatcherType != matchers.DSLMatcher {
+	if !ok && matcher.NeedsPart() {
 		return false, []string{}
 	}
 
@@ -43,6 +43,8 @@ func (request *Request) Match(data map[string]interface{}, matcher *matchers.Mat
 		return matcher.Result(matcher.MatchDSL(data)), []string{}
 	case matchers.XPathMatcher:
 		return matcher.Result(matcher.MatchXPath(item)), []string{}
+	case matchers.ErrorMatcher:
+		return matcher.ResultWithMatchedSnippet(matcher.MatchError(data))
 	}
 	return false, []string{}
 }

--- a/pkg/protocols/protocols.go
+++ b/pkg/protocols/protocols.go
@@ -445,7 +445,7 @@ func MakeDefaultMatchFunc(data map[string]interface{}, matcher *matchers.Matcher
 	}
 
 	partItem, ok := data[part]
-	if !ok && matcher.Type.MatcherType != matchers.DSLMatcher {
+	if !ok && matcher.NeedsPart() {
 		return false, nil
 	}
 	item := types.ToString(partItem)
@@ -464,6 +464,8 @@ func MakeDefaultMatchFunc(data map[string]interface{}, matcher *matchers.Matcher
 		return matcher.Result(matcher.MatchDSL(data)), nil
 	case matchers.XPathMatcher:
 		return matcher.Result(matcher.MatchXPath(item)), []string{}
+	case matchers.ErrorMatcher:
+		return matcher.ResultWithMatchedSnippet(matcher.MatchError(data))
 	}
 	return false, nil
 }

--- a/pkg/protocols/ssl/ssl.go
+++ b/pkg/protocols/ssl/ssl.go
@@ -27,6 +27,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/utils/vardump"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/network/networkclientpool"
 	protocolutils "github.com/projectdiscovery/nuclei/v3/pkg/protocols/utils"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/utils/requesterr"
 	templateTypes "github.com/projectdiscovery/nuclei/v3/pkg/templates/types"
 	"github.com/projectdiscovery/nuclei/v3/pkg/types"
 	"github.com/projectdiscovery/nuclei/v3/pkg/utils/json"
@@ -260,6 +261,23 @@ func (request *Request) ExecuteWithResults(input *contextargs.Context, dynamicVa
 	if err != nil {
 		requestOptions.Output.Request(requestOptions.TemplateID, input.MetaInput.Input, request.Type().String(), err)
 		requestOptions.Progress.IncrementFailedRequestsBy(1)
+		if request.CompiledOperators != nil && request.CompiledOperators.HasErrorMatchers() {
+			data := make(map[string]interface{})
+			maps.Copy(data, payloadValues)
+			data["type"] = request.Type().String()
+			data["host"] = input.MetaInput.Input
+			data["matched"] = addressToDial
+			data["duration"] = duration.Seconds()
+			data["template-path"] = requestOptions.TemplatePath
+			data["template-id"] = requestOptions.TemplateID
+			data["template-info"] = requestOptions.TemplateInfo
+			if input.MetaInput.CustomIP != "" {
+				data["ip"] = hostIp
+			}
+			requesterr.Annotate(data, err, duration)
+			event := eventcreator.CreateEvent(request, data, requestOptions.Options.Debug || requestOptions.Options.DebugResponse)
+			callback(event)
+		}
 		return errkit.Wrap(err, "could not connect to server")
 	}
 

--- a/pkg/protocols/utils/requesterr/requesterr.go
+++ b/pkg/protocols/utils/requesterr/requesterr.go
@@ -1,0 +1,87 @@
+package requesterr
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"os"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// Kind classifies a request execution error for matcher / DSL use.
+type Kind string
+
+const (
+	KindTimeout    Kind = "timeout"
+	KindConnection Kind = "connection"
+	KindUnknown    Kind = "unknown"
+)
+
+// Classify returns the error kind and whether it is a timeout.
+func Classify(err error) (Kind, bool) {
+	if err == nil {
+		return "", false
+	}
+	if isTimeoutErr(err) {
+		return KindTimeout, true
+	}
+	if isConnectionErr(err) {
+		return KindConnection, false
+	}
+	return KindUnknown, false
+}
+
+// Annotate adds error, error_type, timeout, and optional duration fields to an event map.
+func Annotate(event map[string]interface{}, err error, duration time.Duration) {
+	if event == nil || err == nil {
+		return
+	}
+	kind, isTimeout := Classify(err)
+	event["error"] = err.Error()
+	event["error_type"] = string(kind)
+	event["timeout"] = isTimeout
+	if duration > 0 {
+		event["duration"] = duration.Seconds()
+	}
+}
+
+func isTimeoutErr(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, os.ErrDeadlineExceeded) {
+		return true
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "timeout") ||
+		strings.Contains(msg, "deadline exceeded") ||
+		strings.Contains(msg, "i/o timeout") ||
+		strings.Contains(msg, "client.timeout")
+}
+
+func isConnectionErr(err error) bool {
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+	if errors.Is(err, syscall.ECONNREFUSED) ||
+		errors.Is(err, syscall.ECONNRESET) ||
+		errors.Is(err, syscall.EPIPE) ||
+		errors.Is(err, syscall.ENETUNREACH) ||
+		errors.Is(err, syscall.EHOSTUNREACH) {
+		return true
+	}
+	var opErr *net.OpError
+	if errors.As(err, &opErr) {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "connection refused") ||
+		strings.Contains(msg, "connection reset") ||
+		strings.Contains(msg, "no such host") ||
+		strings.Contains(msg, "network is unreachable") ||
+		strings.Contains(msg, "broken pipe")
+}

--- a/pkg/protocols/utils/requesterr/requesterr_test.go
+++ b/pkg/protocols/utils/requesterr/requesterr_test.go
@@ -1,0 +1,74 @@
+package requesterr
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"os"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestClassifyNil(t *testing.T) {
+	kind, isTimeout := Classify(nil)
+	if kind != "" || isTimeout {
+		t.Fatalf("expected empty kind for nil, got kind=%s isTimeout=%v", kind, isTimeout)
+	}
+}
+
+func TestClassifyTimeout(t *testing.T) {
+	cases := []error{
+		context.DeadlineExceeded,
+		os.ErrDeadlineExceeded,
+		errors.New("Client.Timeout exceeded while awaiting headers"),
+		errors.New("i/o timeout"),
+		errors.New("context deadline exceeded"),
+	}
+	for _, err := range cases {
+		kind, isTimeout := Classify(err)
+		if kind != KindTimeout || !isTimeout {
+			t.Fatalf("expected timeout for %v, got kind=%s isTimeout=%v", err, kind, isTimeout)
+		}
+	}
+}
+
+func TestClassifyConnection(t *testing.T) {
+	cases := []error{
+		syscall.ECONNREFUSED,
+		syscall.ECONNRESET,
+		io.EOF,
+		&net.OpError{Op: "dial", Err: errors.New("connect: connection refused")},
+		errors.New("connection refused"),
+		errors.New("no such host"),
+		errors.New("network is unreachable"),
+	}
+	for _, err := range cases {
+		kind, isTimeout := Classify(err)
+		if kind != KindConnection || isTimeout {
+			t.Fatalf("expected connection for %v, got kind=%s isTimeout=%v", err, kind, isTimeout)
+		}
+	}
+}
+
+func TestClassifyUnknown(t *testing.T) {
+	kind, isTimeout := Classify(errors.New("something else entirely"))
+	if kind != KindUnknown || isTimeout {
+		t.Fatalf("expected unknown, got kind=%s isTimeout=%v", kind, isTimeout)
+	}
+}
+
+func TestAnnotate(t *testing.T) {
+	event := map[string]interface{}{}
+	Annotate(event, context.DeadlineExceeded, 1500*time.Millisecond)
+	if event["error"] == nil || event["error_type"] != string(KindTimeout) || event["timeout"] != true {
+		t.Fatalf("unexpected annotate result: %#v", event)
+	}
+	if event["duration"].(float64) != 1.5 {
+		t.Fatalf("unexpected duration: %v", event["duration"])
+	}
+
+	Annotate(nil, context.DeadlineExceeded, time.Second) // no panic
+	Annotate(map[string]interface{}{}, nil, time.Second)  // no fields
+}

--- a/pkg/protocols/websocket/websocket.go
+++ b/pkg/protocols/websocket/websocket.go
@@ -31,6 +31,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/utils/vardump"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/network/networkclientpool"
 	protocolutils "github.com/projectdiscovery/nuclei/v3/pkg/protocols/utils"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/utils/requesterr"
 	templateTypes "github.com/projectdiscovery/nuclei/v3/pkg/templates/types"
 	"github.com/projectdiscovery/nuclei/v3/pkg/types"
 	urlutil "github.com/projectdiscovery/utils/url"
@@ -258,6 +259,19 @@ func (request *Request) executeRequestWithPayloads(target *contextargs.Context, 
 	if err != nil {
 		requestOptions.Output.Request(requestOptions.TemplateID, input, request.Type().String(), err)
 		requestOptions.Progress.IncrementFailedRequestsBy(1)
+		if request.CompiledOperators != nil && request.CompiledOperators.HasErrorMatchers() {
+			data := make(map[string]interface{})
+			data["type"] = request.Type().String()
+			data["host"] = input
+			data["matched"] = addressToDial
+			data["duration"] = handshakeDuration.Seconds()
+			data["ip"] = request.dialer.GetDialedIP(hostname)
+			maps.Copy(data, previous)
+			maps.Copy(data, payloadValues)
+			requesterr.Annotate(data, err, handshakeDuration)
+			event := eventcreator.CreateEvent(request, data, requestOptions.Options.Debug || requestOptions.Options.DebugResponse)
+			callback(event)
+		}
 
 		return errors.Wrap(err, "could not connect to server")
 	}

--- a/pkg/protocols/whois/whois.go
+++ b/pkg/protocols/whois/whois.go
@@ -20,6 +20,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/replacer"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/utils/vardump"
 	protocolutils "github.com/projectdiscovery/nuclei/v3/pkg/protocols/utils"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/utils/requesterr"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/whois/rdapclientpool"
 	templateTypes "github.com/projectdiscovery/nuclei/v3/pkg/templates/types"
 	"github.com/projectdiscovery/nuclei/v3/pkg/types"
@@ -126,6 +127,15 @@ func (request *Request) ExecuteWithResults(input *contextargs.Context, dynamicVa
 	res, err := request.client.Do(rdapReq)
 	duration := time.Since(timeStart)
 	if err != nil {
+		if request.CompiledOperators != nil && request.CompiledOperators.HasErrorMatchers() {
+			data := make(map[string]interface{})
+			data["type"] = request.Type().String()
+			data["host"] = query
+			data["duration"] = duration.Seconds()
+			requesterr.Annotate(data, err, duration)
+			event := eventcreator.CreateEvent(request, data, request.options.Options.Debug || request.options.Options.DebugResponse)
+			callback(event)
+		}
 		return errors.Wrap(err, "could not make whois request")
 	}
 	gologger.Verbose().Msgf("Sent WHOIS request to %s", query)


### PR DESCRIPTION
Adds type: error matcher for request failures (timeout/connection/any or error-message substring) and exposes error, error_type, timeout for DSL. Wired across network-facing protocols; error-matcher templates bypass host-errors cache.

Closes #2346

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added error matchers for detecting connection failures, timeouts, specific error types, wildcards, and text patterns.
  * Error details are now available to matching logic across supported request protocols.
  * Failed requests can emit structured events with error type, timeout status, message, and duration.
  * Error matchers continue to evaluate requests even when hosts are marked unresponsive.

* **Bug Fixes**
  * Improved handling of matchers that do not require response content.
  * Added consistent error classification for timeout, connection, and unknown failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->