### PR TITLE
fix: make -validate report operator compilation errors

### DIFF
--- a/pkg/catalog/loader/loader.go
+++ b/pkg/catalog/loader/loader.go
@@ -95,6 +95,9 @@ type Store struct {
 
 	// parserCacheOnce is used to cache the parser cache result
 	parserCacheOnce func() *templates.Cache
+	// compiledParserCacheOnce caches the compiled-templates cache result, used by
+	// validation so it observes operator-compilation errors.
+	compiledParserCacheOnce func() *templates.Cache
 
 	// metadataIndex is the template metadata cache
 	metadataIndex *index.Index
@@ -169,6 +172,18 @@ func New(cfg *Config) (*Store, error) {
 
 		if parser, ok := cfg.ExecutorOptions.Parser.(*templates.Parser); ok {
 			return parser.Cache()
+		}
+
+		return nil
+	})
+
+	store.compiledParserCacheOnce = sync.OnceValue(func() *templates.Cache {
+		if cfg.ExecutorOptions == nil || cfg.ExecutorOptions.Parser == nil {
+			return nil
+		}
+
+		if parser, ok := cfg.ExecutorOptions.Parser.(*templates.Parser); ok {
+			return parser.CompiledCache()
 		}
 
 		return nil
@@ -656,7 +671,14 @@ func (store *Store) areTemplatesValid(filteredTemplatePaths map[string]struct{})
 
 func (store *Store) areWorkflowOrTemplatesValid(filteredTemplatePaths map[string]struct{}, isWorkflow bool, load func(templatePath string, tagFilter *templates.TagFilter) (bool, error)) bool {
 	areTemplatesValid := true
-	parsedCache := store.parserCacheOnce()
+	// Validation must reuse the *compiled* cache, not the lightweight parsed one.
+	// `Parser.ParseTemplate` stores a syntax-only template in the parsed cache, so
+	// reading from it here made `templates.Parse` below a no-op — and that call is
+	// the only step that compiles protocol requests and operators. Errors raised
+	// during operator compilation (e.g. `group: -1` on a regex extractor) were
+	// therefore invisible to `-validate`, which reported success for templates
+	// that could not run.
+	parsedCache := store.compiledParserCacheOnce()
 
 	for templatePath := range filteredTemplatePaths {
 		if _, err := load(templatePath, store.tagFilter); err != nil {

--- a/pkg/catalog/loader/loader_test.go
+++ b/pkg/catalog/loader/loader_test.go
@@ -553,3 +553,90 @@ http:
 	require.Len(t, loaded, 1)
 	require.Equal(t, "global-matchers-template", loaded[0].ID)
 }
+
+// ValidateTemplates used to read the *lightweight* parsed-template cache, which
+// Parser.ParseTemplate populates before protocol requests and operators are
+// compiled. That made the templates.Parse call in areWorkflowOrTemplatesValid a
+// no-op, so an error raised during operator compilation — here a negative regex
+// extractor group, which CompileExtractors explicitly rejects — was invisible to
+// -validate. The template reported "validated successfully" and then failed to
+// compile at scan time.
+func TestValidateTemplatesReportsOperatorCompileErrors(t *testing.T) {
+	templatePath := filepath.Join(t.TempDir(), "bad-extractor.yaml")
+	err := os.WriteFile(templatePath, []byte(`id: bad-extractor-template
+
+info:
+  name: Bad Extractor Template
+  author: pdteam
+  severity: info
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    extractors:
+      - type: regex
+        group: -1
+        regex:
+          - "(a)(b)"
+`), 0o600)
+	require.NoError(t, err)
+
+	require.Error(t, validateSingleTemplateForTest(t, templatePath, "loader-validate-bad-extractor"))
+}
+
+// Guard rail: a template whose operators compile cleanly must still validate, so
+// the check above cannot be satisfied by failing everything.
+func TestValidateTemplatesAcceptsValidOperators(t *testing.T) {
+	templatePath := filepath.Join(t.TempDir(), "good-extractor.yaml")
+	err := os.WriteFile(templatePath, []byte(`id: good-extractor-template
+
+info:
+  name: Good Extractor Template
+  author: pdteam
+  severity: info
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    extractors:
+      - type: regex
+        group: 1
+        regex:
+          - "(a)(b)"
+`), 0o600)
+	require.NoError(t, err)
+
+	require.NoError(t, validateSingleTemplateForTest(t, templatePath, "loader-validate-good-extractor"))
+}
+
+func validateSingleTemplateForTest(t *testing.T, templatePath, executionID string) error {
+	t.Helper()
+
+	options := testutils.DefaultOptions.Copy()
+	options.Logger = &gologger.Logger{}
+	options.ExecutionId = executionID
+	options.DisableUnsignedTemplates = false
+	options.TemplateLoadingConcurrency = 1
+	options.Templates = []string{templatePath}
+	testutils.Init(options)
+	t.Cleanup(func() {
+		testutils.Cleanup(options)
+	})
+
+	catalog := disk.NewCatalog("")
+	executerOpts := testutils.NewMockExecuterOptions(options, nil)
+	executerOpts.Catalog = catalog
+	executerOpts.Parser = templates.NewParser()
+	executerOpts.Logger = options.Logger
+
+	workflowLoader, err := workflow.NewLoader(executerOpts)
+	require.NoError(t, err)
+	executerOpts.WorkflowLoader = workflowLoader
+
+	store, err := New(NewConfig(options, catalog, executerOpts))
+	require.NoError(t, err)
+
+	return store.ValidateTemplates()
+}


### PR DESCRIPTION
Fixes #7602.

### What was wrong

`-validate` reported success (**exit 0**) for a template that cannot run — while the runtime warning explicitly tells users to run `-validate` to investigate:

```
$ nuclei -t bad.yaml -u example.com
[WRN] Could not parse template bad.yaml: could not compile request: could not compile operators:
      could not compile extractor: regex extractor group must be >= 0, got -1
[WRN] Found 1 templates with runtime error (use -validate flag for further examination)

$ nuclei -t bad.yaml -validate
[INF] All templates validated successfully
$ echo $?
0
```

### Root cause

Traced with instrumentation rather than inspection — my debug prints around `templates.Parse` in `areWorkflowOrTemplatesValid` **never fired**, which is what showed the call was being skipped:

```
DBG iterating /tmp/probeinp/bad1.yaml
DBG cache.Has(/tmp/probeinp/bad1.yaml) tmpl=true err=<nil>     ← cache hit, Parse skipped
[INF] All templates validated successfully
```

`Store.parserCacheOnce` returns `parser.Cache()` — the **lightweight** cache, which `Parser` itself documents as:

> `parsedTemplatesCache` stores lightweight parsed template structures (without raw bytes). Used for validation and filtering.

`Parser.ParseTemplate` stores into it right after YAML decoding, **before** any compilation:

```go
p.parsedTemplatesCache.StoreWithoutRaw(templatePath, template, nil)
```

So validation got a cache hit, skipped `templates.Parse`, and never reached `compileProtocolRequests` → `Executer.Compile()` — the only step that compiles operators.

### The fix

Validation now reads the **compiled** cache via the already-existing `Parser.CompiledCache()`, using the same `sync.OnceValue` pattern as `parserCacheOnce`:

```go
parsedCache := store.compiledParserCacheOnce()
```

`parserCacheOnce` is left untouched — its other caller (`loader.go:406`) legitimately wants the lightweight cache for metadata/tag filtering, so scoping the change to the validation path avoids disturbing it.

After the fix:

```
$ nuclei -t bad.yaml -validate
[ERR] Error occurred parsing template bad.yaml: could not compile request: could not compile operators:
      could not compile extractor: regex extractor group must be >= 0, got -1
[FTL] Could not validate templates: errors occurred during template validation
$ echo $?
1
```

### Regression check against real templates

Since this makes validation stricter, the risk is false positives on the public corpus. I compared old vs new binaries over `nuclei-templates`:

| directory | before | after |
|---|---|---|
| `http/cves` (all years) | validated successfully | validated successfully |
| `http/misconfiguration` | validated successfully | validated successfully |
| `http/exposures` | validated successfully | validated successfully |

Identical results — thousands of real templates, no new failures.

### Tests

| test | asserts |
|---|---|
| `TestValidateTemplatesReportsOperatorCompileErrors` | a template with `group: -1` now makes `ValidateTemplates()` return an error |
| `TestValidateTemplatesAcceptsValidOperators` | the same template with `group: 1` still validates cleanly |

The second is the guard rail — a change that simply failed everything would break it.

Bite-proofed: reverting only `loader.go` makes the first test fail with *"An error is expected but got nil"*, i.e. the exact original bug.

### Verification

`go test ./pkg/catalog/... ./pkg/templates/...` — all **ok**. `gofmt` clean on both touched files (`loader_bench_test.go` is flagged on clean `dev` too, pre-existing and untouched).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Template/workflow validation now consults the compiled template cache, ensuring operator/protocol compilation issues are surfaced accurately (instead of being masked by lighter parsing cache behavior).
  - Valid templates still validate successfully.

- **Tests**
  - Added focused tests for template validation behavior:
    - Invalid regex extractor configurations now correctly fail validation.
    - Valid regex extractor configurations pass validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->