### PR TITLE
docs: add six CLI flags missing from the README help block

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Flags:
 TARGET:
    -u, -target string[]          target URLs/hosts to scan
    -l, -list string              path to file containing a list of target URLs/hosts to scan (one per line)
+   -targets-inline string        inline multiline target list (for use in template profiles)
    -eh, -exclude-hosts string[]  hosts to exclude to scan from the input list (ip, cidr, hostname)
    -resume string                resume scan from and save to specified file (clustering will be disabled)
    -sa, -scan-all-ips            scan all the IP's associated with dns record
@@ -149,6 +150,8 @@ TARGET-FORMAT:
    -im, -input-mode string        mode of input file (list, burp, jsonl, yaml, openapi, swagger) (default "list")
    -ro, -required-only            use only required fields in input format when generating requests
    -sfv, -skip-format-validation  skip format validation (like missing vars) when parsing input file
+   -vtt, -vars-text-templating    enable text templating for vars in input file (only for yaml input mode)
+   -vfp, -var-file-paths string[] list of yaml file contained vars to inject into yaml input
 
 TEMPLATES:
    -nt, -new-templates                    run only new templates added in latest nuclei-templates release
@@ -205,6 +208,7 @@ OUTPUT:
    -se, -sarif-export string     file to export results in SARIF format
    -je, -json-export string      file to export results in JSON format
    -jle, -jsonl-export string    file to export results in JSONL(ine) format
+   -pe, -pdf-export string       file to export results in PDF format
    -rd, -redact string[]         redact given list of keys from query parameter, request header and body
 
 CONFIGURATIONS:
@@ -277,6 +281,7 @@ UNCOVER:
 RATE-LIMIT:
    -rl, -rate-limit int               maximum number of requests to send per second (default 150)
    -rld, -rate-limit-duration value   maximum number of requests to send per second (default 1s)
+   -per-host-rate-limit               enable per-host rate limiting (global rate limit becomes unlimited when enabled)
    -rlm, -rate-limit-minute int       maximum number of requests to send per minute (DEPRECATED)
    -bs, -bulk-size int                maximum number of hosts to be analyzed in parallel per template (default 25)
    -c, -concurrency int               maximum number of templates to be executed in parallel (default 25)
@@ -301,6 +306,7 @@ OPTIMIZATIONS:
    -ss, -scan-strategy value        strategy to use while scanning(auto/host-spray/template-spray) (default auto)
    -irt, -input-read-timeout value  timeout on input read (default 3m0s)
    -nh, -no-httpx                   disable httpx probing for non-url input
+   -preflight-portscan              run preflight resolve + TCP portscan and filter targets before scanning (disabled by default)
    -no-stdin                        disable stdin processing
 
 HEADLESS:


### PR DESCRIPTION
Fixes #7595.

### What was wrong

Six flags are registered in `cmd/nuclei/main.go` and appear in `nuclei -h`, but are missing from the help block in the README — so they're undiscoverable for anyone reading the docs.

### How I verified it

I didn't hand-write these lines. I built the binary from this commit and copied the exact output:

```
go build -o /tmp/nuclei-bin ./cmd/nuclei
/tmp/nuclei-bin -h
```

Then diffed each flag's README line against its `-h` line, normalising whitespace:

```
MATCH  targets-inline
MATCH  vars-text-templating
MATCH  var-file-paths
MATCH  pdf-export
MATCH  per-host-rate-limit
MATCH  preflight-portscan
ALL_MATCH
```

Each line is placed in the same section **and the same position** the binary prints it in — for example `-pe, -pdf-export` goes after `-jle, -jsonl-export`, not next to the other `*-export` flags where I first put it; I corrected that after comparing against the real output.

Column alignment follows the surrounding README block, which is narrower than the raw `-h` output in the `RATE-LIMIT` and `TARGET-FORMAT` sections.

### The change

| flag | section | registered at |
|---|---|---|
| `-targets-inline` | TARGET | `main.go:270` |
| `-vtt, -vars-text-templating` | TARGET-FORMAT | `main.go:281` |
| `-vfp, -var-file-paths` | TARGET-FORMAT | `main.go:282` |
| `-pe, -pdf-export` | OUTPUT | `main.go:343` |
| `-per-host-rate-limit` | RATE-LIMIT | `main.go:421` |
| `-preflight-portscan` | OPTIMIZATIONS | `main.go:450` |

Six added lines, `README.md` only — no code or behaviour changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI help documentation with new options for:
    * Inline multiline target lists
    * Text templating and YAML variable injection
    * PDF result export
    * Per-host rate limiting
    * Initial TCP portscan preflight checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->