### PR TITLE
Add filesize DSL and matcher offset for file protocol

### DIFF
--- a/pkg/operators/matchers/match.go
+++ b/pkg/operators/matchers/match.go
@@ -2,6 +2,7 @@ package matchers
 
 import (
 	"os"
+	"regexp"
 	"strings"
 
 	"github.com/antchfx/htmlquery"
@@ -78,7 +79,7 @@ func (matcher *Matcher) MatchWords(corpus string, data map[string]interface{}) (
 			}
 		}
 		// Continue if the word doesn't match
-		if !strings.Contains(corpus, word) {
+		if !matcher.matchStringAt(corpus, word) {
 			// If we are in an AND request and a match failed,
 			// return false as the AND condition fails on any single mismatch.
 			switch matcher.condition {
@@ -111,33 +112,8 @@ func (matcher *Matcher) MatchRegex(corpus string) (bool, []string) {
 	var matchedRegexes []string
 	// Iterate over all the regexes accepted as valid
 	for i, regex := range matcher.regexCompiled {
-		// Literal prefix short-circuit
-		rstr := regex.String()
-		if !strings.Contains(rstr, "(?i") { // covers (?i) and (?i:
-			if prefix, ok := regex.LiteralPrefix(); ok && prefix != "" {
-				if !strings.Contains(corpus, prefix) {
-					switch matcher.condition {
-					case ANDCondition:
-						return false, []string{}
-					case ORCondition:
-						continue
-					}
-				}
-			}
-		}
-
-		// Fast OR-path: return first match without full scan
-		if matcher.condition == ORCondition && !matcher.MatchAll {
-			m := regex.FindAllString(corpus, 1)
-			if len(m) == 0 {
-				continue
-			}
-			return true, m
-		}
-
-		// Single scan: get all matches directly
-		currentMatches := regex.FindAllString(corpus, -1)
-		if len(currentMatches) == 0 {
+		currentMatches, matched := matcher.findRegexMatches(corpus, regex)
+		if !matched {
 			switch matcher.condition {
 			case ANDCondition:
 				return false, []string{}
@@ -146,7 +122,10 @@ func (matcher *Matcher) MatchRegex(corpus string) (bool, []string) {
 			}
 		}
 
-		// If the condition was an OR (and MatchAll true), we still need to gather all
+		// If the condition was an OR, return on the first match.
+		if matcher.condition == ORCondition && !matcher.MatchAll {
+			return true, currentMatches
+		}
 		matchedRegexes = append(matchedRegexes, currentMatches...)
 
 		// If we are at the end of the regex, return with true
@@ -160,12 +139,50 @@ func (matcher *Matcher) MatchRegex(corpus string) (bool, []string) {
 	return false, []string{}
 }
 
+func (matcher *Matcher) findRegexMatches(corpus string, regex *regexp.Regexp) ([]string, bool) {
+	if matcher.Offset != nil {
+		offset := *matcher.Offset
+		if offset < 0 || offset > len(corpus) {
+			return nil, false
+		}
+		loc := regex.FindStringIndex(corpus[offset:])
+		if loc == nil || loc[0] != 0 {
+			return nil, false
+		}
+		return []string{corpus[offset : offset+loc[1]]}, true
+	}
+
+	// Literal prefix short-circuit
+	rstr := regex.String()
+	if !strings.Contains(rstr, "(?i") { // covers (?i) and (?i:
+		if prefix, ok := regex.LiteralPrefix(); ok && prefix != "" {
+			if !strings.Contains(corpus, prefix) {
+				return nil, false
+			}
+		}
+	}
+
+	if matcher.condition == ORCondition && !matcher.MatchAll {
+		m := regex.FindAllString(corpus, 1)
+		if len(m) == 0 {
+			return nil, false
+		}
+		return m, true
+	}
+
+	currentMatches := regex.FindAllString(corpus, -1)
+	if len(currentMatches) == 0 {
+		return nil, false
+	}
+	return currentMatches, true
+}
+
 // MatchBinary matches a binary check against a corpus
 func (matcher *Matcher) MatchBinary(corpus string) (bool, []string) {
 	var matchedBinary []string
 	// Iterate over all the words accepted as valid
 	for i, binary := range matcher.binaryDecoded {
-		if !strings.Contains(corpus, binary) {
+		if !matcher.matchStringAt(corpus, binary) {
 			// If we are in an AND request and a match failed,
 			// return false as the AND condition fails on any single mismatch.
 			switch matcher.condition {
@@ -189,6 +206,19 @@ func (matcher *Matcher) MatchBinary(corpus string) (bool, []string) {
 		}
 	}
 	return false, []string{}
+}
+
+// matchStringAt reports whether needle is present in corpus, optionally pinned
+// to matcher.Offset when that field is set.
+func (matcher *Matcher) matchStringAt(corpus, needle string) bool {
+	if matcher.Offset == nil {
+		return strings.Contains(corpus, needle)
+	}
+	offset := *matcher.Offset
+	if offset < 0 || offset > len(corpus) || offset+len(needle) > len(corpus) {
+		return false
+	}
+	return corpus[offset:offset+len(needle)] == needle
 }
 
 // MatchDSL matches on a generic map result

--- a/pkg/operators/matchers/match_test.go
+++ b/pkg/operators/matchers/match_test.go
@@ -440,6 +440,55 @@ func TestMatchWords_CaseInsensitive_DynamicValue(t *testing.T) {
 	require.Equal(t, []string{"example.com"}, matched)
 }
 
+func TestMatchOffset(t *testing.T) {
+	offset0 := 0
+	offset2 := 2
+
+	t.Run("word at start", func(t *testing.T) {
+		m := &Matcher{Type: MatcherTypeHolder{MatcherType: WordsMatcher}, Words: []string{"MZ"}, Offset: &offset0}
+		require.NoError(t, m.CompileMatchers())
+		ok, snippets := m.MatchWords("MZ....", nil)
+		require.True(t, ok)
+		require.Equal(t, []string{"MZ"}, snippets)
+		ok, _ = m.MatchWords("xMZ...", nil)
+		require.False(t, ok)
+	})
+
+	t.Run("word at mid offset", func(t *testing.T) {
+		m := &Matcher{Type: MatcherTypeHolder{MatcherType: WordsMatcher}, Words: []string{"AB"}, Offset: &offset2}
+		require.NoError(t, m.CompileMatchers())
+		ok, _ := m.MatchWords("xxAByy", nil)
+		require.True(t, ok)
+		ok, _ = m.MatchWords("ABxxxx", nil)
+		require.False(t, ok)
+	})
+
+	t.Run("binary at start", func(t *testing.T) {
+		m := &Matcher{Type: MatcherTypeHolder{MatcherType: BinaryMatcher}, Binary: []string{"4d5a"}, Offset: &offset0}
+		require.NoError(t, m.CompileMatchers())
+		ok, _ := m.MatchBinary("MZ....")
+		require.True(t, ok)
+		ok, _ = m.MatchBinary("xMZ...")
+		require.False(t, ok)
+	})
+
+	t.Run("regex must start at offset", func(t *testing.T) {
+		m := &Matcher{Type: MatcherTypeHolder{MatcherType: RegexMatcher}, Regex: []string{"MZ"}, Offset: &offset0}
+		require.NoError(t, m.CompileMatchers())
+		ok, snippets := m.MatchRegex("MZPE")
+		require.True(t, ok)
+		require.Equal(t, []string{"MZ"}, snippets)
+		ok, _ = m.MatchRegex("xxMZ")
+		require.False(t, ok)
+	})
+
+	t.Run("negative offset rejected", func(t *testing.T) {
+		neg := -1
+		m := &Matcher{Type: MatcherTypeHolder{MatcherType: WordsMatcher}, Words: []string{"MZ"}, Offset: &neg}
+		require.Error(t, m.CompileMatchers())
+	})
+}
+
 func TestMatcher_MatchDSL_ErrorHandling(t *testing.T) {
 	// First expression errors (division by zero), second is true
 	bad, err := govaluate.NewEvaluableExpression("1 / 0")

--- a/pkg/operators/matchers/matchers.go
+++ b/pkg/operators/matchers/matchers.go
@@ -104,6 +104,15 @@ type Matcher struct {
 	//       []string{"//a[@target=\"_blank\"]"}
 	XPath []string `yaml:"xpath,omitempty" json:"xpath,omitempty" jsonschema:"title=xpath queries to match in response,description=xpath are the XPath queries that will be evaluated against the response part of nuclei matching rules"`
 	// description: |
+	//   Offset is an optional byte index where the matcher must match.
+	//   When set, word/binary values must appear exactly at this offset, and
+	//   regex matches must start at this offset. When omitted, matching uses
+	//   the default anywhere-in-corpus behavior.
+	// examples:
+	//   - name: Match MZ magic at start of file
+	//     value: "0"
+	Offset *int `yaml:"offset,omitempty" json:"offset,omitempty" jsonschema:"title=byte offset to match at,description=Optional byte offset where the matcher must match"`
+	// description: |
 	//   Encoding specifies the encoding for the words field if any.
 	// values:
 	//   - "hex"

--- a/pkg/operators/matchers/validate.go
+++ b/pkg/operators/matchers/validate.go
@@ -41,17 +41,21 @@ func (matcher *Matcher) Validate() error {
 	case SizeMatcher:
 		expectedFields = append(commonExpectedFields, "Size", "Part")
 	case WordsMatcher:
-		expectedFields = append(commonExpectedFields, "Words", "Part", "Encoding", "CaseInsensitive")
+		expectedFields = append(commonExpectedFields, "Words", "Part", "Encoding", "CaseInsensitive", "Offset")
 	case BinaryMatcher:
-		expectedFields = append(commonExpectedFields, "Binary", "Part", "Encoding", "CaseInsensitive")
+		expectedFields = append(commonExpectedFields, "Binary", "Part", "Encoding", "CaseInsensitive", "Offset")
 	case RegexMatcher:
-		expectedFields = append(commonExpectedFields, "Regex", "Part", "Encoding", "CaseInsensitive")
+		expectedFields = append(commonExpectedFields, "Regex", "Part", "Encoding", "CaseInsensitive", "Offset")
 	case XPathMatcher:
 		expectedFields = append(commonExpectedFields, "XPath", "Part")
 	}
 
 	if err = checkFields(matcher, matcherMap, expectedFields...); err != nil {
 		return err
+	}
+
+	if matcher.Offset != nil && *matcher.Offset < 0 {
+		return fmt.Errorf("offset must be >= 0 (got %d)", *matcher.Offset)
 	}
 
 	// validate the XPath query

--- a/pkg/protocols/file/file.go
+++ b/pkg/protocols/file/file.go
@@ -83,6 +83,7 @@ var RequestPartDefinitions = map[string]string{
 	"matched":           "Matched is the input which was matched upon",
 	"path":              "Path is the path of file on local filesystem",
 	"type":              "Type is the type of request made",
+	"filesize":          "Size of the file on disk in bytes",
 	"raw,body,all,data": "Raw contains the raw file contents",
 }
 

--- a/pkg/protocols/file/operators.go
+++ b/pkg/protocols/file/operators.go
@@ -74,12 +74,13 @@ func (request *Request) getMatchPart(part string, data output.InternalEvent) (st
 }
 
 // responseToDSLMap converts a file chunk elaboration to a map for use in DSL matching
-func (request *Request) responseToDSLMap(raw, inputFilePath, matchedFileName string) output.InternalEvent {
+func (request *Request) responseToDSLMap(raw, inputFilePath, matchedFileName string, fileSize int64) output.InternalEvent {
 	return output.InternalEvent{
 		"path":          inputFilePath,
 		"matched":       matchedFileName,
 		"raw":           raw,
 		"type":          request.Type().String(),
+		"filesize":      fileSize,
 		"template-id":   request.options.TemplateID,
 		"template-info": request.options.TemplateInfo,
 		"template-path": request.options.TemplatePath,

--- a/pkg/protocols/file/operators_test.go
+++ b/pkg/protocols/file/operators_test.go
@@ -48,9 +48,10 @@ func TestResponseToDSLMap(t *testing.T) {
 	require.Nil(t, err, "could not compile file request")
 
 	resp := "test-data\r\n"
-	event := request.responseToDSLMap(resp, "one.one.one.one", "one.one.one.one")
-	require.Len(t, event, 7, "could not get correct number of items in dsl map")
+	event := request.responseToDSLMap(resp, "one.one.one.one", "one.one.one.one", 11)
+	require.Len(t, event, 8, "could not get correct number of items in dsl map")
 	require.Equal(t, resp, event["raw"], "could not get correct resp")
+	require.Equal(t, int64(11), event["filesize"])
 }
 
 func TestFileOperatorMatch(t *testing.T) {
@@ -74,8 +75,8 @@ func TestFileOperatorMatch(t *testing.T) {
 	require.Nil(t, err, "could not compile file request")
 
 	resp := "test-data\r\n1.1.1.1\r\n"
-	event := request.responseToDSLMap(resp, "one.one.one.one", "one.one.one.one")
-	require.Len(t, event, 7, "could not get correct number of items in dsl map")
+	event := request.responseToDSLMap(resp, "one.one.one.one", "one.one.one.one", 11)
+	require.Len(t, event, 8, "could not get correct number of items in dsl map")
 	require.Equal(t, resp, event["raw"], "could not get correct resp")
 
 	t.Run("valid", func(t *testing.T) {
@@ -123,8 +124,8 @@ func TestFileOperatorMatch(t *testing.T) {
 
 	t.Run("caseInsensitive", func(t *testing.T) {
 		resp := "TEST-DATA\r\n1.1.1.1\r\n"
-		event := request.responseToDSLMap(resp, "one.one.one.one", "one.one.one.one")
-		require.Len(t, event, 7, "could not get correct number of items in dsl map")
+		event := request.responseToDSLMap(resp, "one.one.one.one", "one.one.one.one", 11)
+		require.Len(t, event, 8, "could not get correct number of items in dsl map")
 		require.Equal(t, resp, event["raw"], "could not get correct resp")
 
 		matcher := &matchers.Matcher{
@@ -163,8 +164,8 @@ func TestFileOperatorExtract(t *testing.T) {
 	require.Nil(t, err, "could not compile file request")
 
 	resp := "test-data\r\n1.1.1.1\r\n"
-	event := request.responseToDSLMap(resp, "one.one.one.one", "one.one.one.one")
-	require.Len(t, event, 7, "could not get correct number of items in dsl map")
+	event := request.responseToDSLMap(resp, "one.one.one.one", "one.one.one.one", 11)
+	require.Len(t, event, 8, "could not get correct number of items in dsl map")
 	require.Equal(t, resp, event["raw"], "could not get correct resp")
 
 	t.Run("extract", func(t *testing.T) {
@@ -282,8 +283,8 @@ func testFileMakeResult(t *testing.T, matchers []*matchers.Matcher, matcherCondi
 	matchedFileName := "test.txt"
 	fileContent := "test-data\r\n1.1.1.1\r\n"
 
-	event := request.responseToDSLMap(fileContent, "/tmp", matchedFileName)
-	require.Len(t, event, 7, "could not get correct number of items in dsl map")
+	event := request.responseToDSLMap(fileContent, "/tmp", matchedFileName, 11)
+	require.Len(t, event, 8, "could not get correct number of items in dsl map")
 	require.Equal(t, fileContent, event["raw"], "could not get correct resp")
 
 	finalEvent := &output.InternalWrappedEvent{InternalEvent: event}

--- a/pkg/protocols/file/request.go
+++ b/pkg/protocols/file/request.go
@@ -226,7 +226,7 @@ func (request *Request) processReader(reader io.Reader, filePath string, input *
 	}
 
 	// build event structure to interface with internal logic
-	return request.buildEvent(input.MetaInput.Input, filePath, fileMatches, opResult, previousInternalEvent), fileMatches, nil
+	return request.buildEvent(input.MetaInput.Input, filePath, totalBytes, fileMatches, opResult, previousInternalEvent), fileMatches, nil
 }
 
 func (request *Request) findMatchesWithReader(reader io.Reader, input *contextargs.Context, filePath string, totalBytes int64, previous output.InternalEvent) ([]FileMatch, *operators.Result) {
@@ -276,7 +276,7 @@ func (request *Request) findMatchesWithReader(reader io.Reader, input *contextar
 		processedBytes := units.BytesSize(float64(currentBytes))
 
 		gologger.Verbose().Msgf("[%s] Processing file %s chunk %s/%s", request.options.TemplateID, filePath, processedBytes, totalBytesString)
-		dslMap := request.responseToDSLMap(lineContent, input.MetaInput.Input, filePath)
+		dslMap := request.responseToDSLMap(lineContent, input.MetaInput.Input, filePath, totalBytes)
 		maps.Copy(dslMap, previous)
 		// add vars to template context
 		request.options.AddTemplateVars(input.MetaInput, request.Type(), request.ID, dslMap)
@@ -342,10 +342,10 @@ func (request *Request) findMatchesWithReader(reader io.Reader, input *contextar
 	return fileMatches, opResult
 }
 
-func (request *Request) buildEvent(input, filePath string, fileMatches []FileMatch, operatorResult *operators.Result, previous output.InternalEvent) *output.InternalWrappedEvent {
+func (request *Request) buildEvent(input, filePath string, fileSize int64, fileMatches []FileMatch, operatorResult *operators.Result, previous output.InternalEvent) *output.InternalWrappedEvent {
 	exprLines := make(map[string][]int)
 	exprBytes := make(map[string][]int)
-	internalEvent := request.responseToDSLMap("", input, filePath)
+	internalEvent := request.responseToDSLMap("", input, filePath, fileSize)
 	maps.Copy(internalEvent, previous)
 	for _, fileMatch := range fileMatches {
 		exprLines[fileMatch.Expr] = append(exprLines[fileMatch.Expr], fileMatch.Line)

--- a/pkg/protocols/file/request_test.go
+++ b/pkg/protocols/file/request_test.go
@@ -212,3 +212,55 @@ func TestFileProtocolConcurrentExecution(t *testing.T) {
 	timesMutex.Lock()
 	defer timesMutex.Unlock()
 }
+
+func TestFileFilesizeAndOffset(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "nuclei-filesize-*")
+	require.NoError(t, err)
+	defer func() { _ = os.RemoveAll(tempDir) }()
+
+	content := []byte("MZPAYLOADDATA")
+	filePath := filepath.Join(tempDir, "sample.bin")
+	require.NoError(t, os.WriteFile(filePath, content, permissionutil.TempFilePermission))
+
+	options := testutils.DefaultOptions
+	testutils.Init(options)
+	templateID := "testing-file-filesize-offset"
+	executerOpts := testutils.NewMockExecuterOptions(options, &testutils.TemplateInfo{
+		ID:   templateID,
+		Info: model.Info{SeverityHolder: severity.Holder{Severity: severity.Low}, Name: "test"},
+	})
+
+	offset0 := 0
+	request := &Request{
+		ID:         templateID,
+		MaxSize:    "1Gb",
+		Extensions: []string{"all"},
+		Operators: operators.Operators{
+			MatchersCondition: "and",
+			Matchers: []*matchers.Matcher{
+				{
+					Type:  matchers.MatcherTypeHolder{MatcherType: matchers.WordsMatcher},
+					Part:  "raw",
+					Words: []string{"MZ"},
+					Offset: &offset0,
+				},
+				{
+					Type: matchers.MatcherTypeHolder{MatcherType: matchers.DSLMatcher},
+					DSL:  []string{"filesize == 13"},
+				},
+			},
+		},
+	}
+	require.NoError(t, request.Compile(executerOpts))
+
+	var matched bool
+	ctxArgs := contextargs.NewWithInput(context.Background(), tempDir)
+	err = request.ExecuteWithResults(ctxArgs, nil, nil, func(event *output.InternalWrappedEvent) {
+		if event.OperatorsResult != nil && event.OperatorsResult.Matched {
+			matched = true
+			require.Equal(t, int64(len(content)), event.InternalEvent["filesize"])
+		}
+	})
+	require.NoError(t, err)
+	require.True(t, matched)
+}


### PR DESCRIPTION
Exposes filesize on file protocol events for DSL, and adds optional offset on word/binary/regex matchers so patterns can be pinned to a byte index (e.g. MZ at 0).

Closes #3340

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional offset-based matching for word, binary, and regular-expression matchers.
  * Added file size information, in bytes, to file-processing results.
  * Added support for matching files based on their recorded size.

* **Bug Fixes**
  * Invalid negative matcher offsets are now rejected during validation.
  * Improved consistency of offset-aware matching across matcher types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->