### PR TITLE
Deduplicate multiformat fuzz HTTP inputs

### DIFF
--- a/internal/server/dedupe.go
+++ b/internal/server/dedupe.go
@@ -1,122 +1,20 @@
 package server
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
-	"net/url"
-	"sort"
-	"strings"
-	"sync"
-
+	"github.com/projectdiscovery/nuclei/v3/pkg/input/dedupe"
 	"github.com/projectdiscovery/nuclei/v3/pkg/input/types"
-	mapsutil "github.com/projectdiscovery/utils/maps"
 )
 
-var dynamicHeaders = map[string]bool{
-	"date":                true,
-	"if-modified-since":   true,
-	"if-unmodified-since": true,
-	"cache-control":       true,
-	"if-none-match":       true,
-	"if-match":            true,
-	"authorization":       true,
-	"cookie":              true,
-	"x-csrf-token":        true,
-	"content-length":      true,
-	"content-md5":         true,
-	"host":                true,
-	"x-request-id":        true,
-	"x-correlation-id":    true,
-	"user-agent":          true,
-	"referer":             true,
-}
-
+// requestDeduplicator wraps the shared HTTP request deduplicator used by
+// live DAST and multiformat fuzz inputs.
 type requestDeduplicator struct {
-	hashes map[string]struct{}
-	lock   *sync.RWMutex
+	inner *dedupe.RequestDeduplicator
 }
 
 func newRequestDeduplicator() *requestDeduplicator {
-	return &requestDeduplicator{
-		hashes: make(map[string]struct{}),
-		lock:   &sync.RWMutex{},
-	}
+	return &requestDeduplicator{inner: dedupe.NewRequestDeduplicator()}
 }
 
 func (r *requestDeduplicator) isDuplicate(req *types.RequestResponse) bool {
-	hash, err := hashRequest(req)
-	if err != nil {
-		return false
-	}
-
-	r.lock.RLock()
-	_, ok := r.hashes[hash]
-	r.lock.RUnlock()
-	if ok {
-		return true
-	}
-
-	r.lock.Lock()
-	r.hashes[hash] = struct{}{}
-	r.lock.Unlock()
-	return false
-}
-
-func hashRequest(req *types.RequestResponse) (string, error) {
-	normalizedURL, err := normalizeURL(req.URL.URL)
-	if err != nil {
-		return "", err
-	}
-
-	var hashContent strings.Builder
-	hashContent.WriteString(req.Request.Method)
-	hashContent.WriteString(normalizedURL)
-
-	headers := sortedNonDynamicHeaders(req.Request.Headers)
-	for _, header := range headers {
-		hashContent.WriteString(header.Key)
-		hashContent.WriteString(header.Value)
-	}
-
-	if len(req.Request.Body) > 0 {
-		hashContent.Write([]byte(req.Request.Body))
-	}
-
-	// Calculate the SHA256 hash
-	hash := sha256.Sum256([]byte(hashContent.String()))
-	return hex.EncodeToString(hash[:]), nil
-}
-
-func normalizeURL(u *url.URL) (string, error) {
-	query := u.Query()
-	sortedQuery := make(url.Values)
-	for k, v := range query {
-		sort.Strings(v)
-		sortedQuery[k] = v
-	}
-	u.RawQuery = sortedQuery.Encode()
-
-	if u.Path == "" {
-		u.Path = "/"
-	}
-	return u.String(), nil
-}
-
-type header struct {
-	Key   string
-	Value string
-}
-
-func sortedNonDynamicHeaders(headers mapsutil.OrderedMap[string, string]) []header {
-	var result []header
-	headers.Iterate(func(k, v string) bool {
-		if !dynamicHeaders[strings.ToLower(k)] {
-			result = append(result, header{Key: k, Value: v})
-		}
-		return true
-	})
-	sort.Slice(result, func(i, j int) bool {
-		return result[i].Key < result[j].Key
-	})
-	return result
+	return r.inner.IsDuplicate(req)
 }

--- a/pkg/input/dedupe/dedupe.go
+++ b/pkg/input/dedupe/dedupe.go
@@ -1,0 +1,161 @@
+// Package dedupe provides request-level deduplication for HTTP inputs used by
+// fuzzing / DAST (burp, openapi, proxify dumps, live dast-server, etc.).
+package dedupe
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"net/url"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/input/types"
+	mapsutil "github.com/projectdiscovery/utils/maps"
+)
+
+// Headers that commonly change between equivalent requests and should not
+// affect the fingerprint used for deduplication.
+var dynamicHeaders = map[string]bool{
+	"date":                true,
+	"if-modified-since":   true,
+	"if-unmodified-since": true,
+	"cache-control":       true,
+	"if-none-match":       true,
+	"if-match":            true,
+	"authorization":       true,
+	"cookie":              true,
+	"x-csrf-token":        true,
+	"content-length":      true,
+	"content-md5":         true,
+	"host":                true,
+	"x-request-id":        true,
+	"x-correlation-id":    true,
+	"user-agent":          true,
+	"referer":             true,
+}
+
+// RequestDeduplicator tracks seen HTTP requests by a stable fingerprint.
+type RequestDeduplicator struct {
+	hashes map[string]struct{}
+	lock   sync.RWMutex
+}
+
+// NewRequestDeduplicator creates an empty request deduplicator.
+func NewRequestDeduplicator() *RequestDeduplicator {
+	return &RequestDeduplicator{
+		hashes: make(map[string]struct{}),
+	}
+}
+
+// IsDuplicate returns true if an equivalent request was already seen.
+// The first occurrence of a fingerprint is recorded and returns false.
+func (r *RequestDeduplicator) IsDuplicate(req *types.RequestResponse) bool {
+	if req == nil {
+		return false
+	}
+	hash, err := HashRequest(req)
+	if err != nil || hash == "" {
+		return false
+	}
+
+	r.lock.RLock()
+	_, ok := r.hashes[hash]
+	r.lock.RUnlock()
+	if ok {
+		return true
+	}
+
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	if _, ok := r.hashes[hash]; ok {
+		return true
+	}
+	r.hashes[hash] = struct{}{}
+	return false
+}
+
+// Len returns the number of unique fingerprints recorded.
+func (r *RequestDeduplicator) Len() int {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+	return len(r.hashes)
+}
+
+// HashRequest builds a stable fingerprint for a request:
+// method + normalized URL + non-dynamic headers + body.
+func HashRequest(req *types.RequestResponse) (string, error) {
+	if req == nil || req.URL.URL == nil {
+		return "", nil
+	}
+
+	normalizedURL, err := NormalizeURL(req.URL.URL)
+	if err != nil {
+		return "", err
+	}
+
+	var hashContent strings.Builder
+	method := "GET"
+	var body string
+	var headers mapsutil.OrderedMap[string, string]
+	if req.Request != nil {
+		if req.Request.Method != "" {
+			method = strings.ToUpper(req.Request.Method)
+		}
+		body = req.Request.Body
+		headers = req.Request.Headers
+	}
+	hashContent.WriteString(method)
+	hashContent.WriteString(normalizedURL)
+
+	for _, header := range sortedNonDynamicHeaders(headers) {
+		hashContent.WriteString(header.Key)
+		hashContent.WriteString(header.Value)
+	}
+
+	if len(body) > 0 {
+		hashContent.WriteString(body)
+	}
+
+	hash := sha256.Sum256([]byte(hashContent.String()))
+	return hex.EncodeToString(hash[:]), nil
+}
+
+// NormalizeURL returns a stable string form of u without mutating the original.
+func NormalizeURL(u *url.URL) (string, error) {
+	if u == nil {
+		return "", nil
+	}
+	cloned := *u
+	query := cloned.Query()
+	sortedQuery := make(url.Values, len(query))
+	for k, v := range query {
+		sorted := append([]string(nil), v...)
+		sort.Strings(sorted)
+		sortedQuery[k] = sorted
+	}
+	cloned.RawQuery = sortedQuery.Encode()
+	if cloned.Path == "" {
+		cloned.Path = "/"
+	}
+	return cloned.String(), nil
+}
+
+type header struct {
+	Key   string
+	Value string
+}
+
+func sortedNonDynamicHeaders(headers mapsutil.OrderedMap[string, string]) []header {
+	var result []header
+	headers.Iterate(func(k, v string) bool {
+		if !dynamicHeaders[strings.ToLower(k)] {
+			result = append(result, header{Key: strings.ToLower(k), Value: v})
+		}
+		return true
+	})
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Key < result[j].Key
+	})
+	return result
+}

--- a/pkg/input/dedupe/dedupe_test.go
+++ b/pkg/input/dedupe/dedupe_test.go
@@ -1,0 +1,109 @@
+package dedupe
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/input/types"
+	mapsutil "github.com/projectdiscovery/utils/maps"
+	urlutil "github.com/projectdiscovery/utils/url"
+	"github.com/stretchr/testify/require"
+)
+
+func mustURL(t *testing.T, raw string) urlutil.URL {
+	t.Helper()
+	parsed, err := urlutil.ParseAbsoluteURL(raw, false)
+	require.NoError(t, err)
+	return *parsed
+}
+
+func newReq(t *testing.T, method, rawURL, body string, headers map[string]string) *types.RequestResponse {
+	t.Helper()
+	om := mapsutil.NewOrderedMap[string, string]()
+	for k, v := range headers {
+		om.Set(k, v)
+	}
+	return &types.RequestResponse{
+		URL: mustURL(t, rawURL),
+		Request: &types.HttpRequest{
+			Method:  method,
+			Body:    body,
+			Headers: om,
+		},
+	}
+}
+
+func TestRequestDeduplicatorDuplicates(t *testing.T) {
+	t.Parallel()
+
+	d := NewRequestDeduplicator()
+	a := newReq(t, "GET", "https://example.com/a?b=2&a=1", "", nil)
+	b := newReq(t, "GET", "https://example.com/a?a=1&b=2", "", nil) // query order differs
+	c := newReq(t, "POST", "https://example.com/a?a=1&b=2", "", nil)
+
+	require.False(t, d.IsDuplicate(a))
+	require.True(t, d.IsDuplicate(b), "normalized query order should collide")
+	require.False(t, d.IsDuplicate(c), "different method should not collide")
+	require.Equal(t, 2, d.Len())
+}
+
+func TestRequestDeduplicatorIgnoresDynamicHeaders(t *testing.T) {
+	t.Parallel()
+
+	d := NewRequestDeduplicator()
+	a := newReq(t, "GET", "https://example.com/x", "", map[string]string{
+		"Cookie":     "a=1",
+		"User-Agent": "ua-a",
+		"X-Custom":   "keep",
+	})
+	b := newReq(t, "GET", "https://example.com/x", "", map[string]string{
+		"Cookie":     "a=2",
+		"User-Agent": "ua-b",
+		"X-Custom":   "keep",
+	})
+	c := newReq(t, "GET", "https://example.com/x", "", map[string]string{
+		"X-Custom": "other",
+	})
+
+	require.False(t, d.IsDuplicate(a))
+	require.True(t, d.IsDuplicate(b), "dynamic headers should be ignored")
+	require.False(t, d.IsDuplicate(c), "stable header change should not collide")
+}
+
+func TestRequestDeduplicatorBodyMatters(t *testing.T) {
+	t.Parallel()
+
+	d := NewRequestDeduplicator()
+	a := newReq(t, "POST", "https://example.com/x", `{"a":1}`, nil)
+	b := newReq(t, "POST", "https://example.com/x", `{"a":2}`, nil)
+
+	require.False(t, d.IsDuplicate(a))
+	require.False(t, d.IsDuplicate(b))
+}
+
+func TestNormalizeURLDoesNotMutateInput(t *testing.T) {
+	t.Parallel()
+
+	u, err := url.Parse("https://example.com/path?b=2&a=1")
+	require.NoError(t, err)
+	original := u.RawQuery
+
+	got, err := NormalizeURL(u)
+	require.NoError(t, err)
+	require.Equal(t, original, u.RawQuery)
+	require.Contains(t, got, "a=1")
+	require.Contains(t, got, "b=2")
+}
+
+func TestHashRequestEmptyPath(t *testing.T) {
+	t.Parallel()
+
+	a := newReq(t, "GET", "https://example.com", "", nil)
+	b := newReq(t, "GET", "https://example.com/", "", nil)
+
+	ha, err := HashRequest(a)
+	require.NoError(t, err)
+	hb, err := HashRequest(b)
+	require.NoError(t, err)
+	require.Equal(t, ha, hb)
+}

--- a/pkg/input/provider/http/multiformat.go
+++ b/pkg/input/provider/http/multiformat.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/projectdiscovery/gologger"
+	"github.com/projectdiscovery/nuclei/v3/pkg/input/dedupe"
 	"github.com/projectdiscovery/nuclei/v3/pkg/input/formats"
 	"github.com/projectdiscovery/nuclei/v3/pkg/input/formats/burp"
 	"github.com/projectdiscovery/nuclei/v3/pkg/input/formats/json"
@@ -38,6 +39,7 @@ type HttpInputProvider struct {
 	inputData []byte
 	inputFile string
 	count     int64
+	dupeCount int64
 }
 
 // NewHttpInputProvider creates a new input provider for nuclei from a file
@@ -59,6 +61,8 @@ func NewHttpInputProvider(opts *HttpMultiFormatOptions) (*HttpInputProvider, err
 	// Do a first pass over the input to identify any errors
 	// and get the count of the input file as well
 	count := int64(0)
+	dupeCount := int64(0)
+	deduplicator := dedupe.NewRequestDeduplicator()
 	var inputFile *os.File
 	var inputReader io.Reader
 	if opts.InputFile != "" {
@@ -86,23 +90,34 @@ func NewHttpInputProvider(opts *HttpMultiFormatOptions) (*HttpInputProvider, err
 	}
 
 	parseErr := format.Parse(bytes.NewReader(data), func(request *types.RequestResponse) bool {
+		if deduplicator.IsDuplicate(request) {
+			dupeCount++
+			return false
+		}
 		count++
 		return false
 	}, opts.InputFile)
 	if parseErr != nil {
 		return nil, errors.Wrap(parseErr, "could not parse input file")
 	}
-	return &HttpInputProvider{format: format, inputData: data, inputFile: opts.InputFile, count: count}, nil
+	if dupeCount > 0 {
+		gologger.Info().Msgf("Supplied %s input was automatically deduplicated (%d removed).", opts.InputMode, dupeCount)
+	}
+	return &HttpInputProvider{format: format, inputData: data, inputFile: opts.InputFile, count: count, dupeCount: dupeCount}, nil
 }
 
-// Count returns the number of items for input provider
+// Count returns the number of unique items for input provider
 func (i *HttpInputProvider) Count() int64 {
 	return i.count
 }
 
-// Iterate over all inputs in order
+// Iterate over all unique inputs in order
 func (i *HttpInputProvider) Iterate(callback func(value *contextargs.MetaInput) bool) {
+	deduplicator := dedupe.NewRequestDeduplicator()
 	err := i.format.Parse(bytes.NewReader(i.inputData), func(request *types.RequestResponse) bool {
+		if deduplicator.IsDuplicate(request) {
+			return false
+		}
 		metaInput := contextargs.NewMetaInput()
 		metaInput.ReqResp = request
 		metaInput.Input = request.URL.String()

--- a/pkg/input/provider/http/multiformat_test.go
+++ b/pkg/input/provider/http/multiformat_test.go
@@ -1,0 +1,61 @@
+package http
+
+import (
+	"testing"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/contextargs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHttpInputProviderDeduplicatesJSONL(t *testing.T) {
+	t.Parallel()
+
+	// Three lines: two equivalent GETs (different Cookie / query order) and one unique POST.
+	input := "" +
+		`{"url":"https://example.com/search?q=1&lang=en","request":{"raw":"GET /search?q=1&lang=en HTTP/1.1\r\nHost: example.com\r\nCookie: a=1\r\n\r\n"}}` + "\n" +
+		`{"url":"https://example.com/search?lang=en&q=1","request":{"raw":"GET /search?lang=en&q=1 HTTP/1.1\r\nHost: example.com\r\nCookie: a=2\r\n\r\n"}}` + "\n" +
+		`{"url":"https://example.com/search","request":{"raw":"POST /search HTTP/1.1\r\nHost: example.com\r\nContent-Type: application/json\r\nContent-Length: 7\r\n\r\n{\"x\":1}"}}` + "\n"
+
+	provider, err := NewHttpInputProvider(&HttpMultiFormatOptions{
+		InputMode:     "jsonl",
+		InputContents: input,
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(2), provider.Count())
+	require.Equal(t, int64(1), provider.dupeCount)
+
+	var methods []string
+	provider.Iterate(func(value *contextargs.MetaInput) bool {
+		require.NotNil(t, value.ReqResp)
+		require.NotNil(t, value.ReqResp.Request)
+		methods = append(methods, value.ReqResp.Request.Method+" "+value.Input)
+		return true
+	})
+	require.Len(t, methods, 2)
+	require.Contains(t, methods[0], "GET")
+	require.Contains(t, methods[1], "POST")
+}
+
+func TestHttpInputProviderIterateSkipsDuplicates(t *testing.T) {
+	t.Parallel()
+
+	input := "" +
+		`{"url":"https://example.com/a","request":{"raw":"GET /a HTTP/1.1\r\nHost: example.com\r\n\r\n"}}` + "\n" +
+		`{"url":"https://example.com/a","request":{"raw":"GET /a HTTP/1.1\r\nHost: example.com\r\nUser-Agent: other\r\n\r\n"}}` + "\n" +
+		`{"url":"https://example.com/b","request":{"raw":"GET /b HTTP/1.1\r\nHost: example.com\r\n\r\n"}}` + "\n"
+
+	provider, err := NewHttpInputProvider(&HttpMultiFormatOptions{
+		InputMode:     "jsonl",
+		InputContents: input,
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(2), provider.Count())
+	require.Equal(t, int64(1), provider.dupeCount)
+
+	var urls []string
+	provider.Iterate(func(value *contextargs.MetaInput) bool {
+		urls = append(urls, value.Input)
+		return true
+	})
+	require.Equal(t, []string{"https://example.com/a", "https://example.com/b"}, urls)
+}


### PR DESCRIPTION
## Summary
- Add shared request fingerprinting (`pkg/input/dedupe`) and use it in multiformat HTTP inputs (burp, openapi, swagger, jsonl, yaml) so equivalent requests are skipped during count/iterate
- Point live DAST server dedupe at the same helper

Closes #4962

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic deduplication for HTTP requests during input processing and iteration.
  * Requests are recognized as duplicates despite differences in query parameter order or dynamic headers.
  * Request bodies and stable headers are considered when distinguishing unique requests.
  * Duplicate counts are tracked and reported during input processing.

* **Bug Fixes**
  * Prevented repeated equivalent requests from being processed multiple times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->