### PR TITLE
fix: avoid panic in BuildRequest when request response has no request

### DIFF
--- a/pkg/input/types/http.go
+++ b/pkg/input/types/http.go
@@ -59,6 +59,14 @@ func (rr *RequestResponse) Clone() *RequestResponse {
 // BuildRequest builds a retryablehttp request from the request response
 func (rr *RequestResponse) BuildRequest() (*retryablehttp.Request, error) {
 	rr.once.Do(func() {
+		// Request is optional: UnmarshalJSON only populates it when a "request"
+		// key is present, so an entry carrying just a "url" leaves it nil.
+		// Dereferencing it below would panic with a nil pointer instead of
+		// surfacing a usable error, taking the whole scan down.
+		if rr.Request == nil {
+			rr.reqErr = fmt.Errorf("could not create request: no request in request response")
+			return
+		}
 		urlx := rr.URL.Clone()
 		var body io.Reader = nil
 		if rr.Request.Body != "" {

--- a/pkg/input/types/http_test.go
+++ b/pkg/input/types/http_test.go
@@ -143,3 +143,34 @@ func TestUnmarshalJSON(t *testing.T) {
 		})
 	}
 }
+
+// BuildRequest used to dereference rr.Request unconditionally. Request is
+// optional — UnmarshalJSON only sets it when a "request" key is present — so an
+// entry carrying just a "url" (see TestUnmarshalJSON above, which relies on
+// exactly that shape) panicked with a nil pointer dereference instead of
+// returning an error, taking down the caller in pkg/protocols/http/request_fuzz.go.
+func TestBuildRequestWithoutRequest(t *testing.T) {
+	var rr RequestResponse
+	err := rr.UnmarshalJSON([]byte(`{"url": "https://example.com/path"}`))
+	require.NoError(t, err)
+	require.Nil(t, rr.Request)
+
+	require.NotPanics(t, func() {
+		req, err := rr.BuildRequest()
+		require.Error(t, err)
+		require.Nil(t, req)
+	})
+}
+
+// Guard rail: a request response that does carry a request must still build
+// normally, so the nil check above can't be satisfied by refusing everything.
+func TestBuildRequestWithRequestStillWorks(t *testing.T) {
+	rr, err := ParseRawRequest("GET /path HTTP/1.1\r\nHost: example.com\r\n\r\n")
+	require.NoError(t, err)
+	require.NotNil(t, rr.Request)
+
+	req, err := rr.BuildRequest()
+	require.NoError(t, err)
+	require.NotNil(t, req)
+	require.Equal(t, "GET", req.Method)
+}


### PR DESCRIPTION
Fixes #7600.

### What was wrong

`RequestResponse.BuildRequest()` dereferenced `rr.Request` unconditionally and panicked when it was absent:

```
panic: runtime error: invalid memory address or nil pointer dereference
```

`Request` is optional — `UnmarshalJSON` only sets it when a `"request"` key is present:

```go
reqBin, ok := m["request"]
if ok { ... rr.Request = &req }
```

So an entry with only a `url` unmarshals cleanly and then panics on use. The repo's existing `TestUnmarshalJSON` already covers that exact shape (`{"url": "example.com"}`), so the state was reachable from code already under test.

**Reachability, verified rather than assumed** — through the public `MetaInput` API, which is JSON round-tripped:

```
ReqResp==nil? false   ReqResp.Request==nil? true
Clone         ok
BuildRequest  PANIC: runtime error: invalid memory address or nil pointer dereference
```

`pkg/protocols/http/request_fuzz.go:61` reaches it after checking only `ReqResp != nil`, not `.Request`.

### The fix

An early nil check that sets `reqErr`, matching how the function already reports its other failure:

```go
if rr.Request == nil {
    rr.reqErr = fmt.Errorf("could not create request: no request in request response")
    return
}
```

This follows the convention already used on the same field elsewhere in the file — `Clone()` and `ID()` both guard with `if rr.Request != nil`. `BuildRequest` was the odd one out. No new error type, no behaviour change for well-formed input.

Placing it inside the existing `sync.Once` keeps the error cached like the other path, so repeat calls stay consistent.

### Tests

| test | asserts |
|---|---|
| `TestBuildRequestWithoutRequest` | unmarshals `{"url": ...}`, confirms `Request` is nil, then `require.NotPanics` + returns an error and a nil request |
| `TestBuildRequestWithRequestStillWorks` | a parsed raw request still builds, method preserved |

The second is the guard rail: a "fix" that simply refused to build anything would pass the first test and fail this one.

Bite-proofed — reverting only `http.go` makes `TestBuildRequestWithoutRequest` fail with the original nil-pointer panic.

### Verification

`go test ./pkg/input/... ./pkg/protocols/common/contextargs/...` — all packages **ok**. `gofmt` clean. Two files, +39 lines, no behaviour change for valid input.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented crashes when request data is missing by returning a clear error during request building.
  * Kept existing behavior intact for valid inputs, including correct HTTP method handling when a request is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->