### PR TITLE
strict probe

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@ OPTIMIZATIONS:
    -ss, -scan-strategy value        strategy to use while scanning(auto/host-spray/template-spray) (default auto)
    -irt, -input-read-timeout value  timeout on input read (default 3m0s)
    -nh, -no-httpx                   disable httpx probing for non-url input
+   -stp, -strict-probe              skip HTTP/headless for non-url inputs that httpx could not confirm (no raw-input fallback)
    -preflight-portscan              run preflight resolve + TCP portscan and filter targets before scanning (disabled by default)
    -no-stdin                        disable stdin processing
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -306,6 +306,7 @@ OPTIMIZATIONS:
    -ss, -scan-strategy value        strategy to use while scanning(auto/host-spray/template-spray) (default auto)
    -irt, -input-read-timeout value  timeout on input read (default 3m0s)
    -nh, -no-httpx                   disable httpx probing for non-url input
+   -stp, -strict-probe              skip HTTP/headless for non-url inputs that httpx could not confirm (no raw-input fallback)
    -preflight-portscan              run preflight resolve + TCP portscan and filter targets before scanning (disabled by default)
    -no-stdin                        disable stdin processing
 

--- a/README_ES.md
+++ b/README_ES.md
@@ -306,6 +306,7 @@ OPTIMIZATIONS:
    -ss, -scan-strategy value        strategy to use while scanning(auto/host-spray/template-spray) (default auto)
    -irt, -input-read-timeout value  timeout on input read (default 3m0s)
    -nh, -no-httpx                   disable httpx probing for non-url input
+   -stp, -strict-probe              skip HTTP/headless for non-url inputs that httpx could not confirm (no raw-input fallback)
    -preflight-portscan              run preflight resolve + TCP portscan and filter targets before scanning (disabled by default)
    -no-stdin                        disable stdin processing
 

--- a/README_ID.md
+++ b/README_ID.md
@@ -306,6 +306,7 @@ OPTIMIZATIONS:
    -ss, -scan-strategy value        strategy to use while scanning(auto/host-spray/template-spray) (default auto)
    -irt, -input-read-timeout value  timeout on input read (default 3m0s)
    -nh, -no-httpx                   disable httpx probing for non-url input
+   -stp, -strict-probe              skip HTTP/headless for non-url inputs that httpx could not confirm (no raw-input fallback)
    -preflight-portscan              run preflight resolve + TCP portscan and filter targets before scanning (disabled by default)
    -no-stdin                        disable stdin processing
 

--- a/README_JP.md
+++ b/README_JP.md
@@ -306,6 +306,7 @@ OPTIMIZATIONS:
    -ss, -scan-strategy value        strategy to use while scanning(auto/host-spray/template-spray) (default auto)
    -irt, -input-read-timeout value  timeout on input read (default 3m0s)
    -nh, -no-httpx                   disable httpx probing for non-url input
+   -stp, -strict-probe              skip HTTP/headless for non-url inputs that httpx could not confirm (no raw-input fallback)
    -preflight-portscan              run preflight resolve + TCP portscan and filter targets before scanning (disabled by default)
    -no-stdin                        disable stdin processing
 

--- a/README_KR.md
+++ b/README_KR.md
@@ -306,6 +306,7 @@ OPTIMIZATIONS:
    -ss, -scan-strategy value        strategy to use while scanning(auto/host-spray/template-spray) (default auto)
    -irt, -input-read-timeout value  timeout on input read (default 3m0s)
    -nh, -no-httpx                   disable httpx probing for non-url input
+   -stp, -strict-probe              skip HTTP/headless for non-url inputs that httpx could not confirm (no raw-input fallback)
    -preflight-portscan              run preflight resolve + TCP portscan and filter targets before scanning (disabled by default)
    -no-stdin                        disable stdin processing
 

--- a/README_PT-BR.md
+++ b/README_PT-BR.md
@@ -306,6 +306,7 @@ OPTIMIZATIONS:
    -ss, -scan-strategy value        strategy to use while scanning(auto/host-spray/template-spray) (default auto)
    -irt, -input-read-timeout value  timeout on input read (default 3m0s)
    -nh, -no-httpx                   disable httpx probing for non-url input
+   -stp, -strict-probe              skip HTTP/headless for non-url inputs that httpx could not confirm (no raw-input fallback)
    -preflight-portscan              run preflight resolve + TCP portscan and filter targets before scanning (disabled by default)
    -no-stdin                        disable stdin processing
 

--- a/README_TR.md
+++ b/README_TR.md
@@ -306,6 +306,7 @@ OPTIMIZATIONS:
    -ss, -scan-strategy value        strategy to use while scanning(auto/host-spray/template-spray) (default auto)
    -irt, -input-read-timeout value  timeout on input read (default 3m0s)
    -nh, -no-httpx                   disable httpx probing for non-url input
+   -stp, -strict-probe              skip HTTP/headless for non-url inputs that httpx could not confirm (no raw-input fallback)
    -preflight-portscan              run preflight resolve + TCP portscan and filter targets before scanning (disabled by default)
    -no-stdin                        disable stdin processing
 

--- a/cmd/nuclei/main.go
+++ b/cmd/nuclei/main.go
@@ -450,6 +450,7 @@ on extensive configurability, massive extensibility and ease of use.`)
 		}),
 		flagSet.DurationVarP(&options.InputReadTimeout, "input-read-timeout", "irt", time.Duration(3*time.Minute), "timeout on input read"),
 		flagSet.BoolVarP(&options.DisableHTTPProbe, "no-httpx", "nh", false, "disable httpx probing for non-url input"),
+		flagSet.BoolVarP(&options.StrictProbe, "strict-probe", "stp", false, "skip HTTP/headless templates for non-url inputs that httpx could not confirm (no raw-input fallback)"),
 		flagSet.BoolVar(&options.PreflightPortScan, "preflight-portscan", false, "run preflight resolve + TCP portscan and filter targets before scanning (disabled by default)"),
 		flagSet.BoolVar(&options.DisableStdin, "no-stdin", false, "disable stdin processing"),
 	)

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -766,6 +766,12 @@ func (r *Runner) RunEnumeration() error {
 			return errors.Wrap(err, "could not probe http input")
 		}
 		executorOpts.InputHelper.InputsHTTP = inputHelpers
+		executorOpts.InputHelper.StrictProbe = r.options.StrictProbe
+		if r.options.StrictProbe {
+			r.Logger.Info().Msgf("Strict probe enabled: non-url hosts without httpx confirmation will be skipped for HTTP/headless templates")
+		}
+	} else if r.options.StrictProbe && r.options.DisableHTTPProbe {
+		r.Logger.Warning().Msgf("strict-probe has no effect with -no-httpx (httpx probing is disabled)")
 	}
 
 	inputCount := int(r.inputProvider.Count())

--- a/pkg/input/transform.go
+++ b/pkg/input/transform.go
@@ -16,6 +16,9 @@ import (
 // Helper is a structure for helping with input transformation
 type Helper struct {
 	InputsHTTP *hybrid.HybridMap
+	// StrictProbe, when InputsHTTP is set, skips HTTP/headless fallback to the
+	// raw input if httpx did not confirm a web service for that host.
+	StrictProbe bool
 }
 
 // NewHelper returns a new input helper instance
@@ -113,6 +116,10 @@ func (h *Helper) convertInputToType(input string, inputType inputType, defaultPo
 		if h.InputsHTTP != nil {
 			if probed, ok := h.InputsHTTP.Get(input); ok {
 				return string(probed)
+			}
+			// Probe ran but this host was not confirmed as HTTP(S).
+			if h.StrictProbe {
+				return ""
 			}
 		}
 		// try to parse it as absolute url and return

--- a/pkg/input/transform_test.go
+++ b/pkg/input/transform_test.go
@@ -72,3 +72,30 @@ func TestConvertInputToType(t *testing.T) {
 		require.Equal(t, test.result, result, "could not get correct result %+v", test)
 	}
 }
+
+func TestStrictProbeSkipsUnconfirmedHTTPInput(t *testing.T) {
+	hm, err := hybrid.New(hybrid.DefaultDiskOptions)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = hm.Close() })
+
+	_ = hm.Set("ok.example", []byte("https://ok.example"))
+
+	helper := &Helper{InputsHTTP: hm, StrictProbe: true}
+
+	require.Equal(t, "https://ok.example", helper.convertInputToType("ok.example", typeURL, ""))
+	require.Equal(t, "", helper.convertInputToType("127.0.0.1:3306", typeURL, ""))
+	require.Equal(t, "", helper.convertInputToType("zombie.example:6379", typeURL, ""))
+	// Already-URL inputs are not gated by probe results.
+	require.Equal(t, "https://direct.example", helper.convertInputToType("https://direct.example", typeURL, ""))
+	// Non-HTTP protocols still transform normally.
+	require.Equal(t, "127.0.0.1:3306", helper.convertInputToType("127.0.0.1:3306", typeHostWithOptionalPort, ""))
+}
+
+func TestStrictProbeDisabledKeepsRawFallback(t *testing.T) {
+	hm, err := hybrid.New(hybrid.DefaultDiskOptions)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = hm.Close() })
+
+	helper := &Helper{InputsHTTP: hm, StrictProbe: false}
+	require.Equal(t, "127.0.0.1:3306", helper.convertInputToType("127.0.0.1:3306", typeURL, ""))
+}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -205,6 +205,9 @@ type Options struct {
 	DebugResponse bool
 	// DisableHTTPProbe disables http probing feature of input normalization
 	DisableHTTPProbe bool
+	// StrictProbe skips HTTP/headless execution for non-URL inputs that httpx
+	// could not confirm as a web service, instead of falling back to the raw input.
+	StrictProbe bool
 	// PreflightPortScan enables a preflight resolve + TCP portscan and filters targets
 	// before running templates. Disabled by default.
 	PreflightPortScan bool
@@ -576,6 +579,7 @@ func (options *Options) Copy() *Options {
 		DebugRequests:                  options.DebugRequests,
 		DebugResponse:                  options.DebugResponse,
 		DisableHTTPProbe:               options.DisableHTTPProbe,
+		StrictProbe:                    options.StrictProbe,
 		PreflightPortScan:              options.PreflightPortScan,
 		PerHostRateLimit:               options.PerHostRateLimit,
 		LeaveDefaultPorts:              options.LeaveDefaultPorts,


### PR DESCRIPTION
## Summary
- Add `-strict-probe` / `-stp` so HTTP/headless templates skip non-URL hosts that httpx did not confirm, instead of falling back to the raw input
- Document the flag in README help text

Closes #6651

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `-stp` / `-strict-probe` command-line option.
  * When enabled, strict probing skips HTTP/headless processing for non-URL inputs that cannot be confirmed, without raw-input fallback.
  * Emits an informational/warning message depending on whether HTTP probing is enabled.

* **Documentation**
  * Updated CLI help text for the new option across all supported README languages.

* **Tests**
  * Added coverage for strict-probe behavior (skipping unconfirmed inputs) and verified the existing raw-fallback behavior when disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->