### PR TITLE
Add PDCP connectivity check to -hc

### DIFF
--- a/internal/runner/healthcheck.go
+++ b/internal/runner/healthcheck.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/config"
 	"github.com/projectdiscovery/nuclei/v3/pkg/types"
+	pdcpauth "github.com/projectdiscovery/utils/auth/pdcp"
 	fileutil "github.com/projectdiscovery/utils/file"
 )
 
@@ -73,5 +74,42 @@ func DoHealthCheck(options *types.Options) string {
 	}
 	fmt.Fprintf(&test, "IPv4 UDP connectivity to scanme.sh:53 => %s\n", testResult)
 
+	appendPDCPHealthCheck(&test, (&pdcpauth.PDCPCredHandler{}).GetCreds, func(key, server, tool string) (*pdcpauth.PDCPCredentials, error) {
+		return (&pdcpauth.PDCPCredHandler{}).ValidateAPIKey(key, server, tool)
+	})
+
 	return test.String()
+}
+
+// appendPDCPHealthCheck validates PDCP API connectivity when credentials are configured.
+func appendPDCPHealthCheck(
+	test *strings.Builder,
+	getCreds func() (*pdcpauth.PDCPCredentials, error),
+	validate func(key, server, tool string) (*pdcpauth.PDCPCredentials, error),
+) {
+	creds, err := getCreds()
+	if err != nil {
+		// Only check when an API key is configured.
+		return
+	}
+	if creds == nil || creds.APIKey == "" {
+		return
+	}
+
+	server := creds.Server
+	if server == "" {
+		server = pdcpauth.DefaultApiServer
+	}
+
+	validated, err := validate(creds.APIKey, server, config.BinaryName)
+	if err != nil {
+		fmt.Fprintf(test, "PDCP API (%s) => Ko (%s)\n", server, err)
+		return
+	}
+
+	identity := validated.Email
+	if validated.Username != "" {
+		identity = "@" + validated.Username
+	}
+	fmt.Fprintf(test, "PDCP API (%s) => Ok (%s)\n", server, identity)
 }

--- a/internal/runner/healthcheck_test.go
+++ b/internal/runner/healthcheck_test.go
@@ -1,0 +1,43 @@
+package runner
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	pdcpauth "github.com/projectdiscovery/utils/auth/pdcp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAppendPDCPHealthCheckSkippedWithoutCreds(t *testing.T) {
+	var b strings.Builder
+	appendPDCPHealthCheck(&b, func() (*pdcpauth.PDCPCredentials, error) {
+		return nil, pdcpauth.ErrNoCreds
+	}, func(key, server, tool string) (*pdcpauth.PDCPCredentials, error) {
+		t.Fatal("validate should not be called")
+		return nil, nil
+	})
+	require.Empty(t, b.String())
+}
+
+func TestAppendPDCPHealthCheckOk(t *testing.T) {
+	var b strings.Builder
+	appendPDCPHealthCheck(&b, func() (*pdcpauth.PDCPCredentials, error) {
+		return &pdcpauth.PDCPCredentials{APIKey: "key", Server: "https://api.example"}, nil
+	}, func(key, server, tool string) (*pdcpauth.PDCPCredentials, error) {
+		require.Equal(t, "key", key)
+		require.Equal(t, "https://api.example", server)
+		return &pdcpauth.PDCPCredentials{Username: "alice", Email: "a@b.c", APIKey: key, Server: server}, nil
+	})
+	require.Equal(t, "PDCP API (https://api.example) => Ok (@alice)\n", b.String())
+}
+
+func TestAppendPDCPHealthCheckKo(t *testing.T) {
+	var b strings.Builder
+	appendPDCPHealthCheck(&b, func() (*pdcpauth.PDCPCredentials, error) {
+		return &pdcpauth.PDCPCredentials{APIKey: "bad", Server: "https://api.example"}, nil
+	}, func(key, server, tool string) (*pdcpauth.PDCPCredentials, error) {
+		return nil, errors.New("invalid status code: 401")
+	})
+	require.Equal(t, "PDCP API (https://api.example) => Ko (invalid status code: 401)\n", b.String())
+}


### PR DESCRIPTION
## Summary
- Add PDCP API connectivity check to -hc when credentials are configured
- Closes #4778

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Health checks now verify PDCP API connectivity when credentials are configured.
  * Results report successful validation with connection details or provide an actionable error message.

* **Bug Fixes**
  * Health checks safely skip PDCP validation when credentials are unavailable.

* **Tests**
  * Added coverage for successful, failed, and skipped PDCP connectivity checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->