### PR TITLE
Add per-template Interactsh eviction timeout

### DIFF
--- a/pkg/protocols/code/code.go
+++ b/pkg/protocols/code/code.go
@@ -358,6 +358,7 @@ func (request *Request) ExecuteWithResults(input *contextargs.Context, dynamicVa
 			Operators:      request.CompiledOperators,
 			MatchFunc:      request.Match,
 			ExtractFunc:    request.Extract,
+			Eviction:       request.options.InteractshEvictionDuration(),
 		})
 	}
 

--- a/pkg/protocols/common/interactsh/eviction_test.go
+++ b/pkg/protocols/common/interactsh/eviction_test.go
@@ -1,0 +1,56 @@
+package interactsh
+
+import (
+	"testing"
+	"time"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/output"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEvictionFromSeconds(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, time.Duration(0), EvictionFromSeconds(0))
+	require.Equal(t, time.Duration(0), EvictionFromSeconds(-1))
+	require.Equal(t, 300*time.Second, EvictionFromSeconds(300))
+}
+
+func TestClientEvictionForUsesRequestOverride(t *testing.T) {
+	t.Parallel()
+
+	client, err := New(&Options{Eviction: 60 * time.Second, CacheSize: 10})
+	require.NoError(t, err)
+
+	require.Equal(t, 60*time.Second, client.evictionFor(nil))
+	require.Equal(t, 60*time.Second, client.evictionFor(&RequestData{}))
+	require.Equal(t, 300*time.Second, client.evictionFor(&RequestData{Eviction: 300 * time.Second}))
+}
+
+func TestRequestEventStoresWithPerRequestEviction(t *testing.T) {
+	t.Parallel()
+
+	client, err := New(&Options{Eviction: 60 * time.Second, CacheSize: 10})
+	require.NoError(t, err)
+	client.hostname = "oast.example"
+
+	id := "abc123"
+	url := id + "." + client.hostname
+	data := &RequestData{
+		Event: &output.InternalWrappedEvent{InternalEvent: map[string]interface{}{
+			templateIdAttribute: "test-template",
+			"host":              "example.com",
+		}},
+		Eviction: 50 * time.Millisecond,
+	}
+
+	client.RequestEvent([]string{url}, data)
+
+	got, err := client.requests.Get(id)
+	require.NoError(t, err)
+	require.Equal(t, data, got)
+
+	require.Eventually(t, func() bool {
+		_, err := client.requests.Get(id)
+		return err != nil
+	}, time.Second, 10*time.Millisecond)
+}

--- a/pkg/protocols/common/interactsh/interactsh.go
+++ b/pkg/protocols/common/interactsh/interactsh.go
@@ -344,6 +344,10 @@ type RequestData struct {
 
 	Parameter string
 	Request   *retryablehttp.Request
+
+	// Eviction overrides the client-wide Interactsh request cache TTL when > 0.
+	// Used for per-template interactsh-eviction.
+	Eviction time.Duration
 }
 
 // RequestEvent is the event for a network request sent by nuclei.
@@ -367,9 +371,27 @@ func (c *Client) RequestEvent(interactshURLs []string, data *RequestData) {
 				}
 			}
 		} else {
-			_ = c.requests.SetWithExpire(id, data, c.eviction)
+			_ = c.requests.SetWithExpire(id, data, c.evictionFor(data))
 		}
 	}
+}
+
+// evictionFor returns the request cache TTL for a RequestEvent.
+// Per-request Eviction overrides the client-wide default when set.
+func (c *Client) evictionFor(data *RequestData) time.Duration {
+	if data != nil && data.Eviction > 0 {
+		return data.Eviction
+	}
+	return c.eviction
+}
+
+// EvictionFromSeconds converts a template/CLI eviction value in seconds to a
+// duration. Non-positive values mean "use the client default".
+func EvictionFromSeconds(seconds int) time.Duration {
+	if seconds <= 0 {
+		return 0
+	}
+	return time.Duration(seconds) * time.Second
 }
 
 // HasMatchers returns true if an operator has interactsh part

--- a/pkg/protocols/headless/request.go
+++ b/pkg/protocols/headless/request.go
@@ -233,6 +233,7 @@ func (request *Request) executeRequestWithPayloads(input *contextargs.Context, p
 			Operators:      request.CompiledOperators,
 			MatchFunc:      request.Match,
 			ExtractFunc:    request.Extract,
+			Eviction:       request.options.InteractshEvictionDuration(),
 		})
 	}
 	if len(page.InteractshURLs) > 0 {

--- a/pkg/protocols/http/request.go
+++ b/pkg/protocols/http/request.go
@@ -288,6 +288,7 @@ func (request *Request) executeParallelHTTP(input *contextargs.Context, dynamicV
 							Operators:      request.CompiledOperators,
 							MatchFunc:      request.Match,
 							ExtractFunc:    request.Extract,
+							Eviction:       request.options.InteractshEvictionDuration(),
 						}
 						allOASTUrls := httputils.GetInteractshURLSFromEvent(event.InternalEvent)
 						allOASTUrls = append(allOASTUrls, t.req.interactshURLs...)
@@ -594,6 +595,7 @@ func (request *Request) ExecuteWithResults(input *contextargs.Context, dynamicVa
 						Operators:      request.CompiledOperators,
 						MatchFunc:      request.Match,
 						ExtractFunc:    request.Extract,
+						Eviction:       request.options.InteractshEvictionDuration(),
 					}
 					allOASTUrls := httputils.GetInteractshURLSFromEvent(event.InternalEvent)
 					allOASTUrls = append(allOASTUrls, generatedHttpRequest.interactshURLs...)

--- a/pkg/protocols/http/request_fuzz.go
+++ b/pkg/protocols/http/request_fuzz.go
@@ -214,6 +214,7 @@ func (request *Request) executeGeneratedFuzzingRequest(gr fuzz.GeneratedRequest,
 				ExtractFunc:    request.Extract,
 				Parameter:      gr.Parameter,
 				Request:        gr.Request,
+				Eviction:       request.options.InteractshEvictionDuration(),
 			}
 			setInteractshCallback = true
 			request.options.Interactsh.RequestEvent(gr.InteractURLs, requestData)

--- a/pkg/protocols/interactsh_eviction_test.go
+++ b/pkg/protocols/interactsh_eviction_test.go
@@ -1,0 +1,15 @@
+package protocols
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInteractshEvictionDuration(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, time.Duration(0), (*ExecutorOptions)(nil).InteractshEvictionDuration())
+	require.Equal(t, time.Duration(0), (&ExecutorOptions{}).InteractshEvictionDuration())
+	require.Equal(t, 300*time.Second, (&ExecutorOptions{InteractshEviction: 300}).InteractshEvictionDuration())
+}

--- a/pkg/protocols/javascript/js.go
+++ b/pkg/protocols/javascript/js.go
@@ -704,6 +704,7 @@ func (request *Request) executeRequestWithPayloads(
 			Operators:      request.CompiledOperators,
 			MatchFunc:      request.Match,
 			ExtractFunc:    request.Extract,
+			Eviction:       request.options.InteractshEvictionDuration(),
 		})
 	}
 	return nil

--- a/pkg/protocols/network/request.go
+++ b/pkg/protocols/network/request.go
@@ -487,6 +487,7 @@ func (request *Request) executeRequestWithPayloads(variables map[string]interfac
 			Operators:      request.CompiledOperators,
 			MatchFunc:      request.Match,
 			ExtractFunc:    request.Extract,
+			Eviction:       request.options.InteractshEvictionDuration(),
 		})
 	}
 	if len(interactshURLs) > 0 {

--- a/pkg/protocols/protocols.go
+++ b/pkg/protocols/protocols.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"sync/atomic"
+	"time"
 
 	"github.com/projectdiscovery/fastdialer/fastdialer"
 	"github.com/projectdiscovery/gologger"
@@ -105,6 +106,10 @@ type ExecutorOptions struct {
 	// Stop execution once first match is found (Assigned while parsing templates)
 	// Note: this is different from Options.StopAtFirstMatch (Assigned from CLI option)
 	StopAtFirstMatch bool
+	// InteractshEviction is an optional per-template Interactsh request cache
+	// TTL in seconds. When > 0 it overrides the global interactions-eviction
+	// duration for requests from this template only.
+	InteractshEviction int
 	// Variables is a list of variables from template
 	Variables variables.Variable
 	// Constants is a list of constants from template
@@ -313,6 +318,7 @@ func (e *ExecutorOptions) Copy() *ExecutorOptions {
 		Interactsh:                   e.Interactsh,
 		HostErrorsCache:              e.HostErrorsCache,
 		StopAtFirstMatch:             e.StopAtFirstMatch,
+		InteractshEviction:           e.InteractshEviction,
 		Variables:                    e.Variables,
 		Constants:                    e.Constants,
 		ExcludeMatchers:              e.ExcludeMatchers,
@@ -338,6 +344,15 @@ func (e *ExecutorOptions) Copy() *ExecutorOptions {
 	copy.ClusterMappings = e.ClusterMappings.Copy()
 	copy.CreateTemplateCtxStore()
 	return copy
+}
+
+// InteractshEvictionDuration returns the per-template Interactsh request
+// cache TTL, or 0 to use the client-wide default.
+func (e *ExecutorOptions) InteractshEvictionDuration() time.Duration {
+	if e == nil {
+		return 0
+	}
+	return interactsh.EvictionFromSeconds(e.InteractshEviction)
 }
 
 // Request is an interface implemented any protocol based request generator.

--- a/pkg/templates/compile.go
+++ b/pkg/templates/compile.go
@@ -555,6 +555,7 @@ func parseTemplateNoVerify(data []byte, srcOptions *protocols.ExecutorOptions) (
 	options.TemplateID = template.ID
 	options.TemplateInfo = template.Info
 	options.StopAtFirstMatch = template.StopAtFirstMatch
+	options.InteractshEviction = template.InteractshEviction
 
 	if template.Variables.Len() > 0 {
 		options.Variables = template.Variables

--- a/pkg/templates/interactsh_eviction_test.go
+++ b/pkg/templates/interactsh_eviction_test.go
@@ -1,0 +1,28 @@
+package templates
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestTemplateInteractshEvictionUnmarshal(t *testing.T) {
+	t.Parallel()
+
+	const raw = `
+id: example-oast
+info:
+  name: example
+  author: pdteam
+  severity: info
+interactsh-eviction: 300
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+`
+	var template Template
+	require.NoError(t, yaml.Unmarshal([]byte(raw), &template))
+	require.Equal(t, 300, template.InteractshEviction)
+}

--- a/pkg/templates/templates.go
+++ b/pkg/templates/templates.go
@@ -132,6 +132,14 @@ type Template struct {
 	StopAtFirstMatch bool `yaml:"stop-at-first-match,omitempty" json:"stop-at-first-match,omitempty" jsonschema:"title=stop at first match,description=Stop at first match for the template"`
 
 	// description: |
+	//   InteractshEviction is the number of seconds to keep this template's
+	//   Interactsh request pending for OAST callbacks before eviction.
+	//   When unset, the global -interactions-eviction value is used.
+	// examples:
+	//   - value: "300"
+	InteractshEviction int `yaml:"interactsh-eviction,omitempty" json:"interactsh-eviction,omitempty" jsonschema:"title=interactsh eviction seconds,description=Per-template Interactsh request eviction timeout in seconds,minimum=1"`
+
+	// description: |
 	//   Signature is the request signature method
 	//   WARNING: 'signature' will be deprecated and will be removed in a future release. Prefer using 'code' protocol for writing cloud checks
 	// values:


### PR DESCRIPTION
## Summary
- Add optional `interactsh-eviction` (seconds) on templates so OAST request cache TTL can be longer for slow callbacks without raising the global `-interactions-eviction` for every template
- Wire it through compile → executor options → Interactsh `RequestEvent` cache expiry; unset keeps the global default

Closes #5061

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional per-template `interactsh-eviction` setting to control how long pending interaction requests are retained.
  - Templates without a custom value continue using the global interaction eviction setting.
  - The setting is supported across HTTP, headless, JavaScript, network, and code-based requests.
  - Non-positive or unset values preserve the default eviction behavior.

- **Bug Fixes**
  - Ensured per-template eviction settings are consistently applied to interaction requests and callback tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->