### PR TITLE
Quiet unresolved-variable skips and summarize at scan end

### DIFF
--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -476,6 +476,7 @@ on extensive configurability, massive extensibility and ease of use.`)
 		flagSet.StringVar(&memProfile, "profile-mem", "", "generate memory (heap) profile & trace files"),
 		flagSet.BoolVar(&options.VerboseVerbose, "vv", false, "display templates loaded for scan"),
 		flagSet.BoolVarP(&options.ShowVarDump, "show-var-dump", "svd", false, "show variables dump for debugging"),
+		flagSet.BoolVarP(&options.LogUnresolved, "log-unresolved", "lu", false, "log per-request warnings for unresolved template variables (summary is always printed)"),
 		flagSet.IntVarP(&options.VarDumpLimit, "var-dump-limit", "vdl", 255, "limit the number of characters displayed in var dump"),
 		flagSet.BoolVarP(&options.EnablePprof, "enable-pprof", "ep", false, "enable pprof debugging server"),
 		flagSet.CallbackVarP(printTemplateVersion, "templates-version", "tv", "shows the version of the installed nuclei-templates"),

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -819,6 +819,14 @@ func (r *Runner) RunEnumeration() error {
 	r.progress.Stop()
 	timeTaken := time.Since(now)
 
+	if skipped := r.progress.SkippedUnresolved(); skipped > 0 {
+		msg := fmt.Sprintf("Skipped %d request(s) due to unresolved variables", skipped)
+		if !r.options.LogUnresolved {
+			msg += " (use -log-unresolved to see details)"
+		}
+		r.Logger.Info().Msg(msg)
+	}
+
 	// Print pool/tracker stats if available (single dialers lookup, reads under lock)
 	if dialers := protocolstate.GetDialersWithId(r.options.ExecutionId); dialers != nil {
 		dialers.Lock()

--- a/internal/tests/testutils/testutils.go
+++ b/internal/tests/testutils/testutils.go
@@ -268,3 +268,9 @@ func (m *MockProgressClient) IncrementErrorsBy(count int64) {}
 // IncrementFailedRequestsBy increments the number of requests counter by count
 // along with errors.
 func (m *MockProgressClient) IncrementFailedRequestsBy(count int64) {}
+
+// IncrementSkippedUnresolved increments requests skipped for unresolved variables.
+func (m *MockProgressClient) IncrementSkippedUnresolved(count int64) {}
+
+// SkippedUnresolved returns requests skipped for unresolved variables.
+func (m *MockProgressClient) SkippedUnresolved() uint64 { return 0 }

--- a/pkg/progress/progress.go
+++ b/pkg/progress/progress.go
@@ -32,6 +32,11 @@ type Progress interface {
 	// IncrementFailedRequestsBy increments the number of requests counter by count
 	// along with errors.
 	IncrementFailedRequestsBy(count int64)
+	// IncrementSkippedUnresolved increments the count of requests skipped because
+	// template variables could not be resolved.
+	IncrementSkippedUnresolved(count int64)
+	// SkippedUnresolved returns how many requests were skipped for unresolved variables.
+	SkippedUnresolved() uint64
 }
 
 var _ Progress = &StatsTicker{}
@@ -84,6 +89,7 @@ func (p *StatsTicker) Init(hostCount int64, rulesCount int, requestCount int64) 
 	p.stats.AddCounter("requests", uint64(0))
 	p.stats.AddCounter("errors", uint64(0))
 	p.stats.AddCounter("matched", uint64(0))
+	p.stats.AddCounter("unresolved", uint64(0))
 	p.stats.AddCounter("total", uint64(requestCount))
 
 	if p.active {
@@ -140,6 +146,17 @@ func (p *StatsTicker) IncrementFailedRequestsBy(count int64) {
 	// mimic dropping by incrementing the completed requests
 	p.stats.IncrementCounter("requests", int(count))
 	p.stats.IncrementCounter("errors", int(count))
+}
+
+// IncrementSkippedUnresolved increments requests skipped due to unresolved variables.
+func (p *StatsTicker) IncrementSkippedUnresolved(count int64) {
+	p.stats.IncrementCounter("unresolved", int(count))
+}
+
+// SkippedUnresolved returns the number of requests skipped due to unresolved variables.
+func (p *StatsTicker) SkippedUnresolved() uint64 {
+	count, _ := p.stats.GetCounter("unresolved")
+	return count
 }
 
 func (p *StatsTicker) makePrintCallback() func(stats clistats.StatisticsClient) interface{} {

--- a/pkg/progress/progress_unresolved_test.go
+++ b/pkg/progress/progress_unresolved_test.go
@@ -1,0 +1,18 @@
+package progress
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSkippedUnresolvedCounter(t *testing.T) {
+	p, err := NewStatsTicker(-1, false, false, false, 0)
+	require.NoError(t, err)
+	p.Init(1, 1, 10)
+	require.Equal(t, uint64(0), p.SkippedUnresolved())
+
+	p.IncrementSkippedUnresolved(1)
+	p.IncrementSkippedUnresolved(2)
+	require.Equal(t, uint64(3), p.SkippedUnresolved())
+}

--- a/pkg/protocols/common/unresolvedvars/unresolvedvars.go
+++ b/pkg/protocols/common/unresolvedvars/unresolvedvars.go
@@ -1,0 +1,31 @@
+package unresolvedvars
+
+import (
+	"strings"
+
+	"github.com/projectdiscovery/gologger"
+	"github.com/projectdiscovery/nuclei/v3/pkg/progress"
+	"github.com/projectdiscovery/nuclei/v3/pkg/types"
+)
+
+const errSubstring = "unresolved variables"
+
+// Is reports whether err is (or wraps) an unresolved-variables skip.
+func Is(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(err.Error()), errSubstring)
+}
+
+// Skip records a request skipped due to unresolved variables and optionally logs it.
+// Per-request warnings are muted unless options.LogUnresolved is set; use the end-of-scan
+// summary from progress.SkippedUnresolved instead.
+func Skip(prog progress.Progress, options *types.Options, templateID, target string, err error) {
+	if prog != nil {
+		prog.IncrementSkippedUnresolved(1)
+	}
+	if options != nil && options.LogUnresolved {
+		gologger.Warning().Msgf("[%s] Could not make request for %s: %v\n", templateID, target, err)
+	}
+}

--- a/pkg/protocols/common/unresolvedvars/unresolvedvars_test.go
+++ b/pkg/protocols/common/unresolvedvars/unresolvedvars_test.go
@@ -1,0 +1,15 @@
+package unresolvedvars
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIs(t *testing.T) {
+	require.True(t, Is(errors.New("unresolved variables found: user")))
+	require.True(t, Is(errors.New("unresolved variables `{{user}}` found in request")))
+	require.False(t, Is(errors.New("connection refused")))
+	require.False(t, Is(nil))
+}

--- a/pkg/protocols/dns/request.go
+++ b/pkg/protocols/dns/request.go
@@ -20,6 +20,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/generators"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/helpers/eventcreator"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/helpers/responsehighlighter"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/unresolvedvars"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/utils/vardump"
 	protocolutils "github.com/projectdiscovery/nuclei/v3/pkg/protocols/utils"
 	templateTypes "github.com/projectdiscovery/nuclei/v3/pkg/templates/types"
@@ -134,7 +135,11 @@ func (request *Request) execute(input *contextargs.Context, domain string, metad
 		// to resolve. See https://github.com/projectdiscovery/nuclei/issues/7374.
 		resolverVars := generators.MergeMaps(vars, metadata)
 		if dnsClient, varErr = request.getDnsClient(request.options, resolverVars); varErr != nil {
-			gologger.Warning().Msgf("[%s] Could not make dns request for %s: %v\n", request.options.TemplateID, domain, varErr)
+			if unresolvedvars.Is(varErr) {
+				unresolvedvars.Skip(request.options.Progress, request.options.Options, request.options.TemplateID, domain, varErr)
+			} else {
+				gologger.Warning().Msgf("[%s] Could not make dns request for %s: %v\n", request.options.TemplateID, domain, varErr)
+			}
 			return nil
 		}
 	}
@@ -148,7 +153,7 @@ func (request *Request) execute(input *contextargs.Context, domain string, metad
 
 	requestString := compiledRequest.String()
 	if varErr := expressions.ContainsUnresolvedVariables(requestString); varErr != nil {
-		gologger.Warning().Msgf("[%s] Could not make dns request for %s: %v\n", request.options.TemplateID, question, varErr)
+		unresolvedvars.Skip(request.options.Progress, request.options.Options, request.options.TemplateID, question, varErr)
 		return nil
 	}
 	if request.options.Options.Debug || request.options.Options.DebugRequests || request.options.Options.StoreResponse {

--- a/pkg/protocols/http/request.go
+++ b/pkg/protocols/http/request.go
@@ -33,6 +33,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/helpers/responsehighlighter"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/interactsh"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/unresolvedvars"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/http/httpclientpool"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/http/httputils"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/http/signer"
@@ -553,6 +554,10 @@ func (request *Request) ExecuteWithResults(input *contextargs.Context, dynamicVa
 				if err == types.ErrNoMoreRequests {
 					return true, nil
 				}
+				if unresolvedvars.Is(err) {
+					unresolvedvars.Skip(request.options.Progress, request.options.Options, request.options.TemplateID, input.MetaInput.Input, err)
+					return true, nil
+				}
 				return true, err
 			}
 			// ideally if http template used a custom port or hostname
@@ -747,12 +752,12 @@ func (request *Request) executeRequest(input *contextargs.Context, generatedRequ
 
 		if ignoreList := GetVariablesNamesSkipList(generatedRequest.original.Signature.Value); ignoreList != nil {
 			if varErr := expressions.ContainsVariablesWithIgnoreList(ignoreList, dumpedRequestString); varErr != nil && !request.SkipVariablesCheck {
-				gologger.Warning().Msgf("[%s] Could not make http request for %s: %v\n", request.options.TemplateID, input.MetaInput.Input, varErr)
+				unresolvedvars.Skip(request.options.Progress, request.options.Options, request.options.TemplateID, input.MetaInput.Input, varErr)
 				return ErrMissingVars
 			}
 		} else { // Check if are there any unresolved variables. If yes, skip unless overridden by user.
 			if varErr := expressions.ContainsUnresolvedVariables(dumpedRequestString); varErr != nil && !request.SkipVariablesCheck {
-				gologger.Warning().Msgf("[%s] Could not make http request for %s: %v\n", request.options.TemplateID, input.MetaInput.Input, varErr)
+				unresolvedvars.Skip(request.options.Progress, request.options.Options, request.options.TemplateID, input.MetaInput.Input, varErr)
 				return ErrMissingVars
 			}
 		}

--- a/pkg/protocols/network/request.go
+++ b/pkg/protocols/network/request.go
@@ -27,6 +27,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/interactsh"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/render"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/replacer"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/unresolvedvars"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/utils/vardump"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/network/networkclientpool"
 	protocolutils "github.com/projectdiscovery/nuclei/v3/pkg/protocols/utils"
@@ -374,7 +375,7 @@ func (request *Request) executeRequestWithPayloads(variables map[string]interfac
 		interactshURLs = result.InteractURLs
 
 		if err := expressions.ContainsUnresolvedVariables(data); err != nil {
-			gologger.Warning().Msgf("[%s] Could not make network request for %s: %v\n", request.options.TemplateID, actualAddress, err)
+			unresolvedvars.Skip(request.options.Progress, request.options.Options, request.options.TemplateID, actualAddress, err)
 			return nil
 		}
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -227,6 +227,10 @@ type Options struct {
 	VerboseVerbose bool
 	// ShowVarDump displays variable dump
 	ShowVarDump bool
+	// LogUnresolved enables per-request warnings when a request is skipped because
+	// template variables could not be resolved. By default those skips are counted
+	// and summarized once at the end of the scan instead of flooding the log.
+	LogUnresolved bool
 	// VarDumpLimit limits the number of characters displayed in var dump
 	VarDumpLimit int
 	// No-Color disables the colored output.
@@ -586,6 +590,7 @@ func (options *Options) Copy() *Options {
 		Verbose:                        options.Verbose,
 		VerboseVerbose:                 options.VerboseVerbose,
 		ShowVarDump:                    options.ShowVarDump,
+		LogUnresolved:                  options.LogUnresolved,
 		VarDumpLimit:                   options.VarDumpLimit,
 		NoColor:                        options.NoColor,
 		UpdateTemplates:                options.UpdateTemplates,


### PR DESCRIPTION
Mutes per-request unresolved-variable warnings by default, counts skips, and prints one end-of-scan summary. Use -log-unresolved to restore per-request details.

Closes #3386

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `-log-unresolved` (`-lu`) to optionally display warnings for requests skipped بسبب unresolved template variables.
  * Progress reporting now includes a count of requests skipped for unresolved variables.
  * DNS, HTTP, and network scans consistently skip unresolved-variable requests and summarize them after execution.

* **Bug Fixes**
  * Reduced repetitive warning messages while preserving visibility into unresolved requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->