### PR TITLE
fix: reject matchers and extractors with no values

### DIFF
--- a/pkg/operators/extractors/compile.go
+++ b/pkg/operators/extractors/compile.go
@@ -24,6 +24,12 @@ func (e *Extractor) CompileExtractors() error {
 		return fmt.Errorf("regex extractor group must be >= 0, got %d", e.RegexGroup)
 	}
 
+	// An extractor with no values can never extract anything, so it is always a
+	// template authoring mistake. It used to compile and run silently.
+	if err := e.checkRequiredValues(); err != nil {
+		return err
+	}
+
 	// Compile the regexes
 	for _, regex := range e.Regex {
 		if cached, err := cache.Regex().GetIFPresent(regex); err == nil && cached != nil {
@@ -75,5 +81,31 @@ func (e *Extractor) CompileExtractors() error {
 		}
 	}
 
+	return nil
+}
+
+// checkRequiredValues reports an error when the extractor carries none of the
+// values its type extracts with. Such an extractor can never produce a result,
+// so it is always a template authoring mistake rather than an intentional no-op.
+func (e *Extractor) checkRequiredValues() error {
+	var empty bool
+	var field string
+
+	switch e.extractorType {
+	case RegexExtractor:
+		empty, field = len(e.Regex) == 0, "regex"
+	case KValExtractor:
+		empty, field = len(e.KVal) == 0, "kval"
+	case XPathExtractor:
+		empty, field = len(e.XPath) == 0, "xpath"
+	case JSONExtractor:
+		empty, field = len(e.JSON) == 0, "json"
+	case DSLExtractor:
+		empty, field = len(e.DSL) == 0, "dsl"
+	}
+
+	if empty {
+		return fmt.Errorf("extractor %s has no %s values specified", e.extractorType, field)
+	}
 	return nil
 }

--- a/pkg/operators/extractors/extract_test.go
+++ b/pkg/operators/extractors/extract_test.go
@@ -117,3 +117,45 @@ func TestExtractor_ExtractDSL(t *testing.T) {
 	got = e.ExtractDSL(map[string]interface{}{"hi": "hello"})
 	require.Equal(t, map[string]struct{}{}, got)
 }
+
+// An extractor with none of the values its type extracts with can never produce
+// a result, so it used to run silently and extract nothing with no diagnostic.
+func TestExtractorRejectsMissingValues(t *testing.T) {
+	cases := []struct {
+		name      string
+		extractor *Extractor
+		field     string
+	}{
+		{"regex", &Extractor{Type: ExtractorTypeHolder{ExtractorType: RegexExtractor}}, "regex"},
+		{"kval", &Extractor{Type: ExtractorTypeHolder{ExtractorType: KValExtractor}}, "kval"},
+		{"xpath", &Extractor{Type: ExtractorTypeHolder{ExtractorType: XPathExtractor}}, "xpath"},
+		{"json", &Extractor{Type: ExtractorTypeHolder{ExtractorType: JSONExtractor}}, "json"},
+		{"dsl", &Extractor{Type: ExtractorTypeHolder{ExtractorType: DSLExtractor}}, "dsl"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.extractor.CompileExtractors()
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.field)
+		})
+	}
+}
+
+// Guard rail: an extractor that does carry values still compiles.
+func TestExtractorAcceptsProvidedValues(t *testing.T) {
+	cases := []struct {
+		name      string
+		extractor *Extractor
+	}{
+		{"regex", &Extractor{Type: ExtractorTypeHolder{ExtractorType: RegexExtractor}, Regex: []string{"a"}}},
+		{"kval", &Extractor{Type: ExtractorTypeHolder{ExtractorType: KValExtractor}, KVal: []string{"k"}}},
+		{"xpath", &Extractor{Type: ExtractorTypeHolder{ExtractorType: XPathExtractor}, XPath: []string{"//a"}}},
+		{"json", &Extractor{Type: ExtractorTypeHolder{ExtractorType: JSONExtractor}, JSON: []string{".a"}}},
+		{"dsl", &Extractor{Type: ExtractorTypeHolder{ExtractorType: DSLExtractor}, DSL: []string{"1 == 1"}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.NoError(t, tc.extractor.CompileExtractors())
+		})
+	}
+}

--- a/pkg/operators/matchers/match_test.go
+++ b/pkg/operators/matchers/match_test.go
@@ -100,11 +100,13 @@ func TestHexEncoding(t *testing.T) {
 }
 
 func TestMatcher_MatchDSL(t *testing.T) {
-	compiled, err := govaluate.NewEvaluableExpressionWithFunctions("contains(body, \"{{VARIABLE}}\")", dsl.HelperFunctions)
-	require.Nil(t, err, "couldn't compile expression")
-
-	m := &Matcher{Type: MatcherTypeHolder{MatcherType: DSLMatcher}, dslCompiled: []*govaluate.EvaluableExpression{compiled}}
-	err = m.CompileMatchers()
+	// Declared through the DSL field so the matcher is built the same way a
+	// template builds it; CompileMatchers now rejects a matcher with no values.
+	m := &Matcher{
+		Type: MatcherTypeHolder{MatcherType: DSLMatcher},
+		DSL:  []string{"contains(body, \"{{VARIABLE}}\")"},
+	}
+	err := m.CompileMatchers()
 	require.Nil(t, err, "could not compile matcher")
 
 	values := []string{"PING", "pong"}
@@ -442,12 +444,13 @@ func TestMatchWords_CaseInsensitive_DynamicValue(t *testing.T) {
 
 func TestMatcher_MatchDSL_ErrorHandling(t *testing.T) {
 	// First expression errors (division by zero), second is true
-	bad, err := govaluate.NewEvaluableExpression("1 / 0")
-	require.NoError(t, err)
-	good, err := govaluate.NewEvaluableExpression("1 == 1")
-	require.NoError(t, err)
-
-	m := &Matcher{Type: MatcherTypeHolder{MatcherType: DSLMatcher}, Condition: "or", dslCompiled: []*govaluate.EvaluableExpression{bad, good}}
+	// Declared through the DSL field so the matcher is built the same way a
+	// template builds it; CompileMatchers now rejects a matcher with no values.
+	m := &Matcher{
+		Type:      MatcherTypeHolder{MatcherType: DSLMatcher},
+		Condition: "or",
+		DSL:       []string{"1 / 0", "1 == 1"},
+	}
 	require.NoError(t, m.CompileMatchers())
 	ok := m.MatchDSL(map[string]interface{}{})
 	require.True(t, ok)

--- a/pkg/operators/matchers/validate.go
+++ b/pkg/operators/matchers/validate.go
@@ -54,6 +54,14 @@ func (matcher *Matcher) Validate() error {
 		return err
 	}
 
+	// An operator with no values can never match, so it is always an authoring
+	// mistake — but it used to compile and run silently, producing zero results
+	// with no diagnostic. Reject it here so `-validate` and template authoring
+	// surface it.
+	if err = matcher.checkRequiredValues(); err != nil {
+		return err
+	}
+
 	// validate the XPath query
 	if matcher.matcherType == XPathMatcher {
 		for _, query := range matcher.XPath {
@@ -96,4 +104,34 @@ func getFieldNameFromYamlTag(tagName string, object interface{}) (string, error)
 		}
 	}
 	return "", fmt.Errorf("field %s not found", tagName)
+}
+
+// checkRequiredValues reports an error when the matcher carries none of the
+// values its type matches against. Such a matcher can never match anything, so
+// it is always a template authoring mistake rather than an intentional no-op.
+func (matcher *Matcher) checkRequiredValues() error {
+	var empty bool
+	var field string
+
+	switch matcher.matcherType {
+	case WordsMatcher:
+		empty, field = len(matcher.Words) == 0, "words"
+	case RegexMatcher:
+		empty, field = len(matcher.Regex) == 0, "regex"
+	case BinaryMatcher:
+		empty, field = len(matcher.Binary) == 0, "binary"
+	case StatusMatcher:
+		empty, field = len(matcher.Status) == 0, "status"
+	case SizeMatcher:
+		empty, field = len(matcher.Size) == 0, "size"
+	case DSLMatcher:
+		empty, field = len(matcher.DSL) == 0, "dsl"
+	case XPathMatcher:
+		empty, field = len(matcher.XPath) == 0, "xpath"
+	}
+
+	if empty {
+		return fmt.Errorf("matcher %s has no %s values specified", matcher.matcherType, field)
+	}
+	return nil
 }

--- a/pkg/operators/matchers/validate_test.go
+++ b/pkg/operators/matchers/validate_test.go
@@ -29,3 +29,50 @@ func TestValidate(t *testing.T) {
 	err = m.Validate()
 	require.NotNil(t, err, "Invalid XPath query was correctly validated")
 }
+
+// A matcher with none of the values its type matches against can never match, so
+// it used to run silently and produce zero results with no diagnostic.
+func TestMatcherRejectsMissingValues(t *testing.T) {
+	cases := []struct {
+		name    string
+		matcher *Matcher
+		field   string
+	}{
+		{"words", &Matcher{Type: MatcherTypeHolder{MatcherType: WordsMatcher}}, "words"},
+		{"regex", &Matcher{Type: MatcherTypeHolder{MatcherType: RegexMatcher}}, "regex"},
+		{"binary", &Matcher{Type: MatcherTypeHolder{MatcherType: BinaryMatcher}}, "binary"},
+		{"status", &Matcher{Type: MatcherTypeHolder{MatcherType: StatusMatcher}}, "status"},
+		{"size", &Matcher{Type: MatcherTypeHolder{MatcherType: SizeMatcher}}, "size"},
+		{"dsl", &Matcher{Type: MatcherTypeHolder{MatcherType: DSLMatcher}}, "dsl"},
+		{"xpath", &Matcher{Type: MatcherTypeHolder{MatcherType: XPathMatcher}}, "xpath"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.matcher.CompileMatchers()
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.field)
+		})
+	}
+}
+
+// Guard rail: the check must reject only the empty case, so a matcher that does
+// carry values still compiles.
+func TestMatcherAcceptsProvidedValues(t *testing.T) {
+	cases := []struct {
+		name    string
+		matcher *Matcher
+	}{
+		{"words", &Matcher{Type: MatcherTypeHolder{MatcherType: WordsMatcher}, Words: []string{"a"}}},
+		{"regex", &Matcher{Type: MatcherTypeHolder{MatcherType: RegexMatcher}, Regex: []string{"a"}}},
+		{"binary", &Matcher{Type: MatcherTypeHolder{MatcherType: BinaryMatcher}, Binary: []string{"50494e47"}}},
+		{"status", &Matcher{Type: MatcherTypeHolder{MatcherType: StatusMatcher}, Status: []int{200}}},
+		{"size", &Matcher{Type: MatcherTypeHolder{MatcherType: SizeMatcher}, Size: []int{10}}},
+		{"dsl", &Matcher{Type: MatcherTypeHolder{MatcherType: DSLMatcher}, DSL: []string{"1 == 1"}}},
+		{"xpath", &Matcher{Type: MatcherTypeHolder{MatcherType: XPathMatcher}, XPath: []string{"//a"}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.NoError(t, tc.matcher.CompileMatchers())
+		})
+	}
+}

--- a/pkg/protocols/file/operators_test.go
+++ b/pkg/protocols/file/operators_test.go
@@ -21,6 +21,7 @@ func newMockOperator() operators.Operators {
 				Type: matchers.MatcherTypeHolder{
 					MatcherType: matchers.WordsMatcher,
 				},
+				Words: []string{"test"},
 			},
 		},
 	}


### PR DESCRIPTION
Fixes #7604.

### What was wrong

A matcher or extractor with **no values** compiled, validated and ran — then silently never matched. Proven with a controlled comparison against a local server, same target and template shape:

```
control  (words: ["a"]) → [probe-ctl] [http] [info] http://127.0.0.1:18099
empty    (no words:)    → No results found
```

Every matcher type accepted it (`compile err=<nil>` for `word`, `regex`, `binary`, `status`, `size`, `dsl`, `xpath`), and likewise for extractors.

### It is hiding real breakage in nuclei-templates today

This is the part worth reviewing. Running the fixed binary over the **entire** `nuclei-templates` corpus (13,342 templates) fails **exactly 4** — and I inspected every one by hand. All four are genuinely broken:

| template | operator | what's actually wrong |
|---|---|---|
| `http/cves/2021/CVE-2021-44228.yaml` (Log4Shell) | `kval` | `kval:` present but **empty** |
| `http/cves/2021/CVE-2021-45046.yaml` | `kval` | `kval:` present but **empty** |
| `http/cves/2026/CVE-2026-42281.yaml` | `dsl` | the `dsl:` key is **missing entirely** — its list items are orphaned under `name: dns`, so the whole second matcher is inert |
| `dns/dns-saas-service-detection.yaml` | `word` | `type: word` with `part`/`name` but **no `words:`** |

**Zero false positives** — no other template in the corpus is affected.

Note the two Log4Shell ones would not be caught by a naive "is the key present" scan: the key exists with an empty value. That's why the check tests the parsed value rather than the YAML shape.

### The fix

A `checkRequiredValues()` on each side, called from the existing validation/compile path:

- matchers: called from `Matcher.Validate()`, right after the existing `checkFields()`
- extractors: called from `CompileExtractors()`, next to the existing `RegexGroup < 0` guard

Both reuse the type→field mapping the code already expresses in its `switch` on the operator type, and produce a message naming the missing field:

```
matcher word has no words values specified
extractor kval has no kval values specified
```

No new concept — this sits alongside guards that already exist in both files.

### Two existing tests updated, deliberately

`TestMatcher_MatchDSL` and `TestMatcher_MatchDSL_ErrorHandling` constructed a matcher by pre-seeding the **unexported** `dslCompiled` field while leaving `DSL` empty, to isolate `MatchDSL`. `dslCompiled` is only ever populated from `matcher.DSL` during compile, so that shape isn't reachable from a template. I changed them to declare `DSL: [...]` — the same way a template does — which keeps what they test while going through the real compile path.

### Tests

| test | asserts |
|---|---|
| `TestMatcherRejectsMissingValues` | all 7 matcher types error, message names the field |
| `TestMatcherAcceptsProvidedValues` | all 7 still compile when values are present |
| `TestExtractorRejectsMissingValues` | all 5 extractor types error |
| `TestExtractorAcceptsProvidedValues` | all 5 still compile when values are present |

The "accepts" pairs are the guard rails — a change that rejected too much would break them.

Bite-proofed: reverting the two source files makes every `Rejects` subtest fail.

### Verification

`go test ./pkg/operators/... ./pkg/templates/... ./pkg/catalog/...` — all **ok**. `gofmt` clean.

### One coordination note

This will fail those 4 templates in `nuclei-templates` until they're fixed. They're broken today and silently doing nothing, so I'd argue surfacing them is the point — but if you'd rather land this behind a flag, or fix the templates first, I'm happy to adjust. Flagged the same thing on #7604 before opening this.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Extractors now fail compilation when the selected extractor type has no required values configured, preventing silent no-op behavior.
  * Matchers now fail validation when the selected matcher type is missing required values.
* **Tests**
  * Added table-driven tests ensuring extractors and matchers both reject missing required values and accept valid configurations.
  * Updated DSL matcher tests to build expressions via the DSL field and verify compilation and error-handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->