### PR TITLE
Expose headless header/cookie DSL variables

### DIFF
--- a/pkg/protocols/headless/engine/headers.go
+++ b/pkg/protocols/headless/engine/headers.go
@@ -1,0 +1,23 @@
+package engine
+
+import (
+	"net/http"
+	"strings"
+)
+
+// addResponseVariables exposes response headers and cookies as DSL variables
+// (same normalization as the HTTP protocol).
+// Header names are lowercased with "-" replaced by "_", e.g. Content-Type -> content_type.
+// Cookie names are lowercased as-is.
+func addResponseVariables(data map[string]interface{}, resp *http.Response) {
+	if resp == nil {
+		return
+	}
+	for _, cookie := range resp.Cookies() {
+		data[strings.ToLower(cookie.Name)] = cookie.Value
+	}
+	for k, v := range resp.Header {
+		k = strings.ToLower(strings.ReplaceAll(strings.TrimSpace(k), "-", "_"))
+		data[k] = strings.Join(v, " ")
+	}
+}

--- a/pkg/protocols/headless/engine/headers_test.go
+++ b/pkg/protocols/headless/engine/headers_test.go
@@ -1,0 +1,32 @@
+package engine
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddResponseVariables(t *testing.T) {
+	resp := &http.Response{Header: make(http.Header)}
+	resp.Header.Set("Content-Type", "text/plain; charset=utf-8")
+	resp.Header.Add("X-Custom", "a")
+	resp.Header.Add("X-Custom", "b")
+	resp.Header.Add("Set-Cookie", "SessionID=abc; Path=/")
+	resp.Header.Add("Set-Cookie", "theme=dark; Path=/")
+
+	data := make(map[string]interface{})
+	addResponseVariables(data, resp)
+
+	require.Equal(t, "text/plain; charset=utf-8", data["content_type"])
+	require.Equal(t, "a b", data["x_custom"])
+	require.Equal(t, "abc", data["sessionid"])
+	require.Equal(t, "dark", data["theme"])
+	require.NotContains(t, data, "header")
+}
+
+func TestAddResponseVariablesNil(t *testing.T) {
+	data := make(map[string]interface{})
+	addResponseVariables(data, nil)
+	require.Empty(t, data)
+}

--- a/pkg/protocols/headless/engine/page.go
+++ b/pkg/protocols/headless/engine/page.go
@@ -219,8 +219,11 @@ func (i *Instance) Run(ctx *contextargs.Context, actions []*Action, payloads map
 
 	if hasHistory {
 		if resp, err := http.ReadResponse(bufio.NewReader(strings.NewReader(firstHistoryItem.RawResponse)), nil); err == nil {
-			data["header"] = utils.HeadersToString(resp.Header)
+			headers := utils.HeadersToString(resp.Header)
+			data["header"] = headers
+			data["all_headers"] = headers
 			data["status_code"] = fmt.Sprint(resp.StatusCode)
+			addResponseVariables(data, resp)
 			defer func() {
 				_ = resp.Body.Close()
 			}()

--- a/pkg/protocols/headless/headless.go
+++ b/pkg/protocols/headless/headless.go
@@ -77,15 +77,17 @@ type Request struct {
 // description. Multiple definitions are separated by commas.
 // Definitions not having a name (generated on runtime) are prefixed & suffixed by <>.
 var RequestPartDefinitions = map[string]string{
-	"template-id":    "ID of the template executed",
-	"template-info":  "Info Block of the template executed",
-	"template-path":  "Path of the template executed",
-	"host":           "Host is the input to the template",
-	"matched":        "Matched is the input which was matched upon",
-	"type":           "Type is the type of request made",
-	"req":            "Headless request made from the client",
-	"duration":       "Latest measured operation duration in seconds",
-	"resp,body,data": "Headless response received from client (default)",
+	"template-id":        "ID of the template executed",
+	"template-info":      "Info Block of the template executed",
+	"template-path":      "Path of the template executed",
+	"host":               "Host is the input to the template",
+	"matched":            "Matched is the input which was matched upon",
+	"type":               "Type is the type of request made",
+	"req":                "Headless request made from the client",
+	"duration":           "Latest measured operation duration in seconds",
+	"resp,body,data":     "Headless response received from client (default)",
+	"header,all_headers": "Headless response headers",
+	"status_code":        "Status code received from the server",
 }
 
 // Step is a headless protocol request step.

--- a/pkg/protocols/headless/operators.go
+++ b/pkg/protocols/headless/operators.go
@@ -90,7 +90,7 @@ func (request *Request) getMatchPart(part string, data output.InternalEvent) (st
 		part = "data"
 	case "history":
 		part = "history"
-	case "header":
+	case "header", "all_headers":
 		part = "header"
 	}
 
@@ -111,6 +111,7 @@ func (request *Request) responseToDSLMap(resp, headers, status_code, req, host, 
 		"req":           req,
 		"data":          resp,
 		"header":        headers,
+		"all_headers":   headers,
 		"status_code":   status_code,
 		"history":       history,
 		"type":          request.Type().String(),

--- a/pkg/protocols/headless/operators_test.go
+++ b/pkg/protocols/headless/operators_test.go
@@ -275,6 +275,11 @@ func TestRequest_getMatchPart(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, "header content", part)
 
+	// Test "all_headers" part (alias of header)
+	part, ok = request.getMatchPart("all_headers", data)
+	require.True(t, ok)
+	require.Equal(t, "header content", part)
+
 	// Test "history" part
 	part, ok = request.getMatchPart("history", data)
 	require.True(t, ok)


### PR DESCRIPTION
## Summary
- Expose headless response headers/cookies as DSL vars (HTTP parity: content_type, all_headers, cookie names)
- Closes #3796

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added access to response headers through both `header` and `all_headers` variables.
  * Added normalized header and cookie values for use in templates, matching, and extraction.
  * Added support for response status codes as a runtime variable.
  * Combined repeated header values into a single space-delimited value.

* **Bug Fixes**
  * Ensured missing responses do not populate runtime variables.
  * Added consistent handling of `all_headers` wherever header matching is supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->