### PR TITLE
refactor(installer): preserve local templates during updates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -416,7 +416,7 @@ require (
 	golang.org/x/crypto v0.53.0 // indirect
 	golang.org/x/exp v0.0.0-20260527015227-08cc5374adb3
 	golang.org/x/mod v0.36.0 // indirect
-	golang.org/x/sys v0.46.0 // indirect
+	golang.org/x/sys v0.46.0
 	golang.org/x/time v0.14.0 // indirect
 	golang.org/x/tools v0.45.0
 	google.golang.org/protobuf v1.36.11

--- a/go.mod
+++ b/go.mod
@@ -414,7 +414,7 @@ require (
 	golang.org/x/crypto v0.54.0 // indirect
 	golang.org/x/exp v0.0.0-20260527015227-08cc5374adb3
 	golang.org/x/mod v0.37.0 // indirect
-	golang.org/x/sys v0.47.0 // indirect
+	golang.org/x/sys v0.47.0
 	golang.org/x/time v0.14.0 // indirect
 	golang.org/x/tools v0.47.0
 	google.golang.org/protobuf v1.36.11

--- a/pkg/catalog/config/nucleiconfig.go
+++ b/pkg/catalog/config/nucleiconfig.go
@@ -299,19 +299,123 @@ func (c *Config) WriteTemplatesConfig() error {
 	if err != nil {
 		return errkit.Newf("failed to marshal nuclei config: %v", err)
 	}
-	if err = os.WriteFile(c.getTemplatesConfigFilePath(), bin, 0600); err != nil {
+	configFilePath := c.getTemplatesConfigFilePath()
+	if err = writeTemplatesConfigFile(configFilePath, bin, replaceTemplatesConfigFile); err != nil {
 		return errkit.Newf("failed to write nuclei config file at %s: %v", c.getTemplatesConfigFilePath(), err)
 	}
 	return nil
 }
 
+func writeTemplatesConfigFile(configFilePath string, contents []byte, replace func(string, string) error) error {
+	writePath := configFilePath
+	if info, err := os.Lstat(configFilePath); err == nil && info.Mode()&os.ModeSymlink != 0 {
+		writePath, err = resolveConfigWritePath(configFilePath)
+		if err != nil {
+			return fmt.Errorf("resolve config file symlink: %w", err)
+		}
+	} else if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("inspect config file path: %w", err)
+	}
+
+	mode := os.FileMode(0o600)
+	preserveMode := false
+
+	if info, err := os.Stat(writePath); err == nil {
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("config file target %q is not a regular file", writePath)
+		}
+
+		mode = info.Mode().Perm()
+		preserveMode = true
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("inspect existing config file: %w", err)
+	}
+
+	temporary, err := os.CreateTemp(filepath.Dir(writePath), filepath.Base(writePath)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create temporary config file: %w", err)
+	}
+
+	defer func() {
+		_ = temporary.Close()
+		_ = os.Remove(temporary.Name())
+	}()
+
+	if _, err := temporary.Write(contents); err != nil {
+		return fmt.Errorf("write temporary config file: %w", err)
+	}
+
+	if preserveMode {
+		if err := temporary.Chmod(mode); err != nil {
+			return fmt.Errorf("preserve config file permissions: %w", err)
+		}
+	}
+
+	if err := temporary.Sync(); err != nil {
+		return fmt.Errorf("sync temporary config file: %w", err)
+	}
+	if err := temporary.Close(); err != nil {
+		return fmt.Errorf("close temporary config file: %w", err)
+	}
+	if err := replace(temporary.Name(), writePath); err != nil {
+		return fmt.Errorf("replace config file: %w", err)
+	}
+
+	return nil
+}
+
+func resolveConfigWritePath(configFilePath string) (string, error) {
+	current := configFilePath
+
+	for range 255 {
+		info, err := os.Lstat(current)
+		if err != nil {
+			if !os.IsNotExist(err) {
+				return "", err
+			}
+
+			parent, err := filepath.EvalSymlinks(filepath.Dir(current))
+			if err != nil {
+				return "", err
+			}
+
+			return filepath.Join(parent, filepath.Base(current)), nil
+		}
+
+		if info.Mode()&os.ModeSymlink == 0 {
+			return filepath.EvalSymlinks(current)
+		}
+
+		target, err := os.Readlink(current)
+		if err != nil {
+			return "", err
+		}
+
+		if !filepath.IsAbs(target) {
+			parent, err := filepath.EvalSymlinks(filepath.Dir(current))
+			if err != nil {
+				return "", err
+			}
+
+			target = filepath.Join(parent, target)
+		}
+
+		current = filepath.Clean(target)
+	}
+
+	return "", fmt.Errorf("too many config file symlinks")
+}
+
 // WriteTemplatesIndex writes the nuclei templates index file
 func (c *Config) WriteTemplatesIndex(index map[string]string) error {
 	indexFile := c.GetTemplateIndexFilePath()
+
 	var buff bytes.Buffer
+
 	for k, v := range index {
 		_, _ = buff.WriteString(k + "," + v + "\n")
 	}
+
 	return os.WriteFile(indexFile, buff.Bytes(), 0600)
 }
 
@@ -327,6 +431,7 @@ func (c *Config) createConfigDirIfNotExists() error {
 			return errkit.Newf("could not create nuclei config directory at %s: %v", c.configDir, err)
 		}
 	}
+
 	return nil
 }
 
@@ -337,6 +442,7 @@ func (c *Config) copyIgnoreFile() {
 		c.Logger.Error().Msgf("Could not create nuclei config directory at %s: %s", c.configDir, err)
 		return
 	}
+
 	ignoreFilePath := c.GetIgnoreFilePath()
 	if !fileutil.FileExists(ignoreFilePath) {
 		// copy ignore file from default config directory

--- a/pkg/catalog/config/nucleiconfig.go
+++ b/pkg/catalog/config/nucleiconfig.go
@@ -315,6 +315,7 @@ func (c *Config) WriteTemplatesIndex(index map[string]string) error {
 	indexFile := c.GetTemplateIndexFilePath()
 
 	var buff bytes.Buffer
+
 	for k, v := range index {
 		_, _ = buff.WriteString(k + "," + v + "\n")
 	}
@@ -329,7 +330,6 @@ func (c *Config) createConfigDirIfNotExists() error {
 			return errkit.Newf("could not create nuclei config directory at %s: %v", c.configDir, err)
 		}
 	}
-
 	return nil
 }
 

--- a/pkg/catalog/config/nucleiconfig_replace.go
+++ b/pkg/catalog/config/nucleiconfig_replace.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package config
+
+import "os"
+
+func replaceTemplatesConfigFile(temporaryPath, configFilePath string) error {
+	return os.Rename(temporaryPath, configFilePath)
+}

--- a/pkg/catalog/config/nucleiconfig_replace_windows.go
+++ b/pkg/catalog/config/nucleiconfig_replace_windows.go
@@ -1,0 +1,48 @@
+package config
+
+import (
+	"errors"
+	"os"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+var replaceFile = windows.NewLazySystemDLL("kernel32.dll").NewProc("ReplaceFileW")
+
+func replaceTemplatesConfigFile(temporaryPath, configFilePath string) error {
+	temporary, err := windows.UTF16PtrFromString(temporaryPath)
+	if err != nil {
+		return err
+	}
+
+	target, err := windows.UTF16PtrFromString(configFilePath)
+	if err != nil {
+		return err
+	}
+
+	if _, err := os.Lstat(configFilePath); err != nil {
+		if !os.IsNotExist(err) {
+			return err
+		}
+
+		return windows.MoveFileEx(temporary, target, windows.MOVEFILE_WRITE_THROUGH)
+	}
+
+	replaced, _, callErr := replaceFile.Call(
+		uintptr(unsafe.Pointer(target)),
+		uintptr(unsafe.Pointer(temporary)),
+		0,
+		0,
+		0,
+		0,
+	)
+	if replaced != 0 {
+		return nil
+	}
+	if errors.Is(callErr, windows.ERROR_FILE_NOT_FOUND) {
+		return windows.MoveFileEx(temporary, target, windows.MOVEFILE_WRITE_THROUGH)
+	}
+
+	return callErr
+}

--- a/pkg/catalog/config/nucleiconfig_replace_windows_test.go
+++ b/pkg/catalog/config/nucleiconfig_replace_windows_test.go
@@ -1,0 +1,40 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReplaceTemplatesConfigFile(t *testing.T) {
+	for _, targetExists := range []bool{false, true} {
+		name := "creates"
+		if targetExists {
+			name = "replaces"
+		}
+		t.Run(name, func(t *testing.T) {
+			directory := t.TempDir()
+			target := filepath.Join(directory, "config.json")
+			if targetExists {
+				if err := os.WriteFile(target, []byte("previous"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			temporary := filepath.Join(directory, "config.tmp")
+			if err := os.WriteFile(temporary, []byte("current"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			if err := replaceTemplatesConfigFile(temporary, target); err != nil {
+				t.Fatal(err)
+			}
+			contents, err := os.ReadFile(target)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(contents) != "current" {
+				t.Fatalf("expected replacement contents, got %q", contents)
+			}
+		})
+	}
+}

--- a/pkg/catalog/config/nucleiconfig_test.go
+++ b/pkg/catalog/config/nucleiconfig_test.go
@@ -1,9 +1,163 @@
 package config
 
 import (
+	"errors"
+	"os"
 	"path/filepath"
 	"testing"
 )
+
+func TestWriteTemplatesConfigFilePreservesPreviousConfigOnReplaceFailure(t *testing.T) {
+	configFilePath := filepath.Join(t.TempDir(), TemplateConfigFileName)
+	previousContents := []byte(`{"nuclei-templates-version":"v1.0.0"}`)
+	if err := os.WriteFile(configFilePath, previousContents, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	replaceErr := errors.New("replace failed")
+
+	err := writeTemplatesConfigFile(configFilePath, []byte(`{"nuclei-templates-version":"v2.0.0"}`), func(string, string) error {
+		return replaceErr
+	})
+	if !errors.Is(err, replaceErr) {
+		t.Fatalf("expected replacement error, got %v", err)
+	}
+	contents, err := os.ReadFile(configFilePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(contents) != string(previousContents) {
+		t.Fatalf("expected prior config contents %q, got %q", previousContents, contents)
+	}
+	temporaryFiles, err := filepath.Glob(configFilePath + ".tmp-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(temporaryFiles) != 0 {
+		t.Fatalf("expected temporary config cleanup, found %v", temporaryFiles)
+	}
+}
+
+func TestWriteTemplatesConfigFilePreservesExistingMode(t *testing.T) {
+	configFilePath := filepath.Join(t.TempDir(), TemplateConfigFileName)
+	if err := os.WriteFile(configFilePath, []byte("previous"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	previousInfo, err := os.Stat(configFilePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := writeTemplatesConfigFile(configFilePath, []byte("current"), os.Rename); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(configFilePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != previousInfo.Mode().Perm() {
+		t.Fatalf("expected mode %04o, got %04o", previousInfo.Mode().Perm(), got)
+	}
+}
+
+func TestWriteTemplatesConfigFilePreservesSymlink(t *testing.T) {
+	targetPath := filepath.Join(t.TempDir(), "managed-config.json")
+	if err := os.WriteFile(targetPath, []byte("previous"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	configFilePath := filepath.Join(t.TempDir(), TemplateConfigFileName)
+	if err := os.Symlink(targetPath, configFilePath); err != nil {
+		t.Skipf("symlinks are unavailable: %v", err)
+	}
+
+	if err := writeTemplatesConfigFile(configFilePath, []byte("current"), os.Rename); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Lstat(configFilePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatal("expected config symlink to remain")
+	}
+	contents, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(contents) != "current" {
+		t.Fatalf("expected symlink target to be updated, got %q", contents)
+	}
+}
+
+func TestWriteTemplatesConfigFileCreatesDanglingSymlinkTarget(t *testing.T) {
+	for _, relative := range []bool{false, true} {
+		name := "absolute"
+		if relative {
+			name = "relative"
+		}
+		t.Run(name, func(t *testing.T) {
+			parent := t.TempDir()
+			targetDir := filepath.Join(parent, "managed")
+			if err := os.Mkdir(targetDir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			targetPath := filepath.Join(targetDir, "config.json")
+			configFilePath := filepath.Join(parent, TemplateConfigFileName)
+			linkTarget := targetPath
+			if relative {
+				var err error
+				linkTarget, err = filepath.Rel(filepath.Dir(configFilePath), targetPath)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := os.Symlink(linkTarget, configFilePath); err != nil {
+				t.Skipf("symlinks are unavailable: %v", err)
+			}
+
+			if err := writeTemplatesConfigFile(configFilePath, []byte("current"), os.Rename); err != nil {
+				t.Fatal(err)
+			}
+			contents, err := os.ReadFile(targetPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(contents) != "current" {
+				t.Fatalf("expected dangling symlink target to be created, got %q", contents)
+			}
+		})
+	}
+}
+
+func TestWriteTemplatesConfigFileResolvesRelativeTargetFromRealParent(t *testing.T) {
+	parent := t.TempDir()
+	realDirectory := filepath.Join(parent, "real", "nested")
+	if err := os.MkdirAll(realDirectory, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	aliasDirectory := filepath.Join(parent, "alias")
+	if err := os.Symlink(realDirectory, aliasDirectory); err != nil {
+		t.Skipf("symlinks are unavailable: %v", err)
+	}
+	configFilePath := filepath.Join(aliasDirectory, TemplateConfigFileName)
+	if err := os.Symlink("../managed.json", configFilePath); err != nil {
+		t.Skipf("symlinks are unavailable: %v", err)
+	}
+	expectedTarget := filepath.Join(filepath.Dir(realDirectory), "managed.json")
+
+	if err := writeTemplatesConfigFile(configFilePath, []byte("current"), os.Rename); err != nil {
+		t.Fatal(err)
+	}
+	contents, err := os.ReadFile(expectedTarget)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(contents) != "current" {
+		t.Fatalf("expected resolved target contents, got %q", contents)
+	}
+	if _, err := os.Stat(filepath.Join(parent, "managed.json")); !os.IsNotExist(err) {
+		t.Fatalf("unexpected lexical target: %v", err)
+	}
+}
 
 func TestIsCustomTemplateUsesPathBoundaries(t *testing.T) {
 	templatesDir := filepath.Join(t.TempDir(), "nuclei-templates")

--- a/pkg/catalog/config/nucleiconfig_unix_test.go
+++ b/pkg/catalog/config/nucleiconfig_unix_test.go
@@ -1,0 +1,57 @@
+//go:build !windows
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+func TestWriteTemplatesConfigFileHonorsUmaskForNewFile(t *testing.T) {
+	configFilePath := filepath.Join(t.TempDir(), TemplateConfigFileName)
+	previousUmask := syscall.Umask(0o777)
+	t.Cleanup(func() { syscall.Umask(previousUmask) })
+
+	if err := writeTemplatesConfigFile(configFilePath, []byte("current"), os.Rename); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(configFilePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0 {
+		t.Fatalf("expected mode 0000 under restrictive umask, got %04o", got)
+	}
+}
+
+func TestWriteTemplatesConfigFileRejectsFIFOThroughSymlink(t *testing.T) {
+	parent := t.TempDir()
+	targetPath := filepath.Join(parent, "managed-config")
+	if err := syscall.Mkfifo(targetPath, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	configFilePath := filepath.Join(parent, TemplateConfigFileName)
+	if err := os.Symlink(targetPath, configFilePath); err != nil {
+		t.Skipf("symlinks are unavailable: %v", err)
+	}
+
+	if err := writeTemplatesConfigFile(configFilePath, []byte("current"), os.Rename); err == nil {
+		t.Fatal("expected non-regular target rejection")
+	}
+	info, err := os.Lstat(targetPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&os.ModeNamedPipe == 0 {
+		t.Fatalf("expected FIFO target to remain, got mode %v", info.Mode())
+	}
+	info, err = os.Lstat(configFilePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatal("expected config symlink to remain")
+	}
+}

--- a/pkg/catalog/config/state.go
+++ b/pkg/catalog/config/state.go
@@ -134,7 +134,7 @@ func atomicWriteFile(path string, data []byte, mode os.FileMode) error {
 
 	temp = nil
 
-	if err := os.Rename(tempPath, path); err != nil {
+	if err := replaceTemplatesConfigFile(tempPath, path); err != nil {
 		return fmt.Errorf("replace %q: %w", path, err)
 	}
 

--- a/pkg/installer/template.go
+++ b/pkg/installer/template.go
@@ -4,15 +4,19 @@ import (
 	"bytes"
 	"context"
 	"crypto/md5"
+	"crypto/rand"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 
 	"github.com/charmbracelet/glamour"
+	"github.com/google/go-github/v30/github"
 	"github.com/olekukonko/tablewriter"
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/config"
@@ -20,13 +24,13 @@ import (
 	filepathutil "github.com/projectdiscovery/nuclei/v3/pkg/utils/filepath"
 	"github.com/projectdiscovery/utils/errkit"
 	fileutil "github.com/projectdiscovery/utils/file"
-	mapsutil "github.com/projectdiscovery/utils/maps"
 	stringsutil "github.com/projectdiscovery/utils/strings"
 	updateutils "github.com/projectdiscovery/utils/update"
 )
 
 const (
-	checkSumFilePerm = 0644
+	checkSumFilePerm              = 0644
+	templateOutputTemporaryPrefix = ".nuclei-write-"
 )
 
 var (
@@ -101,6 +105,10 @@ func (t *TemplateManager) updateIfOutdatedLocked() error {
 		return t.FreshInstallIfNotExists()
 	}
 
+	if err := recoverTemplateOwnership(config.DefaultConfig.TemplatesDirectory); err != nil {
+		return errkit.Wrapf(err, "failed to recover template ownership at %s", config.DefaultConfig.TemplatesDirectory)
+	}
+
 	needsUpdate := config.DefaultConfig.NeedsTemplateUpdate()
 
 	// NOTE(dwisiswant0): if PDTM API data is not available
@@ -130,30 +138,234 @@ func (t *TemplateManager) installTemplatesAt(dir string) error {
 			return errkit.Wrapf(err, "failed to create directory at %s", dir)
 		}
 	}
+
 	if t.DisablePublicTemplates {
 		gologger.Info().Msgf("Skipping installation of public nuclei-templates")
 		return nil
 	}
+
+	if err := recoverTemplateOwnership(dir); err != nil {
+		return errkit.Wrapf(err, "failed to recover template ownership at %s", dir)
+	}
+
 	ghrd, err := updateutils.NewghReleaseDownloader(config.OfficialNucleiTemplatesRepoName)
 	if err != nil {
 		return errkit.Wrapf(err, "failed to install templates at %s", dir)
 	}
 
 	// write templates to disk
-	_, err = t.writeTemplatesToDisk(ghrd, dir)
-	if err != nil {
-		return errkit.Wrapf(err, "failed to write templates to disk at %s", dir)
+	writtenOutputs, writeErr := t.writeTemplatesToDisk(ghrd, dir)
+	if _, finalizeErr := t.finalizeTemplateWrite(config.DefaultConfig, writtenOutputs, ghrd.Latest.GetTagName(), writeErr); finalizeErr != nil {
+		return errkit.Wrapf(finalizeErr, "failed to finalize template installation at %s", dir)
 	}
+
 	gologger.Info().Msgf("Successfully installed nuclei-templates at %s", dir)
+
 	return nil
+}
+
+type templateArchiveFetcher func(version string) (*bytes.Reader, error)
+
+func commitTemplateVersion(cfg *config.Config, version string) error {
+	previousVersion := cfg.TemplateVersion
+	if err := cfg.SetTemplatesVersion(version); err != nil {
+		cfg.TemplateVersion = previousVersion
+
+		return err
+	}
+
+	return nil
+}
+
+func (t *TemplateManager) finalizeTemplateRelease(cfg *config.Config, writtenOutputs map[string]string, version string) (map[string]string, error) {
+	dir := cfg.TemplatesDirectory
+
+	var finalizationErr error
+
+	if err := reconcileTemplateOwnership(dir, writtenOutputs); err != nil {
+		finalizationErr = errors.Join(finalizationErr, fmt.Errorf("reconcile template ownership: %w", err))
+	}
+
+	if err := cfg.UpdateNucleiIgnoreHash(); err != nil {
+		finalizationErr = errors.Join(finalizationErr, errkit.Wrap(err, "failed to update nuclei ignore hash"))
+	}
+
+	checksums, err := t.regenerateTemplateMetadata(cfg)
+	if err != nil {
+		finalizationErr = errors.Join(finalizationErr, fmt.Errorf("regenerate template metadata: %w", err))
+	}
+
+	if finalizationErr != nil {
+		return nil, finalizationErr
+	}
+
+	if err := commitTemplateVersion(cfg, version); err != nil {
+		return nil, errkit.Wrap(err, "failed to update templates version")
+	}
+
+	return checksums, nil
+}
+
+func (t *TemplateManager) finalizeTemplateWrite(cfg *config.Config, writtenOutputs map[string]string, version string, writeErr error) (map[string]string, error) {
+	if writeErr != nil {
+		if ownershipErr := recordPartialTemplateOwnership(cfg.TemplatesDirectory, writtenOutputs); ownershipErr != nil {
+			writeErr = errors.Join(writeErr, fmt.Errorf("record ownership for partially written templates: %w", ownershipErr))
+		}
+
+		return nil, writeErr
+	}
+
+	return t.finalizeTemplateRelease(cfg, writtenOutputs, version)
+}
+
+func (t *TemplateManager) bootstrapTemplateOwnership(dir, version string, fetchArchive templateArchiveFetcher) error {
+	if _, err := loadTemplateOwnership(dir); err == nil {
+		return nil
+	} else if errors.Is(err, errTemplateOwnershipInvalid) {
+		quarantines, recoveryErr := listTemplateOwnershipQuarantines(dir)
+		if recoveryErr != nil {
+			return errors.Join(err, recoveryErr)
+		}
+
+		restoreStates, recoveryErr := listTemplateOwnershipRestoreStates(dir)
+		if recoveryErr != nil {
+			return errors.Join(err, recoveryErr)
+		}
+
+		if len(quarantines) > 0 || len(restoreStates) > 0 {
+			return err
+		}
+
+		gologger.Verbose().Msgf("Replacing invalid template ownership metadata without retiring prior templates: %s", err)
+
+		return nil
+	} else if !errors.Is(err, errTemplateOwnershipMissing) {
+		return err
+	}
+
+	version = strings.TrimSpace(version)
+	if version == "" {
+		return nil
+	}
+
+	archive, err := fetchArchive(version)
+	if err != nil {
+		gologger.Verbose().Msgf("Continuing template update without prior ownership for %q: %s", version, err)
+		return nil
+	}
+
+	if err := t.bootstrapTemplateOwnershipFromArchive(dir, archive); err != nil {
+		if errors.Is(err, errTemplateOwnershipArchiveInvalid) {
+			gologger.Verbose().Msgf("Continuing template update without prior ownership for %q: %s", version, err)
+			return nil
+		}
+
+		return fmt.Errorf("build ownership from prior template release %q: %w", version, err)
+	}
+
+	return nil
+}
+
+func fetchTemplateReleaseArchive(version string) (*bytes.Reader, error) {
+	ctx := context.Background()
+	httpClient := &http.Client{Timeout: updateutils.DownloadUpdateTimeout}
+	client := github.NewClient(httpClient)
+	archiveURL, _, err := client.Repositories.GetArchiveLink(
+		ctx,
+		updateutils.Organization,
+		config.OfficialNucleiTemplatesRepoName,
+		github.Zipball,
+		&github.RepositoryContentGetOptions{Ref: version},
+		true,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("resolve prior template release %q archive: %w", version, err)
+	}
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, archiveURL.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("create prior template release %q archive request: %w", version, err)
+	}
+
+	var contents bytes.Buffer
+	response, err := client.Do(ctx, request, &contents)
+	if err != nil {
+		return nil, fmt.Errorf("download prior template release %q: %w", version, err)
+	}
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("download prior template release %q: unexpected HTTP status %s", version, response.Status)
+	}
+
+	return bytes.NewReader(contents.Bytes()), nil
+}
+
+func (t *TemplateManager) bootstrapTemplateOwnershipFromArchive(dir string, archive *bytes.Reader) error {
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return fmt.Errorf("get absolute templates directory: %w", err)
+	}
+
+	manifest := &templateOwnershipManifest{
+		Version: templateOwnershipVersion,
+		Files:   make(map[string]string),
+	}
+
+	callback := func(uri string, fileInfo fs.FileInfo, reader io.Reader) error {
+		if fileInfo.IsDir() {
+			return nil
+		}
+
+		_, writePath := t.getTemplateOutputLocation(absDir, uri, fileInfo)
+		if writePath == "" {
+			return nil
+		}
+
+		if !config.IsTemplate(writePath) {
+			return nil
+		}
+
+		relativePath, err := filepath.Rel(absDir, writePath)
+		if err != nil {
+			return fmt.Errorf("make prior template path %q relative to %q: %w", writePath, absDir, err)
+		}
+
+		relativePath = filepath.ToSlash(relativePath)
+		if !config.IsTemplate(relativePath) {
+			return nil
+		}
+
+		if err := validateTemplateOwnershipPath(relativePath); err != nil {
+			return err
+		}
+
+		contents, err := io.ReadAll(reader)
+		if err != nil {
+			return fmt.Errorf("read prior template %q: %w", uri, err)
+		}
+
+		manifest.Files[relativePath] = templateDigest(contents)
+		return nil
+	}
+
+	if err := updateutils.UnpackAssetWithCallback(updateutils.Zip, archive, callback); err != nil {
+		return fmt.Errorf("%w: unpack prior template release: %v", errTemplateOwnershipArchiveInvalid, err)
+	}
+
+	return writeTemplateOwnership(absDir, manifest)
 }
 
 // updateTemplatesAt updates templates at given directory
 func (t *TemplateManager) updateTemplatesAt(dir string) error {
 	if t.DisablePublicTemplates {
 		gologger.Info().Msgf("Skipping update of public nuclei-templates")
+
 		return nil
 	}
+
+	if err := t.bootstrapTemplateOwnership(dir, config.DefaultConfig.TemplateVersion, fetchTemplateReleaseArchive); err != nil {
+		return errkit.Wrapf(err, "failed to migrate template ownership at %s", dir)
+	}
+
 	// firstly, read checksums from .checksum file these are used to generate stats
 	oldchecksums, err := t.getChecksumFromDir(dir)
 	if err != nil {
@@ -176,48 +388,14 @@ func (t *TemplateManager) updateTemplatesAt(dir string) error {
 	}
 
 	// write templates to disk
-	writtenPaths, err := t.writeTemplatesToDisk(ghrd, dir)
-	if err != nil {
-		return err
-	}
-
-	// cleanup orphaned templates that exist locally but weren't in the new release
-	if err := t.cleanupOrphanedTemplates(dir, writtenPaths); err != nil {
-		// log warning but don't fail the update
-		gologger.Warning().Msgf("failed to cleanup orphaned templates: %s", err)
-	} else {
-		// Regenerate metadata (index and checksum) after successful cleanup to ensure
-		// metadata accurately reflects the cleaned template tree. This prevents stale
-		// index entries and checksum entries for deleted templates.
-		if err := t.regenerateTemplateMetadata(dir); err != nil {
-			// Log warning but don't fail the update - metadata will be out of sync
-			// but templates are cleaned up correctly
-			gologger.Warning().Msgf("failed to regenerate template metadata after cleanup: %s", err)
-		}
-	}
-
-	// get checksums from new templates
-	newchecksums, err := t.getChecksumFromDir(dir)
-	if err != nil {
-		// unlikely this case will happen
-		return errkit.Wrapf(err, "failed to get checksums from %s after update", dir)
+	writtenOutputs, writeErr := t.writeTemplatesToDisk(ghrd, dir)
+	newchecksums, finalizeErr := t.finalizeTemplateWrite(config.DefaultConfig, writtenOutputs, latestVersion, writeErr)
+	if finalizeErr != nil {
+		return errkit.Wrapf(finalizeErr, "failed to finalize template update at %s", dir)
 	}
 
 	// summarize all changes
 	results := t.summarizeChanges(oldchecksums, newchecksums)
-
-	// remove deleted templates
-	for _, deletion := range results.deletions {
-		// the deletion list comes from the on-disk .checksum file; only remove
-		// paths inside the templates directory.
-		if !filepathutil.IsPathWithinDirectory(deletion, dir) {
-			gologger.Warning().Msgf("skipping deletion of %s: path is outside templates directory %s", deletion, dir)
-			continue
-		}
-		if err := os.Remove(deletion); err != nil && !os.IsNotExist(err) {
-			gologger.Warning().Msgf("failed to remove deleted template %s: %s", deletion, err)
-		}
-	}
 
 	// print summary
 	if results.totalCount > 0 {
@@ -230,6 +408,7 @@ func (t *TemplateManager) updateTemplatesAt(dir string) error {
 	} else {
 		gologger.Info().Msgf("Successfully updated nuclei-templates (%v) to %s. GoodLuck!", ghrd.Latest.GetTagName(), dir)
 	}
+
 	return nil
 }
 
@@ -245,26 +424,30 @@ func (t *TemplateManager) summarizeChanges(old, new map[string]string) *template
 			results.additions = append(results.additions, k)
 		}
 	}
+
 	for k := range old {
 		if _, ok := new[k]; !ok {
 			results.deletions = append(results.deletions, k)
 		}
 	}
+
 	results.totalCount = len(results.additions) + len(results.deletions) + len(results.modifications)
+
 	return results
 }
 
-// getAbsoluteFilePath returns an absolute path where a file should be written based on given uri(i.e., files in zip)
-// if a returned path is empty, it means that file should not be written and skipped
-func (t *TemplateManager) getAbsoluteFilePath(templateDir, uri string, f fs.FileInfo) string {
+// getTemplateOutputLocation returns the safe root and absolute output path for an archive entry.
+// An empty output path means the entry should be skipped.
+func (t *TemplateManager) getTemplateOutputLocation(templateDir, uri string, f fs.FileInfo) (string, string) {
 	// overwrite .nuclei-ignore every time nuclei-templates are downloaded
 	if f.Name() == config.NucleiIgnoreFileName {
-		return config.DefaultConfig.GetIgnoreFilePath()
+		return config.DefaultConfig.GetConfigDir(), config.DefaultConfig.GetIgnoreFilePath()
 	}
+
 	// skip all meta files
 	if !strings.EqualFold(f.Name(), config.NewTemplateAdditionsFileName) {
 		if strings.TrimSpace(f.Name()) == "" || strings.HasPrefix(f.Name(), ".") || strings.EqualFold(f.Name(), "README.md") {
-			return ""
+			return "", ""
 		}
 	}
 
@@ -282,9 +465,9 @@ func (t *TemplateManager) getAbsoluteFilePath(templateDir, uri string, f fs.File
 		// to outside the configured templates directory.
 		fallbackPath := filepath.Clean(filepath.Join(templateDir, uri))
 		if !filepathutil.IsPathWithinDirectory(fallbackPath, templateDir) {
-			return ""
+			return "", ""
 		}
-		return fallbackPath
+		return templateDir, fallbackPath
 	}
 	// separator is also included in rootDir
 	rootDirectory := uri[:index+1]
@@ -292,47 +475,37 @@ func (t *TemplateManager) getAbsoluteFilePath(templateDir, uri string, f fs.File
 
 	// if it is a github meta directory skip it
 	if stringsutil.HasPrefixAny(relPath, ".github", ".git") {
-		return ""
+		return "", ""
 	}
 
 	newPath := filepath.Clean(filepath.Join(templateDir, relPath))
 
 	if !filepathutil.IsPathWithinDirectory(newPath, templateDir) || !filepathutil.IsPathWithinDirectory(filepath.Dir(newPath), templateDir) {
 		// we don't allow LFI
-		return ""
+		return "", ""
 	}
 
 	if filepath.Clean(newPath) == filepath.Clean(templateDir) {
 		// skip writing the folder itself since it already exists
-		return ""
+		return "", ""
 	}
 
-	if relPath != "" && f.IsDir() {
-		// if uri is a directory, create it
-		if err := fileutil.CreateFolder(newPath); err != nil {
-			gologger.Warning().Msgf("uri %v: got %s while installing templates", uri, err)
-		}
-		return ""
-	}
-	return newPath
+	return templateDir, newPath
 }
 
-// writeTemplatesToDisk writes all templates to disk and returns a map of written file paths
-// The returned map contains absolute paths of all template files that were successfully written
-func (t *TemplateManager) writeTemplatesToDisk(ghrd *updateutils.GHReleaseDownloader, dir string) (*mapsutil.SyncLockMap[string, struct{}], error) {
-	localTemplatesIndex, err := config.GetNucleiTemplatesIndex()
-	if err != nil {
-		gologger.Warning().Msgf("failed to get local nuclei-templates index: %s", err)
-		if localTemplatesIndex == nil {
-			localTemplatesIndex = map[string]string{} // no-op
-		}
-	}
-
-	// Track all paths that are successfully written during this update
-	writtenPaths := mapsutil.NewSyncLockMap[string, struct{}]()
+// writeTemplatesToDisk writes release outputs to disk and returns their digests.
+// The returned map includes every successfully written output; ownership
+// reconciliation filters it to official template paths.
+func (t *TemplateManager) writeTemplatesToDisk(ghrd *updateutils.GHReleaseDownloader, dir string) (map[string]string, error) {
+	writtenOutputs := make(map[string]string)
+	touchedDirectories := make(map[string]struct{})
 
 	callbackFunc := func(uri string, f fs.FileInfo, r io.Reader) error {
-		writePath := t.getAbsoluteFilePath(dir, uri, f)
+		if f.IsDir() {
+			return nil
+		}
+
+		rootDir, writePath := t.getTemplateOutputLocation(dir, uri, f)
 		if writePath == "" {
 			// skip writing file
 			return nil
@@ -343,69 +516,33 @@ func (t *TemplateManager) writeTemplatesToDisk(ghrd *updateutils.GHReleaseDownlo
 			// if error occurs, iteration also stops
 			return errkit.Wrapf(err, "failed to read file %s", uri)
 		}
-		// TODO: It might be better to just download index file from nuclei templates repo
-		// instead of creating it from scratch
-		id, _ := config.GetTemplateIDFromReader(bytes.NewReader(bin), uri)
-		if id != "" {
-			// based on template id, check if we are updating a path of official nuclei template
-			if oldPath, ok := localTemplatesIndex[id]; ok {
-				if oldPath != writePath {
-					// write new template at a new path and delete old template
-					if err := os.WriteFile(writePath, bin, f.Mode()); err != nil {
-						return errkit.Wrapf(err, "failed to write file %s", uri)
-					}
-					// Track the new path as written
-					_ = writtenPaths.Set(writePath, struct{}{})
-					// after successful write, remove old template. oldPath comes
-					// from the on-disk .templates-index; only remove paths inside
-					// the templates directory.
-					if !filepathutil.IsPathWithinDirectory(oldPath, dir) {
-						gologger.Warning().Msgf("skipping removal of old template %s: path is outside templates directory %s", oldPath, dir)
-					} else if err := os.Remove(oldPath); err != nil {
-						gologger.Warning().Msgf("failed to remove old template %s: %s", oldPath, err)
-					}
-					return nil
-				}
-			}
+
+		outputResult, outputErr := writeTemplateOutput(rootDir, writePath, bin, f.Mode())
+		for _, directory := range outputResult.touchedDirectories {
+			touchedDirectories[directory] = struct{}{}
 		}
-		// no change in template Path of official templates
-		if err := os.WriteFile(writePath, bin, f.Mode()); err != nil {
-			return errkit.Wrapf(err, "failed to write file %s", uri)
+
+		if outputErr != nil {
+			return errkit.Wrapf(outputErr, "failed to write file %s", uri)
 		}
-		// Track successfully written paths
-		_ = writtenPaths.Set(writePath, struct{}{})
+
+		writtenOutputs[writePath] = templateDigest(bin)
+
 		return nil
 	}
-	err = ghrd.DownloadSourceWithCallback(!HideProgressBar, callbackFunc)
-	if err != nil {
-		return nil, errkit.Wrap(err, "failed to download templates")
+
+	var writeErr error
+
+	if err := ghrd.DownloadSourceWithCallback(!HideProgressBar, callbackFunc); err != nil {
+		writeErr = errkit.Wrap(err, "failed to download templates")
 	}
 
-	if err := config.DefaultConfig.WriteTemplatesConfig(); err != nil {
-		return nil, errkit.Wrap(err, "failed to write templates config")
-	}
-	// update ignore hash after writing new templates
-	if err := config.DefaultConfig.UpdateNucleiIgnoreHash(); err != nil {
-		return nil, errkit.Wrap(err, "failed to update nuclei ignore hash")
+	if err := syncTemplateOutputDirectories(touchedDirectories, syncTemplateOwnershipDirectory); err != nil {
+		writeErr = errors.Join(writeErr, errkit.Wrap(err, "failed to sync template output directories"))
 	}
 
-	// update templates version in config file
-	if err := config.DefaultConfig.SetTemplatesVersion(ghrd.Latest.GetTagName()); err != nil {
-		return nil, errkit.Wrap(err, "failed to update templates version")
-	}
-
-	PurgeEmptyDirectories(dir)
-
-	// generate index of all templates
-	_ = os.Remove(config.DefaultConfig.GetTemplateIndexFilePath())
-
-	index, err := config.GetNucleiTemplatesIndex()
-	if err != nil {
-		return nil, errkit.Wrap(err, "failed to get nuclei templates index")
-	}
-
-	if err = config.DefaultConfig.WriteTemplatesIndex(index); err != nil {
-		return nil, errkit.Wrap(err, "failed to write nuclei templates index")
+	if writeErr != nil {
+		return writtenOutputs, writeErr
 	}
 
 	if !HideReleaseNotes {
@@ -415,148 +552,154 @@ func (t *TemplateManager) writeTemplatesToDisk(ghrd *updateutils.GHReleaseDownlo
 		if err != nil {
 			gologger.Error().Msgf("markdown rendering not supported: %v", err)
 		}
+
 		if rendered, err := r.Render(output); err == nil {
 			output = rendered
 		} else {
 			gologger.Error().Msg(err.Error())
 		}
+
 		gologger.Print().Msgf("\n%v\n\n", output)
 	}
 
-	// after installation, create and write checksums to .checksum file
-	if err := t.writeChecksumFileInDir(dir); err != nil {
-		return nil, err
-	}
-
-	return writtenPaths, nil
+	return writtenOutputs, nil
 }
 
-// cleanupOrphanedTemplates removes template files that exist locally but were not part of the new release
-// It scans the templates directory for template files and deletes those that are not in the writtenPaths set
-// This function handles empty directories gracefully - if the directory is empty, no orphaned files will be found
-func (t *TemplateManager) cleanupOrphanedTemplates(dir string, writtenPaths *mapsutil.SyncLockMap[string, struct{}]) error {
-	absDir, err := filepath.Abs(dir)
-	if err != nil {
-		return errkit.Wrapf(err, "failed to get absolute path of templates directory")
-	}
-	// Use Clean to normalize the path consistently (handles Windows paths better)
-	absDir = filepath.Clean(absDir)
+func syncTemplateOutputDirectories(directories map[string]struct{}, syncDirectory func(*os.Root, string) error) error {
+	var syncErrors error
 
-	// If directory doesn't exist, there's nothing to clean up
-	if !fileutil.FolderExists(absDir) {
-		return nil
-	}
-
-	// Normalize all written paths to absolute paths for comparison
-	normalizedWrittenPaths := mapsutil.NewSyncLockMap[string, struct{}]()
-	for path := range writtenPaths.GetAll() {
-		absPath, err := filepath.Abs(path)
-		if err == nil {
-			// Use Clean to normalize the path consistently (handles Windows paths better)
-			absPath = filepath.Clean(absPath)
-			_ = normalizedWrittenPaths.Set(absPath, struct{}{})
-		}
-	}
-
-	// Get custom template directories to exclude
-	customDirs := config.DefaultConfig.GetAllCustomTemplateDirs()
-	customDirAbs := make([]string, 0, len(customDirs))
-	for _, customDir := range customDirs {
-		if absCustomDir, err := filepath.Abs(customDir); err == nil {
-			// Use Clean to normalize the path consistently (handles Windows paths better)
-			absCustomDir = filepath.Clean(absCustomDir)
-			customDirAbs = append(customDirAbs, absCustomDir)
-		}
-	}
-
-	var orphanedFiles []string
-
-	// Walk the templates directory to find all template files
-	err = filepath.WalkDir(absDir, func(path string, d fs.DirEntry, err error) error {
+	for directory := range directories {
+		root, err := os.OpenRoot(directory)
 		if err != nil {
-			// Log but continue walking
-			gologger.Debug().Msgf("error accessing path %s during orphan cleanup: %s", path, err)
-			return nil
+			syncErrors = errors.Join(syncErrors, fmt.Errorf("open output directory %q: %w", directory, err))
+			continue
 		}
 
-		// Skip directories
-		if d.IsDir() {
-			return nil
+		syncErr := syncDirectory(root, ".")
+		closeErr := root.Close()
+		if syncErr != nil {
+			syncErrors = errors.Join(syncErrors, fmt.Errorf("sync output directory %q: %w", directory, syncErr))
 		}
-
-		absPath, err := filepath.Abs(path)
-		if err != nil {
-			return nil
-		}
-		// Use Clean to normalize the path consistently (handles Windows paths better)
-		absPath = filepath.Clean(absPath)
-
-		// Skip custom template directories
-		if filepathutil.IsPathWithinAnyDirectory(absPath, customDirAbs...) {
-			return nil
-		}
-
-		// Only process template files
-		if !config.IsTemplate(absPath) {
-			return nil
-		}
-
-		// Skip if this file was written in the new release
-		if normalizedWrittenPaths.Has(absPath) {
-			return nil
-		}
-
-		// This is an orphaned template file
-		orphanedFiles = append(orphanedFiles, absPath)
-		return nil
-	})
-
-	if err != nil {
-		return errkit.Wrapf(err, "failed to walk templates directory for orphan cleanup")
-	}
-
-	// Delete orphaned files
-	for _, orphanPath := range orphanedFiles {
-		if err := os.Remove(orphanPath); err != nil {
-			if !os.IsNotExist(err) {
-				gologger.Warning().Msgf("failed to remove orphaned template %s: %s", orphanPath, err)
-			}
-		} else {
-			gologger.Debug().Msgf("removed orphaned template: %s", orphanPath)
+		if closeErr != nil {
+			syncErrors = errors.Join(syncErrors, fmt.Errorf("close output directory %q: %w", directory, closeErr))
 		}
 	}
 
-	if len(orphanedFiles) > 0 {
-		gologger.Info().Msgf("cleaned up %d orphaned template file(s)", len(orphanedFiles))
-	}
-
-	return nil
+	return syncErrors
 }
 
-// regenerateTemplateMetadata regenerates template index and checksum files after cleanup operations.
-// This ensures the metadata accurately reflects the current state of template files on disk.
-func (t *TemplateManager) regenerateTemplateMetadata(dir string) error {
-	// Purge empty directories that may have been left after cleanup
+// templateOutputWriteResult records filesystem state that must be finalized
+// even when the associated write returns an error.
+type templateOutputWriteResult struct {
+	touchedDirectories []string
+}
+
+func writeTemplateOutput(rootDir, writePath string, contents []byte, mode fs.FileMode) (templateOutputWriteResult, error) {
+	var result templateOutputWriteResult
+	relativePath, err := filepath.Rel(rootDir, writePath)
+	if err != nil {
+		return result, err
+	}
+
+	if relativePath == ".." || strings.HasPrefix(relativePath, ".."+string(os.PathSeparator)) || filepath.IsAbs(relativePath) {
+		return result, fmt.Errorf("output path %q escapes root %q", writePath, rootDir)
+	}
+
+	root, err := os.OpenRoot(rootDir)
+	if err != nil {
+		return result, fmt.Errorf("open output root %q: %w", rootDir, err)
+	}
+	defer func() { _ = root.Close() }()
+
+	parent := filepath.Dir(relativePath)
+	if parent != "." {
+		parentsToSync, err := createTemplateDirectories(root, parent)
+		for _, parentToSync := range parentsToSync {
+			result.touchedDirectories = append(result.touchedDirectories, filepath.Clean(filepath.Join(rootDir, parentToSync)))
+		}
+		if err != nil {
+			return result, fmt.Errorf("create output parent %q: %w", parent, err)
+		}
+	}
+	result.touchedDirectories = append(result.touchedDirectories, filepath.Dir(writePath))
+
+	randomSuffix := make([]byte, 16)
+	if _, err := rand.Read(randomSuffix); err != nil {
+		return result, fmt.Errorf("generate temporary output name: %w", err)
+	}
+
+	temporaryPath := filepath.Join(parent, fmt.Sprintf("%s%x", templateOutputTemporaryPrefix, randomSuffix))
+	temporaryMode := mode.Perm()
+	preserveMode := false
+
+	if info, err := root.Lstat(relativePath); err == nil && info.Mode().IsRegular() {
+		temporaryMode = 0o600
+		mode = info.Mode()
+		preserveMode = true
+	} else if err != nil && !os.IsNotExist(err) {
+		return result, fmt.Errorf("inspect existing output %q: %w", relativePath, err)
+	}
+
+	temporary, err := root.OpenFile(temporaryPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, temporaryMode)
+	if err != nil {
+		return result, fmt.Errorf("create temporary output %q: %w", temporaryPath, err)
+	}
+
+	defer func() {
+		_ = temporary.Close()
+		_ = root.Remove(temporaryPath)
+	}()
+
+	if _, err := temporary.Write(contents); err != nil {
+		return result, fmt.Errorf("write temporary output %q: %w", temporaryPath, err)
+	}
+
+	if preserveMode {
+		if err := temporary.Chmod(mode.Perm()); err != nil {
+			return result, fmt.Errorf("preserve output mode %q: %w", temporaryPath, err)
+		}
+	}
+
+	// A release contains thousands of files, so syncing every temporary file
+	// makes installation latency scale with storage flush latency. Closing and
+	// renaming keeps replacement atomic; touched directories are synced once
+	// after extraction and before ownership or version finalization.
+	if err := temporary.Close(); err != nil {
+		return result, fmt.Errorf("close temporary output %q: %w", temporaryPath, err)
+	}
+
+	if err := root.Rename(temporaryPath, relativePath); err != nil {
+		return result, fmt.Errorf("replace output %q: %w", relativePath, err)
+	}
+
+	return result, nil
+}
+
+// regenerateTemplateMetadata rebuilds the index and checksums from the finalized on-disk tree.
+func (t *TemplateManager) regenerateTemplateMetadata(cfg *config.Config) (map[string]string, error) {
+	dir := cfg.TemplatesDirectory
+
+	// Purge empty directories before rebuilding metadata.
 	PurgeEmptyDirectories(dir)
 
-	// Ensure templates directory exists (it may have been purged if empty)
+	// Ensure the templates directory exists if the finalized tree is empty.
 	if !fileutil.FolderExists(dir) {
 		if err := os.MkdirAll(dir, 0755); err != nil {
-			return errkit.Wrapf(err, "failed to recreate templates directory %s after purge", dir)
+			return nil, errkit.Wrapf(err, "failed to recreate templates directory %s after purge", dir)
 		}
 	}
 
 	// Remove old index file and regenerate it from current templates on disk
-	indexFilePath := config.DefaultConfig.GetTemplateIndexFilePath()
+	indexFilePath := cfg.GetTemplateIndexFilePath()
 	if err := os.Remove(indexFilePath); err != nil && !os.IsNotExist(err) {
-		return errkit.Wrapf(err, "failed to remove old index file %s", indexFilePath)
+		return nil, errkit.Wrapf(err, "failed to remove old index file %s", indexFilePath)
 	}
 
 	// Force regeneration by ensuring the file doesn't exist (handles Windows file handle issues)
 	// GetNucleiTemplatesIndex will scan the directory if the file doesn't exist
 	index, err := config.GetNucleiTemplatesIndex()
 	if err != nil {
-		return errkit.Wrap(err, "failed to regenerate nuclei templates index after cleanup")
+		return nil, errkit.Wrap(err, "failed to regenerate nuclei templates index")
 	}
 
 	// Filter out any entries that don't actually exist on disk (Windows file deletion timing issues)
@@ -567,16 +710,20 @@ func (t *TemplateManager) regenerateTemplateMetadata(dir string) error {
 		}
 	}
 
-	if err = config.DefaultConfig.WriteTemplatesIndex(filteredIndex); err != nil {
-		return errkit.Wrap(err, "failed to write nuclei templates index after cleanup")
+	if err = cfg.WriteTemplatesIndex(filteredIndex); err != nil {
+		return nil, errkit.Wrap(err, "failed to write regenerated nuclei templates index")
 	}
 
-	// Regenerate checksum file to reflect current templates on disk
-	if err := t.writeChecksumFileInDir(dir); err != nil {
-		return errkit.Wrap(err, "failed to regenerate checksum file after cleanup")
+	checksumMap, err := t.calculateChecksumMap(dir)
+	if err != nil {
+		return nil, errkit.Wrap(err, "failed to regenerate checksum map")
 	}
 
-	return nil
+	if err := writeChecksumMap(cfg, checksumMap); err != nil {
+		return nil, errkit.Wrap(err, "failed to write regenerated checksum file")
+	}
+
+	return checksumMap, nil
 }
 
 // getChecksumFromDir returns a map containing checksums (md5 hash) of all yaml files (with .yaml extension)
@@ -595,29 +742,40 @@ func (t *TemplateManager) getChecksumFromDir(dir string) (map[string]string, err
 				if len(tmparr) != 2 {
 					continue
 				}
+
 				allChecksums[tmparr[0]] = tmparr[1]
 			}
+
 			return allChecksums, nil
 		}
 	}
+
 	return t.calculateChecksumMap(dir)
 }
 
-// writeChecksumFileInDir creates checksums of all yaml files in given directory
-// and writes them to a file named .checksum
-func (t *TemplateManager) writeChecksumFileInDir(dir string) error {
-	checksumMap, err := t.calculateChecksumMap(dir)
-	if err != nil {
-		return err
-	}
+func writeChecksumMap(cfg *config.Config, checksumMap map[string]string) error {
 	var buff bytes.Buffer
+
 	for k, v := range checksumMap {
 		buff.WriteString(k)
 		buff.WriteString(",")
 		buff.WriteString(v)
 		buff.WriteString(";")
 	}
-	return os.WriteFile(config.DefaultConfig.GetChecksumFilePath(), buff.Bytes(), checkSumFilePerm)
+
+	return os.WriteFile(cfg.GetChecksumFilePath(), buff.Bytes(), checkSumFilePerm)
+}
+
+func isTemplateOutputTemporary(name string) bool {
+	suffix, found := strings.CutPrefix(name, templateOutputTemporaryPrefix)
+	if !found {
+		return false
+	}
+	if isLowerHex(suffix, 32) {
+		return true
+	}
+	pathDigest, token, found := strings.Cut(suffix, "-")
+	return found && isLowerHex(pathDigest, 32) && isLowerHex(token, 32)
 }
 
 // getChecksumMap returns a map containing checksums (md5 hash) of all yaml files (with .yaml extension)
@@ -633,6 +791,7 @@ func (t *TemplateManager) calculateChecksumMap(dir string) (map[string]string, e
 		if err != nil {
 			return "", err
 		}
+
 		return fmt.Sprintf("%x", md5.Sum(bin)), nil
 	}
 
@@ -640,6 +799,18 @@ func (t *TemplateManager) calculateChecksumMap(dir string) (map[string]string, e
 		if err != nil {
 			return err
 		}
+
+		if !d.IsDir() && isTemplateOutputTemporary(filepath.Base(path)) {
+			return nil
+		}
+
+		if filepath.Dir(path) == filepath.Clean(dir) {
+			name := filepath.Base(path)
+			if name == templateOwnershipFileName || strings.HasPrefix(name, templateOwnershipTemporaryPrefix) || strings.HasPrefix(name, templateOwnershipRetiredPrefix) || strings.HasPrefix(name, templateOwnershipRestorePrefix) {
+				return nil
+			}
+		}
+
 		// skip checksums of custom templates i.e github and s3
 		if filepathutil.IsPathWithinAnyDirectory(path, config.DefaultConfig.GetAllCustomTemplateDirs()...) {
 			return nil
@@ -651,9 +822,12 @@ func (t *TemplateManager) calculateChecksumMap(dir string) (map[string]string, e
 			if err != nil {
 				return err
 			}
+
 			checksumMap[path] = checksum
 		}
+
 		return nil
 	})
+
 	return checksumMap, errkit.Wrap(err, "failed to calculate checksums of templates")
 }

--- a/pkg/installer/template.go
+++ b/pkg/installer/template.go
@@ -4,15 +4,19 @@ import (
 	"bytes"
 	"context"
 	"crypto/md5"
+	"crypto/rand"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 
 	"github.com/charmbracelet/glamour"
+	"github.com/google/go-github/v30/github"
 	"github.com/olekukonko/tablewriter"
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/config"
@@ -20,13 +24,13 @@ import (
 	filepathutil "github.com/projectdiscovery/nuclei/v3/pkg/utils/filepath"
 	"github.com/projectdiscovery/utils/errkit"
 	fileutil "github.com/projectdiscovery/utils/file"
-	mapsutil "github.com/projectdiscovery/utils/maps"
 	stringsutil "github.com/projectdiscovery/utils/strings"
 	updateutils "github.com/projectdiscovery/utils/update"
 )
 
 const (
-	checkSumFilePerm = 0644
+	checkSumFilePerm              = 0644
+	templateOutputTemporaryPrefix = ".nuclei-write-"
 )
 
 var (
@@ -104,6 +108,10 @@ func (t *TemplateManager) updateIfOutdatedLocked() error {
 		return t.FreshInstallIfNotExists()
 	}
 
+	if err := recoverTemplateOwnership(config.DefaultConfig.TemplatesDirectory); err != nil {
+		return errkit.Wrapf(err, "failed to recover template ownership at %s", config.DefaultConfig.TemplatesDirectory)
+	}
+
 	needsUpdate := config.DefaultConfig.NeedsTemplateUpdate()
 
 	// NOTE(dwisiswant0): if PDTM API data is not available
@@ -139,15 +147,19 @@ func (t *TemplateManager) installTemplatesAt(dir string) error {
 		return nil
 	}
 
+	if err := recoverTemplateOwnership(dir); err != nil {
+		return errkit.Wrapf(err, "failed to recover template ownership at %s", dir)
+	}
+
 	ghrd, err := updateutils.NewghReleaseDownloader(config.OfficialNucleiTemplatesRepoName)
 	if err != nil {
 		return errkit.Wrapf(err, "failed to install templates at %s", dir)
 	}
 
 	// write templates to disk
-	_, err = t.writeTemplatesToDisk(ghrd, dir)
-	if err != nil {
-		return errkit.Wrapf(err, "failed to write templates to disk at %s", dir)
+	writtenOutputs, writeErr := t.writeTemplatesToDisk(ghrd, dir)
+	if _, finalizeErr := t.finalizeTemplateWrite(config.DefaultConfig, writtenOutputs, ghrd.Latest.GetTagName(), writeErr); finalizeErr != nil {
+		return errkit.Wrapf(finalizeErr, "failed to finalize template installation at %s", dir)
 	}
 
 	gologger.Info().Msgf("Successfully installed nuclei-templates at %s", dir)
@@ -155,11 +167,206 @@ func (t *TemplateManager) installTemplatesAt(dir string) error {
 	return nil
 }
 
+type templateArchiveFetcher func(version string) (*bytes.Reader, error)
+
+func commitTemplateVersion(cfg *config.Config, version string) error {
+	previousVersion := cfg.TemplateVersion
+	if err := cfg.SetTemplatesVersion(version); err != nil {
+		cfg.TemplateVersion = previousVersion
+
+		return err
+	}
+
+	return nil
+}
+
+func (t *TemplateManager) finalizeTemplateRelease(cfg *config.Config, writtenOutputs map[string]string, version string) (map[string]string, error) {
+	dir := cfg.TemplatesDirectory
+
+	var finalizationErr error
+
+	if err := reconcileTemplateOwnership(dir, writtenOutputs); err != nil {
+		finalizationErr = errors.Join(finalizationErr, fmt.Errorf("reconcile template ownership: %w", err))
+	}
+
+	if err := cfg.UpdateNucleiIgnoreHash(); err != nil {
+		finalizationErr = errors.Join(finalizationErr, errkit.Wrap(err, "failed to update nuclei ignore hash"))
+	}
+
+	checksums, err := t.regenerateTemplateMetadata(cfg)
+	if err != nil {
+		finalizationErr = errors.Join(finalizationErr, fmt.Errorf("regenerate template metadata: %w", err))
+	}
+
+	if finalizationErr != nil {
+		return nil, finalizationErr
+	}
+
+	if err := commitTemplateVersion(cfg, version); err != nil {
+		return nil, errkit.Wrap(err, "failed to update templates version")
+	}
+
+	return checksums, nil
+}
+
+func (t *TemplateManager) finalizeTemplateWrite(cfg *config.Config, writtenOutputs map[string]string, version string, writeErr error) (map[string]string, error) {
+	if writeErr != nil {
+		if ownershipErr := recordPartialTemplateOwnership(cfg.TemplatesDirectory, writtenOutputs); ownershipErr != nil {
+			writeErr = errors.Join(writeErr, fmt.Errorf("record ownership for partially written templates: %w", ownershipErr))
+		}
+
+		return nil, writeErr
+	}
+
+	return t.finalizeTemplateRelease(cfg, writtenOutputs, version)
+}
+
+func (t *TemplateManager) bootstrapTemplateOwnership(dir, version string, fetchArchive templateArchiveFetcher) error {
+	if _, err := loadTemplateOwnership(dir); err == nil {
+		return nil
+	} else if errors.Is(err, errTemplateOwnershipInvalid) {
+		quarantines, recoveryErr := listTemplateOwnershipQuarantines(dir)
+		if recoveryErr != nil {
+			return errors.Join(err, recoveryErr)
+		}
+
+		restoreStates, recoveryErr := listTemplateOwnershipRestoreStates(dir)
+		if recoveryErr != nil {
+			return errors.Join(err, recoveryErr)
+		}
+
+		if len(quarantines) > 0 || len(restoreStates) > 0 {
+			return err
+		}
+
+		gologger.Verbose().Msgf("Replacing invalid template ownership metadata without retiring prior templates: %s", err)
+
+		return nil
+	} else if !errors.Is(err, errTemplateOwnershipMissing) {
+		return err
+	}
+
+	version = strings.TrimSpace(version)
+	if version == "" {
+		return nil
+	}
+
+	archive, err := fetchArchive(version)
+	if err != nil {
+		gologger.Verbose().Msgf("Continuing template update without prior ownership for %q: %s", version, err)
+		return nil
+	}
+
+	if err := t.bootstrapTemplateOwnershipFromArchive(dir, archive); err != nil {
+		if errors.Is(err, errTemplateOwnershipArchiveInvalid) {
+			gologger.Verbose().Msgf("Continuing template update without prior ownership for %q: %s", version, err)
+			return nil
+		}
+
+		return fmt.Errorf("build ownership from prior template release %q: %w", version, err)
+	}
+
+	return nil
+}
+
+func fetchTemplateReleaseArchive(version string) (*bytes.Reader, error) {
+	ctx := context.Background()
+	httpClient := &http.Client{Timeout: updateutils.DownloadUpdateTimeout}
+	client := github.NewClient(httpClient)
+	archiveURL, _, err := client.Repositories.GetArchiveLink(
+		ctx,
+		updateutils.Organization,
+		config.OfficialNucleiTemplatesRepoName,
+		github.Zipball,
+		&github.RepositoryContentGetOptions{Ref: version},
+		true,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("resolve prior template release %q archive: %w", version, err)
+	}
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, archiveURL.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("create prior template release %q archive request: %w", version, err)
+	}
+
+	var contents bytes.Buffer
+	response, err := client.Do(ctx, request, &contents)
+	if err != nil {
+		return nil, fmt.Errorf("download prior template release %q: %w", version, err)
+	}
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("download prior template release %q: unexpected HTTP status %s", version, response.Status)
+	}
+
+	return bytes.NewReader(contents.Bytes()), nil
+}
+
+func (t *TemplateManager) bootstrapTemplateOwnershipFromArchive(dir string, archive *bytes.Reader) error {
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return fmt.Errorf("get absolute templates directory: %w", err)
+	}
+
+	manifest := &templateOwnershipManifest{
+		Version: templateOwnershipVersion,
+		Files:   make(map[string]string),
+	}
+
+	callback := func(uri string, fileInfo fs.FileInfo, reader io.Reader) error {
+		if fileInfo.IsDir() {
+			return nil
+		}
+
+		_, writePath := t.getTemplateOutputLocation(absDir, uri, fileInfo)
+		if writePath == "" {
+			return nil
+		}
+
+		if !config.IsTemplate(writePath) {
+			return nil
+		}
+
+		relativePath, err := filepath.Rel(absDir, writePath)
+		if err != nil {
+			return fmt.Errorf("make prior template path %q relative to %q: %w", writePath, absDir, err)
+		}
+
+		relativePath = filepath.ToSlash(relativePath)
+		if !config.IsTemplate(relativePath) {
+			return nil
+		}
+
+		if err := validateTemplateOwnershipPath(relativePath); err != nil {
+			return err
+		}
+
+		contents, err := io.ReadAll(reader)
+		if err != nil {
+			return fmt.Errorf("read prior template %q: %w", uri, err)
+		}
+
+		manifest.Files[relativePath] = templateDigest(contents)
+		return nil
+	}
+
+	if err := updateutils.UnpackAssetWithCallback(updateutils.Zip, archive, callback); err != nil {
+		return fmt.Errorf("%w: unpack prior template release: %v", errTemplateOwnershipArchiveInvalid, err)
+	}
+
+	return writeTemplateOwnership(absDir, manifest)
+}
+
 // updateTemplatesAt updates templates at given directory
 func (t *TemplateManager) updateTemplatesAt(dir string) error {
 	if t.DisablePublicTemplates {
 		gologger.Info().Msgf("Skipping update of public nuclei-templates")
+
 		return nil
+	}
+
+	if err := t.bootstrapTemplateOwnership(dir, config.DefaultConfig.TemplateVersion, fetchTemplateReleaseArchive); err != nil {
+		return errkit.Wrapf(err, "failed to migrate template ownership at %s", dir)
 	}
 
 	// firstly, read checksums from .checksum file these are used to generate stats
@@ -184,48 +391,14 @@ func (t *TemplateManager) updateTemplatesAt(dir string) error {
 	}
 
 	// write templates to disk
-	writtenPaths, err := t.writeTemplatesToDisk(ghrd, dir)
-	if err != nil {
-		return err
-	}
-
-	// cleanup orphaned templates that exist locally but weren't in the new release
-	if err := t.cleanupOrphanedTemplates(dir, writtenPaths); err != nil {
-		// log warning but don't fail the update
-		gologger.Warning().Msgf("failed to cleanup orphaned templates: %s", err)
-	} else {
-		// Regenerate metadata (index and checksum) after successful cleanup to ensure
-		// metadata accurately reflects the cleaned template tree. This prevents stale
-		// index entries and checksum entries for deleted templates.
-		if err := t.regenerateTemplateMetadata(dir); err != nil {
-			// Log warning but don't fail the update - metadata will be out of sync
-			// but templates are cleaned up correctly
-			gologger.Warning().Msgf("failed to regenerate template metadata after cleanup: %s", err)
-		}
-	}
-
-	// get checksums from new templates
-	newchecksums, err := t.getChecksumFromDir(dir)
-	if err != nil {
-		// unlikely this case will happen
-		return errkit.Wrapf(err, "failed to get checksums from %s after update", dir)
+	writtenOutputs, writeErr := t.writeTemplatesToDisk(ghrd, dir)
+	newchecksums, finalizeErr := t.finalizeTemplateWrite(config.DefaultConfig, writtenOutputs, latestVersion, writeErr)
+	if finalizeErr != nil {
+		return errkit.Wrapf(finalizeErr, "failed to finalize template update at %s", dir)
 	}
 
 	// summarize all changes
 	results := t.summarizeChanges(oldchecksums, newchecksums)
-
-	// remove deleted templates
-	for _, deletion := range results.deletions {
-		// the deletion list comes from the on-disk .checksum file; only remove
-		// paths inside the templates directory.
-		if !filepathutil.IsPathWithinDirectory(deletion, dir) {
-			gologger.Warning().Msgf("skipping deletion of %s: path is outside templates directory %s", deletion, dir)
-			continue
-		}
-		if err := os.Remove(deletion); err != nil && !os.IsNotExist(err) {
-			gologger.Warning().Msgf("failed to remove deleted template %s: %s", deletion, err)
-		}
-	}
 
 	// print summary
 	if results.totalCount > 0 {
@@ -238,6 +411,7 @@ func (t *TemplateManager) updateTemplatesAt(dir string) error {
 	} else {
 		gologger.Info().Msgf("Successfully updated nuclei-templates (%v) to %s. GoodLuck!", ghrd.Latest.GetTagName(), dir)
 	}
+
 	return nil
 }
 
@@ -253,26 +427,30 @@ func (t *TemplateManager) summarizeChanges(old, new map[string]string) *template
 			results.additions = append(results.additions, k)
 		}
 	}
+
 	for k := range old {
 		if _, ok := new[k]; !ok {
 			results.deletions = append(results.deletions, k)
 		}
 	}
+
 	results.totalCount = len(results.additions) + len(results.deletions) + len(results.modifications)
+
 	return results
 }
 
-// getAbsoluteFilePath returns an absolute path where a file should be written based on given uri(i.e., files in zip)
-// if a returned path is empty, it means that file should not be written and skipped
-func (t *TemplateManager) getAbsoluteFilePath(templateDir, uri string, f fs.FileInfo) string {
+// getTemplateOutputLocation returns the safe root and absolute output path for an archive entry.
+// An empty output path means the entry should be skipped.
+func (t *TemplateManager) getTemplateOutputLocation(templateDir, uri string, f fs.FileInfo) (string, string) {
 	// overwrite .nuclei-ignore every time nuclei-templates are downloaded
 	if f.Name() == config.NucleiIgnoreFileName {
-		return config.DefaultConfig.GetActiveIgnoreFilePath()
+		return config.DefaultConfig.TemplatesDirectory, config.DefaultConfig.GetActiveIgnoreFilePath()
 	}
+
 	// skip all meta files
 	if !strings.EqualFold(f.Name(), config.NewTemplateAdditionsFileName) {
 		if strings.TrimSpace(f.Name()) == "" || strings.HasPrefix(f.Name(), ".") || strings.EqualFold(f.Name(), "README.md") {
-			return ""
+			return "", ""
 		}
 	}
 
@@ -290,9 +468,9 @@ func (t *TemplateManager) getAbsoluteFilePath(templateDir, uri string, f fs.File
 		// to outside the configured templates directory.
 		fallbackPath := filepath.Clean(filepath.Join(templateDir, uri))
 		if !filepathutil.IsPathWithinDirectory(fallbackPath, templateDir) {
-			return ""
+			return "", ""
 		}
-		return fallbackPath
+		return templateDir, fallbackPath
 	}
 	// separator is also included in rootDir
 	rootDirectory := uri[:index+1]
@@ -300,47 +478,37 @@ func (t *TemplateManager) getAbsoluteFilePath(templateDir, uri string, f fs.File
 
 	// if it is a github meta directory skip it
 	if stringsutil.HasPrefixAny(relPath, ".github", ".git") {
-		return ""
+		return "", ""
 	}
 
 	newPath := filepath.Clean(filepath.Join(templateDir, relPath))
 
 	if !filepathutil.IsPathWithinDirectory(newPath, templateDir) || !filepathutil.IsPathWithinDirectory(filepath.Dir(newPath), templateDir) {
 		// we don't allow LFI
-		return ""
+		return "", ""
 	}
 
 	if filepath.Clean(newPath) == filepath.Clean(templateDir) {
 		// skip writing the folder itself since it already exists
-		return ""
+		return "", ""
 	}
 
-	if relPath != "" && f.IsDir() {
-		// if uri is a directory, create it
-		if err := fileutil.CreateFolder(newPath); err != nil {
-			gologger.Warning().Msgf("uri %v: got %s while installing templates", uri, err)
-		}
-		return ""
-	}
-	return newPath
+	return templateDir, newPath
 }
 
-// writeTemplatesToDisk writes all templates to disk and returns a map of written file paths
-// The returned map contains absolute paths of all template files that were successfully written
-func (t *TemplateManager) writeTemplatesToDisk(ghrd *updateutils.GHReleaseDownloader, dir string) (*mapsutil.SyncLockMap[string, struct{}], error) {
-	localTemplatesIndex, err := config.GetNucleiTemplatesIndex()
-	if err != nil {
-		gologger.Warning().Msgf("failed to get local nuclei-templates index: %s", err)
-		if localTemplatesIndex == nil {
-			localTemplatesIndex = map[string]string{} // no-op
-		}
-	}
-
-	// Track all paths that are successfully written during this update
-	writtenPaths := mapsutil.NewSyncLockMap[string, struct{}]()
+// writeTemplatesToDisk writes release outputs to disk and returns their digests.
+// The returned map includes every successfully written output; ownership
+// reconciliation filters it to official template paths.
+func (t *TemplateManager) writeTemplatesToDisk(ghrd *updateutils.GHReleaseDownloader, dir string) (map[string]string, error) {
+	writtenOutputs := make(map[string]string)
+	touchedDirectories := make(map[string]struct{})
 
 	callbackFunc := func(uri string, f fs.FileInfo, r io.Reader) error {
-		writePath := t.getAbsoluteFilePath(dir, uri, f)
+		if f.IsDir() {
+			return nil
+		}
+
+		rootDir, writePath := t.getTemplateOutputLocation(dir, uri, f)
 		if writePath == "" {
 			// skip writing file
 			return nil
@@ -351,64 +519,33 @@ func (t *TemplateManager) writeTemplatesToDisk(ghrd *updateutils.GHReleaseDownlo
 			// if error occurs, iteration also stops
 			return errkit.Wrapf(err, "failed to read file %s", uri)
 		}
-		// TODO: It might be better to just download index file from nuclei templates repo
-		// instead of creating it from scratch
-		id, _ := config.GetTemplateIDFromReader(bytes.NewReader(bin), uri)
-		if id != "" {
-			// based on template id, check if we are updating a path of official nuclei template
-			if oldPath, ok := localTemplatesIndex[id]; ok {
-				if oldPath != writePath {
-					// write new template at a new path and delete old template
-					if err := os.WriteFile(writePath, bin, f.Mode()); err != nil {
-						return errkit.Wrapf(err, "failed to write file %s", uri)
-					}
-					// Track the new path as written
-					_ = writtenPaths.Set(writePath, struct{}{})
-					// after successful write, remove old template. oldPath comes
-					// from the on-disk .templates-index; only remove paths inside
-					// the templates directory.
-					if !filepathutil.IsPathWithinDirectory(oldPath, dir) {
-						gologger.Warning().Msgf("skipping removal of old template %s: path is outside templates directory %s", oldPath, dir)
-					} else if err := os.Remove(oldPath); err != nil {
-						gologger.Warning().Msgf("failed to remove old template %s: %s", oldPath, err)
-					}
-					return nil
-				}
-			}
+
+		outputResult, outputErr := writeTemplateOutput(rootDir, writePath, bin, f.Mode())
+		for _, directory := range outputResult.touchedDirectories {
+			touchedDirectories[directory] = struct{}{}
 		}
-		// no change in template Path of official templates
-		if err := os.WriteFile(writePath, bin, f.Mode()); err != nil {
-			return errkit.Wrapf(err, "failed to write file %s", uri)
+
+		if outputErr != nil {
+			return errkit.Wrapf(outputErr, "failed to write file %s", uri)
 		}
-		// Track successfully written paths
-		_ = writtenPaths.Set(writePath, struct{}{})
+
+		writtenOutputs[writePath] = templateDigest(bin)
+
 		return nil
 	}
-	err = ghrd.DownloadSourceWithCallback(!HideProgressBar, callbackFunc)
-	if err != nil {
-		return nil, errkit.Wrap(err, "failed to download templates")
+
+	var writeErr error
+
+	if err := ghrd.DownloadSourceWithCallback(!HideProgressBar, callbackFunc); err != nil {
+		writeErr = errkit.Wrap(err, "failed to download templates")
 	}
 
-	if err := config.DefaultConfig.WriteTemplatesConfig(); err != nil {
-		return nil, errkit.Wrap(err, "failed to write templates config")
-	}
-	// update templates version in config file
-	if err := config.DefaultConfig.SetTemplatesVersion(ghrd.Latest.GetTagName()); err != nil {
-		return nil, errkit.Wrap(err, "failed to update templates version")
+	if err := syncTemplateOutputDirectories(touchedDirectories, syncTemplateOwnershipDirectory); err != nil {
+		writeErr = errors.Join(writeErr, errkit.Wrap(err, "failed to sync template output directories"))
 	}
 
-	PurgeEmptyDirectories(dir)
-
-	// generate index of all templates
-	_ = os.Remove(config.DefaultConfig.GetTemplateIndexFilePath())
-
-	index, err := config.GetNucleiTemplatesIndex()
-	if err != nil {
-		return nil, errkit.Wrap(err, "failed to get nuclei templates index")
-	}
-
-	if err = config.DefaultConfig.WriteTemplatesIndex(index); err != nil {
-		return nil, errkit.Wrap(err, "failed to write nuclei templates index")
+	if writeErr != nil {
+		return writtenOutputs, writeErr
 	}
 
 	if !HideReleaseNotes {
@@ -418,148 +555,154 @@ func (t *TemplateManager) writeTemplatesToDisk(ghrd *updateutils.GHReleaseDownlo
 		if err != nil {
 			gologger.Error().Msgf("markdown rendering not supported: %v", err)
 		}
+
 		if rendered, err := r.Render(output); err == nil {
 			output = rendered
 		} else {
 			gologger.Error().Msg(err.Error())
 		}
+
 		gologger.Print().Msgf("\n%v\n\n", output)
 	}
 
-	// after installation, create and write checksums to .checksum file
-	if err := t.writeChecksumFileInDir(dir); err != nil {
-		return nil, err
-	}
-
-	return writtenPaths, nil
+	return writtenOutputs, nil
 }
 
-// cleanupOrphanedTemplates removes template files that exist locally but were not part of the new release
-// It scans the templates directory for template files and deletes those that are not in the writtenPaths set
-// This function handles empty directories gracefully - if the directory is empty, no orphaned files will be found
-func (t *TemplateManager) cleanupOrphanedTemplates(dir string, writtenPaths *mapsutil.SyncLockMap[string, struct{}]) error {
-	absDir, err := filepath.Abs(dir)
-	if err != nil {
-		return errkit.Wrapf(err, "failed to get absolute path of templates directory")
-	}
-	// Use Clean to normalize the path consistently (handles Windows paths better)
-	absDir = filepath.Clean(absDir)
+func syncTemplateOutputDirectories(directories map[string]struct{}, syncDirectory func(*os.Root, string) error) error {
+	var syncErrors error
 
-	// If directory doesn't exist, there's nothing to clean up
-	if !fileutil.FolderExists(absDir) {
-		return nil
-	}
-
-	// Normalize all written paths to absolute paths for comparison
-	normalizedWrittenPaths := mapsutil.NewSyncLockMap[string, struct{}]()
-	for path := range writtenPaths.GetAll() {
-		absPath, err := filepath.Abs(path)
-		if err == nil {
-			// Use Clean to normalize the path consistently (handles Windows paths better)
-			absPath = filepath.Clean(absPath)
-			_ = normalizedWrittenPaths.Set(absPath, struct{}{})
-		}
-	}
-
-	// Get custom template directories to exclude
-	customDirs := config.DefaultConfig.GetAllCustomTemplateDirs()
-	customDirAbs := make([]string, 0, len(customDirs))
-	for _, customDir := range customDirs {
-		if absCustomDir, err := filepath.Abs(customDir); err == nil {
-			// Use Clean to normalize the path consistently (handles Windows paths better)
-			absCustomDir = filepath.Clean(absCustomDir)
-			customDirAbs = append(customDirAbs, absCustomDir)
-		}
-	}
-
-	var orphanedFiles []string
-
-	// Walk the templates directory to find all template files
-	err = filepath.WalkDir(absDir, func(path string, d fs.DirEntry, err error) error {
+	for directory := range directories {
+		root, err := os.OpenRoot(directory)
 		if err != nil {
-			// Log but continue walking
-			gologger.Debug().Msgf("error accessing path %s during orphan cleanup: %s", path, err)
-			return nil
+			syncErrors = errors.Join(syncErrors, fmt.Errorf("open output directory %q: %w", directory, err))
+			continue
 		}
 
-		// Skip directories
-		if d.IsDir() {
-			return nil
+		syncErr := syncDirectory(root, ".")
+		closeErr := root.Close()
+		if syncErr != nil {
+			syncErrors = errors.Join(syncErrors, fmt.Errorf("sync output directory %q: %w", directory, syncErr))
 		}
-
-		absPath, err := filepath.Abs(path)
-		if err != nil {
-			return nil
-		}
-		// Use Clean to normalize the path consistently (handles Windows paths better)
-		absPath = filepath.Clean(absPath)
-
-		// Skip custom template directories
-		if filepathutil.IsPathWithinAnyDirectory(absPath, customDirAbs...) {
-			return nil
-		}
-
-		// Only process template files
-		if !config.IsTemplate(absPath) {
-			return nil
-		}
-
-		// Skip if this file was written in the new release
-		if normalizedWrittenPaths.Has(absPath) {
-			return nil
-		}
-
-		// This is an orphaned template file
-		orphanedFiles = append(orphanedFiles, absPath)
-		return nil
-	})
-
-	if err != nil {
-		return errkit.Wrapf(err, "failed to walk templates directory for orphan cleanup")
-	}
-
-	// Delete orphaned files
-	for _, orphanPath := range orphanedFiles {
-		if err := os.Remove(orphanPath); err != nil {
-			if !os.IsNotExist(err) {
-				gologger.Warning().Msgf("failed to remove orphaned template %s: %s", orphanPath, err)
-			}
-		} else {
-			gologger.Debug().Msgf("removed orphaned template: %s", orphanPath)
+		if closeErr != nil {
+			syncErrors = errors.Join(syncErrors, fmt.Errorf("close output directory %q: %w", directory, closeErr))
 		}
 	}
 
-	if len(orphanedFiles) > 0 {
-		gologger.Info().Msgf("cleaned up %d orphaned template file(s)", len(orphanedFiles))
-	}
-
-	return nil
+	return syncErrors
 }
 
-// regenerateTemplateMetadata regenerates template index and checksum files after cleanup operations.
-// This ensures the metadata accurately reflects the current state of template files on disk.
-func (t *TemplateManager) regenerateTemplateMetadata(dir string) error {
-	// Purge empty directories that may have been left after cleanup
+// templateOutputWriteResult records filesystem state that must be finalized
+// even when the associated write returns an error.
+type templateOutputWriteResult struct {
+	touchedDirectories []string
+}
+
+func writeTemplateOutput(rootDir, writePath string, contents []byte, mode fs.FileMode) (templateOutputWriteResult, error) {
+	var result templateOutputWriteResult
+	relativePath, err := filepath.Rel(rootDir, writePath)
+	if err != nil {
+		return result, err
+	}
+
+	if relativePath == ".." || strings.HasPrefix(relativePath, ".."+string(os.PathSeparator)) || filepath.IsAbs(relativePath) {
+		return result, fmt.Errorf("output path %q escapes root %q", writePath, rootDir)
+	}
+
+	root, err := os.OpenRoot(rootDir)
+	if err != nil {
+		return result, fmt.Errorf("open output root %q: %w", rootDir, err)
+	}
+	defer func() { _ = root.Close() }()
+
+	parent := filepath.Dir(relativePath)
+	if parent != "." {
+		parentsToSync, err := createTemplateDirectories(root, parent)
+		for _, parentToSync := range parentsToSync {
+			result.touchedDirectories = append(result.touchedDirectories, filepath.Clean(filepath.Join(rootDir, parentToSync)))
+		}
+		if err != nil {
+			return result, fmt.Errorf("create output parent %q: %w", parent, err)
+		}
+	}
+	result.touchedDirectories = append(result.touchedDirectories, filepath.Dir(writePath))
+
+	randomSuffix := make([]byte, 16)
+	if _, err := rand.Read(randomSuffix); err != nil {
+		return result, fmt.Errorf("generate temporary output name: %w", err)
+	}
+
+	temporaryPath := filepath.Join(parent, fmt.Sprintf("%s%x", templateOutputTemporaryPrefix, randomSuffix))
+	temporaryMode := mode.Perm()
+	preserveMode := false
+
+	if info, err := root.Lstat(relativePath); err == nil && info.Mode().IsRegular() {
+		temporaryMode = 0o600
+		mode = info.Mode()
+		preserveMode = true
+	} else if err != nil && !os.IsNotExist(err) {
+		return result, fmt.Errorf("inspect existing output %q: %w", relativePath, err)
+	}
+
+	temporary, err := root.OpenFile(temporaryPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, temporaryMode)
+	if err != nil {
+		return result, fmt.Errorf("create temporary output %q: %w", temporaryPath, err)
+	}
+
+	defer func() {
+		_ = temporary.Close()
+		_ = root.Remove(temporaryPath)
+	}()
+
+	if _, err := temporary.Write(contents); err != nil {
+		return result, fmt.Errorf("write temporary output %q: %w", temporaryPath, err)
+	}
+
+	if preserveMode {
+		if err := temporary.Chmod(mode.Perm()); err != nil {
+			return result, fmt.Errorf("preserve output mode %q: %w", temporaryPath, err)
+		}
+	}
+
+	// A release contains thousands of files, so syncing every temporary file
+	// makes installation latency scale with storage flush latency. Closing and
+	// renaming keeps replacement atomic; touched directories are synced once
+	// after extraction and before ownership or version finalization.
+	if err := temporary.Close(); err != nil {
+		return result, fmt.Errorf("close temporary output %q: %w", temporaryPath, err)
+	}
+
+	if err := root.Rename(temporaryPath, relativePath); err != nil {
+		return result, fmt.Errorf("replace output %q: %w", relativePath, err)
+	}
+
+	return result, nil
+}
+
+// regenerateTemplateMetadata rebuilds the index and checksums from the finalized on-disk tree.
+func (t *TemplateManager) regenerateTemplateMetadata(cfg *config.Config) (map[string]string, error) {
+	dir := cfg.TemplatesDirectory
+
+	// Purge empty directories before rebuilding metadata.
 	PurgeEmptyDirectories(dir)
 
-	// Ensure templates directory exists (it may have been purged if empty)
+	// Ensure the templates directory exists if the finalized tree is empty.
 	if !fileutil.FolderExists(dir) {
 		if err := os.MkdirAll(dir, 0755); err != nil {
-			return errkit.Wrapf(err, "failed to recreate templates directory %s after purge", dir)
+			return nil, errkit.Wrapf(err, "failed to recreate templates directory %s after purge", dir)
 		}
 	}
 
 	// Remove old index file and regenerate it from current templates on disk
-	indexFilePath := config.DefaultConfig.GetTemplateIndexFilePath()
+	indexFilePath := cfg.GetTemplateIndexFilePath()
 	if err := os.Remove(indexFilePath); err != nil && !os.IsNotExist(err) {
-		return errkit.Wrapf(err, "failed to remove old index file %s", indexFilePath)
+		return nil, errkit.Wrapf(err, "failed to remove old index file %s", indexFilePath)
 	}
 
 	// Force regeneration by ensuring the file doesn't exist (handles Windows file handle issues)
 	// GetNucleiTemplatesIndex will scan the directory if the file doesn't exist
 	index, err := config.GetNucleiTemplatesIndex()
 	if err != nil {
-		return errkit.Wrap(err, "failed to regenerate nuclei templates index after cleanup")
+		return nil, errkit.Wrap(err, "failed to regenerate nuclei templates index")
 	}
 
 	// Filter out any entries that don't actually exist on disk (Windows file deletion timing issues)
@@ -570,16 +713,20 @@ func (t *TemplateManager) regenerateTemplateMetadata(dir string) error {
 		}
 	}
 
-	if err = config.DefaultConfig.WriteTemplatesIndex(filteredIndex); err != nil {
-		return errkit.Wrap(err, "failed to write nuclei templates index after cleanup")
+	if err = cfg.WriteTemplatesIndex(filteredIndex); err != nil {
+		return nil, errkit.Wrap(err, "failed to write regenerated nuclei templates index")
 	}
 
-	// Regenerate checksum file to reflect current templates on disk
-	if err := t.writeChecksumFileInDir(dir); err != nil {
-		return errkit.Wrap(err, "failed to regenerate checksum file after cleanup")
+	checksumMap, err := t.calculateChecksumMap(dir)
+	if err != nil {
+		return nil, errkit.Wrap(err, "failed to regenerate checksum map")
 	}
 
-	return nil
+	if err := writeChecksumMap(cfg, checksumMap); err != nil {
+		return nil, errkit.Wrap(err, "failed to write regenerated checksum file")
+	}
+
+	return checksumMap, nil
 }
 
 // getChecksumFromDir returns a map containing checksums (md5 hash) of all yaml files (with .yaml extension)
@@ -598,23 +745,31 @@ func (t *TemplateManager) getChecksumFromDir(dir string) (map[string]string, err
 				if len(tmparr) != 2 {
 					continue
 				}
+
 				allChecksums[tmparr[0]] = tmparr[1]
 			}
+
 			return allChecksums, nil
 		}
 	}
+
 	return t.calculateChecksumMap(dir)
 }
 
-// writeChecksumFileInDir creates checksums of all yaml files in given directory
-// and writes them to a file named .checksum
+// writeChecksumFileInDir creates checksums of all YAML files in dir and writes
+// them to the configured checksum file.
 func (t *TemplateManager) writeChecksumFileInDir(dir string) error {
 	checksumMap, err := t.calculateChecksumMap(dir)
 	if err != nil {
 		return err
 	}
 
+	return writeChecksumMap(config.DefaultConfig, checksumMap)
+}
+
+func writeChecksumMap(cfg *config.Config, checksumMap map[string]string) error {
 	var buff bytes.Buffer
+
 	for k, v := range checksumMap {
 		buff.WriteString(k)
 		buff.WriteString(",")
@@ -622,7 +777,19 @@ func (t *TemplateManager) writeChecksumFileInDir(dir string) error {
 		buff.WriteString(";")
 	}
 
-	return os.WriteFile(config.DefaultConfig.GetChecksumFilePath(), buff.Bytes(), checkSumFilePerm)
+	return os.WriteFile(cfg.GetChecksumFilePath(), buff.Bytes(), checkSumFilePerm)
+}
+
+func isTemplateOutputTemporary(name string) bool {
+	suffix, found := strings.CutPrefix(name, templateOutputTemporaryPrefix)
+	if !found {
+		return false
+	}
+	if isLowerHex(suffix, 32) {
+		return true
+	}
+	pathDigest, token, found := strings.Cut(suffix, "-")
+	return found && isLowerHex(pathDigest, 32) && isLowerHex(token, 32)
 }
 
 // getChecksumMap returns a map containing checksums (md5 hash) of all yaml files (with .yaml extension)
@@ -638,6 +805,7 @@ func (t *TemplateManager) calculateChecksumMap(dir string) (map[string]string, e
 		if err != nil {
 			return "", err
 		}
+
 		return fmt.Sprintf("%x", md5.Sum(bin)), nil
 	}
 
@@ -645,6 +813,18 @@ func (t *TemplateManager) calculateChecksumMap(dir string) (map[string]string, e
 		if err != nil {
 			return err
 		}
+
+		if !d.IsDir() && isTemplateOutputTemporary(filepath.Base(path)) {
+			return nil
+		}
+
+		if filepath.Dir(path) == filepath.Clean(dir) {
+			name := filepath.Base(path)
+			if name == templateOwnershipFileName || strings.HasPrefix(name, templateOwnershipTemporaryPrefix) || strings.HasPrefix(name, templateOwnershipRetiredPrefix) || strings.HasPrefix(name, templateOwnershipRestorePrefix) {
+				return nil
+			}
+		}
+
 		// skip checksums of custom templates i.e github and s3
 		if filepathutil.IsPathWithinAnyDirectory(path, config.DefaultConfig.GetAllCustomTemplateDirs()...) {
 			return nil
@@ -656,9 +836,12 @@ func (t *TemplateManager) calculateChecksumMap(dir string) (map[string]string, e
 			if err != nil {
 				return err
 			}
+
 			checksumMap[path] = checksum
 		}
+
 		return nil
 	})
+
 	return checksumMap, errkit.Wrap(err, "failed to calculate checksums of templates")
 }

--- a/pkg/installer/template.go
+++ b/pkg/installer/template.go
@@ -189,10 +189,6 @@ func (t *TemplateManager) finalizeTemplateRelease(cfg *config.Config, writtenOut
 		finalizationErr = errors.Join(finalizationErr, fmt.Errorf("reconcile template ownership: %w", err))
 	}
 
-	if err := cfg.UpdateNucleiIgnoreHash(); err != nil {
-		finalizationErr = errors.Join(finalizationErr, errkit.Wrap(err, "failed to update nuclei ignore hash"))
-	}
-
 	checksums, err := t.regenerateTemplateMetadata(cfg)
 	if err != nil {
 		finalizationErr = errors.Join(finalizationErr, fmt.Errorf("regenerate template metadata: %w", err))

--- a/pkg/installer/template_output_unix_test.go
+++ b/pkg/installer/template_output_unix_test.go
@@ -1,0 +1,42 @@
+//go:build !windows
+
+package installer
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteTemplateOutputHonorsUmask(t *testing.T) {
+	previousUmask := syscall.Umask(0o077)
+	t.Cleanup(func() { syscall.Umask(previousUmask) })
+
+	outputPath := filepath.Join(t.TempDir(), "official.yaml")
+	_, err := writeTemplateOutput(filepath.Dir(outputPath), outputPath, []byte("release"), 0o666)
+	require.NoError(t, err)
+	info, err := os.Stat(outputPath)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+}
+
+func TestCopyQuarantinedTemplatePreservesMode(t *testing.T) {
+	templatesDir := t.TempDir()
+	quarantinePath := templateOwnershipRetiredPrefix + "mode"
+	require.NoError(t, os.WriteFile(filepath.Join(templatesDir, quarantinePath), []byte("modified"), 0o644))
+
+	previousUmask := syscall.Umask(0o077)
+	t.Cleanup(func() { syscall.Umask(previousUmask) })
+
+	root, err := os.OpenRoot(templatesDir)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, root.Close()) })
+
+	require.NoError(t, copyQuarantinedTemplate(root, "retired.yaml", quarantinePath))
+	info, err := root.Stat("retired.yaml")
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o644), info.Mode().Perm())
+}

--- a/pkg/installer/template_ownership.go
+++ b/pkg/installer/template_ownership.go
@@ -1,0 +1,1393 @@
+package installer
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/projectdiscovery/gologger"
+	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/config"
+)
+
+const (
+	templateOwnershipFileName        = ".templates-ownership"
+	templateOwnershipVersion         = 1
+	templateOwnershipTemporaryPrefix = templateOwnershipFileName + ".tmp-"
+	templateOwnershipRetiredPrefix   = templateOwnershipFileName + ".retired-"
+	templateOwnershipRestorePrefix   = templateOwnershipFileName + ".restore-"
+)
+
+type templateRestoreState struct {
+	retiredPath   string
+	temporaryPath string
+	statePath     string
+	kind          templateRestoreKind
+	digest        string
+}
+
+type templateRestoreKind string
+
+const (
+	templateRestoreCopy templateRestoreKind = "copy"
+	templateRestoreMove templateRestoreKind = "move"
+)
+
+type templateOwnershipRecoveryEntry struct {
+	relativePath string
+	digest       string
+}
+
+var (
+	errTemplateOwnershipMissing        = errors.New("template ownership metadata is missing")
+	errTemplateOwnershipInvalid        = errors.New("template ownership metadata is invalid")
+	errTemplateOwnershipArchiveInvalid = errors.New("prior template release archive is invalid")
+)
+
+type templateOwnershipManifest struct {
+	Version int               `json:"version"`
+	Files   map[string]string `json:"files"`
+}
+
+// reconcileTemplateOwnership removes only unchanged files owned by the
+// previous release, then records the files owned by the current release.
+func reconcileTemplateOwnership(dir string, writtenOutputs map[string]string) error {
+	current, err := buildTemplateOwnership(dir, writtenOutputs)
+	if err != nil {
+		return err
+	}
+
+	var reconcileErr error
+
+	previous, loadErr := loadTemplateOwnership(dir)
+	if loadErr == nil {
+		ownershipToRetry, cleanupErr := cleanupRetiredTemplates(dir, previous, current)
+		for relativePath, digest := range ownershipToRetry {
+			current.Files[relativePath] = digest
+		}
+		reconcileErr = cleanupErr
+	} else if !errors.Is(loadErr, errTemplateOwnershipMissing) {
+		gologger.Warning().Msgf("Skipping retired template cleanup: %s", loadErr)
+	}
+
+	if writeErr := writeTemplateOwnership(dir, current); writeErr != nil {
+		reconcileErr = errors.Join(reconcileErr, writeErr)
+	}
+
+	return reconcileErr
+}
+
+// recordPartialTemplateOwnership merges successfully written outputs into the
+// previous manifest without retiring paths that the interrupted release did not visit.
+func recordPartialTemplateOwnership(dir string, writtenOutputs map[string]string) error {
+	if len(writtenOutputs) == 0 {
+		return nil
+	}
+
+	partial, err := buildTemplateOwnership(dir, writtenOutputs)
+	if err != nil {
+		return err
+	}
+	if len(partial.Files) == 0 {
+		return nil
+	}
+
+	previous, err := loadTemplateOwnership(dir)
+	if err == nil {
+		for relativePath, digest := range previous.Files {
+			if _, wasWritten := partial.Files[relativePath]; !wasWritten {
+				partial.Files[relativePath] = digest
+			}
+		}
+	} else if !errors.Is(err, errTemplateOwnershipMissing) && !errors.Is(err, errTemplateOwnershipInvalid) {
+		return err
+	}
+
+	return writeTemplateOwnership(dir, partial)
+}
+
+func buildTemplateOwnership(dir string, writtenOutputs map[string]string) (*templateOwnershipManifest, error) {
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return nil, fmt.Errorf("get absolute templates directory: %w", err)
+	}
+
+	root, err := os.OpenRoot(absDir)
+	if err != nil {
+		return nil, fmt.Errorf("open templates directory %q: %w", absDir, err)
+	}
+
+	defer func() { _ = root.Close() }()
+
+	manifest := &templateOwnershipManifest{
+		Version: templateOwnershipVersion,
+		Files:   make(map[string]string),
+	}
+
+	for writtenPath, digest := range writtenOutputs {
+		if !config.IsTemplate(writtenPath) {
+			continue
+		}
+
+		absPath, err := filepath.Abs(writtenPath)
+		if err != nil {
+			return nil, fmt.Errorf("get absolute template path %q: %w", writtenPath, err)
+		}
+
+		relativePath, err := filepath.Rel(absDir, absPath)
+		if err != nil {
+			return nil, fmt.Errorf("make template path %q relative to %q: %w", absPath, absDir, err)
+		}
+		if relativePath == ".." || strings.HasPrefix(relativePath, ".."+string(os.PathSeparator)) {
+			continue
+		}
+
+		relativePath = filepath.ToSlash(relativePath)
+		if !config.IsTemplate(relativePath) {
+			continue
+		}
+
+		hasSymlink, err := templatePathHasSymlink(root, relativePath)
+		if err != nil {
+			return nil, fmt.Errorf("inspect installed template path %q: %w", absPath, err)
+		}
+
+		if hasSymlink {
+			return nil, fmt.Errorf("installed template path %q contains a symbolic link", absPath)
+		}
+
+		manifest.Files[relativePath] = digest
+	}
+
+	if err := validateTemplateOwnership(manifest); err != nil {
+		return nil, fmt.Errorf("validate current template ownership: %w", err)
+	}
+
+	return manifest, nil
+}
+
+func templateDigest(contents []byte) string {
+	digest := sha256.Sum256(contents)
+
+	return hex.EncodeToString(digest[:])
+}
+
+// recoverTemplateOwnership resolves cleanup interrupted after a template was
+// quarantined. Callers run this before writing a new release so a reintroduced
+// path cannot hide or overwrite the quarantined contents before recovery.
+func recoverTemplateOwnership(dir string) error {
+	quarantineEntries, err := listTemplateOwnershipQuarantines(dir)
+	if err != nil {
+		return err
+	}
+
+	restoreEntries, err := listTemplateOwnershipRestoreStates(dir)
+	if err != nil {
+		return err
+	}
+
+	if len(quarantineEntries) == 0 && len(restoreEntries) == 0 {
+		return nil
+	}
+
+	previous, err := loadTemplateOwnership(dir)
+	if err != nil {
+		return fmt.Errorf("load template ownership for recovery: %w", err)
+	}
+
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		return fmt.Errorf("open templates directory %q for recovery: %w", dir, err)
+	}
+	defer func() { _ = root.Close() }()
+
+	expected := make(map[string]templateOwnershipRecoveryEntry, len(previous.Files))
+	expectedRestorePrefixes := make(map[string]templateOwnershipRecoveryEntry, len(previous.Files))
+	for relativePath, previousDigest := range previous.Files {
+		expected[retiredTemplateQuarantinePath(relativePath)] = templateOwnershipRecoveryEntry{relativePath: relativePath, digest: previousDigest}
+		expectedRestorePrefixes[templateRestoreStatePrefix(filepath.FromSlash(relativePath))] = templateOwnershipRecoveryEntry{relativePath: relativePath, digest: previousDigest}
+	}
+
+	var recoveryErr error
+
+	handledQuarantines := make(map[string]struct{})
+
+	for _, statePath := range restoreEntries {
+		entry, state, stateErr := parseTemplateRestoreState(root, statePath, expectedRestorePrefixes)
+		if stateErr != nil {
+			recoveryErr = errors.Join(recoveryErr, stateErr)
+			continue
+		}
+
+		quarantinePath := retiredTemplateQuarantinePath(entry.relativePath)
+		if _, err := root.Lstat(quarantinePath); err == nil {
+			completed, resumeErr := resumeTemplateRestoreState(root, state, quarantinePath, root.Link)
+			if resumeErr != nil {
+				recoveryErr = errors.Join(recoveryErr, fmt.Errorf("resume template restore %q: %w", entry.relativePath, resumeErr))
+				handledQuarantines[quarantinePath] = struct{}{}
+
+				continue
+			}
+
+			if completed {
+				handledQuarantines[quarantinePath] = struct{}{}
+			}
+
+			continue
+		} else if !os.IsNotExist(err) {
+			recoveryErr = errors.Join(recoveryErr, fmt.Errorf("inspect quarantine for restore state %q: %w", statePath, err))
+
+			continue
+		}
+
+		if err := cleanupCommittedTemplateRestore(root, state); err != nil {
+			recoveryErr = errors.Join(recoveryErr, fmt.Errorf("clean up committed template restore %q: %w", entry.relativePath, err))
+		}
+	}
+
+	for _, quarantinePath := range quarantineEntries {
+		if _, handled := handledQuarantines[quarantinePath]; handled {
+			continue
+		}
+
+		entry, ok := expected[quarantinePath]
+		if !ok {
+			recoveryErr = errors.Join(recoveryErr, fmt.Errorf("unrecognized template ownership quarantine %q", quarantinePath))
+			continue
+		}
+
+		if _, err := cleanupQuarantinedTemplate(root, filepath.FromSlash(entry.relativePath), quarantinePath, entry.digest); err != nil {
+			recoveryErr = errors.Join(recoveryErr, fmt.Errorf("recover quarantined retired template %q: %w", entry.relativePath, err))
+		}
+	}
+
+	return recoveryErr
+}
+
+func resumeTemplateRestoreState(root *os.Root, state templateRestoreState, quarantinePath string, link func(string, string) error) (bool, error) {
+	if _, err := root.Lstat(state.retiredPath); err == nil {
+		if state.kind == templateRestoreMove {
+			return false, fmt.Errorf("move restore state %q still has quarantine %q", state.statePath, quarantinePath)
+		}
+
+		completed, err := finishInterruptedTemplateRestore(root, state.retiredPath, quarantinePath, syncTemplateOwnershipFile)
+		if err != nil || completed {
+			return completed, err
+		}
+
+		if err := rollbackTemplateRestoreState(root, state); err != nil {
+			return false, err
+		}
+
+		return false, nil
+	} else if !os.IsNotExist(err) {
+		return false, fmt.Errorf("inspect restored template %q: %w", state.retiredPath, err)
+	}
+
+	if info, err := root.Lstat(state.temporaryPath); err == nil {
+		if state.kind != templateRestoreCopy {
+			return false, fmt.Errorf("move restore state %q has unexpected temporary file %q", state.statePath, state.temporaryPath)
+		}
+
+		if !info.Mode().IsRegular() {
+			return false, fmt.Errorf("temporary restored template %q is not a regular file", state.temporaryPath)
+		}
+
+		if err := publishTemplateRestore(root, state.temporaryPath, state.retiredPath, link); err != nil {
+			return false, err
+		}
+
+		return false, nil
+	} else if !os.IsNotExist(err) {
+		return false, fmt.Errorf("inspect temporary restored template %q: %w", state.temporaryPath, err)
+	}
+
+	if state.kind != templateRestoreMove {
+		return false, fmt.Errorf("copy restore state %q lost temporary file %q before publication", state.statePath, state.temporaryPath)
+	}
+
+	if err := renameTemplateRestoreNoReplace(root, quarantinePath, state.retiredPath); err != nil {
+		return false, err
+	}
+
+	if err := cleanupTemplateRestoreState(root, state); err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+func listTemplateOwnershipRestoreStates(dir string) ([]string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+
+		return nil, fmt.Errorf("inspect templates directory %q for restore state: %w", dir, err)
+	}
+
+	states := make([]string, 0)
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), templateOwnershipRestorePrefix) {
+			states = append(states, entry.Name())
+		}
+	}
+
+	return states, nil
+}
+
+func parseTemplateRestoreState(root *os.Root, statePath string, expected map[string]templateOwnershipRecoveryEntry) (templateOwnershipRecoveryEntry, templateRestoreState, error) {
+	for prefix, entry := range expected {
+		token, found := strings.CutPrefix(statePath, prefix)
+		if !found || !isLowerHex(token, 32) {
+			continue
+		}
+
+		retiredPath := filepath.FromSlash(entry.relativePath)
+		state := templateRestoreState{
+			retiredPath:   retiredPath,
+			temporaryPath: templateRestoreTemporaryPath(retiredPath) + "-" + token,
+			statePath:     statePath,
+		}
+
+		if err := loadTemplateRestoreState(root, &state); err != nil {
+			return templateOwnershipRecoveryEntry{}, templateRestoreState{}, err
+		}
+
+		return entry, state, nil
+	}
+
+	return templateOwnershipRecoveryEntry{}, templateRestoreState{}, fmt.Errorf("unrecognized template restore state %q", statePath)
+}
+
+func listTemplateOwnershipQuarantines(dir string) ([]string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+
+		return nil, fmt.Errorf("inspect templates directory %q for recovery: %w", dir, err)
+	}
+
+	quarantines := make([]string, 0)
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), templateOwnershipRetiredPrefix) {
+			quarantines = append(quarantines, entry.Name())
+		}
+	}
+
+	return quarantines, nil
+}
+
+func loadTemplateOwnership(dir string) (*templateOwnershipManifest, error) {
+	manifestPath := filepath.Join(dir, templateOwnershipFileName)
+
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		return nil, fmt.Errorf("open templates directory %q: %w", dir, err)
+	}
+	defer func() { _ = root.Close() }()
+
+	info, err := root.Lstat(templateOwnershipFileName)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("%w: %s", errTemplateOwnershipMissing, manifestPath)
+		}
+
+		return nil, fmt.Errorf("inspect template ownership metadata %q: %w", manifestPath, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("template ownership metadata %q is a symbolic link", manifestPath)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("template ownership metadata %q is not a regular file", manifestPath)
+	}
+
+	contents, err := root.ReadFile(templateOwnershipFileName)
+	if err != nil {
+		return nil, fmt.Errorf("read template ownership metadata %q: %w", manifestPath, err)
+	}
+
+	var manifest templateOwnershipManifest
+
+	if err := json.Unmarshal(contents, &manifest); err != nil {
+		return nil, fmt.Errorf("%w: decode template ownership metadata %q: %v", errTemplateOwnershipInvalid, manifestPath, err)
+	}
+
+	if err := validateTemplateOwnership(&manifest); err != nil {
+		return nil, fmt.Errorf("%w: validate template ownership metadata %q: %v", errTemplateOwnershipInvalid, manifestPath, err)
+	}
+
+	return &manifest, nil
+}
+
+func validateTemplateOwnership(manifest *templateOwnershipManifest) error {
+	if manifest.Version != templateOwnershipVersion {
+		return fmt.Errorf("unsupported version %d", manifest.Version)
+	}
+
+	if manifest.Files == nil {
+		return errors.New("files map is missing")
+	}
+
+	for relativePath, digest := range manifest.Files {
+		if err := validateTemplateOwnershipPath(relativePath); err != nil {
+			return err
+		}
+
+		decoded, err := hex.DecodeString(digest)
+		if err != nil || len(decoded) != sha256.Size || digest != strings.ToLower(digest) {
+			return fmt.Errorf("path %q has an invalid SHA-256 digest", relativePath)
+		}
+	}
+
+	return nil
+}
+
+func validateTemplateOwnershipPath(relativePath string) error {
+	switch {
+	case relativePath == "":
+		return errors.New("template path is empty")
+	case strings.ContainsRune(relativePath, '\x00'):
+		return fmt.Errorf("path %q contains a NUL byte", relativePath)
+	case strings.Contains(relativePath, `\`):
+		return fmt.Errorf("path %q contains a non-portable separator", relativePath)
+	case path.IsAbs(relativePath):
+		return fmt.Errorf("path %q is absolute", relativePath)
+	case filepath.VolumeName(filepath.FromSlash(relativePath)) != "" || len(relativePath) >= 2 && relativePath[1] == ':':
+		return fmt.Errorf("path %q contains a volume name", relativePath)
+	case relativePath == ".." || strings.HasPrefix(relativePath, "../"):
+		return fmt.Errorf("path %q escapes the templates directory", relativePath)
+	case path.Clean(relativePath) != relativePath:
+		return fmt.Errorf("path %q is not normalized", relativePath)
+	case !config.IsTemplate(relativePath):
+		return fmt.Errorf("path %q is not a template", relativePath)
+	default:
+		return nil
+	}
+}
+
+// cleanupRetiredTemplates removes unchanged templates retired by the current release.
+// It returns ownership entries to retry after transient cleanup failures. Modified
+// files and paths containing symlinks are preserved but deliberately relinquish
+// installer ownership so later updates cannot delete user-controlled content.
+func cleanupRetiredTemplates(dir string, previous, current *templateOwnershipManifest) (map[string]string, error) {
+	retired := make(map[string]string)
+	for relativePath, previousDigest := range previous.Files {
+		if _, stillOwned := current.Files[relativePath]; !stillOwned {
+			retired[relativePath] = previousDigest
+		}
+	}
+
+	if len(retired) == 0 {
+		return retired, nil
+	}
+
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		return retired, fmt.Errorf("open templates directory %q for cleanup: %w", dir, err)
+	}
+	defer func() { _ = root.Close() }()
+
+	currentPathsByFoldedName := make(map[string][]string, len(current.Files))
+	for relativePath := range current.Files {
+		foldedName := strings.ToLower(relativePath)
+		currentPathsByFoldedName[foldedName] = append(currentPathsByFoldedName[foldedName], relativePath)
+	}
+
+	ownershipToRetry := make(map[string]string)
+	var cleanupErr error
+	for relativePath, previousDigest := range retired {
+		templatePath := filepath.Join(dir, filepath.FromSlash(relativePath))
+		quarantinePath := retiredTemplateQuarantinePath(relativePath)
+
+		hasSymlink, err := templatePathHasSymlink(root, relativePath)
+		if err != nil {
+			if !os.IsNotExist(err) {
+				ownershipToRetry[relativePath] = previousDigest
+				cleanupErr = errors.Join(cleanupErr, fmt.Errorf("inspect retired template path %q: %w", templatePath, err))
+			}
+
+			continue
+		}
+
+		if hasSymlink {
+			// gologger.Warning().Msgf("Preserving retired template path containing a symbolic link: %s", templatePath)
+			continue
+		}
+
+		info, err := root.Stat(filepath.FromSlash(relativePath))
+		if err != nil {
+			if !os.IsNotExist(err) {
+				ownershipToRetry[relativePath] = previousDigest
+				cleanupErr = errors.Join(cleanupErr, fmt.Errorf("inspect retired template %q: %w", templatePath, err))
+			}
+			continue
+		}
+
+		if !info.Mode().IsRegular() {
+			// gologger.Warning().Msgf("Preserving non-regular retired template path: %s", templatePath)
+			continue
+		}
+
+		aliasesCurrentTemplate, err := retiredTemplateAliasesCurrent(root, relativePath, currentPathsByFoldedName)
+		if err != nil {
+			if !os.IsNotExist(err) {
+				ownershipToRetry[relativePath] = previousDigest
+				cleanupErr = errors.Join(cleanupErr, fmt.Errorf("compare retired template path %q with current templates: %w", templatePath, err))
+			}
+			continue
+		}
+
+		if aliasesCurrentTemplate {
+			continue
+		}
+
+		if err := quarantineRetiredTemplate(root, filepath.FromSlash(relativePath), quarantinePath); err != nil {
+			if !os.IsNotExist(err) {
+				ownershipToRetry[relativePath] = previousDigest
+				cleanupErr = errors.Join(cleanupErr, fmt.Errorf("quarantine retired template %q: %w", templatePath, err))
+			}
+			continue
+		}
+
+		disposition, err := cleanupQuarantinedTemplate(root, filepath.FromSlash(relativePath), quarantinePath, previousDigest)
+		if disposition == retainTemplateOwnership {
+			ownershipToRetry[relativePath] = previousDigest
+		}
+
+		if err != nil {
+			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("clean up quarantined retired template %q: %w", templatePath, err))
+		}
+	}
+
+	return ownershipToRetry, cleanupErr
+}
+
+func retiredTemplateQuarantinePath(relativePath string) string {
+	digest := sha256.Sum256([]byte(relativePath))
+
+	return templateOwnershipRetiredPrefix + hex.EncodeToString(digest[:])
+}
+
+func quarantineRetiredTemplate(root *os.Root, retiredPath, quarantinePath string) error {
+	if err := root.Rename(retiredPath, quarantinePath); err != nil {
+		return err
+	}
+
+	if err := syncTemplateOwnershipDirectory(root, "."); err != nil {
+		return fmt.Errorf("sync quarantine directory after moving %q: %w", retiredPath, err)
+	}
+
+	parent := filepath.Dir(retiredPath)
+	if parent != "." {
+		if err := syncTemplateOwnershipDirectory(root, parent); err != nil {
+			return fmt.Errorf("sync source directory %q after quarantining %q: %w", parent, retiredPath, err)
+		}
+	}
+
+	return nil
+}
+
+type templateOwnershipDisposition uint8
+
+const (
+	relinquishTemplateOwnership templateOwnershipDisposition = iota
+	retainTemplateOwnership
+)
+
+func cleanupQuarantinedTemplate(root *os.Root, retiredPath, quarantinePath, previousDigest string) (templateOwnershipDisposition, error) {
+	info, err := root.Lstat(quarantinePath)
+	if err != nil {
+		restoreErr := restoreQuarantinedTemplate(root, retiredPath, quarantinePath)
+		return retainTemplateOwnership, errors.Join(fmt.Errorf("inspect quarantine path %q: %w", quarantinePath, err), restoreErr)
+	}
+
+	if info.Mode()&os.ModeSymlink != 0 {
+		restoreErr := restoreQuarantinedTemplate(root, retiredPath, quarantinePath)
+		if restoreErr != nil {
+			return retainTemplateOwnership, restoreErr
+		}
+
+		// gologger.Warning().Msgf("Preserving retired template path containing a symbolic link: %s", retiredPath)
+
+		return relinquishTemplateOwnership, nil
+	}
+
+	if !info.Mode().IsRegular() {
+		restoreErr := restoreQuarantinedTemplate(root, retiredPath, quarantinePath)
+		if restoreErr != nil {
+			return retainTemplateOwnership, restoreErr
+		}
+
+		// gologger.Warning().Msgf("Preserving non-regular retired template path: %s", retiredPath)
+
+		return relinquishTemplateOwnership, nil
+	}
+
+	contents, err := root.ReadFile(quarantinePath)
+	if err != nil {
+		restoreErr := restoreQuarantinedTemplate(root, retiredPath, quarantinePath)
+
+		return retainTemplateOwnership, errors.Join(fmt.Errorf("read quarantine path %q: %w", quarantinePath, err), restoreErr)
+	}
+
+	if templateDigest(contents) != previousDigest {
+		restoreErr := restoreQuarantinedTemplate(root, retiredPath, quarantinePath)
+		if restoreErr != nil {
+			return retainTemplateOwnership, restoreErr
+		}
+
+		// gologger.Warning().Msgf("Preserving locally modified retired template: %s", retiredPath)
+
+		return relinquishTemplateOwnership, nil
+	}
+
+	if err := root.Remove(quarantinePath); err != nil {
+		restoreErr := restoreQuarantinedTemplate(root, retiredPath, quarantinePath)
+		return retainTemplateOwnership, errors.Join(fmt.Errorf("remove quarantine path %q: %w", quarantinePath, err), restoreErr)
+	}
+
+	if err := syncTemplateOwnershipDirectory(root, "."); err != nil {
+		return retainTemplateOwnership, fmt.Errorf("sync quarantine directory after removing %q: %w", quarantinePath, err)
+	}
+
+	if _, err := root.Lstat(retiredPath); err == nil {
+		return retainTemplateOwnership, nil
+	} else if !os.IsNotExist(err) {
+		return retainTemplateOwnership, fmt.Errorf("inspect restored retired template %q: %w", retiredPath, err)
+	}
+
+	return relinquishTemplateOwnership, nil
+}
+
+func restoreQuarantinedTemplate(root *os.Root, retiredPath, quarantinePath string) error {
+	return restoreQuarantinedTemplateWithLink(root, retiredPath, quarantinePath, root.Link)
+}
+
+func restoreQuarantinedTemplateWithLink(root *os.Root, retiredPath, quarantinePath string, link func(string, string) error) error {
+	parent := filepath.Dir(retiredPath)
+	if parent != "." {
+		parentsToSync, err := createTemplateDirectories(root, parent)
+		if err != nil {
+			return fmt.Errorf("recreate parent directory %q for retired template %q: %w", parent, retiredPath, err)
+		}
+		for _, parentToSync := range parentsToSync {
+			if err := syncTemplateOwnershipDirectory(root, parentToSync); err != nil {
+				return fmt.Errorf("sync recreated directory parent %q: %w", parentToSync, err)
+			}
+		}
+	}
+
+	completed, err := finishInterruptedTemplateRestore(root, retiredPath, quarantinePath, syncTemplateOwnershipFile)
+	if err != nil {
+		return err
+	}
+	if completed {
+		return nil
+	}
+
+	if err := link(quarantinePath, retiredPath); err == nil {
+		return commitQuarantinedTemplateRestore(root, retiredPath, quarantinePath)
+	} else if os.IsExist(err) {
+		return fmt.Errorf("restore retired template %q; quarantined contents remain at %q: %w", retiredPath, quarantinePath, err)
+	}
+
+	moveErr := moveQuarantinedTemplate(root, retiredPath, quarantinePath)
+	if moveErr == nil {
+		return nil
+	}
+
+	if os.IsExist(moveErr) {
+		return fmt.Errorf("restore retired template %q; quarantined contents remain at %q: %w", retiredPath, quarantinePath, moveErr)
+	}
+
+	if copyErr := copyQuarantinedTemplateWithLink(root, retiredPath, quarantinePath, link); copyErr != nil {
+		return errors.Join(moveErr, copyErr)
+	}
+
+	return nil
+}
+
+func moveQuarantinedTemplate(root *os.Root, retiredPath, quarantinePath string) error {
+	state, err := newTemplateRestoreState(retiredPath)
+	if err != nil {
+		return err
+	}
+
+	contents, err := root.ReadFile(quarantinePath)
+	if err != nil {
+		return fmt.Errorf("read quarantined template %q before moving: %w", quarantinePath, err)
+	}
+
+	state.digest = templateDigest(contents)
+	state.kind = templateRestoreMove
+
+	if err := createTemplateRestoreState(root, state); err != nil {
+		return err
+	}
+
+	if err := renameTemplateRestoreNoReplace(root, quarantinePath, retiredPath); err != nil {
+		return errors.Join(err, cleanupTemplateRestoreState(root, state))
+	}
+
+	return cleanupTemplateRestoreState(root, state)
+}
+
+func createTemplateDirectories(root *os.Root, parent string) ([]string, error) {
+	current := ""
+	var parentsToSync []string
+
+	for _, component := range strings.Split(filepath.Clean(parent), string(os.PathSeparator)) {
+		current = filepath.Join(current, component)
+		parentsToSync = append(parentsToSync, filepath.Dir(current))
+		info, err := root.Lstat(current)
+		if err == nil {
+			if !info.IsDir() {
+				return nil, fmt.Errorf("template parent path %q is not a directory", current)
+			}
+			continue
+		}
+
+		if !os.IsNotExist(err) {
+			return nil, fmt.Errorf("inspect template parent path %q: %w", current, err)
+		}
+
+	}
+
+	if err := root.MkdirAll(parent, 0o755); err != nil {
+		return parentsToSync, err
+	}
+
+	return parentsToSync, nil
+}
+
+func finishInterruptedTemplateRestore(root *os.Root, retiredPath, quarantinePath string, syncFile func(*os.Root, string, fs.FileMode) error) (bool, error) {
+	retiredInfo, err := root.Lstat(retiredPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("inspect restored retired template %q: %w", retiredPath, err)
+	}
+
+	quarantineInfo, err := root.Lstat(quarantinePath)
+	if err != nil {
+		return false, fmt.Errorf("inspect quarantine path %q for completed restore: %w", quarantinePath, err)
+	}
+	if !retiredInfo.Mode().IsRegular() || !quarantineInfo.Mode().IsRegular() {
+		return false, nil
+	}
+
+	sameFile := os.SameFile(retiredInfo, quarantineInfo)
+	identical := sameFile
+
+	var restoreState templateRestoreState
+
+	if !identical {
+		var found bool
+
+		restoreState, found, err = findTemplateRestoreState(root, retiredPath)
+		if err != nil {
+			return false, err
+		}
+
+		if !found || retiredInfo.Mode().Perm() != quarantineInfo.Mode().Perm() {
+			return false, nil
+		}
+
+		temporaryInfo, err := root.Lstat(restoreState.temporaryPath)
+		if err == nil && (!temporaryInfo.Mode().IsRegular() || !os.SameFile(retiredInfo, temporaryInfo)) {
+			return false, nil
+		}
+
+		if err != nil && !os.IsNotExist(err) {
+			return false, fmt.Errorf("inspect temporary restored template %q: %w", restoreState.temporaryPath, err)
+		}
+
+		retiredContents, err := root.ReadFile(retiredPath)
+		if err != nil {
+			return false, fmt.Errorf("read restored retired template %q: %w", retiredPath, err)
+		}
+
+		quarantinedContents, err := root.ReadFile(quarantinePath)
+		if err != nil {
+			return false, fmt.Errorf("read quarantine path %q for completed restore: %w", quarantinePath, err)
+		}
+
+		identical = bytes.Equal(retiredContents, quarantinedContents)
+	}
+
+	if !identical {
+		return false, nil
+	}
+
+	if !sameFile {
+		if err := syncFile(root, retiredPath, quarantineInfo.Mode().Perm()); err != nil {
+			return false, fmt.Errorf("sync copied restored template %q: %w", retiredPath, err)
+		}
+	}
+
+	if err := commitQuarantinedTemplateRestore(root, retiredPath, quarantinePath); err != nil {
+		return false, err
+	}
+
+	if !sameFile {
+		if err := cleanupTemplateRestoreState(root, restoreState); err != nil {
+			return false, err
+		}
+	}
+
+	return true, nil
+}
+
+func commitQuarantinedTemplateRestore(root *os.Root, retiredPath, quarantinePath string) error {
+	parent := filepath.Dir(retiredPath)
+	if err := syncTemplateOwnershipDirectory(root, parent); err != nil {
+		return fmt.Errorf("sync restored template directory %q: %w", parent, err)
+	}
+
+	if err := root.Remove(quarantinePath); err != nil {
+		return fmt.Errorf("remove restored quarantine path %q: %w", quarantinePath, err)
+	}
+
+	if err := syncTemplateOwnershipDirectory(root, "."); err != nil {
+		return fmt.Errorf("sync quarantine directory after removing %q: %w", quarantinePath, err)
+	}
+
+	return nil
+}
+
+func copyQuarantinedTemplate(root *os.Root, retiredPath, quarantinePath string) error {
+	return copyQuarantinedTemplateWithLink(root, retiredPath, quarantinePath, root.Link)
+}
+
+func copyQuarantinedTemplateWithLink(root *os.Root, retiredPath, quarantinePath string, link func(string, string) error) error {
+	quarantined, err := root.Open(quarantinePath)
+	if err != nil {
+		return fmt.Errorf("open quarantined template %q for restore: %w", quarantinePath, err)
+	}
+	defer func() { _ = quarantined.Close() }()
+
+	info, err := quarantined.Stat()
+	if err != nil {
+		return fmt.Errorf("inspect quarantined template %q for restore: %w", quarantinePath, err)
+	}
+
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("restore retired template %q; non-regular quarantined contents remain at %q", retiredPath, quarantinePath)
+	}
+
+	restoreState, err := newTemplateRestoreState(retiredPath)
+	if err != nil {
+		return err
+	}
+
+	restored, err := root.OpenFile(restoreState.temporaryPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return fmt.Errorf("create temporary restored template %q; quarantined contents remain at %q: %w", restoreState.temporaryPath, quarantinePath, err)
+	}
+
+	published := false
+	defer func() {
+		_ = restored.Close()
+		if !published {
+			_ = root.Remove(restoreState.temporaryPath)
+		}
+	}()
+
+	digest := sha256.New()
+	if _, err := io.Copy(io.MultiWriter(restored, digest), quarantined); err != nil {
+		return fmt.Errorf("restore retired template %q from %q: %w", retiredPath, quarantinePath, err)
+	}
+
+	restoreState.digest = hex.EncodeToString(digest.Sum(nil))
+	restoreState.kind = templateRestoreCopy
+
+	if err := restored.Chmod(info.Mode().Perm()); err != nil {
+		return fmt.Errorf("restore permissions on retired template %q: %w", retiredPath, err)
+	}
+
+	if err := restored.Sync(); err != nil {
+		return fmt.Errorf("sync restored retired template %q: %w", retiredPath, err)
+	}
+
+	if err := restored.Close(); err != nil {
+		return fmt.Errorf("close restored retired template %q: %w", retiredPath, err)
+	}
+
+	if err := createTemplateRestoreState(root, restoreState); err != nil {
+		return err
+	}
+
+	if err := publishTemplateRestore(root, restoreState.temporaryPath, retiredPath, link); err != nil {
+		cleanupErr := cleanupTemplateRestoreState(root, restoreState)
+		return errors.Join(fmt.Errorf("publish restored retired template %q without overwriting; quarantined contents remain at %q: %w", retiredPath, quarantinePath, err), cleanupErr)
+	}
+
+	published = true
+
+	if err := verifyCopiedTemplateRestore(root, retiredPath, quarantinePath, info.Mode()); err != nil {
+		return err
+	}
+
+	if err := commitQuarantinedTemplateRestore(root, retiredPath, quarantinePath); err != nil {
+		return err
+	}
+
+	return cleanupTemplateRestoreState(root, restoreState)
+}
+
+func verifyCopiedTemplateRestore(root *os.Root, retiredPath, quarantinePath string, mode fs.FileMode) error {
+	restoredInfo, err := root.Stat(retiredPath)
+	if err != nil {
+		return fmt.Errorf("inspect copied restored template %q: %w", retiredPath, err)
+	}
+
+	quarantineInfo, err := root.Stat(quarantinePath)
+	if err != nil {
+		return fmt.Errorf("inspect quarantine after copying %q: %w", quarantinePath, err)
+	}
+
+	if restoredInfo.Mode().Perm() != mode.Perm() || quarantineInfo.Mode().Perm() != mode.Perm() {
+		return fmt.Errorf("quarantined template %q changed permissions while being restored", quarantinePath)
+	}
+
+	restoredContents, err := root.ReadFile(retiredPath)
+	if err != nil {
+		return fmt.Errorf("read copied restored template %q: %w", retiredPath, err)
+	}
+
+	quarantinedContents, err := root.ReadFile(quarantinePath)
+	if err != nil {
+		return fmt.Errorf("read quarantine after copying %q: %w", quarantinePath, err)
+	}
+
+	if !bytes.Equal(restoredContents, quarantinedContents) {
+		return fmt.Errorf("quarantined template %q changed while being restored", quarantinePath)
+	}
+
+	return nil
+}
+
+func publishTemplateRestore(root *os.Root, temporaryPath, retiredPath string, link func(string, string) error) error {
+	if err := link(temporaryPath, retiredPath); err == nil {
+		return nil
+	} else if os.IsExist(err) {
+		return err
+	}
+
+	return renameTemplateRestoreNoReplace(root, temporaryPath, retiredPath)
+}
+
+func templateRestoreTemporaryPath(retiredPath string) string {
+	digest := sha256.Sum256([]byte(filepath.ToSlash(retiredPath)))
+
+	return filepath.Join(filepath.Dir(retiredPath), templateOutputTemporaryPrefix+hex.EncodeToString(digest[:16]))
+}
+
+func templateRestoreStatePrefix(retiredPath string) string {
+	digest := sha256.Sum256([]byte(filepath.ToSlash(retiredPath)))
+
+	return templateOwnershipRestorePrefix + hex.EncodeToString(digest[:]) + "-"
+}
+
+func newTemplateRestoreState(retiredPath string) (templateRestoreState, error) {
+	randomSuffix := make([]byte, 16)
+	if _, err := rand.Read(randomSuffix); err != nil {
+		return templateRestoreState{}, fmt.Errorf("generate temporary restore name: %w", err)
+	}
+
+	token := hex.EncodeToString(randomSuffix)
+	return templateRestoreState{
+		retiredPath:   retiredPath,
+		temporaryPath: templateRestoreTemporaryPath(retiredPath) + "-" + token,
+		statePath:     templateRestoreStatePrefix(retiredPath) + token,
+	}, nil
+}
+
+func createTemplateRestoreState(root *os.Root, state templateRestoreState) error {
+	if state.kind != templateRestoreCopy && state.kind != templateRestoreMove {
+		return fmt.Errorf("template restore state %q has an invalid kind", state.statePath)
+	}
+
+	if !isLowerHex(state.digest, sha256.Size*2) {
+		return fmt.Errorf("template restore state %q has an invalid digest", state.statePath)
+	}
+
+	stateFile, err := root.OpenFile(state.statePath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return fmt.Errorf("create template restore state %q: %w", state.statePath, err)
+	}
+
+	_, writeErr := stateFile.Write([]byte(string(state.kind) + "\n" + state.digest))
+	syncErr := stateFile.Sync()
+	closeErr := stateFile.Close()
+
+	if err := errors.Join(writeErr, syncErr, closeErr); err != nil {
+		_ = root.Remove(state.statePath)
+
+		return fmt.Errorf("persist template restore state %q: %w", state.statePath, err)
+	}
+
+	if err := syncTemplateOwnershipDirectory(root, "."); err != nil {
+		return fmt.Errorf("sync template restore state %q: %w", state.statePath, err)
+	}
+
+	return nil
+}
+
+func findTemplateRestoreState(root *os.Root, retiredPath string) (templateRestoreState, bool, error) {
+	directory, err := root.Open(".")
+	if err != nil {
+		return templateRestoreState{}, false, fmt.Errorf("open templates directory for restore state: %w", err)
+	}
+
+	entries, readErr := directory.ReadDir(-1)
+	closeErr := directory.Close()
+
+	if err := errors.Join(readErr, closeErr); err != nil {
+		return templateRestoreState{}, false, fmt.Errorf("inspect templates directory for restore state: %w", err)
+	}
+
+	prefix := templateRestoreStatePrefix(retiredPath)
+
+	var found templateRestoreState
+
+	for _, entry := range entries {
+		token, ok := strings.CutPrefix(entry.Name(), prefix)
+		if !ok || !isLowerHex(token, 32) {
+			continue
+		}
+
+		if found.statePath != "" {
+			return templateRestoreState{}, false, fmt.Errorf("multiple template restore states for %q", retiredPath)
+		}
+
+		found = templateRestoreState{
+			retiredPath:   retiredPath,
+			temporaryPath: templateRestoreTemporaryPath(retiredPath) + "-" + token,
+			statePath:     entry.Name(),
+		}
+	}
+
+	if found.statePath == "" {
+		return found, false, nil
+	}
+
+	if err := loadTemplateRestoreState(root, &found); err != nil {
+		return templateRestoreState{}, false, err
+	}
+
+	return found, true, nil
+}
+
+func loadTemplateRestoreState(root *os.Root, state *templateRestoreState) error {
+	info, err := root.Lstat(state.statePath)
+	if err != nil {
+		return fmt.Errorf("inspect template restore state %q: %w", state.statePath, err)
+	}
+
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("template restore state %q is not a regular file", state.statePath)
+	}
+
+	stateFile, err := root.Open(state.statePath)
+	if err != nil {
+		return fmt.Errorf("open template restore state %q: %w", state.statePath, err)
+	}
+
+	contents, readErr := io.ReadAll(io.LimitReader(stateFile, 70))
+	closeErr := stateFile.Close()
+
+	if err := errors.Join(readErr, closeErr); err != nil {
+		return fmt.Errorf("read template restore state %q: %w", state.statePath, err)
+	}
+
+	kind, digest, found := strings.Cut(string(contents), "\n")
+	if !found {
+		return fmt.Errorf("template restore state %q is malformed", state.statePath)
+	}
+
+	state.kind = templateRestoreKind(kind)
+	state.digest = digest
+
+	if state.kind != templateRestoreCopy && state.kind != templateRestoreMove {
+		return fmt.Errorf("template restore state %q has an invalid kind", state.statePath)
+	}
+
+	if !isLowerHex(state.digest, sha256.Size*2) {
+		return fmt.Errorf("template restore state %q has an invalid digest", state.statePath)
+	}
+
+	return nil
+}
+
+func cleanupCommittedTemplateRestore(root *os.Root, state templateRestoreState) error {
+	retiredInfo, err := root.Lstat(state.retiredPath)
+	if err != nil {
+		return fmt.Errorf("inspect committed restored template %q: %w", state.retiredPath, err)
+	}
+
+	if !retiredInfo.Mode().IsRegular() {
+		return fmt.Errorf("committed restored template %q is not a regular file", state.retiredPath)
+	}
+
+	if state.kind == templateRestoreMove {
+		return cleanupTemplateRestoreState(root, state)
+	}
+
+	temporaryInfo, err := root.Lstat(state.temporaryPath)
+	if err == nil && (!temporaryInfo.Mode().IsRegular() || !os.SameFile(retiredInfo, temporaryInfo)) {
+		return fmt.Errorf("temporary restore state %q does not identify restored template %q", state.statePath, state.retiredPath)
+	}
+
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("inspect temporary restored template %q: %w", state.temporaryPath, err)
+	}
+
+	if os.IsNotExist(err) {
+		matches, err := templateRestoreFileMatchesDigest(root, state.retiredPath, state.digest)
+		if err != nil {
+			return err
+		}
+
+		if !matches {
+			return fmt.Errorf("restore state %q does not identify restored template %q", state.statePath, state.retiredPath)
+		}
+	}
+
+	return cleanupTemplateRestoreState(root, state)
+}
+
+func rollbackTemplateRestoreState(root *os.Root, state templateRestoreState) error {
+	if state.kind != templateRestoreCopy {
+		return fmt.Errorf("restore state %q does not own a copied destination", state.statePath)
+	}
+
+	retiredInfo, err := root.Lstat(state.retiredPath)
+	if err != nil {
+		return fmt.Errorf("inspect stale restored template %q: %w", state.retiredPath, err)
+	}
+
+	temporaryInfo, temporaryErr := root.Lstat(state.temporaryPath)
+	if temporaryErr == nil {
+		if !temporaryInfo.Mode().IsRegular() || !os.SameFile(retiredInfo, temporaryInfo) {
+			return fmt.Errorf("restore state %q does not own stale destination %q", state.statePath, state.retiredPath)
+		}
+	} else if os.IsNotExist(temporaryErr) {
+		// A no-replace rename consumes the temporary path; the persisted digest
+		// below proves the destination still contains that published copy.
+	} else {
+		return fmt.Errorf("inspect temporary restored template %q: %w", state.temporaryPath, temporaryErr)
+	}
+
+	matches, err := templateRestoreFileMatchesDigest(root, state.retiredPath, state.digest)
+	if err != nil {
+		return err
+	}
+
+	if !matches {
+		return fmt.Errorf("restore state %q does not own replacement %q", state.statePath, state.retiredPath)
+	}
+
+	if err := root.Remove(state.retiredPath); err != nil {
+		return fmt.Errorf("remove stale restored template %q: %w", state.retiredPath, err)
+	}
+
+	if err := syncTemplateOwnershipDirectory(root, filepath.Dir(state.retiredPath)); err != nil {
+		return fmt.Errorf("sync restored template directory after rollback: %w", err)
+	}
+
+	return cleanupTemplateRestoreState(root, state)
+}
+
+func templateRestoreFileMatchesDigest(root *os.Root, relativePath, digest string) (bool, error) {
+	contents, err := root.ReadFile(relativePath)
+	if err != nil {
+		return false, fmt.Errorf("read restored template %q: %w", relativePath, err)
+	}
+
+	return templateDigest(contents) == digest, nil
+}
+
+func cleanupTemplateRestoreState(root *os.Root, state templateRestoreState) error {
+	if state.kind == templateRestoreCopy {
+		if err := removeRegularTemplateRestoreFile(root, state.temporaryPath); err != nil {
+			return err
+		}
+	}
+
+	if err := syncTemplateOwnershipDirectory(root, filepath.Dir(state.temporaryPath)); err != nil {
+		return fmt.Errorf("sync restored template directory %q after temporary cleanup: %w", filepath.Dir(state.temporaryPath), err)
+	}
+
+	if err := removeRegularTemplateRestoreFile(root, state.statePath); err != nil {
+		return err
+	}
+
+	if err := syncTemplateOwnershipDirectory(root, "."); err != nil {
+		return fmt.Errorf("sync templates directory after restore-state cleanup: %w", err)
+	}
+
+	return nil
+}
+
+func removeRegularTemplateRestoreFile(root *os.Root, relativePath string) error {
+	info, err := root.Lstat(relativePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+
+		return fmt.Errorf("inspect template restore file %q: %w", relativePath, err)
+	}
+
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("template restore file %q is not a regular file", relativePath)
+	}
+
+	if err := root.Remove(relativePath); err != nil {
+		return fmt.Errorf("remove template restore file %q: %w", relativePath, err)
+	}
+
+	return nil
+}
+
+func isLowerHex(value string, length int) bool {
+	if len(value) != length {
+		return false
+	}
+
+	for _, character := range value {
+		if (character < '0' || character > '9') && (character < 'a' || character > 'f') {
+			return false
+		}
+	}
+
+	return true
+}
+
+func retiredTemplateAliasesCurrent(root *os.Root, retiredPath string, currentPathsByFoldedName map[string][]string) (bool, error) {
+	candidates := currentPathsByFoldedName[strings.ToLower(retiredPath)]
+	if len(candidates) == 0 {
+		return false, nil
+	}
+
+	retiredInfo, err := root.Stat(filepath.FromSlash(retiredPath))
+	if err != nil {
+		return false, err
+	}
+
+	for _, currentPath := range candidates {
+		currentInfo, err := root.Stat(filepath.FromSlash(currentPath))
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return false, err
+		}
+
+		if os.SameFile(retiredInfo, currentInfo) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func writeTemplateOwnership(dir string, manifest *templateOwnershipManifest) error {
+	if err := validateTemplateOwnership(manifest); err != nil {
+		return fmt.Errorf("validate template ownership metadata: %w", err)
+	}
+
+	contents, err := json.Marshal(manifest)
+	if err != nil {
+		return fmt.Errorf("encode template ownership metadata: %w", err)
+	}
+
+	contents = append(contents, '\n')
+	manifestPath := filepath.Join(dir, templateOwnershipFileName)
+
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		return fmt.Errorf("open templates directory %q: %w", dir, err)
+	}
+	defer func() { _ = root.Close() }()
+
+	if info, err := root.Lstat(templateOwnershipFileName); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("template ownership metadata %q is a symbolic link", manifestPath)
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("inspect template ownership metadata %q: %w", manifestPath, err)
+	}
+
+	temporary, err := os.CreateTemp(dir, templateOwnershipTemporaryPrefix+"*")
+	if err != nil {
+		return fmt.Errorf("create temporary template ownership metadata in %q: %w", dir, err)
+	}
+
+	temporaryName := filepath.Base(temporary.Name())
+
+	defer func() {
+		_ = temporary.Close()
+		_ = root.Remove(temporaryName)
+	}()
+
+	if _, err := temporary.Write(contents); err != nil {
+		return fmt.Errorf("write temporary template ownership metadata %q: %w", temporary.Name(), err)
+	}
+
+	if err := temporary.Sync(); err != nil {
+		return fmt.Errorf("sync temporary template ownership metadata %q: %w", temporary.Name(), err)
+	}
+
+	if err := temporary.Close(); err != nil {
+		return fmt.Errorf("close temporary template ownership metadata %q: %w", temporary.Name(), err)
+	}
+
+	if err := root.Rename(temporaryName, templateOwnershipFileName); err != nil {
+		return fmt.Errorf("replace template ownership metadata %q: %w", manifestPath, err)
+	}
+
+	if err := syncTemplateOwnershipDirectory(root, "."); err != nil {
+		return fmt.Errorf("sync templates directory %q after ownership update: %w", dir, err)
+	}
+
+	return nil
+}
+
+func templatePathHasSymlink(root *os.Root, relativePath string) (bool, error) {
+	currentPath := ""
+	for _, component := range strings.Split(filepath.FromSlash(relativePath), string(os.PathSeparator)) {
+		currentPath = filepath.Join(currentPath, component)
+
+		info, err := root.Lstat(currentPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return false, nil
+			}
+
+			return false, err
+		}
+
+		if info.Mode()&os.ModeSymlink != 0 {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/pkg/installer/template_ownership.go
+++ b/pkg/installer/template_ownership.go
@@ -315,7 +315,7 @@ func resumeTemplateRestoreState(root *os.Root, state templateRestoreState, quara
 		return false, fmt.Errorf("copy restore state %q lost temporary file %q before publication", state.statePath, state.temporaryPath)
 	}
 
-	if err := renameTemplateRestoreNoReplace(root, quarantinePath, state.retiredPath); err != nil {
+	if err := relocateTemplateRestoreNoReplace(root, quarantinePath, state.retiredPath); err != nil {
 		return false, err
 	}
 
@@ -738,7 +738,7 @@ func moveQuarantinedTemplate(root *os.Root, retiredPath, quarantinePath string) 
 		return err
 	}
 
-	if err := renameTemplateRestoreNoReplace(root, quarantinePath, retiredPath); err != nil {
+	if err := relocateTemplateRestoreNoReplace(root, quarantinePath, retiredPath); err != nil {
 		return errors.Join(err, cleanupTemplateRestoreState(root, state))
 	}
 
@@ -989,7 +989,73 @@ func publishTemplateRestore(root *os.Root, temporaryPath, retiredPath string, li
 		return err
 	}
 
-	return renameTemplateRestoreNoReplace(root, temporaryPath, retiredPath)
+	return relocateTemplateRestoreNoReplace(root, temporaryPath, retiredPath)
+}
+
+// relocateTemplateRestoreNoReplace moves source to destination without
+// overwriting. When the platform rename flag is unsupported, it falls back to
+// an O_CREATE|O_EXCL create-and-copy so restores still succeed on filesystems
+// that reject RENAME_NOREPLACE / RENAME_EXCL.
+func relocateTemplateRestoreNoReplace(root *os.Root, sourcePath, destinationPath string) error {
+	err := renameTemplateRestoreNoReplaceFn(root, sourcePath, destinationPath)
+	if err == nil || os.IsExist(err) || !errors.Is(err, errors.ErrUnsupported) {
+		return err
+	}
+
+	return exclusivePublishTemplateRestore(root, sourcePath, destinationPath)
+}
+
+// renameTemplateRestoreNoReplaceFn is the platform exclusive-rename implementation.
+// Tests may override it to exercise the unsupported-flag fallback.
+var renameTemplateRestoreNoReplaceFn = renameTemplateRestoreNoReplace
+
+func exclusivePublishTemplateRestore(root *os.Root, sourcePath, destinationPath string) error {
+	source, err := root.Open(sourcePath)
+	if err != nil {
+		return fmt.Errorf("open restore source %q: %w", sourcePath, err)
+	}
+	defer func() { _ = source.Close() }()
+
+	info, err := source.Stat()
+	if err != nil {
+		return fmt.Errorf("inspect restore source %q: %w", sourcePath, err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("restore source %q is not a regular file", sourcePath)
+	}
+
+	destination, err := root.OpenFile(destinationPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return fmt.Errorf("create exclusive restore destination %q: %w", destinationPath, err)
+	}
+
+	published := false
+	defer func() {
+		_ = destination.Close()
+		if !published {
+			_ = root.Remove(destinationPath)
+		}
+	}()
+
+	if _, err := io.Copy(destination, source); err != nil {
+		return fmt.Errorf("copy restore source %q to %q: %w", sourcePath, destinationPath, err)
+	}
+	if err := destination.Chmod(info.Mode().Perm()); err != nil {
+		return fmt.Errorf("restore permissions on %q: %w", destinationPath, err)
+	}
+	if err := destination.Sync(); err != nil {
+		return fmt.Errorf("sync exclusive restore destination %q: %w", destinationPath, err)
+	}
+	if err := destination.Close(); err != nil {
+		return fmt.Errorf("close exclusive restore destination %q: %w", destinationPath, err)
+	}
+
+	if err := root.Remove(sourcePath); err != nil {
+		return fmt.Errorf("remove restore source %q after exclusive publish: %w", sourcePath, err)
+	}
+
+	published = true
+	return nil
 }
 
 func templateRestoreTemporaryPath(retiredPath string) string {

--- a/pkg/installer/template_ownership_publish_darwin.go
+++ b/pkg/installer/template_ownership_publish_darwin.go
@@ -3,6 +3,8 @@
 package installer
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -22,5 +24,19 @@ func renameTemplateRestoreNoReplace(root *os.Root, temporaryPath, retiredPath st
 	}
 	defer func() { _ = destinationDirectory.Close() }()
 
-	return unix.RenameatxNp(int(sourceDirectory.Fd()), filepath.Base(temporaryPath), int(destinationDirectory.Fd()), filepath.Base(retiredPath), unix.RENAME_EXCL)
+	err = unix.RenameatxNp(int(sourceDirectory.Fd()), filepath.Base(temporaryPath), int(destinationDirectory.Fd()), filepath.Base(retiredPath), unix.RENAME_EXCL)
+	return mapRenameNoReplaceError(err)
+}
+
+func mapRenameNoReplaceError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	switch {
+	case errors.Is(err, unix.ENOTSUP), errors.Is(err, unix.ENOSYS), errors.Is(err, unix.EINVAL):
+		return fmt.Errorf("%w: %w", errors.ErrUnsupported, err)
+	default:
+		return err
+	}
 }

--- a/pkg/installer/template_ownership_publish_darwin.go
+++ b/pkg/installer/template_ownership_publish_darwin.go
@@ -1,0 +1,26 @@
+//go:build darwin
+
+package installer
+
+import (
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/unix"
+)
+
+func renameTemplateRestoreNoReplace(root *os.Root, temporaryPath, retiredPath string) error {
+	sourceDirectory, err := root.Open(filepath.Dir(temporaryPath))
+	if err != nil {
+		return err
+	}
+	defer func() { _ = sourceDirectory.Close() }()
+
+	destinationDirectory, err := root.Open(filepath.Dir(retiredPath))
+	if err != nil {
+		return err
+	}
+	defer func() { _ = destinationDirectory.Close() }()
+
+	return unix.RenameatxNp(int(sourceDirectory.Fd()), filepath.Base(temporaryPath), int(destinationDirectory.Fd()), filepath.Base(retiredPath), unix.RENAME_EXCL)
+}

--- a/pkg/installer/template_ownership_publish_linux.go
+++ b/pkg/installer/template_ownership_publish_linux.go
@@ -1,0 +1,26 @@
+//go:build linux
+
+package installer
+
+import (
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/unix"
+)
+
+func renameTemplateRestoreNoReplace(root *os.Root, temporaryPath, retiredPath string) error {
+	sourceDirectory, err := root.Open(filepath.Dir(temporaryPath))
+	if err != nil {
+		return err
+	}
+	defer func() { _ = sourceDirectory.Close() }()
+
+	destinationDirectory, err := root.Open(filepath.Dir(retiredPath))
+	if err != nil {
+		return err
+	}
+	defer func() { _ = destinationDirectory.Close() }()
+
+	return unix.Renameat2(int(sourceDirectory.Fd()), filepath.Base(temporaryPath), int(destinationDirectory.Fd()), filepath.Base(retiredPath), unix.RENAME_NOREPLACE)
+}

--- a/pkg/installer/template_ownership_publish_linux.go
+++ b/pkg/installer/template_ownership_publish_linux.go
@@ -3,6 +3,8 @@
 package installer
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -22,5 +24,19 @@ func renameTemplateRestoreNoReplace(root *os.Root, temporaryPath, retiredPath st
 	}
 	defer func() { _ = destinationDirectory.Close() }()
 
-	return unix.Renameat2(int(sourceDirectory.Fd()), filepath.Base(temporaryPath), int(destinationDirectory.Fd()), filepath.Base(retiredPath), unix.RENAME_NOREPLACE)
+	err = unix.Renameat2(int(sourceDirectory.Fd()), filepath.Base(temporaryPath), int(destinationDirectory.Fd()), filepath.Base(retiredPath), unix.RENAME_NOREPLACE)
+	return mapRenameNoReplaceError(err)
+}
+
+func mapRenameNoReplaceError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	switch {
+	case errors.Is(err, unix.ENOSYS), errors.Is(err, unix.EINVAL), errors.Is(err, unix.EOPNOTSUPP):
+		return fmt.Errorf("%w: %w", errors.ErrUnsupported, err)
+	default:
+		return err
+	}
 }

--- a/pkg/installer/template_ownership_publish_linux_test.go
+++ b/pkg/installer/template_ownership_publish_linux_test.go
@@ -1,0 +1,67 @@
+//go:build linux
+
+package installer
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCopyQuarantinedTemplateWithoutHardLinks(t *testing.T) {
+	root, err := os.OpenRoot(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, root.Close()) })
+
+	quarantinePath := templateOwnershipRetiredPrefix + "no-hard-links"
+	contents := []byte("locally modified contents")
+	require.NoError(t, root.WriteFile(quarantinePath, contents, 0o640))
+	openQuarantine, err := root.OpenFile(quarantinePath, os.O_RDWR, 0)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, openQuarantine.Close()) })
+
+	err = restoreQuarantinedTemplateWithLink(root, "retired.yaml", quarantinePath, func(string, string) error {
+		return errors.ErrUnsupported
+	})
+	require.NoError(t, err)
+	require.NoError(t, openQuarantine.Truncate(0))
+	_, err = openQuarantine.WriteAt([]byte("late local write"), 0)
+	require.NoError(t, err)
+	restored, err := root.ReadFile("retired.yaml")
+	require.NoError(t, err)
+	require.Equal(t, []byte("late local write"), restored)
+	info, err := root.Stat("retired.yaml")
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o640), info.Mode().Perm())
+}
+
+func TestResumeTemplateRestoreStateWithoutHardLinks(t *testing.T) {
+	root, err := os.OpenRoot(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, root.Close()) })
+
+	retiredPath := "retired.yaml"
+	quarantinePath := templateOwnershipRetiredPrefix + "pre-publication"
+	contents := []byte("locally modified contents")
+	require.NoError(t, root.WriteFile(quarantinePath, contents, 0o600))
+	state, err := newTemplateRestoreState(retiredPath)
+	require.NoError(t, err)
+	state.kind = templateRestoreCopy
+	state.digest = templateDigest(contents)
+	require.NoError(t, root.WriteFile(state.temporaryPath, contents, 0o600))
+	require.NoError(t, createTemplateRestoreState(root, state))
+
+	completed, err := resumeTemplateRestoreState(root, state, quarantinePath, func(string, string) error {
+		return errors.ErrUnsupported
+	})
+	require.NoError(t, err)
+	require.False(t, completed)
+	require.NoError(t, restoreQuarantinedTemplate(root, retiredPath, quarantinePath))
+	restored, err := root.ReadFile(retiredPath)
+	require.NoError(t, err)
+	require.Equal(t, contents, restored)
+	_, err = root.Lstat(state.statePath)
+	require.ErrorIs(t, err, os.ErrNotExist)
+}

--- a/pkg/installer/template_ownership_publish_other.go
+++ b/pkg/installer/template_ownership_publish_other.go
@@ -1,0 +1,12 @@
+//go:build !linux && !darwin && !windows
+
+package installer
+
+import (
+	"errors"
+	"os"
+)
+
+func renameTemplateRestoreNoReplace(_ *os.Root, _, _ string) error {
+	return errors.ErrUnsupported
+}

--- a/pkg/installer/template_ownership_publish_windows.go
+++ b/pkg/installer/template_ownership_publish_windows.go
@@ -1,0 +1,81 @@
+//go:build windows
+
+package installer
+
+import (
+	"os"
+	"path/filepath"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+type templateRestoreRenameInformation struct {
+	replaceIfExists uint32
+	rootDirectory   windows.Handle
+	fileNameLength  uint32
+	fileName        [1]uint16
+}
+
+func renameTemplateRestoreNoReplace(root *os.Root, temporaryPath, retiredPath string) error {
+	sourceDirectory, err := root.Open(filepath.Dir(temporaryPath))
+	if err != nil {
+		return err
+	}
+	defer func() { _ = sourceDirectory.Close() }()
+
+	destinationDirectory, err := root.Open(filepath.Dir(retiredPath))
+	if err != nil {
+		return err
+	}
+	defer func() { _ = destinationDirectory.Close() }()
+
+	objectName, err := windows.NewNTUnicodeString(filepath.Base(temporaryPath))
+	if err != nil {
+		return err
+	}
+
+	attributes := &windows.OBJECT_ATTRIBUTES{
+		Length:        uint32(unsafe.Sizeof(windows.OBJECT_ATTRIBUTES{})),
+		RootDirectory: windows.Handle(sourceDirectory.Fd()),
+		ObjectName:    objectName,
+		Attributes:    windows.OBJ_CASE_INSENSITIVE,
+	}
+
+	var source windows.Handle
+	var status windows.IO_STATUS_BLOCK
+
+	if err := windows.NtCreateFile(
+		&source,
+		windows.SYNCHRONIZE|windows.DELETE,
+		attributes,
+		&status,
+		nil,
+		0,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
+		windows.FILE_OPEN,
+		windows.FILE_OPEN_REPARSE_POINT|windows.FILE_OPEN_FOR_BACKUP_INTENT|windows.FILE_SYNCHRONOUS_IO_NONALERT,
+		0,
+		0,
+	); err != nil {
+		return err
+	}
+	defer windows.CloseHandle(source)
+
+	targetName, err := windows.UTF16FromString(filepath.Base(retiredPath))
+	if err != nil {
+		return err
+	}
+
+	targetNameLength := (len(targetName) - 1) * 2
+
+	var header templateRestoreRenameInformation
+
+	buffer := make([]byte, int(unsafe.Offsetof(header.fileName))+targetNameLength)
+	info := (*templateRestoreRenameInformation)(unsafe.Pointer(&buffer[0]))
+	info.rootDirectory = windows.Handle(destinationDirectory.Fd())
+	info.fileNameLength = uint32(targetNameLength)
+	copy((*[windows.MAX_LONG_PATH]uint16)(unsafe.Pointer(&info.fileName[0]))[:targetNameLength/2:targetNameLength/2], targetName)
+
+	return windows.NtSetInformationFile(source, &status, &buffer[0], uint32(len(buffer)), windows.FileRenameInformation)
+}

--- a/pkg/installer/template_ownership_state_unix_test.go
+++ b/pkg/installer/template_ownership_state_unix_test.go
@@ -1,0 +1,27 @@
+//go:build !windows
+
+package installer
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadTemplateRestoreStateRejectsFIFO(t *testing.T) {
+	templatesDir := t.TempDir()
+	root, err := os.OpenRoot(templatesDir)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, root.Close()) })
+
+	state := templateRestoreState{
+		retiredPath: "retired.yaml",
+		statePath:   templateRestoreStatePrefix("retired.yaml") + strings.Repeat("a", 32),
+	}
+	require.NoError(t, syscall.Mkfifo(filepath.Join(templatesDir, state.statePath), 0o600))
+	require.ErrorContains(t, loadTemplateRestoreState(root, &state), "is not a regular file")
+}

--- a/pkg/installer/template_ownership_sync.go
+++ b/pkg/installer/template_ownership_sync.go
@@ -1,0 +1,34 @@
+//go:build !windows
+
+package installer
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+)
+
+func syncTemplateOwnershipFile(root *os.Root, relativePath string, mode fs.FileMode) error {
+	file, err := root.Open(relativePath)
+	if err != nil {
+		return err
+	}
+
+	if err := file.Chmod(mode.Perm()); err != nil {
+		_ = file.Close()
+		return err
+	}
+
+	return errors.Join(file.Sync(), file.Close())
+}
+
+func syncTemplateOwnershipDirectory(root *os.Root, relativePath string) error {
+	directory, err := root.Open(relativePath)
+	if err != nil {
+		return err
+	}
+
+	defer func() { _ = directory.Close() }()
+
+	return directory.Sync()
+}

--- a/pkg/installer/template_ownership_sync_windows.go
+++ b/pkg/installer/template_ownership_sync_windows.go
@@ -1,0 +1,35 @@
+package installer
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+)
+
+func syncTemplateOwnershipFile(root *os.Root, relativePath string, mode fs.FileMode) error {
+	return syncTemplateOwnershipFileWithOpen(root, relativePath, mode, func() (*os.File, error) {
+		return root.OpenFile(relativePath, os.O_RDWR, 0)
+	})
+}
+
+func syncTemplateOwnershipFileWithOpen(root *os.Root, relativePath string, mode fs.FileMode, open func() (*os.File, error)) error {
+	if err := root.Chmod(relativePath, 0o600); err != nil {
+		return err
+	}
+
+	file, err := open()
+	if err != nil {
+		return errors.Join(err, root.Chmod(relativePath, mode.Perm()))
+	}
+
+	if err := file.Chmod(mode.Perm()); err != nil {
+		return errors.Join(err, file.Close(), root.Chmod(relativePath, mode.Perm()))
+	}
+
+	return errors.Join(file.Sync(), file.Close())
+}
+
+// Windows cannot flush the read-only directory handle exposed by os.Root.
+func syncTemplateOwnershipDirectory(_ *os.Root, _ string) error {
+	return nil
+}

--- a/pkg/installer/template_ownership_sync_windows_test.go
+++ b/pkg/installer/template_ownership_sync_windows_test.go
@@ -1,0 +1,73 @@
+package installer
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSyncTemplateOwnershipDirectory(t *testing.T) {
+	root, err := os.OpenRoot(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, root.Close()) })
+	require.NoError(t, syncTemplateOwnershipDirectory(root, "."))
+}
+
+func TestSyncTemplateOwnershipFileRestoresModeAfterOpenFailure(t *testing.T) {
+	root, err := os.OpenRoot(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, root.Close()) })
+	require.NoError(t, root.WriteFile("restored.yaml", []byte("restored"), 0o444))
+	originalInfo, err := root.Stat("restored.yaml")
+	require.NoError(t, err)
+	openErr := errors.New("open failed")
+
+	err = syncTemplateOwnershipFileWithOpen(root, "restored.yaml", originalInfo.Mode(), func() (*os.File, error) {
+		return nil, openErr
+	})
+	require.ErrorIs(t, err, openErr)
+	info, err := root.Stat("restored.yaml")
+	require.NoError(t, err)
+	require.Equal(t, originalInfo.Mode().Perm(), info.Mode().Perm())
+}
+
+func TestRenameTemplateRestoreNoReplaceUsesOpenedRoot(t *testing.T) {
+	parent := t.TempDir()
+	openedParent := filepath.Join(parent, "opened")
+	currentParent := filepath.Join(parent, "current")
+	rootPath := filepath.Join(openedParent, "templates")
+	currentRootPath := filepath.Join(currentParent, "templates")
+	require.NoError(t, os.MkdirAll(filepath.Join(rootPath, "source"), 0o755))
+	require.NoError(t, os.Mkdir(filepath.Join(rootPath, "destination"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(currentRootPath, "source"), 0o755))
+	require.NoError(t, os.Mkdir(filepath.Join(currentRootPath, "destination"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(currentRootPath, "source", "temporary.yaml"), []byte("wrong root"), 0o600))
+
+	t.Chdir(openedParent)
+	root, err := os.OpenRoot("templates")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, root.Close()) })
+	require.NoError(t, root.WriteFile(filepath.Join("source", "temporary.yaml"), []byte("restored"), 0o600))
+
+	t.Chdir(currentParent)
+	require.NoError(t, renameTemplateRestoreNoReplace(root, filepath.Join("source", "temporary.yaml"), filepath.Join("destination", "retired.yaml")))
+	require.FileExists(t, filepath.Join(rootPath, "destination", "retired.yaml"))
+	require.NoFileExists(t, filepath.Join(currentRootPath, "destination", "retired.yaml"))
+
+	require.NoError(t, os.Rename(filepath.Join(rootPath, "source"), filepath.Join(rootPath, "moved-source")))
+	require.NoError(t, os.Rename(filepath.Join(rootPath, "destination"), filepath.Join(rootPath, "moved-destination")))
+}
+
+func TestSyncTemplateOwnershipFile(t *testing.T) {
+	root, err := os.OpenRoot(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, root.Close()) })
+	require.NoError(t, root.WriteFile("restored.yaml", []byte("restored"), 0o444))
+	require.NoError(t, syncTemplateOwnershipFile(root, "restored.yaml", 0o444))
+	info, err := root.Stat("restored.yaml")
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o444), info.Mode().Perm())
+}

--- a/pkg/installer/template_ownership_test.go
+++ b/pkg/installer/template_ownership_test.go
@@ -668,6 +668,36 @@ func TestRestoreQuarantinedTemplatePreservesEqualContentReplacement(t *testing.T
 	require.Equal(t, contents, quarantinedContents)
 }
 
+func TestRestoreQuarantinedTemplateWithoutHardLinksOrRename(t *testing.T) {
+	previousRename := renameTemplateRestoreNoReplaceFn
+	renameTemplateRestoreNoReplaceFn = func(*os.Root, string, string) error {
+		return errors.ErrUnsupported
+	}
+	t.Cleanup(func() { renameTemplateRestoreNoReplaceFn = previousRename })
+
+	root, err := os.OpenRoot(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, root.Close()) })
+
+	quarantinePath := templateOwnershipRetiredPrefix + "no-hard-links-or-rename"
+	contents := []byte("locally modified contents")
+	require.NoError(t, root.WriteFile(quarantinePath, contents, 0o640))
+
+	err = restoreQuarantinedTemplateWithLink(root, "retired.yaml", quarantinePath, func(string, string) error {
+		return errors.ErrUnsupported
+	})
+	require.NoError(t, err)
+
+	restored, err := root.ReadFile("retired.yaml")
+	require.NoError(t, err)
+	require.Equal(t, contents, restored)
+	info, err := root.Stat("retired.yaml")
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o640), info.Mode().Perm())
+	_, err = root.Lstat(quarantinePath)
+	require.ErrorIs(t, err, os.ErrNotExist)
+}
+
 func TestRecoverTemplateOwnershipRestoresInterruptedQuarantine(t *testing.T) {
 	templatesDir := t.TempDir()
 	retiredPath := filepath.Join(templatesDir, "retired.yaml")

--- a/pkg/installer/template_ownership_test.go
+++ b/pkg/installer/template_ownership_test.go
@@ -1,0 +1,1196 @@
+package installer
+
+import (
+	"archive/zip"
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/projectdiscovery/gologger"
+	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/config"
+	fileutil "github.com/projectdiscovery/utils/file"
+	"github.com/stretchr/testify/require"
+)
+
+func newWrittenTemplates(t *testing.T, paths ...string) map[string]string {
+	t.Helper()
+	written := make(map[string]string)
+	for _, templatePath := range paths {
+		contents, err := os.ReadFile(templatePath)
+		require.NoError(t, err)
+		written[templatePath] = templateDigest(contents)
+	}
+	return written
+}
+
+func seedTemplateOwnership(t *testing.T, dir string, paths ...string) {
+	t.Helper()
+	manifest := &templateOwnershipManifest{
+		Version: templateOwnershipVersion,
+		Files:   make(map[string]string, len(paths)),
+	}
+	for _, templatePath := range paths {
+		contents, err := os.ReadFile(templatePath)
+		require.NoError(t, err)
+		relativePath, err := filepath.Rel(dir, templatePath)
+		require.NoError(t, err)
+		manifest.Files[filepath.ToSlash(relativePath)] = templateDigest(contents)
+	}
+	require.NoError(t, validateTemplateOwnership(manifest))
+	require.NoError(t, writeTemplateOwnership(dir, manifest))
+}
+
+func newTemplateReleaseArchive(t *testing.T, archivePath string, contents []byte) *bytes.Reader {
+	t.Helper()
+	var archive bytes.Buffer
+	zipWriter := zip.NewWriter(&archive)
+	entry, err := zipWriter.Create(archivePath)
+	require.NoError(t, err)
+	_, err = entry.Write(contents)
+	require.NoError(t, err)
+	require.NoError(t, zipWriter.Close())
+	return bytes.NewReader(archive.Bytes())
+}
+
+func TestValidateTemplateOwnershipPath(t *testing.T) {
+	invalidPaths := []string{
+		"",
+		"/absolute.yaml",
+		`nested\template.yaml`,
+		"C:/volume.yaml",
+		"../outside.yaml",
+		"nested/../template.yaml",
+		"nested//template.yaml",
+		"nul\x00.yaml",
+		"README.md",
+	}
+	for _, relativePath := range invalidPaths {
+		t.Run(relativePath, func(t *testing.T) {
+			require.Error(t, validateTemplateOwnershipPath(relativePath))
+		})
+	}
+	require.NoError(t, validateTemplateOwnershipPath("http/example.yaml"))
+}
+
+func TestBuildTemplateOwnershipSkipsNonTemplateOutputsBeforeRelativizing(t *testing.T) {
+	templatesDir := t.TempDir()
+	nonTemplatePath := filepath.Join(t.TempDir(), config.NucleiIgnoreFileName)
+	if volume := filepath.VolumeName(templatesDir); volume != "" {
+		otherVolume := "Z:"
+		if strings.EqualFold(volume, otherVolume) {
+			otherVolume = "Y:"
+		}
+		nonTemplatePath = otherVolume + string(os.PathSeparator) + config.NucleiIgnoreFileName
+	}
+
+	manifest, err := buildTemplateOwnership(templatesDir, map[string]string{
+		nonTemplatePath: templateDigest([]byte("ignore contents")),
+	})
+	require.NoError(t, err)
+	require.Empty(t, manifest.Files)
+}
+
+func TestBuildTemplateOwnershipSkipsExcludedTemplateDirectories(t *testing.T) {
+	templatesDir := t.TempDir()
+	helperPath := filepath.Join(templatesDir, "helpers", "payloads", "swagger.json")
+
+	manifest, err := buildTemplateOwnership(templatesDir, map[string]string{
+		helperPath: templateDigest([]byte("helper contents")),
+	})
+	require.NoError(t, err)
+	require.Empty(t, manifest.Files)
+}
+
+func TestBootstrapTemplateOwnershipFromArchive(t *testing.T) {
+	templatesDir := t.TempDir()
+	retiredTemplate := filepath.Join(templatesDir, "http", "retired.yaml")
+	localTemplate := filepath.Join(templatesDir, "local.yaml")
+	releaseContents := []byte("release contents")
+	require.NoError(t, os.Mkdir(filepath.Dir(retiredTemplate), 0755))
+	require.NoError(t, os.WriteFile(retiredTemplate, releaseContents, 0644))
+	require.NoError(t, os.WriteFile(localTemplate, []byte("local contents"), 0644))
+
+	tm := &TemplateManager{}
+	archive := newTemplateReleaseArchive(t, "projectdiscovery-nuclei-templates-release/http/retired.yaml", releaseContents)
+	require.NoError(t, tm.bootstrapTemplateOwnershipFromArchive(templatesDir, archive))
+	manifest, err := loadTemplateOwnership(templatesDir)
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{"http/retired.yaml": templateDigest(releaseContents)}, manifest.Files)
+
+	require.NoError(t, reconcileTemplateOwnership(templatesDir, newWrittenTemplates(t)))
+	require.NoFileExists(t, retiredTemplate, "unchanged templates retired from the legacy release should be removed")
+	require.FileExists(t, localTemplate, "files absent from the official prior release must remain unowned")
+}
+
+func TestBootstrapTemplateOwnershipSkipsNonOwnedOutputs(t *testing.T) {
+	testCases := []string{
+		config.NucleiIgnoreFileName,
+		"helpers/payloads/swagger.json",
+	}
+	for _, archivePath := range testCases {
+		t.Run(archivePath, func(t *testing.T) {
+			templatesDir := t.TempDir()
+			archive := newTemplateReleaseArchive(t, "projectdiscovery-nuclei-templates-release/"+archivePath, []byte("non-template contents"))
+
+			tm := &TemplateManager{}
+			require.NoError(t, tm.bootstrapTemplateOwnershipFromArchive(templatesDir, archive))
+			manifest, err := loadTemplateOwnership(templatesDir)
+			require.NoError(t, err)
+			require.Empty(t, manifest.Files)
+		})
+	}
+}
+
+func TestBootstrapTemplateOwnershipUsesArchiveFetcher(t *testing.T) {
+	tm := &TemplateManager{}
+
+	t.Run("writes ownership from fetched prior release", func(t *testing.T) {
+		templatesDir := t.TempDir()
+		contents := []byte("release contents")
+		archive := newTemplateReleaseArchive(t, "projectdiscovery-nuclei-templates-release/http/official.yaml", contents)
+		var fetchedVersion string
+		err := tm.bootstrapTemplateOwnership(templatesDir, "v1.2.3", func(version string) (*bytes.Reader, error) {
+			fetchedVersion = version
+			return archive, nil
+		})
+		require.NoError(t, err)
+		require.Equal(t, "v1.2.3", fetchedVersion)
+		manifest, err := loadTemplateOwnership(templatesDir)
+		require.NoError(t, err)
+		require.Equal(t, map[string]string{"http/official.yaml": templateDigest(contents)}, manifest.Files)
+	})
+
+	t.Run("continues after fetch failure without writing ownership", func(t *testing.T) {
+		templatesDir := t.TempDir()
+		err := tm.bootstrapTemplateOwnership(templatesDir, "v1.2.3", func(string) (*bytes.Reader, error) {
+			return nil, errors.New("fetch failed")
+		})
+		require.NoError(t, err)
+		_, loadErr := loadTemplateOwnership(templatesDir)
+		require.ErrorIs(t, loadErr, errTemplateOwnershipMissing)
+	})
+
+	t.Run("continues after invalid prior archive", func(t *testing.T) {
+		templatesDir := t.TempDir()
+		err := tm.bootstrapTemplateOwnership(templatesDir, "v1.2.3", func(string) (*bytes.Reader, error) {
+			return bytes.NewReader([]byte("not a release archive")), nil
+		})
+		require.NoError(t, err)
+		_, loadErr := loadTemplateOwnership(templatesDir)
+		require.ErrorIs(t, loadErr, errTemplateOwnershipMissing)
+	})
+}
+
+func TestBootstrapTemplateOwnershipHandlesInvalidManifest(t *testing.T) {
+	t.Run("replaces invalid manifest when no recovery is pending", func(t *testing.T) {
+		templatesDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(templatesDir, templateOwnershipFileName), []byte("not json"), 0600))
+		fetchCalled := false
+		tm := &TemplateManager{}
+		require.NoError(t, tm.bootstrapTemplateOwnership(templatesDir, "v1.2.3", func(string) (*bytes.Reader, error) {
+			fetchCalled = true
+			return nil, errors.New("unexpected fetch")
+		}))
+		require.False(t, fetchCalled)
+
+		templatePath := filepath.Join(templatesDir, "official.yaml")
+		require.NoError(t, os.WriteFile(templatePath, []byte("release contents"), 0644))
+		require.NoError(t, reconcileTemplateOwnership(templatesDir, newWrittenTemplates(t, templatePath)))
+		manifest, err := loadTemplateOwnership(templatesDir)
+		require.NoError(t, err)
+		require.Contains(t, manifest.Files, "official.yaml")
+	})
+
+	t.Run("rejects invalid manifest when recovery is pending", func(t *testing.T) {
+		templatesDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(templatesDir, templateOwnershipFileName), []byte("not json"), 0600))
+		require.NoError(t, os.WriteFile(filepath.Join(templatesDir, retiredTemplateQuarantinePath("retired.yaml")), []byte("quarantined contents"), 0600))
+		tm := &TemplateManager{}
+		err := tm.bootstrapTemplateOwnership(templatesDir, "v1.2.3", func(string) (*bytes.Reader, error) {
+			return nil, errors.New("unexpected fetch")
+		})
+		require.ErrorContains(t, err, "decode template ownership metadata")
+	})
+
+	t.Run("rejects invalid manifest when restore state is pending", func(t *testing.T) {
+		templatesDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(templatesDir, templateOwnershipFileName), []byte("not json"), 0o600))
+		require.NoError(t, os.WriteFile(filepath.Join(templatesDir, templateRestoreStatePrefix("retired.yaml")+strings.Repeat("a", 32)), nil, 0o600))
+		tm := &TemplateManager{}
+		err := tm.bootstrapTemplateOwnership(templatesDir, "v1.2.3", func(string) (*bytes.Reader, error) {
+			return nil, errors.New("unexpected fetch")
+		})
+		require.ErrorContains(t, err, "decode template ownership metadata")
+	})
+}
+
+func TestReconcileTemplateOwnershipUsesWrittenContents(t *testing.T) {
+	templatesDir := t.TempDir()
+	templatePath := filepath.Join(templatesDir, "official.yaml")
+	releaseContents := []byte("release contents")
+	localContents := []byte("concurrent local edit")
+	require.NoError(t, os.WriteFile(templatePath, releaseContents, 0644))
+
+	written := map[string]string{templatePath: templateDigest(releaseContents)}
+	require.NoError(t, os.WriteFile(templatePath, localContents, 0644))
+	require.NoError(t, reconcileTemplateOwnership(templatesDir, written))
+
+	manifest, err := loadTemplateOwnership(templatesDir)
+	require.NoError(t, err)
+	require.Equal(t, written[templatePath], manifest.Files["official.yaml"])
+	require.NoError(t, reconcileTemplateOwnership(templatesDir, newWrittenTemplates(t)))
+	contents, err := os.ReadFile(templatePath)
+	require.NoError(t, err)
+	require.Equal(t, localContents, contents, "a concurrent local edit must not be certified as release-owned or deleted")
+}
+
+func TestRecordPartialTemplateOwnershipPreservesUnvisitedPaths(t *testing.T) {
+	templatesDir := t.TempDir()
+	visitedPath := filepath.Join(templatesDir, "visited.yaml")
+	unvisitedPath := filepath.Join(templatesDir, "unvisited.yaml")
+	addedPath := filepath.Join(templatesDir, "added.yaml")
+	require.NoError(t, os.WriteFile(visitedPath, []byte("old visited contents"), 0644))
+	require.NoError(t, os.WriteFile(unvisitedPath, []byte("unvisited contents"), 0644))
+	seedTemplateOwnership(t, templatesDir, visitedPath, unvisitedPath)
+
+	require.NoError(t, os.WriteFile(visitedPath, []byte("new visited contents"), 0644))
+	require.NoError(t, os.WriteFile(addedPath, []byte("partially added contents"), 0644))
+	require.NoError(t, recordPartialTemplateOwnership(templatesDir, newWrittenTemplates(t, visitedPath, addedPath)))
+
+	manifest, err := loadTemplateOwnership(templatesDir)
+	require.NoError(t, err)
+	require.Equal(t, templateDigest([]byte("new visited contents")), manifest.Files["visited.yaml"])
+	require.Equal(t, templateDigest([]byte("unvisited contents")), manifest.Files["unvisited.yaml"])
+	require.Equal(t, templateDigest([]byte("partially added contents")), manifest.Files["added.yaml"])
+
+	require.NoError(t, reconcileTemplateOwnership(templatesDir, newWrittenTemplates(t)))
+	require.NoFileExists(t, visitedPath)
+	require.NoFileExists(t, unvisitedPath)
+	require.NoFileExists(t, addedPath, "a later release that omits the partially added path must retire it")
+}
+
+func TestReconcileTemplateOwnershipPreservesCurrentFileAlias(t *testing.T) {
+	templatesDir := t.TempDir()
+	currentPath := filepath.Join(templatesDir, "official.yaml")
+	retiredPath := filepath.Join(templatesDir, "Official.yaml")
+	contents := []byte("release contents")
+	require.NoError(t, os.WriteFile(currentPath, contents, 0644))
+	if err := os.Link(currentPath, retiredPath); err != nil {
+		if _, statErr := os.Stat(retiredPath); statErr != nil {
+			t.Skipf("filesystem aliases are unavailable: %v", err)
+		}
+	}
+
+	seedTemplateOwnership(t, templatesDir, retiredPath)
+	require.NoError(t, reconcileTemplateOwnership(templatesDir, newWrittenTemplates(t, currentPath)))
+	require.FileExists(t, currentPath)
+	require.FileExists(t, retiredPath, "cleanup must not remove a path that aliases a current release template")
+}
+
+func TestReconcileTemplateOwnershipPreservesNonRegularRetiredPath(t *testing.T) {
+	templatesDir := t.TempDir()
+	retiredPath := filepath.Join(templatesDir, "retired.yaml")
+	require.NoError(t, os.WriteFile(retiredPath, []byte("release contents"), 0644))
+	seedTemplateOwnership(t, templatesDir, retiredPath)
+	require.NoError(t, os.Remove(retiredPath))
+	require.NoError(t, os.Mkdir(retiredPath, 0755))
+
+	require.NoError(t, reconcileTemplateOwnership(templatesDir, newWrittenTemplates(t)))
+	require.DirExists(t, retiredPath)
+	require.NoFileExists(t, filepath.Join(templatesDir, retiredTemplateQuarantinePath("retired.yaml")))
+	manifest, err := loadTemplateOwnership(templatesDir)
+	require.NoError(t, err)
+	require.Empty(t, manifest.Files, "non-regular replacements should relinquish installer ownership")
+}
+
+func TestCleanupQuarantinedTemplatePreservesConcurrentReplacement(t *testing.T) {
+	templatesDir := t.TempDir()
+	root, err := os.OpenRoot(templatesDir)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, root.Close()) })
+
+	retiredPath := "retired.yaml"
+	releaseContents := []byte("release contents")
+	replacementContents := []byte("concurrent user replacement")
+	require.NoError(t, root.WriteFile(retiredPath, releaseContents, 0644))
+	quarantinePath := retiredTemplateQuarantinePath(retiredPath)
+	require.NoError(t, quarantineRetiredTemplate(root, retiredPath, quarantinePath))
+	require.NoError(t, root.WriteFile(retiredPath, replacementContents, 0644))
+
+	disposition, err := cleanupQuarantinedTemplate(root, retiredPath, quarantinePath, templateDigest(releaseContents))
+	require.NoError(t, err)
+	require.Equal(t, retainTemplateOwnership, disposition, "the prior ownership entry must survive until the replacement is classified")
+	contents, err := root.ReadFile(retiredPath)
+	require.NoError(t, err)
+	require.Equal(t, replacementContents, contents)
+	_, err = root.Stat(quarantinePath)
+	require.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestCleanupQuarantinedTemplateRetainsOwnershipOnRestoreFailure(t *testing.T) {
+	templatesDir := t.TempDir()
+	root, err := os.OpenRoot(templatesDir)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, root.Close()) })
+
+	retiredPath := "retired.yaml"
+	releaseContents := []byte("release contents")
+	modifiedContents := []byte("locally modified contents")
+	replacementContents := []byte("concurrent user replacement")
+	quarantinePath := retiredTemplateQuarantinePath(retiredPath)
+	require.NoError(t, root.WriteFile(quarantinePath, modifiedContents, 0644))
+	require.NoError(t, root.WriteFile(retiredPath, replacementContents, 0644))
+
+	disposition, err := cleanupQuarantinedTemplate(root, retiredPath, quarantinePath, templateDigest(releaseContents))
+	require.Error(t, err)
+	require.Equal(t, retainTemplateOwnership, disposition, "failed recovery must retain the prior ownership entry for retry")
+	contents, readErr := root.ReadFile(retiredPath)
+	require.NoError(t, readErr)
+	require.Equal(t, replacementContents, contents)
+	contents, readErr = root.ReadFile(quarantinePath)
+	require.NoError(t, readErr)
+	require.Equal(t, modifiedContents, contents)
+}
+
+func TestCreateTemplateDirectoriesReportsParentsOnRetry(t *testing.T) {
+	root, err := os.OpenRoot(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, root.Close()) })
+
+	expectedParents := []string{".", "first"}
+	for range 2 {
+		parentsToSync, err := createTemplateDirectories(root, filepath.Join("first", "second"))
+		require.NoError(t, err)
+		require.ElementsMatch(t, expectedParents, parentsToSync)
+	}
+}
+
+func TestRestoreQuarantinedTemplateCompletesInterruptedRestore(t *testing.T) {
+	testCases := []struct {
+		name    string
+		restore func(t *testing.T, root *os.Root, quarantinePath, retiredPath string, contents []byte)
+	}{
+		{
+			name: "hard link",
+			restore: func(t *testing.T, root *os.Root, quarantinePath, retiredPath string, _ []byte) {
+				require.NoError(t, root.Link(quarantinePath, retiredPath))
+			},
+		},
+		{
+			name: "copied file",
+			restore: func(t *testing.T, root *os.Root, _ string, retiredPath string, contents []byte) {
+				token := strings.Repeat("a", 32)
+				temporaryPath := templateRestoreTemporaryPath(retiredPath) + "-" + token
+				require.NoError(t, root.WriteFile(temporaryPath, contents, 0o644))
+				require.NoError(t, root.Link(temporaryPath, retiredPath))
+				require.NoError(t, root.WriteFile(templateRestoreStatePrefix(retiredPath)+token, []byte("copy\n"+templateDigest(contents)), 0o600))
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			templatesDir := t.TempDir()
+			root, err := os.OpenRoot(templatesDir)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, root.Close()) })
+
+			retiredPath := "retired.yaml"
+			quarantinePath := retiredTemplateQuarantinePath(retiredPath)
+			contents := []byte("locally modified contents")
+			require.NoError(t, root.WriteFile(quarantinePath, contents, 0644))
+			testCase.restore(t, root, quarantinePath, retiredPath, contents)
+
+			require.NoError(t, restoreQuarantinedTemplate(root, retiredPath, quarantinePath))
+			restored, err := root.ReadFile(retiredPath)
+			require.NoError(t, err)
+			require.Equal(t, contents, restored)
+			_, err = root.Lstat(quarantinePath)
+			require.ErrorIs(t, err, os.ErrNotExist)
+		})
+	}
+}
+
+func TestFinishInterruptedTemplateRestoreSyncsCopiedFile(t *testing.T) {
+	testCases := []struct {
+		name              string
+		copyRestore       bool
+		expectedSyncCalls int
+	}{
+		{name: "hard link", expectedSyncCalls: 0},
+		{name: "copied file", copyRestore: true, expectedSyncCalls: 1},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			root, err := os.OpenRoot(t.TempDir())
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, root.Close()) })
+
+			retiredPath := "retired.yaml"
+			quarantinePath := retiredTemplateQuarantinePath(retiredPath)
+			contents := []byte("locally modified contents")
+			require.NoError(t, root.WriteFile(quarantinePath, contents, 0o644))
+			quarantineInfo, err := root.Stat(quarantinePath)
+			require.NoError(t, err)
+			if testCase.copyRestore {
+				token := strings.Repeat("a", 32)
+				temporaryPath := templateRestoreTemporaryPath(retiredPath) + "-" + token
+				require.NoError(t, root.WriteFile(temporaryPath, contents, 0o644))
+				require.NoError(t, root.Link(temporaryPath, retiredPath))
+				require.NoError(t, root.WriteFile(templateRestoreStatePrefix(retiredPath)+token, []byte("copy\n"+templateDigest(contents)), 0o600))
+			} else {
+				require.NoError(t, root.Link(quarantinePath, retiredPath))
+			}
+
+			syncCalls := 0
+			completed, err := finishInterruptedTemplateRestore(root, retiredPath, quarantinePath, func(_ *os.Root, _ string, mode os.FileMode) error {
+				syncCalls++
+				require.Equal(t, quarantineInfo.Mode().Perm(), mode.Perm())
+				return nil
+			})
+			require.NoError(t, err)
+			require.True(t, completed)
+			require.Equal(t, testCase.expectedSyncCalls, syncCalls)
+			if testCase.copyRestore {
+				_, err = root.Lstat(templateRestoreTemporaryPath(retiredPath) + "-" + strings.Repeat("a", 32))
+				require.ErrorIs(t, err, os.ErrNotExist)
+			}
+		})
+	}
+}
+
+func TestRecoverTemplateOwnershipCleansCommittedCopyState(t *testing.T) {
+	templatesDir := t.TempDir()
+	retiredPath := "retired.yaml"
+	contents := []byte("locally modified contents")
+	require.NoError(t, os.WriteFile(filepath.Join(templatesDir, retiredPath), contents, 0o644))
+	seedTemplateOwnership(t, templatesDir, filepath.Join(templatesDir, retiredPath))
+
+	root, err := os.OpenRoot(templatesDir)
+	require.NoError(t, err)
+	token := strings.Repeat("a", 32)
+	temporaryPath := templateRestoreTemporaryPath(retiredPath) + "-" + token
+	statePath := templateRestoreStatePrefix(retiredPath) + token
+	require.NoError(t, root.Link(retiredPath, temporaryPath))
+	require.NoError(t, root.WriteFile(statePath, []byte("copy\n"+templateDigest(contents)), 0o600))
+	require.NoError(t, root.Close())
+
+	require.NoError(t, recoverTemplateOwnership(templatesDir))
+	require.FileExists(t, filepath.Join(templatesDir, retiredPath))
+	require.NoFileExists(t, filepath.Join(templatesDir, temporaryPath))
+	require.NoFileExists(t, filepath.Join(templatesDir, statePath))
+}
+
+func TestRecoverTemplateOwnershipResolvesPublishedCopyState(t *testing.T) {
+	t.Run("finishes matching published copy", func(t *testing.T) {
+		templatesDir := t.TempDir()
+		retiredPath := "retired.yaml"
+		releaseContents := []byte("release contents")
+		localContents := []byte("locally modified contents")
+		require.NoError(t, os.WriteFile(filepath.Join(templatesDir, retiredPath), releaseContents, 0o644))
+		seedTemplateOwnership(t, templatesDir, filepath.Join(templatesDir, retiredPath))
+
+		root, err := os.OpenRoot(templatesDir)
+		require.NoError(t, err)
+		quarantinePath := retiredTemplateQuarantinePath(retiredPath)
+		require.NoError(t, root.WriteFile(quarantinePath, localContents, 0o644))
+		require.NoError(t, root.WriteFile(retiredPath, localContents, 0o644))
+		token := strings.Repeat("a", 32)
+		temporaryPath := templateRestoreTemporaryPath(retiredPath) + "-" + token
+		statePath := templateRestoreStatePrefix(retiredPath) + token
+		require.NoError(t, root.Link(retiredPath, temporaryPath))
+		require.NoError(t, root.WriteFile(statePath, []byte("copy\n"+templateDigest(localContents)), 0o600))
+		require.NoError(t, root.Close())
+
+		require.NoError(t, recoverTemplateOwnership(templatesDir))
+		contents, err := os.ReadFile(filepath.Join(templatesDir, retiredPath))
+		require.NoError(t, err)
+		require.Equal(t, localContents, contents)
+		require.NoFileExists(t, filepath.Join(templatesDir, quarantinePath))
+		require.NoFileExists(t, filepath.Join(templatesDir, temporaryPath))
+		require.NoFileExists(t, filepath.Join(templatesDir, statePath))
+	})
+
+	t.Run("rolls back stale copy and retries current quarantine", func(t *testing.T) {
+		templatesDir := t.TempDir()
+		retiredPath := "retired.yaml"
+		releaseContents := []byte("release contents")
+		staleContents := []byte("stale local contents")
+		currentContents := []byte("current local contents")
+		require.NoError(t, os.WriteFile(filepath.Join(templatesDir, retiredPath), releaseContents, 0o644))
+		seedTemplateOwnership(t, templatesDir, filepath.Join(templatesDir, retiredPath))
+
+		root, err := os.OpenRoot(templatesDir)
+		require.NoError(t, err)
+		quarantinePath := retiredTemplateQuarantinePath(retiredPath)
+		require.NoError(t, root.WriteFile(quarantinePath, currentContents, 0o644))
+		require.NoError(t, root.WriteFile(retiredPath, staleContents, 0o644))
+		token := strings.Repeat("a", 32)
+		temporaryPath := templateRestoreTemporaryPath(retiredPath) + "-" + token
+		statePath := templateRestoreStatePrefix(retiredPath) + token
+		require.NoError(t, root.Link(retiredPath, temporaryPath))
+		require.NoError(t, root.WriteFile(statePath, []byte("copy\n"+templateDigest(staleContents)), 0o600))
+		require.NoError(t, root.Close())
+
+		require.NoError(t, recoverTemplateOwnership(templatesDir))
+		contents, err := os.ReadFile(filepath.Join(templatesDir, retiredPath))
+		require.NoError(t, err)
+		require.Equal(t, currentContents, contents)
+		require.NoFileExists(t, filepath.Join(templatesDir, quarantinePath))
+		require.NoFileExists(t, filepath.Join(templatesDir, temporaryPath))
+		require.NoFileExists(t, filepath.Join(templatesDir, statePath))
+	})
+
+	t.Run("preserves unrelated replacement", func(t *testing.T) {
+		templatesDir := t.TempDir()
+		retiredPath := "retired.yaml"
+		releaseContents := []byte("release contents")
+		staleContents := []byte("stale local contents")
+		currentContents := []byte("current local contents")
+		replacementContents := []byte("unrelated replacement")
+		require.NoError(t, os.WriteFile(filepath.Join(templatesDir, retiredPath), releaseContents, 0o644))
+		seedTemplateOwnership(t, templatesDir, filepath.Join(templatesDir, retiredPath))
+
+		root, err := os.OpenRoot(templatesDir)
+		require.NoError(t, err)
+		quarantinePath := retiredTemplateQuarantinePath(retiredPath)
+		require.NoError(t, root.WriteFile(quarantinePath, currentContents, 0o644))
+		require.NoError(t, root.WriteFile(retiredPath, replacementContents, 0o644))
+		token := strings.Repeat("a", 32)
+		statePath := templateRestoreStatePrefix(retiredPath) + token
+		require.NoError(t, root.WriteFile(statePath, []byte("copy\n"+templateDigest(staleContents)), 0o600))
+		require.NoError(t, root.Close())
+
+		err = recoverTemplateOwnership(templatesDir)
+		require.Error(t, err)
+		contents, readErr := os.ReadFile(filepath.Join(templatesDir, retiredPath))
+		require.NoError(t, readErr)
+		require.Equal(t, replacementContents, contents)
+		require.FileExists(t, filepath.Join(templatesDir, quarantinePath))
+		require.FileExists(t, filepath.Join(templatesDir, statePath))
+	})
+
+	t.Run("preserves a published copy mutated after publication", func(t *testing.T) {
+		templatesDir := t.TempDir()
+		retiredPath := "retired.yaml"
+		releaseContents := []byte("release contents")
+		publishedContents := []byte("published local contents")
+		currentContents := []byte("current quarantine contents")
+		lateContents := []byte("late destination edit")
+		require.NoError(t, os.WriteFile(filepath.Join(templatesDir, retiredPath), releaseContents, 0o644))
+		seedTemplateOwnership(t, templatesDir, filepath.Join(templatesDir, retiredPath))
+
+		root, err := os.OpenRoot(templatesDir)
+		require.NoError(t, err)
+		quarantinePath := retiredTemplateQuarantinePath(retiredPath)
+		require.NoError(t, root.WriteFile(quarantinePath, currentContents, 0o644))
+		require.NoError(t, root.WriteFile(retiredPath, publishedContents, 0o644))
+		token := strings.Repeat("a", 32)
+		temporaryPath := templateRestoreTemporaryPath(retiredPath) + "-" + token
+		statePath := templateRestoreStatePrefix(retiredPath) + token
+		require.NoError(t, root.Link(retiredPath, temporaryPath))
+		require.NoError(t, root.WriteFile(statePath, []byte("copy\n"+templateDigest(publishedContents)), 0o600))
+		require.NoError(t, root.WriteFile(retiredPath, lateContents, 0o644))
+		require.NoError(t, root.Close())
+
+		err = recoverTemplateOwnership(templatesDir)
+		require.Error(t, err)
+		contents, readErr := os.ReadFile(filepath.Join(templatesDir, retiredPath))
+		require.NoError(t, readErr)
+		require.Equal(t, lateContents, contents)
+		require.FileExists(t, filepath.Join(templatesDir, quarantinePath))
+		require.FileExists(t, filepath.Join(templatesDir, temporaryPath))
+		require.FileExists(t, filepath.Join(templatesDir, statePath))
+	})
+}
+
+func TestRecoverTemplateOwnershipFinishesMovedStateAfterLateWrite(t *testing.T) {
+	templatesDir := t.TempDir()
+	retiredPath := "retired.yaml"
+	releaseContents := []byte("release contents")
+	localContents := []byte("locally modified contents")
+	lateContents := []byte("late local write")
+	require.NoError(t, os.WriteFile(filepath.Join(templatesDir, retiredPath), releaseContents, 0o644))
+	seedTemplateOwnership(t, templatesDir, filepath.Join(templatesDir, retiredPath))
+	require.NoError(t, os.WriteFile(filepath.Join(templatesDir, retiredPath), localContents, 0o644))
+
+	root, err := os.OpenRoot(templatesDir)
+	require.NoError(t, err)
+	quarantinePath := retiredTemplateQuarantinePath(retiredPath)
+	require.NoError(t, quarantineRetiredTemplate(root, retiredPath, quarantinePath))
+	state, err := newTemplateRestoreState(retiredPath)
+	require.NoError(t, err)
+	state.kind = templateRestoreMove
+	state.digest = templateDigest(localContents)
+	require.NoError(t, createTemplateRestoreState(root, state))
+	openQuarantine, err := root.OpenFile(quarantinePath, os.O_RDWR, 0)
+	require.NoError(t, err)
+	require.NoError(t, renameTemplateRestoreNoReplace(root, quarantinePath, retiredPath))
+	require.NoError(t, openQuarantine.Truncate(0))
+	_, err = openQuarantine.WriteAt(lateContents, 0)
+	require.NoError(t, err)
+	require.NoError(t, openQuarantine.Close())
+	require.NoError(t, root.Close())
+
+	require.NoError(t, recoverTemplateOwnership(templatesDir))
+	contents, err := os.ReadFile(filepath.Join(templatesDir, retiredPath))
+	require.NoError(t, err)
+	require.Equal(t, lateContents, contents)
+	require.NoFileExists(t, filepath.Join(templatesDir, state.statePath))
+}
+
+func TestRestoreQuarantinedTemplatePreservesEqualContentReplacement(t *testing.T) {
+	root, err := os.OpenRoot(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, root.Close()) })
+
+	retiredPath := "retired.yaml"
+	quarantinePath := retiredTemplateQuarantinePath(retiredPath)
+	contents := []byte("same contents")
+	require.NoError(t, root.WriteFile(quarantinePath, contents, 0o644))
+	require.NoError(t, root.WriteFile(retiredPath, contents, 0o600))
+	beforeInfo, err := root.Stat(retiredPath)
+	require.NoError(t, err)
+
+	err = restoreQuarantinedTemplate(root, retiredPath, quarantinePath)
+	require.Error(t, err)
+	restoredInfo, statErr := root.Stat(retiredPath)
+	require.NoError(t, statErr)
+	require.Equal(t, beforeInfo.Mode().Perm(), restoredInfo.Mode().Perm())
+	restoredContents, readErr := root.ReadFile(retiredPath)
+	require.NoError(t, readErr)
+	require.Equal(t, contents, restoredContents)
+	quarantinedContents, readErr := root.ReadFile(quarantinePath)
+	require.NoError(t, readErr)
+	require.Equal(t, contents, quarantinedContents)
+}
+
+func TestRecoverTemplateOwnershipRestoresInterruptedQuarantine(t *testing.T) {
+	templatesDir := t.TempDir()
+	retiredPath := filepath.Join(templatesDir, "retired.yaml")
+	releaseContents := []byte("release contents")
+	modifiedContents := []byte("locally modified contents")
+	require.NoError(t, os.WriteFile(retiredPath, releaseContents, 0644))
+	seedTemplateOwnership(t, templatesDir, retiredPath)
+	require.NoError(t, os.WriteFile(retiredPath, modifiedContents, 0644))
+
+	root, err := os.OpenRoot(templatesDir)
+	require.NoError(t, err)
+	quarantinePath := retiredTemplateQuarantinePath("retired.yaml")
+	require.NoError(t, quarantineRetiredTemplate(root, "retired.yaml", quarantinePath))
+	require.NoError(t, root.Close())
+
+	require.NoError(t, recoverTemplateOwnership(templatesDir))
+	contents, err := os.ReadFile(retiredPath)
+	require.NoError(t, err)
+	require.Equal(t, modifiedContents, contents)
+	require.NoFileExists(t, filepath.Join(templatesDir, quarantinePath))
+
+	require.NoError(t, reconcileTemplateOwnership(templatesDir, newWrittenTemplates(t)))
+	contents, err = os.ReadFile(retiredPath)
+	require.NoError(t, err)
+	require.Equal(t, modifiedContents, contents)
+}
+
+func TestRecoverTemplateOwnershipBeforeReintroducedPath(t *testing.T) {
+	templatesDir := t.TempDir()
+	relativePath := filepath.Join("nested", "deeper", "retired.yaml")
+	retiredPath := filepath.Join(templatesDir, relativePath)
+	releaseContents := []byte("release contents")
+	modifiedContents := []byte("locally modified contents")
+	require.NoError(t, os.MkdirAll(filepath.Dir(retiredPath), 0755))
+	require.NoError(t, os.WriteFile(retiredPath, releaseContents, 0644))
+	seedTemplateOwnership(t, templatesDir, retiredPath)
+	require.NoError(t, os.WriteFile(retiredPath, modifiedContents, 0644))
+
+	root, err := os.OpenRoot(templatesDir)
+	require.NoError(t, err)
+	quarantinePath := retiredTemplateQuarantinePath(filepath.ToSlash(relativePath))
+	require.NoError(t, quarantineRetiredTemplate(root, relativePath, quarantinePath))
+	require.NoError(t, root.Close())
+	require.NoError(t, os.RemoveAll(filepath.Join(templatesDir, "nested")), "simulate an interrupted cleanup that purged multiple parent levels")
+
+	// Recovery runs before a new release can write a reintroduced retiredPath.
+	require.NoError(t, recoverTemplateOwnership(templatesDir))
+	contents, err := os.ReadFile(retiredPath)
+	require.NoError(t, err)
+	require.Equal(t, modifiedContents, contents)
+	require.NoFileExists(t, filepath.Join(templatesDir, quarantinePath))
+}
+
+func TestRecoverTemplateOwnershipRejectsUnknownQuarantine(t *testing.T) {
+	templatesDir := t.TempDir()
+	require.NoError(t, writeTemplateOwnership(templatesDir, &templateOwnershipManifest{
+		Version: templateOwnershipVersion,
+		Files:   map[string]string{},
+	}))
+	require.NoError(t, os.WriteFile(filepath.Join(templatesDir, templateOwnershipRetiredPrefix+"unknown"), []byte("unknown"), 0600))
+
+	err := recoverTemplateOwnership(templatesDir)
+	require.ErrorContains(t, err, "unrecognized template ownership quarantine")
+}
+
+func TestUpdateIfOutdatedRecoversSameVersionQuarantine(t *testing.T) {
+	templatesDir := t.TempDir()
+	retiredPath := filepath.Join(templatesDir, "retired.yaml")
+	releaseContents := []byte("release contents")
+	modifiedContents := []byte("locally modified contents")
+	require.NoError(t, os.WriteFile(retiredPath, releaseContents, 0644))
+	seedTemplateOwnership(t, templatesDir, retiredPath)
+	require.NoError(t, os.WriteFile(retiredPath, modifiedContents, 0644))
+
+	root, err := os.OpenRoot(templatesDir)
+	require.NoError(t, err)
+	quarantinePath := retiredTemplateQuarantinePath("retired.yaml")
+	require.NoError(t, quarantineRetiredTemplate(root, "retired.yaml", quarantinePath))
+	require.NoError(t, root.Close())
+
+	previousConfig := config.DefaultConfig
+	cfg := &config.Config{
+		TemplateVersion:              "v1.0.0",
+		LatestNucleiTemplatesVersion: "v1.0.0",
+		Logger:                       gologger.DefaultLogger,
+	}
+	cfg.SetTemplatesDir(templatesDir)
+	config.DefaultConfig = cfg
+	t.Cleanup(func() { config.DefaultConfig = previousConfig })
+
+	tm := &TemplateManager{}
+	require.NoError(t, tm.UpdateIfOutdated())
+	contents, err := os.ReadFile(retiredPath)
+	require.NoError(t, err)
+	require.Equal(t, modifiedContents, contents)
+	require.NoFileExists(t, filepath.Join(templatesDir, quarantinePath))
+}
+
+func TestCopyQuarantinedTemplate(t *testing.T) {
+	t.Run("restores without overwriting", func(t *testing.T) {
+		templatesDir := t.TempDir()
+		root, err := os.OpenRoot(templatesDir)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, root.Close()) })
+
+		quarantinePath := templateOwnershipRetiredPrefix + "test"
+		contents := []byte("locally modified contents")
+		require.NoError(t, root.WriteFile(quarantinePath, contents, 0644))
+		err = copyQuarantinedTemplate(root, "retired.yaml", quarantinePath)
+		require.NoError(t, err)
+		restoredContents, err := root.ReadFile("retired.yaml")
+		require.NoError(t, err)
+		require.Equal(t, contents, restoredContents)
+		_, err = root.Stat(quarantinePath)
+		require.ErrorIs(t, err, os.ErrNotExist)
+	})
+
+	t.Run("bypasses an incomplete temporary copy", func(t *testing.T) {
+		templatesDir := t.TempDir()
+		root, err := os.OpenRoot(templatesDir)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, root.Close()) })
+
+		retiredPath := filepath.Join("nested", "retired.yaml")
+		quarantinePath := templateOwnershipRetiredPrefix + "interrupted-copy"
+		contents := []byte("locally modified contents")
+		require.NoError(t, root.WriteFile(quarantinePath, contents, 0o644))
+		require.NoError(t, root.MkdirAll(filepath.Dir(retiredPath), 0o755))
+		temporaryPath := templateRestoreTemporaryPath(retiredPath) + "-partial"
+		require.NoError(t, root.WriteFile(temporaryPath, []byte("partial"), 0o600))
+
+		require.NoError(t, copyQuarantinedTemplate(root, retiredPath, quarantinePath))
+		restoredContents, err := root.ReadFile(retiredPath)
+		require.NoError(t, err)
+		require.Equal(t, contents, restoredContents)
+		partialContents, err := root.ReadFile(temporaryPath)
+		require.NoError(t, err)
+		require.Equal(t, []byte("partial"), partialContents)
+		_, err = root.Lstat(quarantinePath)
+		require.ErrorIs(t, err, os.ErrNotExist)
+	})
+
+	t.Run("preserves an unknown temporary-named file", func(t *testing.T) {
+		templatesDir := t.TempDir()
+		root, err := os.OpenRoot(templatesDir)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, root.Close()) })
+
+		retiredPath := filepath.Join("nested", "retired.yaml")
+		quarantinePath := templateOwnershipRetiredPrefix + "unknown-temporary"
+		quarantinedContents := []byte("locally modified contents")
+		sentinelContents := []byte("unrelated local file")
+		require.NoError(t, root.WriteFile(quarantinePath, quarantinedContents, 0o644))
+		require.NoError(t, root.MkdirAll(filepath.Dir(retiredPath), 0o755))
+		sentinelPath := templateRestoreTemporaryPath(retiredPath)
+		require.NoError(t, root.WriteFile(sentinelPath, sentinelContents, 0o600))
+
+		require.NoError(t, copyQuarantinedTemplate(root, retiredPath, quarantinePath))
+		contents, err := root.ReadFile(retiredPath)
+		require.NoError(t, err)
+		require.Equal(t, quarantinedContents, contents)
+		contents, err = root.ReadFile(sentinelPath)
+		require.NoError(t, err)
+		require.Equal(t, sentinelContents, contents)
+	})
+
+	t.Run("preserves a concurrent replacement", func(t *testing.T) {
+		templatesDir := t.TempDir()
+		root, err := os.OpenRoot(templatesDir)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, root.Close()) })
+
+		quarantinePath := templateOwnershipRetiredPrefix + "test"
+		quarantinedContents := []byte("locally modified contents")
+		replacementContents := []byte("concurrent replacement")
+		require.NoError(t, root.WriteFile(quarantinePath, quarantinedContents, 0644))
+		require.NoError(t, root.WriteFile("retired.yaml", replacementContents, 0644))
+		err = copyQuarantinedTemplate(root, "retired.yaml", quarantinePath)
+		require.Error(t, err)
+		contents, readErr := root.ReadFile("retired.yaml")
+		require.NoError(t, readErr)
+		require.Equal(t, replacementContents, contents)
+		contents, readErr = root.ReadFile(quarantinePath)
+		require.NoError(t, readErr)
+		require.Equal(t, quarantinedContents, contents)
+	})
+}
+
+func TestWriteTemplateOwnershipReplacesManifest(t *testing.T) {
+	templatesDir := t.TempDir()
+	first := &templateOwnershipManifest{
+		Version: templateOwnershipVersion,
+		Files:   map[string]string{"first.yaml": strings.Repeat("0", 64)},
+	}
+	second := &templateOwnershipManifest{
+		Version: templateOwnershipVersion,
+		Files:   map[string]string{"second.yaml": strings.Repeat("1", 64)},
+	}
+	require.NoError(t, writeTemplateOwnership(templatesDir, first))
+	require.NoError(t, writeTemplateOwnership(templatesDir, second))
+
+	loaded, err := loadTemplateOwnership(templatesDir)
+	require.NoError(t, err)
+	require.Equal(t, second, loaded)
+	temporaryFiles, err := filepath.Glob(filepath.Join(templatesDir, templateOwnershipFileName+".tmp-*"))
+	require.NoError(t, err)
+	require.Empty(t, temporaryFiles)
+}
+
+func TestLoadTemplateOwnershipRejectsNonRegularManifest(t *testing.T) {
+	templatesDir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(templatesDir, templateOwnershipFileName), 0755))
+	_, err := loadTemplateOwnership(templatesDir)
+	require.ErrorContains(t, err, "is not a regular file")
+}
+
+func TestReconcileTemplateOwnership(t *testing.T) {
+	t.Run("removes unchanged retired owned templates", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		// Create subdirectories for templates
+		templatesDir1 := filepath.Join(tmpDir, "cves", "2023")
+		templatesDir2 := filepath.Join(tmpDir, "exposures", "configs")
+		require.NoError(t, os.MkdirAll(templatesDir1, 0755))
+		require.NoError(t, os.MkdirAll(templatesDir2, 0755))
+
+		// Create template files
+		template1 := filepath.Join(templatesDir1, "CVE-2023-1234.yaml")
+		template2 := filepath.Join(templatesDir1, "CVE-2023-5678.yaml")
+		template3 := filepath.Join(templatesDir2, "git-config-exposure.yaml")
+		retiredTemplate1 := filepath.Join(templatesDir1, "old-template.yaml")
+		retiredTemplate2 := filepath.Join(templatesDir2, "removed-template.yaml")
+
+		// Write valid template files
+		templateContent := `id: test-template
+info:
+  name: Test Template
+  author: test
+  severity: info`
+		require.NoError(t, os.WriteFile(template1, []byte(templateContent), 0644))
+		require.NoError(t, os.WriteFile(template2, []byte(templateContent), 0644))
+		require.NoError(t, os.WriteFile(template3, []byte(templateContent), 0644))
+		require.NoError(t, os.WriteFile(retiredTemplate1, []byte(templateContent), 0644))
+		require.NoError(t, os.WriteFile(retiredTemplate2, []byte(templateContent), 0644))
+		seedTemplateOwnership(t, tmpDir, template1, template2, template3, retiredTemplate1, retiredTemplate2)
+
+		// The current release still owns only template1, template2, and template3.
+		absTemplate1, _ := filepath.Abs(template1)
+		absTemplate2, _ := filepath.Abs(template2)
+		absTemplate3, _ := filepath.Abs(template3)
+		// Normalize paths consistently with ownership reconciliation.
+		absTemplate1 = filepath.Clean(absTemplate1)
+		absTemplate2 = filepath.Clean(absTemplate2)
+		absTemplate3 = filepath.Clean(absTemplate3)
+		writtenTemplates := newWrittenTemplates(t, absTemplate1, absTemplate2, absTemplate3)
+
+		// Reconcile previous ownership with the current release.
+		err := reconcileTemplateOwnership(tmpDir, writtenTemplates)
+		require.NoError(t, err)
+
+		// Unchanged templates retired by the current release are removed.
+		require.NoFileExists(t, retiredTemplate1, "retired owned template should be removed")
+		require.NoFileExists(t, retiredTemplate2, "retired owned template should be removed")
+
+		// Templates owned by the current release remain in place.
+		require.FileExists(t, template1, "template from new release should exist")
+		require.FileExists(t, template2, "template from new release should exist")
+		require.FileExists(t, template3, "template from new release should exist")
+	})
+
+	t.Run("preserves unowned templates in custom directories", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		// Create custom template directory
+		customGitHubDir := filepath.Join(tmpDir, "github", "owner", "repo")
+		require.NoError(t, os.MkdirAll(customGitHubDir, 0755))
+
+		// Create custom template file
+		customTemplate := filepath.Join(customGitHubDir, "custom-template.yaml")
+		templateContent := `id: custom-template
+info:
+  name: Custom Template
+  author: test
+  severity: info`
+		require.NoError(t, os.WriteFile(customTemplate, []byte(templateContent), 0644))
+
+		// The custom template was never recorded as release-owned.
+		writtenTemplates := newWrittenTemplates(t)
+
+		// Reconciliation must not infer ownership by scanning the tree.
+		err := reconcileTemplateOwnership(tmpDir, writtenTemplates)
+		require.NoError(t, err)
+
+		// Verify custom template was NOT removed
+		require.FileExists(t, customTemplate, "custom template should be preserved")
+	})
+
+	t.Run("preserves locally saved custom templates", func(t *testing.T) {
+		templatesDir := t.TempDir()
+
+		officialTemplate := filepath.Join(templatesDir, "http", "official.yaml")
+		localTemplate := filepath.Join(templatesDir, "my-custom-template.yaml")
+		require.NoError(t, os.MkdirAll(filepath.Dir(officialTemplate), 0755))
+		require.NoError(t, os.WriteFile(officialTemplate, []byte(`id: official-template
+info:
+  name: Official Template
+  author: projectdiscovery
+  severity: info`), 0644))
+		require.NoError(t, os.WriteFile(localTemplate, []byte(`id: my-custom-template
+info:
+  name: My Custom Template
+  author: local
+  severity: info`), 0644))
+
+		writtenTemplates := newWrittenTemplates(t, officialTemplate)
+
+		err := reconcileTemplateOwnership(templatesDir, writtenTemplates)
+		require.NoError(t, err)
+		require.NoError(t, reconcileTemplateOwnership(templatesDir, writtenTemplates), "custom template should survive subsequent updates after ownership is recorded")
+		require.FileExists(t, officialTemplate, "template from the new release should be preserved")
+		require.FileExists(t, localTemplate, "locally saved custom template should be preserved")
+	})
+
+	t.Run("preserves locally modified retired templates", func(t *testing.T) {
+		templatesDir := t.TempDir()
+
+		retiredTemplate := filepath.Join(templatesDir, "retired.yaml")
+		require.NoError(t, os.WriteFile(retiredTemplate, []byte("original release contents"), 0644))
+		seedTemplateOwnership(t, templatesDir, retiredTemplate)
+		require.NoError(t, os.WriteFile(retiredTemplate, []byte("locally modified contents"), 0644))
+
+		writtenTemplates := newWrittenTemplates(t)
+		require.NoError(t, reconcileTemplateOwnership(templatesDir, writtenTemplates))
+		contents, err := os.ReadFile(retiredTemplate)
+		require.NoError(t, err)
+		require.Equal(t, "locally modified contents", string(contents), "locally modified retired template should be preserved unchanged")
+	})
+
+	t.Run("does not follow retired template symlinks outside the templates directory", func(t *testing.T) {
+		templatesDir := t.TempDir()
+		externalDir := t.TempDir()
+		retiredDir := filepath.Join(templatesDir, "retired")
+		retiredTemplate := filepath.Join(retiredDir, "official.yaml")
+		contents := []byte("original release contents")
+
+		require.NoError(t, os.Mkdir(retiredDir, 0755))
+		require.NoError(t, os.WriteFile(retiredTemplate, contents, 0644))
+		seedTemplateOwnership(t, templatesDir, retiredTemplate)
+		require.NoError(t, os.Remove(retiredTemplate))
+		require.NoError(t, os.Remove(retiredDir))
+
+		externalTemplate := filepath.Join(externalDir, "official.yaml")
+		require.NoError(t, os.WriteFile(externalTemplate, contents, 0644))
+		if err := os.Symlink(externalDir, retiredDir); err != nil {
+			t.Skipf("symlinks are unavailable: %v", err)
+		}
+
+		writtenTemplates := newWrittenTemplates(t)
+		require.NoError(t, reconcileTemplateOwnership(templatesDir, writtenTemplates))
+		require.FileExists(t, externalTemplate, "ownership cleanup must remain confined to the templates directory")
+	})
+
+	t.Run("rejects ownership paths outside the templates directory", func(t *testing.T) {
+		parentDir := t.TempDir()
+		templatesDir := filepath.Join(parentDir, "templates")
+		require.NoError(t, os.Mkdir(templatesDir, 0755))
+		externalTemplate := filepath.Join(parentDir, "outside.yaml")
+		require.NoError(t, os.WriteFile(externalTemplate, []byte("external contents"), 0644))
+
+		invalidManifest := `{"version":1,"files":{"../outside.yaml":"` + strings.Repeat("0", 64) + `"}}`
+		require.NoError(t, os.WriteFile(filepath.Join(templatesDir, templateOwnershipFileName), []byte(invalidManifest), 0600))
+
+		writtenTemplates := newWrittenTemplates(t)
+		require.NoError(t, reconcileTemplateOwnership(templatesDir, writtenTemplates))
+		require.FileExists(t, externalTemplate, "invalid ownership metadata must not authorize deletion")
+		manifest, err := loadTemplateOwnership(templatesDir)
+		require.NoError(t, err)
+		require.Empty(t, manifest.Files, "invalid ownership metadata should be replaced with current release ownership")
+	})
+
+	t.Run("removes retired owned templates next to custom directories", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		customGitHubDir := filepath.Join(tmpDir, "github", "owner", "repo")
+		require.NoError(t, os.MkdirAll(customGitHubDir, 0755))
+		customTemplate := filepath.Join(customGitHubDir, "custom-template.yaml")
+		require.NoError(t, os.WriteFile(customTemplate, []byte(`id: custom-template
+info:
+  name: Custom Template
+  author: test
+  severity: info`), 0644))
+
+		siblingDir := filepath.Join(tmpDir, "github-evil")
+		require.NoError(t, os.MkdirAll(siblingDir, 0755))
+		siblingTemplate := filepath.Join(siblingDir, "retired-template.yaml")
+		require.NoError(t, os.WriteFile(siblingTemplate, []byte(`id: retired-template
+info:
+  name: Retired Template
+  author: test
+  severity: info`), 0644))
+		seedTemplateOwnership(t, tmpDir, siblingTemplate)
+
+		writtenTemplates := newWrittenTemplates(t)
+
+		err := reconcileTemplateOwnership(tmpDir, writtenTemplates)
+		require.NoError(t, err)
+
+		require.FileExists(t, customTemplate, "custom template should be preserved")
+		require.NoFileExists(t, siblingTemplate, "custom directory sibling prefix should not be preserved")
+	})
+
+	t.Run("preserves unowned non-template files", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		// Create non-template files
+		readmeFile := filepath.Join(tmpDir, "README.md")
+		configFile := filepath.Join(tmpDir, "cves.json")
+		checksumFile := filepath.Join(tmpDir, ".checksum")
+
+		require.NoError(t, os.WriteFile(readmeFile, []byte("# Templates"), 0644))
+		require.NoError(t, os.WriteFile(configFile, []byte("{}"), 0644))
+		require.NoError(t, os.WriteFile(checksumFile, []byte(""), 0644))
+
+		// No file was recorded as release-owned.
+		writtenTemplates := newWrittenTemplates(t)
+
+		// Reconciliation preserves every unowned file.
+		err := reconcileTemplateOwnership(tmpDir, writtenTemplates)
+		require.NoError(t, err)
+
+		// Verify non-template files were NOT removed
+		require.FileExists(t, readmeFile, "README.md should be preserved")
+		require.FileExists(t, configFile, "config file should be preserved")
+		require.FileExists(t, checksumFile, "checksum file should be preserved")
+	})
+
+	t.Run("removes owned templates when the current release is empty", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		// Create template files
+		template1 := filepath.Join(tmpDir, "template1.yaml")
+		templateContent := `id: test-template
+info:
+  name: Test Template
+  author: test
+  severity: info`
+		require.NoError(t, os.WriteFile(template1, []byte(templateContent), 0644))
+		seedTemplateOwnership(t, tmpDir, template1)
+
+		// The current release contains no templates.
+		writtenTemplates := newWrittenTemplates(t)
+
+		// Reconciliation removes the unchanged template owned by the prior release.
+		err := reconcileTemplateOwnership(tmpDir, writtenTemplates)
+		require.NoError(t, err)
+
+		// The prior owned template is absent from the current release.
+		require.NoFileExists(t, template1, "template retired by the current release should be removed")
+	})
+
+	t.Run("accepts absolute written template paths", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		// Create template file
+		template1 := filepath.Join(tmpDir, "template1.yaml")
+		templateContent := `id: test-template
+info:
+  name: Test Template
+  author: test
+  severity: info`
+		require.NoError(t, os.WriteFile(template1, []byte(templateContent), 0644))
+
+		writtenTemplates := newWrittenTemplates(t, template1)
+
+		// Reconciliation normalizes the absolute path into the relative manifest key.
+		err := reconcileTemplateOwnership(tmpDir, writtenTemplates)
+		require.NoError(t, err)
+
+		// The current release retains ownership of the template.
+		require.FileExists(t, template1, "template owned by the current release should be preserved")
+	})
+}
+
+func TestReconcileTemplateOwnershipDirectoryValidation(t *testing.T) {
+	t.Run("handles empty templates directory", func(t *testing.T) {
+		// Create temporary directories
+		tmpDir, err := os.MkdirTemp("", "nuclei-cleanup-empty-dir-test-*")
+		require.NoError(t, err)
+		defer func() {
+			_ = os.RemoveAll(tmpDir)
+		}()
+
+		cfgdir, err := os.MkdirTemp("", "nuclei-config-*")
+		require.NoError(t, err)
+		defer func() {
+			_ = os.RemoveAll(cfgdir)
+		}()
+
+		config.DefaultConfig.SetConfigDir(cfgdir)
+		config.DefaultConfig.SetTemplatesDir(tmpDir)
+
+		// Directory exists but is empty (user deleted all templates)
+		require.True(t, fileutil.FolderExists(tmpDir), "templates directory should exist")
+
+		// The current release contains no templates.
+		writtenTemplates := newWrittenTemplates(t)
+
+		// Reconciliation accepts an existing empty templates directory.
+		err = reconcileTemplateOwnership(tmpDir, writtenTemplates)
+		require.NoError(t, err, "reconciliation should accept an empty templates directory")
+
+		// Reconciliation does not remove the templates directory itself.
+		require.True(t, fileutil.FolderExists(tmpDir), "templates directory should still exist")
+	})
+
+	t.Run("rejects non-existent templates directory", func(t *testing.T) {
+		nonExistentDir := filepath.Join(t.TempDir(), "missing")
+		require.False(t, fileutil.FolderExists(nonExistentDir), "directory should not exist")
+
+		writtenTemplates := newWrittenTemplates(t)
+
+		// Reconciliation is only valid after the templates directory is installed.
+		err := reconcileTemplateOwnership(nonExistentDir, writtenTemplates)
+		require.Error(t, err, "reconciliation should reject a non-existent templates directory")
+	})
+}

--- a/pkg/installer/template_ownership_test.go
+++ b/pkg/installer/template_ownership_test.go
@@ -682,6 +682,8 @@ func TestRestoreQuarantinedTemplateWithoutHardLinksOrRename(t *testing.T) {
 	quarantinePath := templateOwnershipRetiredPrefix + "no-hard-links-or-rename"
 	contents := []byte("locally modified contents")
 	require.NoError(t, root.WriteFile(quarantinePath, contents, 0o640))
+	quarantinedInfo, err := root.Stat(quarantinePath)
+	require.NoError(t, err)
 
 	err = restoreQuarantinedTemplateWithLink(root, "retired.yaml", quarantinePath, func(string, string) error {
 		return errors.ErrUnsupported
@@ -693,7 +695,7 @@ func TestRestoreQuarantinedTemplateWithoutHardLinksOrRename(t *testing.T) {
 	require.Equal(t, contents, restored)
 	info, err := root.Stat("retired.yaml")
 	require.NoError(t, err)
-	require.Equal(t, os.FileMode(0o640), info.Mode().Perm())
+	require.Equal(t, quarantinedInfo.Mode().Perm(), info.Mode().Perm())
 	_, err = root.Lstat(quarantinePath)
 	require.ErrorIs(t, err, os.ErrNotExist)
 }

--- a/pkg/installer/template_test.go
+++ b/pkg/installer/template_test.go
@@ -1,14 +1,16 @@
 package installer
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/config"
 	fileutil "github.com/projectdiscovery/utils/file"
-	mapsutil "github.com/projectdiscovery/utils/maps"
 	"github.com/stretchr/testify/require"
 )
 
@@ -59,6 +61,9 @@ func TestTemplateInstallation(t *testing.T) {
 	require.Greater(t, counter, 1000)
 	// every time we install templates, it should override the ignore file with latest one
 	require.FileExists(t, config.DefaultConfig.GetIgnoreFilePath())
+	ownership, err := loadTemplateOwnership(templatesTempDir)
+	require.NoError(t, err)
+	require.NotEmpty(t, ownership.Files, "fresh installation should record official template ownership")
 	t.Logf("Installed %d templates", counter)
 }
 
@@ -101,277 +106,232 @@ func TestIsOutdatedVersion(t *testing.T) {
 	}
 }
 
-func TestCleanupOrphanedTemplates(t *testing.T) {
-	HideProgressBar = true
+func TestWriteTemplateOutput(t *testing.T) {
+	t.Run("replaces a final symlink without modifying its target", func(t *testing.T) {
+		templatesDir := t.TempDir()
+		externalPath := filepath.Join(t.TempDir(), "external.yaml")
+		require.NoError(t, os.WriteFile(externalPath, []byte("external"), 0o644))
 
+		outputPath := filepath.Join(templatesDir, "official.yaml")
+		if err := os.Symlink(externalPath, outputPath); err != nil {
+			t.Skipf("symlinks are unavailable: %v", err)
+		}
+
+		_, err := writeTemplateOutput(templatesDir, outputPath, []byte("release"), 0o644)
+		require.NoError(t, err)
+		require.FileExists(t, outputPath)
+		info, err := os.Lstat(outputPath)
+		require.NoError(t, err)
+		require.Zero(t, info.Mode()&os.ModeSymlink)
+		contents, err := os.ReadFile(outputPath)
+		require.NoError(t, err)
+		require.Equal(t, "release", string(contents))
+		require.FileExists(t, externalPath)
+		contents, err = os.ReadFile(externalPath)
+		require.NoError(t, err)
+		require.Equal(t, "external", string(contents))
+	})
+
+	t.Run("rejects a parent symlink outside the templates directory", func(t *testing.T) {
+		templatesDir := t.TempDir()
+		externalDir := t.TempDir()
+		linkedParent := filepath.Join(templatesDir, "nested")
+		if err := os.Symlink(externalDir, linkedParent); err != nil {
+			t.Skipf("symlinks are unavailable: %v", err)
+		}
+
+		_, err := writeTemplateOutput(templatesDir, filepath.Join(linkedParent, "official.yaml"), []byte("release"), 0o644)
+		require.Error(t, err)
+		require.NoFileExists(t, filepath.Join(externalDir, "official.yaml"))
+	})
+
+	t.Run("preserves permissions on an existing regular file", func(t *testing.T) {
+		templatesDir := t.TempDir()
+		outputPath := filepath.Join(templatesDir, "official.yaml")
+		require.NoError(t, os.WriteFile(outputPath, []byte("previous"), 0o600))
+		previousInfo, err := os.Stat(outputPath)
+		require.NoError(t, err)
+
+		_, err = writeTemplateOutput(templatesDir, outputPath, []byte("release"), 0o777)
+		require.NoError(t, err)
+		info, err := os.Stat(outputPath)
+		require.NoError(t, err)
+		require.Equal(t, previousInfo.Mode().Perm(), info.Mode().Perm())
+	})
+
+	t.Run("reports every directory touched by nested output creation", func(t *testing.T) {
+		templatesDir := t.TempDir()
+		firstParent := filepath.Join(templatesDir, "first")
+		outputParent := filepath.Join(firstParent, "second")
+		outputPath := filepath.Join(outputParent, "official.yaml")
+
+		result, err := writeTemplateOutput(templatesDir, outputPath, []byte("release"), 0o644)
+		require.NoError(t, err)
+		require.ElementsMatch(t, []string{templatesDir, firstParent, outputParent}, result.touchedDirectories)
+	})
+
+	t.Run("reports the parent touched by a failed replacement", func(t *testing.T) {
+		templatesDir := t.TempDir()
+		outputPath := filepath.Join(templatesDir, "existing-directory")
+		require.NoError(t, os.Mkdir(outputPath, 0o755))
+
+		result, err := writeTemplateOutput(templatesDir, outputPath, []byte("release"), 0o644)
+		require.Error(t, err)
+		require.Equal(t, []string{templatesDir}, result.touchedDirectories)
+	})
+}
+
+func TestSyncTemplateOutputDirectories(t *testing.T) {
+	t.Run("syncs each distinct directory once", func(t *testing.T) {
+		directories := map[string]struct{}{
+			t.TempDir(): {},
+			t.TempDir(): {},
+		}
+		syncCalls := 0
+
+		err := syncTemplateOutputDirectories(directories, func(*os.Root, string) error {
+			syncCalls++
+			return nil
+		})
+		require.NoError(t, err)
+		require.Equal(t, len(directories), syncCalls)
+	})
+
+	t.Run("continues after a sync failure", func(t *testing.T) {
+		directories := map[string]struct{}{
+			t.TempDir(): {},
+			t.TempDir(): {},
+		}
+		syncErr := errors.New("sync failed")
+		syncCalls := 0
+
+		err := syncTemplateOutputDirectories(directories, func(*os.Root, string) error {
+			syncCalls++
+			if syncCalls == 1 {
+				return syncErr
+			}
+			return nil
+		})
+		require.ErrorIs(t, err, syncErr)
+		require.Equal(t, len(directories), syncCalls)
+	})
+}
+
+func BenchmarkWriteTemplateOutputs(b *testing.B) {
+	b.Run("batched", func(b *testing.B) {
+		benchmarkWriteTemplateOutputs(b, false)
+	})
+	b.Run("per-output-sync", func(b *testing.B) {
+		benchmarkWriteTemplateOutputs(b, true)
+	})
+}
+
+func benchmarkWriteTemplateOutputs(b *testing.B, syncEachOutput bool) {
+	rootDir := b.TempDir()
+	contents := []byte("id: benchmark\ninfo:\n  name: Benchmark\n  author: test\n  severity: info\n")
+	touchedDirectories := make(map[string]struct{})
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for index := 0; index < b.N; index++ {
+		writePath := filepath.Join(rootDir, fmt.Sprintf("group-%d", index%16), fmt.Sprintf("template-%d.yaml", index))
+		outputResult, err := writeTemplateOutput(rootDir, writePath, contents, 0o644)
+		if err != nil {
+			b.Fatal(err)
+		}
+		for _, directory := range outputResult.touchedDirectories {
+			touchedDirectories[directory] = struct{}{}
+		}
+
+		if syncEachOutput {
+			output, err := os.OpenFile(writePath, os.O_RDWR, 0)
+			if err != nil {
+				b.Fatal(err)
+			}
+			syncErr := output.Sync()
+			closeErr := output.Close()
+			if err := errors.Join(syncErr, closeErr); err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+
+	if err := syncTemplateOutputDirectories(touchedDirectories, syncTemplateOwnershipDirectory); err != nil {
+		b.Fatal(err)
+	}
+}
+
+func TestGetTemplateOutputLocationRoutesIgnoreFile(t *testing.T) {
+	previousConfig := config.DefaultConfig
+	cfg := &config.Config{}
+	cfg.SetConfigDir(t.TempDir())
+	config.DefaultConfig = cfg
+	t.Cleanup(func() { config.DefaultConfig = previousConfig })
+
+	ignoreEntry := filepath.Join(t.TempDir(), config.NucleiIgnoreFileName)
+	require.NoError(t, os.WriteFile(ignoreEntry, nil, 0o600))
+	info, err := os.Stat(ignoreEntry)
+	require.NoError(t, err)
+	rootDir, writePath := (&TemplateManager{}).getTemplateOutputLocation(t.TempDir(), "nuclei-templates/"+config.NucleiIgnoreFileName, info)
+	require.Equal(t, cfg.GetConfigDir(), rootDir)
+	require.Equal(t, cfg.GetIgnoreFilePath(), writePath)
+}
+
+func TestCommitTemplateVersionRestoresMemoryOnWriteFailure(t *testing.T) {
+	cfg := &config.Config{TemplateVersion: "v1.2.3"}
+
+	err := commitTemplateVersion(cfg, "v2.0.0")
+	require.Error(t, err)
+	require.Equal(t, "v1.2.3", cfg.TemplateVersion)
+}
+
+func TestFinalizeTemplateReleaseCommitsVersionLast(t *testing.T) {
+	newConfig := func(t *testing.T) *config.Config {
+		t.Helper()
+		configDir := t.TempDir()
+		templatesDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(configDir, config.TemplateConfigFileName), []byte("{}"), 0600))
+		require.NoError(t, os.WriteFile(filepath.Join(configDir, config.NucleiIgnoreFileName), []byte("ignore contents"), 0600))
+		cfg := &config.Config{Logger: gologger.DefaultLogger}
+		cfg.SetConfigDir(configDir)
+		cfg.SetTemplatesDir(templatesDir)
+		cfg.TemplateVersion = "v1.0.0"
+
+		previousConfig := config.DefaultConfig
+		config.DefaultConfig = cfg
+		t.Cleanup(func() { config.DefaultConfig = previousConfig })
+		return cfg
+	}
+
+	t.Run("commits after successful finalization", func(t *testing.T) {
+		cfg := newConfig(t)
+		templatePath := filepath.Join(cfg.TemplatesDirectory, "official.yaml")
+		require.NoError(t, os.WriteFile(templatePath, []byte("id: official\ninfo:\n  name: Official\n  author: test\n  severity: info\n"), 0644))
+
+		tm := &TemplateManager{}
+		_, err := tm.finalizeTemplateRelease(cfg, newWrittenTemplates(t, templatePath), "v2.0.0")
+		require.NoError(t, err)
+		require.Equal(t, "v2.0.0", cfg.TemplateVersion)
+	})
+
+	t.Run("preserves version when metadata finalization fails", func(t *testing.T) {
+		cfg := newConfig(t)
+		templatePath := filepath.Join(cfg.TemplatesDirectory, "official.yaml")
+		require.NoError(t, os.WriteFile(templatePath, []byte("id: official\ninfo:\n  name: Official\n  author: test\n  severity: info\n"), 0644))
+		require.NoError(t, os.Mkdir(cfg.GetTemplateIndexFilePath(), 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(cfg.GetTemplateIndexFilePath(), "keep"), []byte("keep"), 0600))
+
+		tm := &TemplateManager{}
+		_, err := tm.finalizeTemplateRelease(cfg, newWrittenTemplates(t, templatePath), "v2.0.0")
+		require.Error(t, err)
+		require.Equal(t, "v1.0.0", cfg.TemplateVersion)
+	})
+}
+
+func TestCalculateChecksumMap(t *testing.T) {
 	tm := &TemplateManager{}
-
-	t.Run("removes orphaned templates", func(t *testing.T) {
-		// Create temporary directories
-		tmpDir, err := os.MkdirTemp("", "nuclei-cleanup-test-*")
-		require.NoError(t, err)
-		defer func() {
-			_ = os.RemoveAll(tmpDir)
-		}()
-
-		cfgdir, err := os.MkdirTemp("", "nuclei-config-*")
-		require.NoError(t, err)
-		defer func() {
-			_ = os.RemoveAll(cfgdir)
-		}()
-
-		config.DefaultConfig.SetConfigDir(cfgdir)
-		config.DefaultConfig.SetTemplatesDir(tmpDir)
-
-		// Create subdirectories for templates
-		templatesDir1 := filepath.Join(tmpDir, "cves", "2023")
-		templatesDir2 := filepath.Join(tmpDir, "exposures", "configs")
-		require.NoError(t, os.MkdirAll(templatesDir1, 0755))
-		require.NoError(t, os.MkdirAll(templatesDir2, 0755))
-
-		// Create template files
-		template1 := filepath.Join(templatesDir1, "CVE-2023-1234.yaml")
-		template2 := filepath.Join(templatesDir1, "CVE-2023-5678.yaml")
-		template3 := filepath.Join(templatesDir2, "git-config-exposure.yaml")
-		orphanedTemplate1 := filepath.Join(templatesDir1, "old-template.yaml")
-		orphanedTemplate2 := filepath.Join(templatesDir2, "removed-template.yaml")
-
-		// Write valid template files
-		templateContent := `id: test-template
-info:
-  name: Test Template
-  author: test
-  severity: info`
-		require.NoError(t, os.WriteFile(template1, []byte(templateContent), 0644))
-		require.NoError(t, os.WriteFile(template2, []byte(templateContent), 0644))
-		require.NoError(t, os.WriteFile(template3, []byte(templateContent), 0644))
-		require.NoError(t, os.WriteFile(orphanedTemplate1, []byte(templateContent), 0644))
-		require.NoError(t, os.WriteFile(orphanedTemplate2, []byte(templateContent), 0644))
-
-		// Simulate written paths from new release (only template1, template2, template3)
-		writtenPaths := mapsutil.NewSyncLockMap[string, struct{}]()
-		absTemplate1, _ := filepath.Abs(template1)
-		absTemplate2, _ := filepath.Abs(template2)
-		absTemplate3, _ := filepath.Abs(template3)
-		// Normalize paths consistently (same as cleanupOrphanedTemplates does)
-		absTemplate1 = filepath.Clean(absTemplate1)
-		absTemplate2 = filepath.Clean(absTemplate2)
-		absTemplate3 = filepath.Clean(absTemplate3)
-		_ = writtenPaths.Set(absTemplate1, struct{}{})
-		_ = writtenPaths.Set(absTemplate2, struct{}{})
-		_ = writtenPaths.Set(absTemplate3, struct{}{})
-
-		// Run cleanup
-		err = tm.cleanupOrphanedTemplates(tmpDir, writtenPaths)
-		require.NoError(t, err)
-
-		// Verify orphaned templates were removed
-		require.NoFileExists(t, orphanedTemplate1, "orphaned template should be removed")
-		require.NoFileExists(t, orphanedTemplate2, "orphaned template should be removed")
-
-		// Verify non-orphaned templates still exist
-		require.FileExists(t, template1, "template from new release should exist")
-		require.FileExists(t, template2, "template from new release should exist")
-		require.FileExists(t, template3, "template from new release should exist")
-	})
-
-	t.Run("preserves custom templates", func(t *testing.T) {
-		// Create temporary directories
-		tmpDir, err := os.MkdirTemp("", "nuclei-cleanup-custom-test-*")
-		require.NoError(t, err)
-		defer func() {
-			_ = os.RemoveAll(tmpDir)
-		}()
-
-		cfgdir, err := os.MkdirTemp("", "nuclei-config-*")
-		require.NoError(t, err)
-		defer func() {
-			_ = os.RemoveAll(cfgdir)
-		}()
-
-		config.DefaultConfig.SetConfigDir(cfgdir)
-		config.DefaultConfig.SetTemplatesDir(tmpDir)
-
-		// Create custom template directory
-		customGitHubDir := filepath.Join(tmpDir, "github", "owner", "repo")
-		require.NoError(t, os.MkdirAll(customGitHubDir, 0755))
-
-		// Create custom template file
-		customTemplate := filepath.Join(customGitHubDir, "custom-template.yaml")
-		templateContent := `id: custom-template
-info:
-  name: Custom Template
-  author: test
-  severity: info`
-		require.NoError(t, os.WriteFile(customTemplate, []byte(templateContent), 0644))
-
-		// Empty written paths (simulating no custom templates in new release)
-		writtenPaths := mapsutil.NewSyncLockMap[string, struct{}]()
-
-		// Run cleanup
-		err = tm.cleanupOrphanedTemplates(tmpDir, writtenPaths)
-		require.NoError(t, err)
-
-		// Verify custom template was NOT removed
-		require.FileExists(t, customTemplate, "custom template should be preserved")
-	})
-
-	t.Run("removes orphaned templates from custom dir sibling prefixes", func(t *testing.T) {
-		tmpDir, err := os.MkdirTemp("", "nuclei-cleanup-custom-prefix-test-*")
-		require.NoError(t, err)
-		defer func() {
-			_ = os.RemoveAll(tmpDir)
-		}()
-
-		cfgdir, err := os.MkdirTemp("", "nuclei-config-*")
-		require.NoError(t, err)
-		defer func() {
-			_ = os.RemoveAll(cfgdir)
-		}()
-
-		config.DefaultConfig.SetConfigDir(cfgdir)
-		config.DefaultConfig.SetTemplatesDir(tmpDir)
-
-		customGitHubDir := filepath.Join(tmpDir, "github", "owner", "repo")
-		require.NoError(t, os.MkdirAll(customGitHubDir, 0755))
-		customTemplate := filepath.Join(customGitHubDir, "custom-template.yaml")
-		require.NoError(t, os.WriteFile(customTemplate, []byte(`id: custom-template
-info:
-  name: Custom Template
-  author: test
-  severity: info`), 0644))
-
-		siblingDir := filepath.Join(tmpDir, "github-evil")
-		require.NoError(t, os.MkdirAll(siblingDir, 0755))
-		siblingTemplate := filepath.Join(siblingDir, "orphaned-template.yaml")
-		require.NoError(t, os.WriteFile(siblingTemplate, []byte(`id: orphaned-template
-info:
-  name: Orphaned Template
-  author: test
-  severity: info`), 0644))
-
-		writtenPaths := mapsutil.NewSyncLockMap[string, struct{}]()
-
-		err = tm.cleanupOrphanedTemplates(tmpDir, writtenPaths)
-		require.NoError(t, err)
-
-		require.FileExists(t, customTemplate, "custom template should be preserved")
-		require.NoFileExists(t, siblingTemplate, "custom directory sibling prefix should not be preserved")
-	})
-
-	t.Run("skips non-template files", func(t *testing.T) {
-		// Create temporary directories
-		tmpDir, err := os.MkdirTemp("", "nuclei-cleanup-nontemplate-test-*")
-		require.NoError(t, err)
-		defer func() {
-			_ = os.RemoveAll(tmpDir)
-		}()
-
-		cfgdir, err := os.MkdirTemp("", "nuclei-config-*")
-		require.NoError(t, err)
-		defer func() {
-			_ = os.RemoveAll(cfgdir)
-		}()
-
-		config.DefaultConfig.SetConfigDir(cfgdir)
-		config.DefaultConfig.SetTemplatesDir(tmpDir)
-
-		// Create non-template files
-		readmeFile := filepath.Join(tmpDir, "README.md")
-		configFile := filepath.Join(tmpDir, "cves.json")
-		checksumFile := filepath.Join(tmpDir, ".checksum")
-
-		require.NoError(t, os.WriteFile(readmeFile, []byte("# Templates"), 0644))
-		require.NoError(t, os.WriteFile(configFile, []byte("{}"), 0644))
-		require.NoError(t, os.WriteFile(checksumFile, []byte(""), 0644))
-
-		// Empty written paths
-		writtenPaths := mapsutil.NewSyncLockMap[string, struct{}]()
-
-		// Run cleanup
-		err = tm.cleanupOrphanedTemplates(tmpDir, writtenPaths)
-		require.NoError(t, err)
-
-		// Verify non-template files were NOT removed
-		require.FileExists(t, readmeFile, "README.md should be preserved")
-		require.FileExists(t, configFile, "config file should be preserved")
-		require.FileExists(t, checksumFile, "checksum file should be preserved")
-	})
-
-	t.Run("handles empty written paths", func(t *testing.T) {
-		// Create temporary directories
-		tmpDir, err := os.MkdirTemp("", "nuclei-cleanup-empty-test-*")
-		require.NoError(t, err)
-		defer func() {
-			_ = os.RemoveAll(tmpDir)
-		}()
-
-		cfgdir, err := os.MkdirTemp("", "nuclei-config-*")
-		require.NoError(t, err)
-		defer func() {
-			_ = os.RemoveAll(cfgdir)
-		}()
-
-		config.DefaultConfig.SetConfigDir(cfgdir)
-		config.DefaultConfig.SetTemplatesDir(tmpDir)
-
-		// Create template files
-		template1 := filepath.Join(tmpDir, "template1.yaml")
-		templateContent := `id: test-template
-info:
-  name: Test Template
-  author: test
-  severity: info`
-		require.NoError(t, os.WriteFile(template1, []byte(templateContent), 0644))
-
-		// Empty written paths
-		writtenPaths := mapsutil.NewSyncLockMap[string, struct{}]()
-
-		// Run cleanup
-		err = tm.cleanupOrphanedTemplates(tmpDir, writtenPaths)
-		require.NoError(t, err)
-
-		// Verify template was removed (since it's not in written paths)
-		require.NoFileExists(t, template1, "template should be removed when not in written paths")
-	})
-
-	t.Run("handles relative and absolute paths correctly", func(t *testing.T) {
-		// Create temporary directories
-		tmpDir, err := os.MkdirTemp("", "nuclei-cleanup-path-test-*")
-		require.NoError(t, err)
-		defer func() {
-			_ = os.RemoveAll(tmpDir)
-		}()
-
-		cfgdir, err := os.MkdirTemp("", "nuclei-config-*")
-		require.NoError(t, err)
-		defer func() {
-			_ = os.RemoveAll(cfgdir)
-		}()
-
-		config.DefaultConfig.SetConfigDir(cfgdir)
-		config.DefaultConfig.SetTemplatesDir(tmpDir)
-
-		// Create template file
-		template1 := filepath.Join(tmpDir, "template1.yaml")
-		templateContent := `id: test-template
-info:
-  name: Test Template
-  author: test
-  severity: info`
-		require.NoError(t, os.WriteFile(template1, []byte(templateContent), 0644))
-
-		// Use relative path in written paths
-		writtenPaths := mapsutil.NewSyncLockMap[string, struct{}]()
-		_ = writtenPaths.Set(template1, struct{}{}) // relative path
-
-		// Run cleanup - should normalize paths correctly
-		err = tm.cleanupOrphanedTemplates(tmpDir, writtenPaths)
-		require.NoError(t, err)
-
-		// Verify template was NOT removed (it was in written paths)
-		require.FileExists(t, template1, "template should be preserved when in written paths")
-	})
+	previousTemplatesDir := config.DefaultConfig.TemplatesDirectory
+	t.Cleanup(func() { config.DefaultConfig.SetTemplatesDir(previousTemplatesDir) })
 
 	t.Run("checksums custom dir sibling prefixes", func(t *testing.T) {
 		tmpDir, err := os.MkdirTemp("", "nuclei-checksum-custom-prefix-test-*")
@@ -380,13 +340,6 @@ info:
 			_ = os.RemoveAll(tmpDir)
 		}()
 
-		cfgdir, err := os.MkdirTemp("", "nuclei-config-*")
-		require.NoError(t, err)
-		defer func() {
-			_ = os.RemoveAll(cfgdir)
-		}()
-
-		config.DefaultConfig.SetConfigDir(cfgdir)
 		config.DefaultConfig.SetTemplatesDir(tmpDir)
 
 		customGitHubDir := filepath.Join(tmpDir, "github")
@@ -413,50 +366,39 @@ info:
 		require.Contains(t, checksums, siblingTemplate, "custom directory sibling prefix should be checksummed")
 	})
 
-	t.Run("handles empty templates directory", func(t *testing.T) {
-		// Create temporary directories
-		tmpDir, err := os.MkdirTemp("", "nuclei-cleanup-empty-dir-test-*")
+	t.Run("excludes internal temporary files from checksums", func(t *testing.T) {
+		templatesDir := t.TempDir()
+		config.DefaultConfig.SetTemplatesDir(templatesDir)
+
+		templateFile := filepath.Join(templatesDir, "template.yaml")
+		ownershipTemporary := filepath.Join(templatesDir, templateOwnershipFileName+".tmp-interrupted")
+		retiredQuarantine := filepath.Join(templatesDir, templateOwnershipRetiredPrefix+"interrupted")
+		nestedDir := filepath.Join(templatesDir, "nested")
+		nestedOwnershipTemporary := filepath.Join(nestedDir, templateOwnershipFileName+".tmp-user")
+		outputTemporary := filepath.Join(nestedDir, templateOutputTemporaryPrefix+strings.Repeat("a", 32))
+		restoreTemporary := filepath.Join(nestedDir, templateOutputTemporaryPrefix+strings.Repeat("b", 32)+"-"+strings.Repeat("c", 32))
+		restoreState := filepath.Join(templatesDir, templateOwnershipRestorePrefix+strings.Repeat("d", 64)+"-"+strings.Repeat("e", 32))
+		userFileWithSimilarName := filepath.Join(nestedDir, templateOutputTemporaryPrefix+"user.yaml")
+		require.NoError(t, os.Mkdir(nestedDir, 0755))
+		require.NoError(t, os.WriteFile(templateFile, []byte("template"), 0644))
+		require.NoError(t, os.WriteFile(ownershipTemporary, []byte("partial manifest"), 0600))
+		require.NoError(t, os.WriteFile(retiredQuarantine, []byte("retired template"), 0600))
+		require.NoError(t, os.WriteFile(nestedOwnershipTemporary, []byte("user file"), 0644))
+		require.NoError(t, os.WriteFile(outputTemporary, []byte("interrupted write"), 0600))
+		require.NoError(t, os.WriteFile(restoreTemporary, []byte("interrupted restore"), 0600))
+		require.NoError(t, os.WriteFile(restoreState, nil, 0600))
+		require.NoError(t, os.WriteFile(userFileWithSimilarName, []byte("user file"), 0644))
+
+		checksums, err := tm.calculateChecksumMap(templatesDir)
 		require.NoError(t, err)
-		defer func() {
-			_ = os.RemoveAll(tmpDir)
-		}()
-
-		cfgdir, err := os.MkdirTemp("", "nuclei-config-*")
-		require.NoError(t, err)
-		defer func() {
-			_ = os.RemoveAll(cfgdir)
-		}()
-
-		config.DefaultConfig.SetConfigDir(cfgdir)
-		config.DefaultConfig.SetTemplatesDir(tmpDir)
-
-		// Directory exists but is empty (user deleted all templates)
-		require.True(t, fileutil.FolderExists(tmpDir), "templates directory should exist")
-
-		// Written paths from new release
-		writtenPaths := mapsutil.NewSyncLockMap[string, struct{}]()
-
-		// Run cleanup - should handle empty directory gracefully
-		err = tm.cleanupOrphanedTemplates(tmpDir, writtenPaths)
-		require.NoError(t, err, "cleanup should handle empty directory without error")
-
-		// Directory should still exist after cleanup
-		require.True(t, fileutil.FolderExists(tmpDir), "templates directory should still exist")
-	})
-
-	t.Run("handles non-existent directory gracefully", func(t *testing.T) {
-		// Use a non-existent directory path
-		nonExistentDir := "/tmp/nuclei-test-non-existent-dir-12345"
-
-		// Ensure it doesn't exist
-		_ = os.RemoveAll(nonExistentDir)
-		require.False(t, fileutil.FolderExists(nonExistentDir), "directory should not exist")
-
-		writtenPaths := mapsutil.NewSyncLockMap[string, struct{}]()
-
-		// Run cleanup - should handle non-existent directory gracefully
-		err := tm.cleanupOrphanedTemplates(nonExistentDir, writtenPaths)
-		require.NoError(t, err, "cleanup should handle non-existent directory without error")
+		require.Contains(t, checksums, templateFile)
+		require.NotContains(t, checksums, ownershipTemporary)
+		require.NotContains(t, checksums, retiredQuarantine)
+		require.NotContains(t, checksums, outputTemporary)
+		require.NotContains(t, checksums, restoreTemporary)
+		require.NotContains(t, checksums, restoreState)
+		require.Contains(t, checksums, nestedOwnershipTemporary, "only root-level ownership artifacts are internal metadata")
+		require.Contains(t, checksums, userFileWithSimilarName, "only names matching the complete internal write pattern are excluded")
 	})
 }
 
@@ -500,7 +442,7 @@ info:
 		require.NoError(t, os.WriteFile(template2, []byte(template2Content), 0644))
 
 		// Regenerate metadata
-		err = tm.regenerateTemplateMetadata(tmpDir)
+		_, err = tm.regenerateTemplateMetadata(config.DefaultConfig)
 		require.NoError(t, err)
 
 		// Verify index file was created
@@ -524,7 +466,7 @@ info:
 		require.Contains(t, checksums, template2, "checksum should contain template2")
 	})
 
-	t.Run("excludes deleted templates from index after cleanup", func(t *testing.T) {
+	t.Run("excludes retired templates from the regenerated index", func(t *testing.T) {
 		tmpDir, err := os.MkdirTemp("", "nuclei-metadata-cleanup-test-*")
 		require.NoError(t, err)
 		defer func() {
@@ -543,7 +485,7 @@ info:
 		// Create template files
 		template1 := filepath.Join(tmpDir, "kept-template.yaml")
 		template2 := filepath.Join(tmpDir, "deleted-template.yaml")
-		orphanedTemplate := filepath.Join(tmpDir, "orphaned-template.yaml")
+		retiredTemplate := filepath.Join(tmpDir, "retired-template.yaml")
 
 		template1Content := `id: test-template-1
 info:
@@ -555,21 +497,21 @@ info:
   name: Test Template 2
   author: test
   severity: info`
-		orphanedContent := `id: test-template-orphaned
+		retiredContent := `id: test-template-retired
 info:
-  name: Test Template Orphaned
+  name: Test Template Retired
   author: test
   severity: info`
 
 		require.NoError(t, os.WriteFile(template1, []byte(template1Content), 0644))
 		require.NoError(t, os.WriteFile(template2, []byte(template2Content), 0644))
-		require.NoError(t, os.WriteFile(orphanedTemplate, []byte(orphanedContent), 0644))
+		require.NoError(t, os.WriteFile(retiredTemplate, []byte(retiredContent), 0644))
 
-		// Create initial index with all templates (simulating state before cleanup)
+		// Create initial index with all previously owned templates.
 		initialIndex := map[string]string{
-			"test-template-1":        template1,
-			"test-template-2":        template2,
-			"test-template-orphaned": orphanedTemplate,
+			"test-template-1":       template1,
+			"test-template-2":       template2,
+			"test-template-retired": retiredTemplate,
 		}
 		err = config.DefaultConfig.WriteTemplatesIndex(initialIndex)
 		require.NoError(t, err)
@@ -577,33 +519,25 @@ info:
 		// Verify initial index contains all templates
 		index, err := config.GetNucleiTemplatesIndex()
 		require.NoError(t, err)
-		require.Contains(t, index, "test-template-orphaned", "initial index should contain orphaned template")
+		require.Contains(t, index, "test-template-retired", "initial index should contain the retired template")
 
-		// Simulate cleanup: remove orphaned template
-		writtenPaths := mapsutil.NewSyncLockMap[string, struct{}]()
-		absTemplate1, _ := filepath.Abs(template1)
-		// Normalize path consistently (same as cleanupOrphanedTemplates does)
-		absTemplate1 = filepath.Clean(absTemplate1)
-		_ = writtenPaths.Set(absTemplate1, struct{}{})
+		// Arrange the post-reconciliation tree directly; reconciliation has dedicated coverage.
+		require.NoError(t, os.Remove(template2))
+		require.NoError(t, os.Remove(retiredTemplate))
 
-		err = tm.cleanupOrphanedTemplates(tmpDir, writtenPaths)
-		require.NoError(t, err)
-		require.NoFileExists(t, orphanedTemplate, "orphaned template should be deleted")
-		require.NoFileExists(t, template2, "template2 should be deleted since it's not in writtenPaths")
-
-		// Regenerate metadata after cleanup
-		err = tm.regenerateTemplateMetadata(tmpDir)
+		// Regenerate metadata from the arranged post-reconciliation tree.
+		_, err = tm.regenerateTemplateMetadata(config.DefaultConfig)
 		require.NoError(t, err)
 
-		// Verify index no longer contains deleted template
+		// The regenerated index excludes templates retired by the release.
 		index, err = config.GetNucleiTemplatesIndex()
 		require.NoError(t, err)
-		require.NotContains(t, index, "test-template-orphaned", "index should not contain deleted orphaned template")
+		require.NotContains(t, index, "test-template-retired", "index should not contain a retired template")
 		require.Contains(t, index, "test-template-1", "index should still contain kept template")
 		require.NotContains(t, index, "test-template-2", "index should not contain template that was deleted but not cleaned")
 	})
 
-	t.Run("excludes deleted templates from checksum after cleanup", func(t *testing.T) {
+	t.Run("excludes retired templates from the regenerated checksum", func(t *testing.T) {
 		tmpDir, err := os.MkdirTemp("", "nuclei-checksum-cleanup-test-*")
 		require.NoError(t, err)
 		defer func() {
@@ -621,7 +555,7 @@ info:
 
 		// Create template files
 		keptTemplate := filepath.Join(tmpDir, "kept.yaml")
-		orphanedTemplate := filepath.Join(tmpDir, "orphaned.yaml")
+		retiredTemplate := filepath.Join(tmpDir, "retired.yaml")
 
 		templateContent := `id: test-template
 info:
@@ -630,40 +564,34 @@ info:
   severity: info`
 
 		require.NoError(t, os.WriteFile(keptTemplate, []byte(templateContent), 0644))
-		require.NoError(t, os.WriteFile(orphanedTemplate, []byte(templateContent), 0644))
+		require.NoError(t, os.WriteFile(retiredTemplate, []byte(templateContent), 0644))
 
 		// Create initial checksum with both templates
-		err = tm.writeChecksumFileInDir(tmpDir)
+		checksumMap, err := tm.calculateChecksumMap(tmpDir)
+		require.NoError(t, err)
+		err = writeChecksumMap(config.DefaultConfig, checksumMap)
 		require.NoError(t, err)
 
 		// Verify initial checksum contains both templates
 		initialChecksums, err := tm.getChecksumFromDir(tmpDir)
 		require.NoError(t, err)
-		require.Contains(t, initialChecksums, orphanedTemplate, "initial checksum should contain orphaned template")
+		require.Contains(t, initialChecksums, retiredTemplate, "initial checksum should contain the retired template")
 
-		// Simulate cleanup: remove orphaned template
-		writtenPaths := mapsutil.NewSyncLockMap[string, struct{}]()
-		absKept, _ := filepath.Abs(keptTemplate)
-		// Normalize path consistently (same as cleanupOrphanedTemplates does)
-		absKept = filepath.Clean(absKept)
-		_ = writtenPaths.Set(absKept, struct{}{})
+		// Arrange the post-reconciliation tree directly; reconciliation has dedicated coverage.
+		require.NoError(t, os.Remove(retiredTemplate))
 
-		err = tm.cleanupOrphanedTemplates(tmpDir, writtenPaths)
-		require.NoError(t, err)
-		require.NoFileExists(t, orphanedTemplate, "orphaned template should be deleted")
-
-		// Regenerate metadata after cleanup
-		err = tm.regenerateTemplateMetadata(tmpDir)
+		// Regenerate metadata from the arranged post-reconciliation tree.
+		_, err = tm.regenerateTemplateMetadata(config.DefaultConfig)
 		require.NoError(t, err)
 
-		// Verify checksum no longer contains deleted template
+		// The regenerated checksum excludes templates retired by the release.
 		checksums, err := tm.getChecksumFromDir(tmpDir)
 		require.NoError(t, err)
-		require.NotContains(t, checksums, orphanedTemplate, "checksum should not contain deleted orphaned template")
+		require.NotContains(t, checksums, retiredTemplate, "checksum should not contain a retired template")
 		require.Contains(t, checksums, keptTemplate, "checksum should still contain kept template")
 	})
 
-	t.Run("cleanup and metadata regeneration integration", func(t *testing.T) {
+	t.Run("reconciles ownership before metadata regeneration", func(t *testing.T) {
 		tmpDir, err := os.MkdirTemp("", "nuclei-integration-test-*")
 		require.NoError(t, err)
 		defer func() {
@@ -682,12 +610,12 @@ info:
 		// Create multiple templates
 		template1 := filepath.Join(tmpDir, "cves", "2023", "cve1.yaml")
 		template2 := filepath.Join(tmpDir, "cves", "2023", "cve2.yaml")
-		orphaned1 := filepath.Join(tmpDir, "cves", "2022", "old-cve.yaml")
-		orphaned2 := filepath.Join(tmpDir, "exposures", "old-exposure.yaml")
+		retired1 := filepath.Join(tmpDir, "cves", "2022", "old-cve.yaml")
+		retired2 := filepath.Join(tmpDir, "exposures", "old-exposure.yaml")
 
 		require.NoError(t, os.MkdirAll(filepath.Dir(template1), 0755))
-		require.NoError(t, os.MkdirAll(filepath.Dir(orphaned1), 0755))
-		require.NoError(t, os.MkdirAll(filepath.Dir(orphaned2), 0755))
+		require.NoError(t, os.MkdirAll(filepath.Dir(retired1), 0755))
+		require.NoError(t, os.MkdirAll(filepath.Dir(retired2), 0755))
 
 		template1Content := `id: cve1
 info:
@@ -699,12 +627,12 @@ info:
   name: CVE2
   author: test
   severity: info`
-		orphaned1Content := `id: old-cve
+		retired1Content := `id: old-cve
 info:
   name: Old CVE
   author: test
   severity: info`
-		orphaned2Content := `id: old-exposure
+		retired2Content := `id: old-exposure
 info:
   name: Old Exposure
   author: test
@@ -712,27 +640,26 @@ info:
 
 		require.NoError(t, os.WriteFile(template1, []byte(template1Content), 0644))
 		require.NoError(t, os.WriteFile(template2, []byte(template2Content), 0644))
-		require.NoError(t, os.WriteFile(orphaned1, []byte(orphaned1Content), 0644))
-		require.NoError(t, os.WriteFile(orphaned2, []byte(orphaned2Content), 0644))
+		require.NoError(t, os.WriteFile(retired1, []byte(retired1Content), 0644))
+		require.NoError(t, os.WriteFile(retired2, []byte(retired2Content), 0644))
+		seedTemplateOwnership(t, tmpDir, template1, template2, retired1, retired2)
 
-		// Simulate written paths from new release
-		writtenPaths := mapsutil.NewSyncLockMap[string, struct{}]()
+		// The current release retains template1 and template2.
 		absTemplate1, _ := filepath.Abs(template1)
 		absTemplate2, _ := filepath.Abs(template2)
-		// Normalize paths consistently (same as cleanupOrphanedTemplates does)
+		// Normalize paths consistently with ownership reconciliation.
 		absTemplate1 = filepath.Clean(absTemplate1)
 		absTemplate2 = filepath.Clean(absTemplate2)
-		_ = writtenPaths.Set(absTemplate1, struct{}{})
-		_ = writtenPaths.Set(absTemplate2, struct{}{})
+		writtenTemplates := newWrittenTemplates(t, absTemplate1, absTemplate2)
 
-		// Perform cleanup
-		err = tm.cleanupOrphanedTemplates(tmpDir, writtenPaths)
+		// Reconcile prior ownership with the current release.
+		err = reconcileTemplateOwnership(tmpDir, writtenTemplates)
 		require.NoError(t, err)
-		require.NoFileExists(t, orphaned1, "orphaned template 1 should be deleted")
-		require.NoFileExists(t, orphaned2, "orphaned template 2 should be deleted")
+		require.NoFileExists(t, retired1, "retired template 1 should be deleted")
+		require.NoFileExists(t, retired2, "retired template 2 should be deleted")
 
 		// Regenerate metadata (simulating what updateTemplatesAt does)
-		err = tm.regenerateTemplateMetadata(tmpDir)
+		_, err = tm.regenerateTemplateMetadata(config.DefaultConfig)
 		require.NoError(t, err)
 
 		// Verify index only contains kept templates
@@ -748,12 +675,12 @@ info:
 		require.NoError(t, err)
 		require.Contains(t, checksums, template1, "checksum should contain kept template1")
 		require.Contains(t, checksums, template2, "checksum should contain kept template2")
-		require.NotContains(t, checksums, orphaned1, "checksum should not contain deleted template")
-		require.NotContains(t, checksums, orphaned2, "checksum should not contain deleted template")
+		require.NotContains(t, checksums, retired1, "checksum should not contain deleted template")
+		require.NotContains(t, checksums, retired2, "checksum should not contain deleted template")
 
 		// Verify empty directories are purged
-		require.False(t, fileutil.FolderExists(filepath.Dir(orphaned1)), "empty directory should be purged")
-		require.False(t, fileutil.FolderExists(filepath.Dir(orphaned2)), "empty directory should be purged")
+		require.False(t, fileutil.FolderExists(filepath.Dir(retired1)), "empty directory should be purged")
+		require.False(t, fileutil.FolderExists(filepath.Dir(retired2)), "empty directory should be purged")
 	})
 
 	t.Run("handles empty templates directory", func(t *testing.T) {
@@ -776,7 +703,7 @@ info:
 		require.NoError(t, os.MkdirAll(tmpDir, 0755))
 
 		// Regenerate metadata on empty directory
-		err = tm.regenerateTemplateMetadata(tmpDir)
+		_, err = tm.regenerateTemplateMetadata(config.DefaultConfig)
 		require.NoError(t, err, "should handle empty directory without error")
 
 		// Index should exist but be empty or minimal
@@ -820,7 +747,7 @@ info:
   severity: info`), 0644))
 
 		// Regenerate metadata (should purge empty directories)
-		err = tm.regenerateTemplateMetadata(tmpDir)
+		_, err = tm.regenerateTemplateMetadata(config.DefaultConfig)
 		require.NoError(t, err)
 
 		// Verify empty directories were purged

--- a/pkg/installer/template_test.go
+++ b/pkg/installer/template_test.go
@@ -1,14 +1,16 @@
 package installer
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/config"
 	fileutil "github.com/projectdiscovery/utils/file"
-	mapsutil "github.com/projectdiscovery/utils/maps"
 	"github.com/stretchr/testify/require"
 )
 
@@ -59,6 +61,9 @@ func TestTemplateInstallation(t *testing.T) {
 	require.Greater(t, counter, 1000)
 	// every time we install templates, it should override the ignore file with latest one
 	require.FileExists(t, config.DefaultConfig.GetActiveIgnoreFilePath())
+	ownership, err := loadTemplateOwnership(templatesTempDir)
+	require.NoError(t, err)
+	require.NotEmpty(t, ownership.Files, "fresh installation should record official template ownership")
 	t.Logf("Installed %d templates", counter)
 }
 
@@ -101,277 +106,235 @@ func TestIsOutdatedVersion(t *testing.T) {
 	}
 }
 
-func TestCleanupOrphanedTemplates(t *testing.T) {
-	HideProgressBar = true
+func TestWriteTemplateOutput(t *testing.T) {
+	t.Run("replaces a final symlink without modifying its target", func(t *testing.T) {
+		templatesDir := t.TempDir()
+		externalPath := filepath.Join(t.TempDir(), "external.yaml")
+		require.NoError(t, os.WriteFile(externalPath, []byte("external"), 0o644))
 
+		outputPath := filepath.Join(templatesDir, "official.yaml")
+		if err := os.Symlink(externalPath, outputPath); err != nil {
+			t.Skipf("symlinks are unavailable: %v", err)
+		}
+
+		_, err := writeTemplateOutput(templatesDir, outputPath, []byte("release"), 0o644)
+		require.NoError(t, err)
+		require.FileExists(t, outputPath)
+		info, err := os.Lstat(outputPath)
+		require.NoError(t, err)
+		require.Zero(t, info.Mode()&os.ModeSymlink)
+		contents, err := os.ReadFile(outputPath)
+		require.NoError(t, err)
+		require.Equal(t, "release", string(contents))
+		require.FileExists(t, externalPath)
+		contents, err = os.ReadFile(externalPath)
+		require.NoError(t, err)
+		require.Equal(t, "external", string(contents))
+	})
+
+	t.Run("rejects a parent symlink outside the templates directory", func(t *testing.T) {
+		templatesDir := t.TempDir()
+		externalDir := t.TempDir()
+		linkedParent := filepath.Join(templatesDir, "nested")
+		if err := os.Symlink(externalDir, linkedParent); err != nil {
+			t.Skipf("symlinks are unavailable: %v", err)
+		}
+
+		_, err := writeTemplateOutput(templatesDir, filepath.Join(linkedParent, "official.yaml"), []byte("release"), 0o644)
+		require.Error(t, err)
+		require.NoFileExists(t, filepath.Join(externalDir, "official.yaml"))
+	})
+
+	t.Run("preserves permissions on an existing regular file", func(t *testing.T) {
+		templatesDir := t.TempDir()
+		outputPath := filepath.Join(templatesDir, "official.yaml")
+		require.NoError(t, os.WriteFile(outputPath, []byte("previous"), 0o600))
+		previousInfo, err := os.Stat(outputPath)
+		require.NoError(t, err)
+
+		_, err = writeTemplateOutput(templatesDir, outputPath, []byte("release"), 0o777)
+		require.NoError(t, err)
+		info, err := os.Stat(outputPath)
+		require.NoError(t, err)
+		require.Equal(t, previousInfo.Mode().Perm(), info.Mode().Perm())
+	})
+
+	t.Run("reports every directory touched by nested output creation", func(t *testing.T) {
+		templatesDir := t.TempDir()
+		firstParent := filepath.Join(templatesDir, "first")
+		outputParent := filepath.Join(firstParent, "second")
+		outputPath := filepath.Join(outputParent, "official.yaml")
+
+		result, err := writeTemplateOutput(templatesDir, outputPath, []byte("release"), 0o644)
+		require.NoError(t, err)
+		require.ElementsMatch(t, []string{templatesDir, firstParent, outputParent}, result.touchedDirectories)
+	})
+
+	t.Run("reports the parent touched by a failed replacement", func(t *testing.T) {
+		templatesDir := t.TempDir()
+		outputPath := filepath.Join(templatesDir, "existing-directory")
+		require.NoError(t, os.Mkdir(outputPath, 0o755))
+
+		result, err := writeTemplateOutput(templatesDir, outputPath, []byte("release"), 0o644)
+		require.Error(t, err)
+		require.Equal(t, []string{templatesDir}, result.touchedDirectories)
+	})
+}
+
+func TestSyncTemplateOutputDirectories(t *testing.T) {
+	t.Run("syncs each distinct directory once", func(t *testing.T) {
+		directories := map[string]struct{}{
+			t.TempDir(): {},
+			t.TempDir(): {},
+		}
+		syncCalls := 0
+
+		err := syncTemplateOutputDirectories(directories, func(*os.Root, string) error {
+			syncCalls++
+			return nil
+		})
+		require.NoError(t, err)
+		require.Equal(t, len(directories), syncCalls)
+	})
+
+	t.Run("continues after a sync failure", func(t *testing.T) {
+		directories := map[string]struct{}{
+			t.TempDir(): {},
+			t.TempDir(): {},
+		}
+		syncErr := errors.New("sync failed")
+		syncCalls := 0
+
+		err := syncTemplateOutputDirectories(directories, func(*os.Root, string) error {
+			syncCalls++
+			if syncCalls == 1 {
+				return syncErr
+			}
+			return nil
+		})
+		require.ErrorIs(t, err, syncErr)
+		require.Equal(t, len(directories), syncCalls)
+	})
+}
+
+func BenchmarkWriteTemplateOutputs(b *testing.B) {
+	b.Run("batched", func(b *testing.B) {
+		benchmarkWriteTemplateOutputs(b, false)
+	})
+	b.Run("per-output-sync", func(b *testing.B) {
+		benchmarkWriteTemplateOutputs(b, true)
+	})
+}
+
+func benchmarkWriteTemplateOutputs(b *testing.B, syncEachOutput bool) {
+	rootDir := b.TempDir()
+	contents := []byte("id: benchmark\ninfo:\n  name: Benchmark\n  author: test\n  severity: info\n")
+	touchedDirectories := make(map[string]struct{})
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for index := 0; index < b.N; index++ {
+		writePath := filepath.Join(rootDir, fmt.Sprintf("group-%d", index%16), fmt.Sprintf("template-%d.yaml", index))
+		outputResult, err := writeTemplateOutput(rootDir, writePath, contents, 0o644)
+		if err != nil {
+			b.Fatal(err)
+		}
+		for _, directory := range outputResult.touchedDirectories {
+			touchedDirectories[directory] = struct{}{}
+		}
+
+		if syncEachOutput {
+			output, err := os.OpenFile(writePath, os.O_RDWR, 0)
+			if err != nil {
+				b.Fatal(err)
+			}
+			syncErr := output.Sync()
+			closeErr := output.Close()
+			if err := errors.Join(syncErr, closeErr); err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+
+	if err := syncTemplateOutputDirectories(touchedDirectories, syncTemplateOwnershipDirectory); err != nil {
+		b.Fatal(err)
+	}
+}
+
+func TestGetTemplateOutputLocationRoutesIgnoreFile(t *testing.T) {
+	previousConfig := config.DefaultConfig
+	templatesDir := t.TempDir()
+	cfg := &config.Config{}
+	cfg.SetTemplatesDir(templatesDir)
+	config.DefaultConfig = cfg
+	t.Cleanup(func() { config.DefaultConfig = previousConfig })
+
+	ignoreEntry := filepath.Join(t.TempDir(), config.NucleiIgnoreFileName)
+	require.NoError(t, os.WriteFile(ignoreEntry, nil, 0o600))
+	info, err := os.Stat(ignoreEntry)
+	require.NoError(t, err)
+	rootDir, writePath := (&TemplateManager{}).getTemplateOutputLocation(templatesDir, "nuclei-templates/"+config.NucleiIgnoreFileName, info)
+	require.Equal(t, templatesDir, rootDir)
+	require.Equal(t, cfg.GetActiveIgnoreFilePath(), writePath)
+}
+
+func TestCommitTemplateVersionRestoresMemoryOnWriteFailure(t *testing.T) {
+	stateDir := filepath.Join(t.TempDir(), "state")
+	require.NoError(t, os.WriteFile(stateDir, nil, 0o600))
+	cfg := &config.Config{TemplateVersion: "v1.2.3"}
+	cfg.SetStateDir(stateDir)
+
+	err := commitTemplateVersion(cfg, "v2.0.0")
+	require.Error(t, err)
+	require.Equal(t, "v1.2.3", cfg.TemplateVersion)
+}
+
+func TestFinalizeTemplateReleaseCommitsVersionLast(t *testing.T) {
+	newConfig := func(t *testing.T) *config.Config {
+		t.Helper()
+		configDir := t.TempDir()
+		templatesDir := t.TempDir()
+		cfg := &config.Config{Logger: gologger.DefaultLogger}
+		cfg.SetConfigDir(configDir)
+		cfg.SetTemplatesDir(templatesDir)
+		require.NoError(t, os.WriteFile(cfg.GetActiveIgnoreFilePath(), []byte("ignore contents"), 0o600))
+		cfg.TemplateVersion = "v1.0.0"
+
+		previousConfig := config.DefaultConfig
+		config.DefaultConfig = cfg
+		t.Cleanup(func() { config.DefaultConfig = previousConfig })
+		return cfg
+	}
+
+	t.Run("commits after successful finalization", func(t *testing.T) {
+		cfg := newConfig(t)
+		templatePath := filepath.Join(cfg.TemplatesDirectory, "official.yaml")
+		require.NoError(t, os.WriteFile(templatePath, []byte("id: official\ninfo:\n  name: Official\n  author: test\n  severity: info\n"), 0644))
+
+		tm := &TemplateManager{}
+		_, err := tm.finalizeTemplateRelease(cfg, newWrittenTemplates(t, templatePath), "v2.0.0")
+		require.NoError(t, err)
+		require.Equal(t, "v2.0.0", cfg.TemplateVersion)
+	})
+
+	t.Run("preserves version when metadata finalization fails", func(t *testing.T) {
+		cfg := newConfig(t)
+		templatePath := filepath.Join(cfg.TemplatesDirectory, "official.yaml")
+		require.NoError(t, os.WriteFile(templatePath, []byte("id: official\ninfo:\n  name: Official\n  author: test\n  severity: info\n"), 0644))
+		require.NoError(t, os.Mkdir(cfg.GetTemplateIndexFilePath(), 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(cfg.GetTemplateIndexFilePath(), "keep"), []byte("keep"), 0600))
+
+		tm := &TemplateManager{}
+		_, err := tm.finalizeTemplateRelease(cfg, newWrittenTemplates(t, templatePath), "v2.0.0")
+		require.Error(t, err)
+		require.Equal(t, "v1.0.0", cfg.TemplateVersion)
+	})
+}
+
+func TestCalculateChecksumMap(t *testing.T) {
 	tm := &TemplateManager{}
-
-	t.Run("removes orphaned templates", func(t *testing.T) {
-		// Create temporary directories
-		tmpDir, err := os.MkdirTemp("", "nuclei-cleanup-test-*")
-		require.NoError(t, err)
-		defer func() {
-			_ = os.RemoveAll(tmpDir)
-		}()
-
-		cfgdir, err := os.MkdirTemp("", "nuclei-config-*")
-		require.NoError(t, err)
-		defer func() {
-			_ = os.RemoveAll(cfgdir)
-		}()
-
-		config.DefaultConfig.SetConfigDir(cfgdir)
-		config.DefaultConfig.SetTemplatesDir(tmpDir)
-
-		// Create subdirectories for templates
-		templatesDir1 := filepath.Join(tmpDir, "cves", "2023")
-		templatesDir2 := filepath.Join(tmpDir, "exposures", "configs")
-		require.NoError(t, os.MkdirAll(templatesDir1, 0755))
-		require.NoError(t, os.MkdirAll(templatesDir2, 0755))
-
-		// Create template files
-		template1 := filepath.Join(templatesDir1, "CVE-2023-1234.yaml")
-		template2 := filepath.Join(templatesDir1, "CVE-2023-5678.yaml")
-		template3 := filepath.Join(templatesDir2, "git-config-exposure.yaml")
-		orphanedTemplate1 := filepath.Join(templatesDir1, "old-template.yaml")
-		orphanedTemplate2 := filepath.Join(templatesDir2, "removed-template.yaml")
-
-		// Write valid template files
-		templateContent := `id: test-template
-info:
-  name: Test Template
-  author: test
-  severity: info`
-		require.NoError(t, os.WriteFile(template1, []byte(templateContent), 0644))
-		require.NoError(t, os.WriteFile(template2, []byte(templateContent), 0644))
-		require.NoError(t, os.WriteFile(template3, []byte(templateContent), 0644))
-		require.NoError(t, os.WriteFile(orphanedTemplate1, []byte(templateContent), 0644))
-		require.NoError(t, os.WriteFile(orphanedTemplate2, []byte(templateContent), 0644))
-
-		// Simulate written paths from new release (only template1, template2, template3)
-		writtenPaths := mapsutil.NewSyncLockMap[string, struct{}]()
-		absTemplate1, _ := filepath.Abs(template1)
-		absTemplate2, _ := filepath.Abs(template2)
-		absTemplate3, _ := filepath.Abs(template3)
-		// Normalize paths consistently (same as cleanupOrphanedTemplates does)
-		absTemplate1 = filepath.Clean(absTemplate1)
-		absTemplate2 = filepath.Clean(absTemplate2)
-		absTemplate3 = filepath.Clean(absTemplate3)
-		_ = writtenPaths.Set(absTemplate1, struct{}{})
-		_ = writtenPaths.Set(absTemplate2, struct{}{})
-		_ = writtenPaths.Set(absTemplate3, struct{}{})
-
-		// Run cleanup
-		err = tm.cleanupOrphanedTemplates(tmpDir, writtenPaths)
-		require.NoError(t, err)
-
-		// Verify orphaned templates were removed
-		require.NoFileExists(t, orphanedTemplate1, "orphaned template should be removed")
-		require.NoFileExists(t, orphanedTemplate2, "orphaned template should be removed")
-
-		// Verify non-orphaned templates still exist
-		require.FileExists(t, template1, "template from new release should exist")
-		require.FileExists(t, template2, "template from new release should exist")
-		require.FileExists(t, template3, "template from new release should exist")
-	})
-
-	t.Run("preserves custom templates", func(t *testing.T) {
-		// Create temporary directories
-		tmpDir, err := os.MkdirTemp("", "nuclei-cleanup-custom-test-*")
-		require.NoError(t, err)
-		defer func() {
-			_ = os.RemoveAll(tmpDir)
-		}()
-
-		cfgdir, err := os.MkdirTemp("", "nuclei-config-*")
-		require.NoError(t, err)
-		defer func() {
-			_ = os.RemoveAll(cfgdir)
-		}()
-
-		config.DefaultConfig.SetConfigDir(cfgdir)
-		config.DefaultConfig.SetTemplatesDir(tmpDir)
-
-		// Create custom template directory
-		customGitHubDir := filepath.Join(tmpDir, "github", "owner", "repo")
-		require.NoError(t, os.MkdirAll(customGitHubDir, 0755))
-
-		// Create custom template file
-		customTemplate := filepath.Join(customGitHubDir, "custom-template.yaml")
-		templateContent := `id: custom-template
-info:
-  name: Custom Template
-  author: test
-  severity: info`
-		require.NoError(t, os.WriteFile(customTemplate, []byte(templateContent), 0644))
-
-		// Empty written paths (simulating no custom templates in new release)
-		writtenPaths := mapsutil.NewSyncLockMap[string, struct{}]()
-
-		// Run cleanup
-		err = tm.cleanupOrphanedTemplates(tmpDir, writtenPaths)
-		require.NoError(t, err)
-
-		// Verify custom template was NOT removed
-		require.FileExists(t, customTemplate, "custom template should be preserved")
-	})
-
-	t.Run("removes orphaned templates from custom dir sibling prefixes", func(t *testing.T) {
-		tmpDir, err := os.MkdirTemp("", "nuclei-cleanup-custom-prefix-test-*")
-		require.NoError(t, err)
-		defer func() {
-			_ = os.RemoveAll(tmpDir)
-		}()
-
-		cfgdir, err := os.MkdirTemp("", "nuclei-config-*")
-		require.NoError(t, err)
-		defer func() {
-			_ = os.RemoveAll(cfgdir)
-		}()
-
-		config.DefaultConfig.SetConfigDir(cfgdir)
-		config.DefaultConfig.SetTemplatesDir(tmpDir)
-
-		customGitHubDir := filepath.Join(tmpDir, "github", "owner", "repo")
-		require.NoError(t, os.MkdirAll(customGitHubDir, 0755))
-		customTemplate := filepath.Join(customGitHubDir, "custom-template.yaml")
-		require.NoError(t, os.WriteFile(customTemplate, []byte(`id: custom-template
-info:
-  name: Custom Template
-  author: test
-  severity: info`), 0644))
-
-		siblingDir := filepath.Join(tmpDir, "github-evil")
-		require.NoError(t, os.MkdirAll(siblingDir, 0755))
-		siblingTemplate := filepath.Join(siblingDir, "orphaned-template.yaml")
-		require.NoError(t, os.WriteFile(siblingTemplate, []byte(`id: orphaned-template
-info:
-  name: Orphaned Template
-  author: test
-  severity: info`), 0644))
-
-		writtenPaths := mapsutil.NewSyncLockMap[string, struct{}]()
-
-		err = tm.cleanupOrphanedTemplates(tmpDir, writtenPaths)
-		require.NoError(t, err)
-
-		require.FileExists(t, customTemplate, "custom template should be preserved")
-		require.NoFileExists(t, siblingTemplate, "custom directory sibling prefix should not be preserved")
-	})
-
-	t.Run("skips non-template files", func(t *testing.T) {
-		// Create temporary directories
-		tmpDir, err := os.MkdirTemp("", "nuclei-cleanup-nontemplate-test-*")
-		require.NoError(t, err)
-		defer func() {
-			_ = os.RemoveAll(tmpDir)
-		}()
-
-		cfgdir, err := os.MkdirTemp("", "nuclei-config-*")
-		require.NoError(t, err)
-		defer func() {
-			_ = os.RemoveAll(cfgdir)
-		}()
-
-		config.DefaultConfig.SetConfigDir(cfgdir)
-		config.DefaultConfig.SetTemplatesDir(tmpDir)
-
-		// Create non-template files
-		readmeFile := filepath.Join(tmpDir, "README.md")
-		configFile := filepath.Join(tmpDir, "cves.json")
-		checksumFile := filepath.Join(tmpDir, ".checksum")
-
-		require.NoError(t, os.WriteFile(readmeFile, []byte("# Templates"), 0644))
-		require.NoError(t, os.WriteFile(configFile, []byte("{}"), 0644))
-		require.NoError(t, os.WriteFile(checksumFile, []byte(""), 0644))
-
-		// Empty written paths
-		writtenPaths := mapsutil.NewSyncLockMap[string, struct{}]()
-
-		// Run cleanup
-		err = tm.cleanupOrphanedTemplates(tmpDir, writtenPaths)
-		require.NoError(t, err)
-
-		// Verify non-template files were NOT removed
-		require.FileExists(t, readmeFile, "README.md should be preserved")
-		require.FileExists(t, configFile, "config file should be preserved")
-		require.FileExists(t, checksumFile, "checksum file should be preserved")
-	})
-
-	t.Run("handles empty written paths", func(t *testing.T) {
-		// Create temporary directories
-		tmpDir, err := os.MkdirTemp("", "nuclei-cleanup-empty-test-*")
-		require.NoError(t, err)
-		defer func() {
-			_ = os.RemoveAll(tmpDir)
-		}()
-
-		cfgdir, err := os.MkdirTemp("", "nuclei-config-*")
-		require.NoError(t, err)
-		defer func() {
-			_ = os.RemoveAll(cfgdir)
-		}()
-
-		config.DefaultConfig.SetConfigDir(cfgdir)
-		config.DefaultConfig.SetTemplatesDir(tmpDir)
-
-		// Create template files
-		template1 := filepath.Join(tmpDir, "template1.yaml")
-		templateContent := `id: test-template
-info:
-  name: Test Template
-  author: test
-  severity: info`
-		require.NoError(t, os.WriteFile(template1, []byte(templateContent), 0644))
-
-		// Empty written paths
-		writtenPaths := mapsutil.NewSyncLockMap[string, struct{}]()
-
-		// Run cleanup
-		err = tm.cleanupOrphanedTemplates(tmpDir, writtenPaths)
-		require.NoError(t, err)
-
-		// Verify template was removed (since it's not in written paths)
-		require.NoFileExists(t, template1, "template should be removed when not in written paths")
-	})
-
-	t.Run("handles relative and absolute paths correctly", func(t *testing.T) {
-		// Create temporary directories
-		tmpDir, err := os.MkdirTemp("", "nuclei-cleanup-path-test-*")
-		require.NoError(t, err)
-		defer func() {
-			_ = os.RemoveAll(tmpDir)
-		}()
-
-		cfgdir, err := os.MkdirTemp("", "nuclei-config-*")
-		require.NoError(t, err)
-		defer func() {
-			_ = os.RemoveAll(cfgdir)
-		}()
-
-		config.DefaultConfig.SetConfigDir(cfgdir)
-		config.DefaultConfig.SetTemplatesDir(tmpDir)
-
-		// Create template file
-		template1 := filepath.Join(tmpDir, "template1.yaml")
-		templateContent := `id: test-template
-info:
-  name: Test Template
-  author: test
-  severity: info`
-		require.NoError(t, os.WriteFile(template1, []byte(templateContent), 0644))
-
-		// Use relative path in written paths
-		writtenPaths := mapsutil.NewSyncLockMap[string, struct{}]()
-		_ = writtenPaths.Set(template1, struct{}{}) // relative path
-
-		// Run cleanup - should normalize paths correctly
-		err = tm.cleanupOrphanedTemplates(tmpDir, writtenPaths)
-		require.NoError(t, err)
-
-		// Verify template was NOT removed (it was in written paths)
-		require.FileExists(t, template1, "template should be preserved when in written paths")
-	})
+	previousTemplatesDir := config.DefaultConfig.TemplatesDirectory
+	t.Cleanup(func() { config.DefaultConfig.SetTemplatesDir(previousTemplatesDir) })
 
 	t.Run("checksums custom dir sibling prefixes", func(t *testing.T) {
 		tmpDir, err := os.MkdirTemp("", "nuclei-checksum-custom-prefix-test-*")
@@ -380,13 +343,6 @@ info:
 			_ = os.RemoveAll(tmpDir)
 		}()
 
-		cfgdir, err := os.MkdirTemp("", "nuclei-config-*")
-		require.NoError(t, err)
-		defer func() {
-			_ = os.RemoveAll(cfgdir)
-		}()
-
-		config.DefaultConfig.SetConfigDir(cfgdir)
 		config.DefaultConfig.SetTemplatesDir(tmpDir)
 
 		customGitHubDir := filepath.Join(tmpDir, "github")
@@ -413,50 +369,39 @@ info:
 		require.Contains(t, checksums, siblingTemplate, "custom directory sibling prefix should be checksummed")
 	})
 
-	t.Run("handles empty templates directory", func(t *testing.T) {
-		// Create temporary directories
-		tmpDir, err := os.MkdirTemp("", "nuclei-cleanup-empty-dir-test-*")
+	t.Run("excludes internal temporary files from checksums", func(t *testing.T) {
+		templatesDir := t.TempDir()
+		config.DefaultConfig.SetTemplatesDir(templatesDir)
+
+		templateFile := filepath.Join(templatesDir, "template.yaml")
+		ownershipTemporary := filepath.Join(templatesDir, templateOwnershipFileName+".tmp-interrupted")
+		retiredQuarantine := filepath.Join(templatesDir, templateOwnershipRetiredPrefix+"interrupted")
+		nestedDir := filepath.Join(templatesDir, "nested")
+		nestedOwnershipTemporary := filepath.Join(nestedDir, templateOwnershipFileName+".tmp-user")
+		outputTemporary := filepath.Join(nestedDir, templateOutputTemporaryPrefix+strings.Repeat("a", 32))
+		restoreTemporary := filepath.Join(nestedDir, templateOutputTemporaryPrefix+strings.Repeat("b", 32)+"-"+strings.Repeat("c", 32))
+		restoreState := filepath.Join(templatesDir, templateOwnershipRestorePrefix+strings.Repeat("d", 64)+"-"+strings.Repeat("e", 32))
+		userFileWithSimilarName := filepath.Join(nestedDir, templateOutputTemporaryPrefix+"user.yaml")
+		require.NoError(t, os.Mkdir(nestedDir, 0755))
+		require.NoError(t, os.WriteFile(templateFile, []byte("template"), 0644))
+		require.NoError(t, os.WriteFile(ownershipTemporary, []byte("partial manifest"), 0600))
+		require.NoError(t, os.WriteFile(retiredQuarantine, []byte("retired template"), 0600))
+		require.NoError(t, os.WriteFile(nestedOwnershipTemporary, []byte("user file"), 0644))
+		require.NoError(t, os.WriteFile(outputTemporary, []byte("interrupted write"), 0600))
+		require.NoError(t, os.WriteFile(restoreTemporary, []byte("interrupted restore"), 0600))
+		require.NoError(t, os.WriteFile(restoreState, nil, 0600))
+		require.NoError(t, os.WriteFile(userFileWithSimilarName, []byte("user file"), 0644))
+
+		checksums, err := tm.calculateChecksumMap(templatesDir)
 		require.NoError(t, err)
-		defer func() {
-			_ = os.RemoveAll(tmpDir)
-		}()
-
-		cfgdir, err := os.MkdirTemp("", "nuclei-config-*")
-		require.NoError(t, err)
-		defer func() {
-			_ = os.RemoveAll(cfgdir)
-		}()
-
-		config.DefaultConfig.SetConfigDir(cfgdir)
-		config.DefaultConfig.SetTemplatesDir(tmpDir)
-
-		// Directory exists but is empty (user deleted all templates)
-		require.True(t, fileutil.FolderExists(tmpDir), "templates directory should exist")
-
-		// Written paths from new release
-		writtenPaths := mapsutil.NewSyncLockMap[string, struct{}]()
-
-		// Run cleanup - should handle empty directory gracefully
-		err = tm.cleanupOrphanedTemplates(tmpDir, writtenPaths)
-		require.NoError(t, err, "cleanup should handle empty directory without error")
-
-		// Directory should still exist after cleanup
-		require.True(t, fileutil.FolderExists(tmpDir), "templates directory should still exist")
-	})
-
-	t.Run("handles non-existent directory gracefully", func(t *testing.T) {
-		// Use a non-existent directory path
-		nonExistentDir := "/tmp/nuclei-test-non-existent-dir-12345"
-
-		// Ensure it doesn't exist
-		_ = os.RemoveAll(nonExistentDir)
-		require.False(t, fileutil.FolderExists(nonExistentDir), "directory should not exist")
-
-		writtenPaths := mapsutil.NewSyncLockMap[string, struct{}]()
-
-		// Run cleanup - should handle non-existent directory gracefully
-		err := tm.cleanupOrphanedTemplates(nonExistentDir, writtenPaths)
-		require.NoError(t, err, "cleanup should handle non-existent directory without error")
+		require.Contains(t, checksums, templateFile)
+		require.NotContains(t, checksums, ownershipTemporary)
+		require.NotContains(t, checksums, retiredQuarantine)
+		require.NotContains(t, checksums, outputTemporary)
+		require.NotContains(t, checksums, restoreTemporary)
+		require.NotContains(t, checksums, restoreState)
+		require.Contains(t, checksums, nestedOwnershipTemporary, "only root-level ownership artifacts are internal metadata")
+		require.Contains(t, checksums, userFileWithSimilarName, "only names matching the complete internal write pattern are excluded")
 	})
 }
 
@@ -500,7 +445,7 @@ info:
 		require.NoError(t, os.WriteFile(template2, []byte(template2Content), 0644))
 
 		// Regenerate metadata
-		err = tm.regenerateTemplateMetadata(tmpDir)
+		_, err = tm.regenerateTemplateMetadata(config.DefaultConfig)
 		require.NoError(t, err)
 
 		// Verify index file was created
@@ -524,7 +469,7 @@ info:
 		require.Contains(t, checksums, template2, "checksum should contain template2")
 	})
 
-	t.Run("excludes deleted templates from index after cleanup", func(t *testing.T) {
+	t.Run("excludes retired templates from the regenerated index", func(t *testing.T) {
 		tmpDir, err := os.MkdirTemp("", "nuclei-metadata-cleanup-test-*")
 		require.NoError(t, err)
 		defer func() {
@@ -543,7 +488,7 @@ info:
 		// Create template files
 		template1 := filepath.Join(tmpDir, "kept-template.yaml")
 		template2 := filepath.Join(tmpDir, "deleted-template.yaml")
-		orphanedTemplate := filepath.Join(tmpDir, "orphaned-template.yaml")
+		retiredTemplate := filepath.Join(tmpDir, "retired-template.yaml")
 
 		template1Content := `id: test-template-1
 info:
@@ -555,21 +500,21 @@ info:
   name: Test Template 2
   author: test
   severity: info`
-		orphanedContent := `id: test-template-orphaned
+		retiredContent := `id: test-template-retired
 info:
-  name: Test Template Orphaned
+  name: Test Template Retired
   author: test
   severity: info`
 
 		require.NoError(t, os.WriteFile(template1, []byte(template1Content), 0644))
 		require.NoError(t, os.WriteFile(template2, []byte(template2Content), 0644))
-		require.NoError(t, os.WriteFile(orphanedTemplate, []byte(orphanedContent), 0644))
+		require.NoError(t, os.WriteFile(retiredTemplate, []byte(retiredContent), 0644))
 
-		// Create initial index with all templates (simulating state before cleanup)
+		// Create initial index with all previously owned templates.
 		initialIndex := map[string]string{
-			"test-template-1":        template1,
-			"test-template-2":        template2,
-			"test-template-orphaned": orphanedTemplate,
+			"test-template-1":       template1,
+			"test-template-2":       template2,
+			"test-template-retired": retiredTemplate,
 		}
 		err = config.DefaultConfig.WriteTemplatesIndex(initialIndex)
 		require.NoError(t, err)
@@ -577,33 +522,25 @@ info:
 		// Verify initial index contains all templates
 		index, err := config.GetNucleiTemplatesIndex()
 		require.NoError(t, err)
-		require.Contains(t, index, "test-template-orphaned", "initial index should contain orphaned template")
+		require.Contains(t, index, "test-template-retired", "initial index should contain the retired template")
 
-		// Simulate cleanup: remove orphaned template
-		writtenPaths := mapsutil.NewSyncLockMap[string, struct{}]()
-		absTemplate1, _ := filepath.Abs(template1)
-		// Normalize path consistently (same as cleanupOrphanedTemplates does)
-		absTemplate1 = filepath.Clean(absTemplate1)
-		_ = writtenPaths.Set(absTemplate1, struct{}{})
+		// Arrange the post-reconciliation tree directly; reconciliation has dedicated coverage.
+		require.NoError(t, os.Remove(template2))
+		require.NoError(t, os.Remove(retiredTemplate))
 
-		err = tm.cleanupOrphanedTemplates(tmpDir, writtenPaths)
-		require.NoError(t, err)
-		require.NoFileExists(t, orphanedTemplate, "orphaned template should be deleted")
-		require.NoFileExists(t, template2, "template2 should be deleted since it's not in writtenPaths")
-
-		// Regenerate metadata after cleanup
-		err = tm.regenerateTemplateMetadata(tmpDir)
+		// Regenerate metadata from the arranged post-reconciliation tree.
+		_, err = tm.regenerateTemplateMetadata(config.DefaultConfig)
 		require.NoError(t, err)
 
-		// Verify index no longer contains deleted template
+		// The regenerated index excludes templates retired by the release.
 		index, err = config.GetNucleiTemplatesIndex()
 		require.NoError(t, err)
-		require.NotContains(t, index, "test-template-orphaned", "index should not contain deleted orphaned template")
+		require.NotContains(t, index, "test-template-retired", "index should not contain a retired template")
 		require.Contains(t, index, "test-template-1", "index should still contain kept template")
 		require.NotContains(t, index, "test-template-2", "index should not contain template that was deleted but not cleaned")
 	})
 
-	t.Run("excludes deleted templates from checksum after cleanup", func(t *testing.T) {
+	t.Run("excludes retired templates from the regenerated checksum", func(t *testing.T) {
 		tmpDir, err := os.MkdirTemp("", "nuclei-checksum-cleanup-test-*")
 		require.NoError(t, err)
 		defer func() {
@@ -621,7 +558,7 @@ info:
 
 		// Create template files
 		keptTemplate := filepath.Join(tmpDir, "kept.yaml")
-		orphanedTemplate := filepath.Join(tmpDir, "orphaned.yaml")
+		retiredTemplate := filepath.Join(tmpDir, "retired.yaml")
 
 		templateContent := `id: test-template
 info:
@@ -630,40 +567,34 @@ info:
   severity: info`
 
 		require.NoError(t, os.WriteFile(keptTemplate, []byte(templateContent), 0644))
-		require.NoError(t, os.WriteFile(orphanedTemplate, []byte(templateContent), 0644))
+		require.NoError(t, os.WriteFile(retiredTemplate, []byte(templateContent), 0644))
 
 		// Create initial checksum with both templates
-		err = tm.writeChecksumFileInDir(tmpDir)
+		checksumMap, err := tm.calculateChecksumMap(tmpDir)
+		require.NoError(t, err)
+		err = writeChecksumMap(config.DefaultConfig, checksumMap)
 		require.NoError(t, err)
 
 		// Verify initial checksum contains both templates
 		initialChecksums, err := tm.getChecksumFromDir(tmpDir)
 		require.NoError(t, err)
-		require.Contains(t, initialChecksums, orphanedTemplate, "initial checksum should contain orphaned template")
+		require.Contains(t, initialChecksums, retiredTemplate, "initial checksum should contain the retired template")
 
-		// Simulate cleanup: remove orphaned template
-		writtenPaths := mapsutil.NewSyncLockMap[string, struct{}]()
-		absKept, _ := filepath.Abs(keptTemplate)
-		// Normalize path consistently (same as cleanupOrphanedTemplates does)
-		absKept = filepath.Clean(absKept)
-		_ = writtenPaths.Set(absKept, struct{}{})
+		// Arrange the post-reconciliation tree directly; reconciliation has dedicated coverage.
+		require.NoError(t, os.Remove(retiredTemplate))
 
-		err = tm.cleanupOrphanedTemplates(tmpDir, writtenPaths)
-		require.NoError(t, err)
-		require.NoFileExists(t, orphanedTemplate, "orphaned template should be deleted")
-
-		// Regenerate metadata after cleanup
-		err = tm.regenerateTemplateMetadata(tmpDir)
+		// Regenerate metadata from the arranged post-reconciliation tree.
+		_, err = tm.regenerateTemplateMetadata(config.DefaultConfig)
 		require.NoError(t, err)
 
-		// Verify checksum no longer contains deleted template
+		// The regenerated checksum excludes templates retired by the release.
 		checksums, err := tm.getChecksumFromDir(tmpDir)
 		require.NoError(t, err)
-		require.NotContains(t, checksums, orphanedTemplate, "checksum should not contain deleted orphaned template")
+		require.NotContains(t, checksums, retiredTemplate, "checksum should not contain a retired template")
 		require.Contains(t, checksums, keptTemplate, "checksum should still contain kept template")
 	})
 
-	t.Run("cleanup and metadata regeneration integration", func(t *testing.T) {
+	t.Run("reconciles ownership before metadata regeneration", func(t *testing.T) {
 		tmpDir, err := os.MkdirTemp("", "nuclei-integration-test-*")
 		require.NoError(t, err)
 		defer func() {
@@ -682,12 +613,12 @@ info:
 		// Create multiple templates
 		template1 := filepath.Join(tmpDir, "cves", "2023", "cve1.yaml")
 		template2 := filepath.Join(tmpDir, "cves", "2023", "cve2.yaml")
-		orphaned1 := filepath.Join(tmpDir, "cves", "2022", "old-cve.yaml")
-		orphaned2 := filepath.Join(tmpDir, "exposures", "old-exposure.yaml")
+		retired1 := filepath.Join(tmpDir, "cves", "2022", "old-cve.yaml")
+		retired2 := filepath.Join(tmpDir, "exposures", "old-exposure.yaml")
 
 		require.NoError(t, os.MkdirAll(filepath.Dir(template1), 0755))
-		require.NoError(t, os.MkdirAll(filepath.Dir(orphaned1), 0755))
-		require.NoError(t, os.MkdirAll(filepath.Dir(orphaned2), 0755))
+		require.NoError(t, os.MkdirAll(filepath.Dir(retired1), 0755))
+		require.NoError(t, os.MkdirAll(filepath.Dir(retired2), 0755))
 
 		template1Content := `id: cve1
 info:
@@ -699,12 +630,12 @@ info:
   name: CVE2
   author: test
   severity: info`
-		orphaned1Content := `id: old-cve
+		retired1Content := `id: old-cve
 info:
   name: Old CVE
   author: test
   severity: info`
-		orphaned2Content := `id: old-exposure
+		retired2Content := `id: old-exposure
 info:
   name: Old Exposure
   author: test
@@ -712,27 +643,26 @@ info:
 
 		require.NoError(t, os.WriteFile(template1, []byte(template1Content), 0644))
 		require.NoError(t, os.WriteFile(template2, []byte(template2Content), 0644))
-		require.NoError(t, os.WriteFile(orphaned1, []byte(orphaned1Content), 0644))
-		require.NoError(t, os.WriteFile(orphaned2, []byte(orphaned2Content), 0644))
+		require.NoError(t, os.WriteFile(retired1, []byte(retired1Content), 0644))
+		require.NoError(t, os.WriteFile(retired2, []byte(retired2Content), 0644))
+		seedTemplateOwnership(t, tmpDir, template1, template2, retired1, retired2)
 
-		// Simulate written paths from new release
-		writtenPaths := mapsutil.NewSyncLockMap[string, struct{}]()
+		// The current release retains template1 and template2.
 		absTemplate1, _ := filepath.Abs(template1)
 		absTemplate2, _ := filepath.Abs(template2)
-		// Normalize paths consistently (same as cleanupOrphanedTemplates does)
+		// Normalize paths consistently with ownership reconciliation.
 		absTemplate1 = filepath.Clean(absTemplate1)
 		absTemplate2 = filepath.Clean(absTemplate2)
-		_ = writtenPaths.Set(absTemplate1, struct{}{})
-		_ = writtenPaths.Set(absTemplate2, struct{}{})
+		writtenTemplates := newWrittenTemplates(t, absTemplate1, absTemplate2)
 
-		// Perform cleanup
-		err = tm.cleanupOrphanedTemplates(tmpDir, writtenPaths)
+		// Reconcile prior ownership with the current release.
+		err = reconcileTemplateOwnership(tmpDir, writtenTemplates)
 		require.NoError(t, err)
-		require.NoFileExists(t, orphaned1, "orphaned template 1 should be deleted")
-		require.NoFileExists(t, orphaned2, "orphaned template 2 should be deleted")
+		require.NoFileExists(t, retired1, "retired template 1 should be deleted")
+		require.NoFileExists(t, retired2, "retired template 2 should be deleted")
 
 		// Regenerate metadata (simulating what updateTemplatesAt does)
-		err = tm.regenerateTemplateMetadata(tmpDir)
+		_, err = tm.regenerateTemplateMetadata(config.DefaultConfig)
 		require.NoError(t, err)
 
 		// Verify index only contains kept templates
@@ -748,12 +678,12 @@ info:
 		require.NoError(t, err)
 		require.Contains(t, checksums, template1, "checksum should contain kept template1")
 		require.Contains(t, checksums, template2, "checksum should contain kept template2")
-		require.NotContains(t, checksums, orphaned1, "checksum should not contain deleted template")
-		require.NotContains(t, checksums, orphaned2, "checksum should not contain deleted template")
+		require.NotContains(t, checksums, retired1, "checksum should not contain deleted template")
+		require.NotContains(t, checksums, retired2, "checksum should not contain deleted template")
 
 		// Verify empty directories are purged
-		require.False(t, fileutil.FolderExists(filepath.Dir(orphaned1)), "empty directory should be purged")
-		require.False(t, fileutil.FolderExists(filepath.Dir(orphaned2)), "empty directory should be purged")
+		require.False(t, fileutil.FolderExists(filepath.Dir(retired1)), "empty directory should be purged")
+		require.False(t, fileutil.FolderExists(filepath.Dir(retired2)), "empty directory should be purged")
 	})
 
 	t.Run("handles empty templates directory", func(t *testing.T) {
@@ -776,7 +706,7 @@ info:
 		require.NoError(t, os.MkdirAll(tmpDir, 0755))
 
 		// Regenerate metadata on empty directory
-		err = tm.regenerateTemplateMetadata(tmpDir)
+		_, err = tm.regenerateTemplateMetadata(config.DefaultConfig)
 		require.NoError(t, err, "should handle empty directory without error")
 
 		// Index should exist but be empty or minimal
@@ -820,7 +750,7 @@ info:
   severity: info`), 0644))
 
 		// Regenerate metadata (should purge empty directories)
-		err = tm.regenerateTemplateMetadata(tmpDir)
+		_, err = tm.regenerateTemplateMetadata(config.DefaultConfig)
 		require.NoError(t, err)
 
 		// Verify empty directories were purged

--- a/pkg/installer/zipslip_unix_test.go
+++ b/pkg/installer/zipslip_unix_test.go
@@ -64,19 +64,19 @@ func TestZipSlip(t *testing.T) {
 
 		for _, filePathFromZip := range filePathsFromZip {
 			var tmp fs.FileInfo = &tempFileInfo{name: filePathFromZip}
-			writePath := tm.getAbsoluteFilePath(configuredTemplateDirectory, filePathFromZip, tmp)
+			_, writePath := tm.getTemplateOutputLocation(configuredTemplateDirectory, filePathFromZip, tmp)
 			require.Equal(t, "", writePath, filePathFromZip)
 		}
 	})
 
 	t.Run("positive no-slash fallback", func(t *testing.T) {
 		// Entry names with no slash exercise the fallback branch in
-		// getAbsoluteFilePath. Legitimate single-name entries must still be
+		// getTemplateOutputLocation. Legitimate single-name entries must still be
 		// written into templateDir (regression test for the containment check
 		// added to that branch).
 		tm := TemplateManager{}
 		var tmp fs.FileInfo = &tempFileInfo{name: "single-file.yaml"}
-		writePath := tm.getAbsoluteFilePath(configuredTemplateDirectory, "single-file.yaml", tmp)
+		_, writePath := tm.getTemplateOutputLocation(configuredTemplateDirectory, "single-file.yaml", tmp)
 		require.Equal(t, filepath.Join(configuredTemplateDirectory, "single-file.yaml"), writePath)
 	})
 
@@ -89,7 +89,7 @@ func TestZipSlip(t *testing.T) {
 
 		for filePathFromZip, expectedWritePath := range filePathsFromZip {
 			var tmp fs.FileInfo = &tempFileInfo{name: filePathFromZip}
-			writePath := tm.getAbsoluteFilePath(configuredTemplateDirectory, filePathFromZip, tmp)
+			_, writePath := tm.getTemplateOutputLocation(configuredTemplateDirectory, filePathFromZip, tmp)
 			require.Equal(t, expectedWritePath, writePath, filePathFromZip)
 		}
 	})
@@ -101,7 +101,7 @@ func TestZipSlip(t *testing.T) {
 
 		tm := TemplateManager{}
 		var tmp fs.FileInfo = &tempFileInfo{name: "nuclei-templates/cves/test.yaml"}
-		writePath := tm.getAbsoluteFilePath(aliasDir, "nuclei-templates/cves/test.yaml", tmp)
+		_, writePath := tm.getTemplateOutputLocation(aliasDir, "nuclei-templates/cves/test.yaml", tmp)
 		require.Equal(t, filepath.Join(aliasDir, "cves", "test.yaml"), writePath)
 	})
 
@@ -109,7 +109,7 @@ func TestZipSlip(t *testing.T) {
 	// path component is itself a symlink that points outside the configured
 	// templates directory. Because both the entry's leaf and its parent on
 	// disk may be missing, a naive lexical containment check could miss the
-	// escape. canonicalizePath inside IsPathWithinDirectory walks up to the
+		// escape. canonicalizePath inside IsPathWithinDirectory walks up to the
 	// nearest existing ancestor (the symlink) and resolves it, which is what
 	// makes this rejection sound. This test pins that behavior.
 	t.Run("negative symlinked ancestor escapes templateDir", func(t *testing.T) {
@@ -117,7 +117,7 @@ func TestZipSlip(t *testing.T) {
 		outsideDir := t.TempDir()
 		// Plant a symlink "evil" inside templateDir that points outside.
 		// A malicious zip entry that traverses through it must be rejected
-		// before it ever reaches WriteFile / CreateFolder.
+		// before it reaches the root-confined write boundary.
 		require.NoError(t, os.Symlink(outsideDir, filepath.Join(templateDir, "evil")))
 
 		tm := TemplateManager{}
@@ -128,7 +128,7 @@ func TestZipSlip(t *testing.T) {
 		}
 		for _, entry := range entries {
 			var tmp fs.FileInfo = &tempFileInfo{name: entry}
-			writePath := tm.getAbsoluteFilePath(templateDir, entry, tmp)
+			_, writePath := tm.getTemplateOutputLocation(templateDir, entry, tmp)
 			require.Equal(t, "", writePath, entry)
 		}
 	})


### PR DESCRIPTION
## Proposed changes

Track files installed by each official release and
remove only retired templates whose contents still
match the recorded digest. Bootstrap ownership for
existing installations so upgrades keep unknown
and locally modified templates intact.

Write templates, ownership state, and config thru
synced temporary files. Recover interrupted
cleanup before another update and record the new
version only after metadata finalization succeeds.

### Proof

<!-- How has this been tested? Please describe the tests that you ran to verify your changes. -->

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Template installation and updates now provide safer atomic replacement and recovery after interruptions.
  * File permissions and ownership are better preserved during template writes, restores, and quarantined-file handling.
  * Configuration updates use safer replacement behavior with improved state and template-directory handling.
  * Template metadata, indexes, and checksums are finalized more consistently after successful updates.
  * Improved protection against unsafe archive paths, special files, and symlink-based write escapes.
* **Bug Fixes**
  * Improved template restoration on systems that do not support hard links or exclusive rename operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->