### PR TITLE
Print config directories in -hc and verbose modes

### DIFF
--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -776,9 +776,7 @@ func disableUpdatesCallback() {
 // printVersion prints the nuclei version and exits.
 func printVersion() {
 	options.Logger.Info().Msgf("Nuclei Engine Version: %s", config.Version)
-	options.Logger.Info().Msgf("Nuclei Config Directory: %s", config.DefaultConfig.GetConfigDir())
-	options.Logger.Info().Msgf("Nuclei Cache Directory: %s", config.DefaultConfig.GetCacheDir()) // cache dir contains resume files
-	options.Logger.Info().Msgf("PDCP Directory: %s", pdcp.PDCPDir)
+	runner.LogDirectoryInfo(options.Logger)
 	os.Exit(0)
 }
 

--- a/internal/runner/directories.go
+++ b/internal/runner/directories.go
@@ -1,0 +1,35 @@
+package runner
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/projectdiscovery/gologger"
+	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/config"
+	pdcpauth "github.com/projectdiscovery/utils/auth/pdcp"
+)
+
+// AppendDirectoryInfo writes nuclei config/cache/PDCP directory paths.
+func AppendDirectoryInfo(w io.Writer) {
+	fmt.Fprintf(w, "Nuclei Config Directory: %s\n", config.DefaultConfig.GetConfigDir())
+	fmt.Fprintf(w, "Nuclei Cache Directory: %s\n", config.DefaultConfig.GetCacheDir())
+	fmt.Fprintf(w, "PDCP Directory: %s\n", pdcpauth.PDCPDir)
+}
+
+// DirectoryInfo returns nuclei config/cache/PDCP directory paths as a string.
+func DirectoryInfo() string {
+	var b strings.Builder
+	AppendDirectoryInfo(&b)
+	return b.String()
+}
+
+// LogDirectoryInfo logs nuclei config/cache/PDCP directory paths at info level.
+func LogDirectoryInfo(logger *gologger.Logger) {
+	if logger == nil {
+		return
+	}
+	logger.Info().Msgf("Nuclei Config Directory: %s", config.DefaultConfig.GetConfigDir())
+	logger.Info().Msgf("Nuclei Cache Directory: %s", config.DefaultConfig.GetCacheDir())
+	logger.Info().Msgf("PDCP Directory: %s", pdcpauth.PDCPDir)
+}

--- a/internal/runner/directories.go
+++ b/internal/runner/directories.go
@@ -12,9 +12,9 @@ import (
 
 // AppendDirectoryInfo writes nuclei config/cache/PDCP directory paths.
 func AppendDirectoryInfo(w io.Writer) {
-	fmt.Fprintf(w, "Nuclei Config Directory: %s\n", config.DefaultConfig.GetConfigDir())
-	fmt.Fprintf(w, "Nuclei Cache Directory: %s\n", config.DefaultConfig.GetCacheDir())
-	fmt.Fprintf(w, "PDCP Directory: %s\n", pdcpauth.PDCPDir)
+	_, _ = fmt.Fprintf(w, "Nuclei Config Directory: %s\n", config.DefaultConfig.GetConfigDir())
+	_, _ = fmt.Fprintf(w, "Nuclei Cache Directory: %s\n", config.DefaultConfig.GetCacheDir())
+	_, _ = fmt.Fprintf(w, "PDCP Directory: %s\n", pdcpauth.PDCPDir)
 }
 
 // DirectoryInfo returns nuclei config/cache/PDCP directory paths as a string.

--- a/internal/runner/directories_test.go
+++ b/internal/runner/directories_test.go
@@ -1,23 +1,25 @@
 package runner
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/config"
+	pdcpauth "github.com/projectdiscovery/utils/auth/pdcp"
 )
 
 func TestDirectoryInfoContainsKnownLabels(t *testing.T) {
 	info := DirectoryInfo()
-	require.Contains(t, info, "Nuclei Config Directory:")
-	require.Contains(t, info, "Nuclei Cache Directory:")
-	require.Contains(t, info, "PDCP Directory:")
-	require.Equal(t, 3, strings.Count(info, "\n"))
-}
+	cfg := config.DefaultConfig
 
-func TestDoHealthCheckIncludesDirectoryInfo(t *testing.T) {
-	out := DoHealthCheck(nil)
-	require.Contains(t, out, "Nuclei Config Directory:")
-	require.Contains(t, out, "Nuclei Cache Directory:")
-	require.Contains(t, out, "PDCP Directory:")
+	require.Equal(t, strings.Join([]string{
+		fmt.Sprintf("Nuclei Config Directory: %s", cfg.GetConfigDir()),
+		fmt.Sprintf("Nuclei Cache Directory: %s", cfg.GetCacheDir()),
+		fmt.Sprintf("PDCP Directory: %s", pdcpauth.PDCPDir),
+		"",
+	}, "\n"), info)
+	require.Equal(t, 3, strings.Count(info, "\n"))
 }

--- a/internal/runner/directories_test.go
+++ b/internal/runner/directories_test.go
@@ -1,0 +1,23 @@
+package runner
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDirectoryInfoContainsKnownLabels(t *testing.T) {
+	info := DirectoryInfo()
+	require.Contains(t, info, "Nuclei Config Directory:")
+	require.Contains(t, info, "Nuclei Cache Directory:")
+	require.Contains(t, info, "PDCP Directory:")
+	require.Equal(t, 3, strings.Count(info, "\n"))
+}
+
+func TestDoHealthCheckIncludesDirectoryInfo(t *testing.T) {
+	out := DoHealthCheck(nil)
+	require.Contains(t, out, "Nuclei Config Directory:")
+	require.Contains(t, out, "Nuclei Cache Directory:")
+	require.Contains(t, out, "PDCP Directory:")
+}

--- a/internal/runner/healthcheck.go
+++ b/internal/runner/healthcheck.go
@@ -20,6 +20,7 @@ func DoHealthCheck(options *types.Options) string {
 	fmt.Fprintf(&test, "Architecture: %s\n", runtime.GOARCH)
 	fmt.Fprintf(&test, "Go Version: %s\n", runtime.Version())
 	fmt.Fprintf(&test, "Compiler: %s\n", runtime.Compiler)
+	AppendDirectoryInfo(&test)
 
 	var testResult string
 	cfg := config.DefaultConfig

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -122,6 +122,10 @@ func New(options *types.Options) (*Runner, error) {
 		os.Exit(0)
 	}
 
+	if options.Verbose || options.VerboseVerbose {
+		LogDirectoryInfo(runner.Logger)
+	}
+
 	//  Version check by default
 	if config.DefaultConfig.CanCheckForUpdates() {
 		if err := installer.NucleiVersionCheck(); err != nil {


### PR DESCRIPTION
## Summary
- Share config/cache/PDCP directory printing helper
- Include dirs in -hc output and on -v/-vv startup (-version unchanged)
- Closes #4880

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configuration/cache/PDCP directory details to health-check output.
  * When verbose modes are enabled, startup logs now display configuration, cache, and PDCP directory locations.
  * Version output now includes the relevant nuclei directory paths.
* **Bug Fixes**
  * Standardized directory reporting across health checks, verbose startup logs, and version output.
* **Tests**
  * Added a unit test to verify the directory info output format/content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->