### PR TITLE
fix(extractors): reject a regex group the pattern cannot produce

### DIFF
--- a/pkg/operators/extractors/compile.go
+++ b/pkg/operators/extractors/compile.go
@@ -27,12 +27,18 @@ func (e *Extractor) CompileExtractors() error {
 	// Compile the regexes
 	for _, regex := range e.Regex {
 		if cached, err := cache.Regex().GetIFPresent(regex); err == nil && cached != nil {
+			if err := validateRegexGroup(e, cached, regex); err != nil {
+				return err
+			}
 			e.regexCompiled = append(e.regexCompiled, cached)
 			continue
 		}
 		compiled, err := regexp.Compile(regex)
 		if err != nil {
 			return fmt.Errorf("could not compile regex: %s", regex)
+		}
+		if err := validateRegexGroup(e, compiled, regex); err != nil {
+			return err
 		}
 		_ = cache.Regex().Set(regex, compiled)
 		e.regexCompiled = append(e.regexCompiled, compiled)
@@ -75,5 +81,26 @@ func (e *Extractor) CompileExtractors() error {
 		}
 	}
 
+	return nil
+}
+
+// validateRegexGroup rejects a group index the pattern cannot produce.
+//
+// ExtractRegex skips any submatch where `len(match) < RegexGroup+1`, and
+// FindAllStringSubmatch returns exactly NumSubexp()+1 entries, so a group
+// beyond that count can never match anything. Without this the template
+// compiles, runs, and silently extracts nothing — the failure mode is an
+// empty result rather than an error, which is indistinguishable from "the
+// pattern didn't match the target".
+func validateRegexGroup(e *Extractor, compiled *regexp.Regexp, pattern string) error {
+	if e.extractorType != RegexExtractor || e.RegexGroup == 0 {
+		return nil
+	}
+	if groups := compiled.NumSubexp(); e.RegexGroup > groups {
+		return fmt.Errorf(
+			"regex extractor group %d is out of range for pattern %q, which has %d capture group(s)",
+			e.RegexGroup, pattern, groups,
+		)
+	}
 	return nil
 }

--- a/pkg/operators/extractors/extract_test.go
+++ b/pkg/operators/extractors/extract_test.go
@@ -29,6 +29,52 @@ func TestExtractor_CompileRejectsNegativeRegexGroup(t *testing.T) {
 	require.ErrorContains(t, err, "group must be >= 0")
 }
 
+func TestExtractor_CompileRejectsOutOfRangeRegexGroup(t *testing.T) {
+	// A group beyond what the pattern captures can never match:
+	// FindAllStringSubmatch returns NumSubexp()+1 entries, so ExtractRegex
+	// skips every submatch and yields nothing. Before this check the template
+	// compiled and ran, and an empty result was indistinguishable from "the
+	// pattern didn't match the target".
+	e := &Extractor{
+		Type:       ExtractorTypeHolder{ExtractorType: RegexExtractor},
+		Regex:      []string{`(\d+)`},
+		RegexGroup: 5,
+	}
+	err := e.CompileExtractors()
+	require.ErrorContains(t, err, "out of range")
+	require.ErrorContains(t, err, "1 capture group")
+}
+
+func TestExtractor_CompileAcceptsInRangeRegexGroup(t *testing.T) {
+	e := &Extractor{
+		Type:       ExtractorTypeHolder{ExtractorType: RegexExtractor},
+		Regex:      []string{`(\w+)@(\w+)`},
+		RegexGroup: 2,
+	}
+	require.NoError(t, e.CompileExtractors())
+	require.Equal(t, map[string]struct{}{"example": {}}, e.ExtractRegex("user@example"))
+}
+
+func TestExtractor_CompileValidatesGroupOnCachedRegex(t *testing.T) {
+	// The compile path short-circuits on a cache hit. Validating only the
+	// freshly-compiled branch would let the same pattern pass unchecked once
+	// any other template had already compiled it.
+	pattern := `(?:cached)-(\d+)-marker`
+
+	warm := &Extractor{
+		Type:  ExtractorTypeHolder{ExtractorType: RegexExtractor},
+		Regex: []string{pattern},
+	}
+	require.NoError(t, warm.CompileExtractors())
+
+	reuse := &Extractor{
+		Type:       ExtractorTypeHolder{ExtractorType: RegexExtractor},
+		Regex:      []string{pattern},
+		RegexGroup: 4,
+	}
+	require.ErrorContains(t, reuse.CompileExtractors(), "out of range")
+}
+
 func TestExtractor_ExtractRegexNegativeGroupDoesNotPanic(t *testing.T) {
 	// Defense in depth: even if an extractor is built programmatically (or
 	// otherwise ends up with compiled regexes) without compilation-time checks,

--- a/pkg/operators/extractors/fuzz_harness.go
+++ b/pkg/operators/extractors/fuzz_harness.go
@@ -210,7 +210,38 @@ func (candidate *fuzzExtractorCandidate) build() (*Extractor, bool) {
 		extractor.Regex = append([]string(nil), candidate.values...)
 	}
 
+	// The fuzzer picks a group index independently of the patterns it picks,
+	// so it routinely asks for a group the pattern cannot produce (its own
+	// defaults include the group-less `https?://[^\s"']+`). CompileExtractors
+	// now rejects that, which is correct for real templates but would make the
+	// harness fail on inputs it deliberately generates. Clamp to what the
+	// narrowest pattern actually captures so the fuzzer keeps exercising
+	// extraction rather than dying at compile time.
+	if extractor.RegexGroup > 0 {
+		extractor.RegexGroup = clampFuzzRegexGroup(extractor.Regex, extractor.RegexGroup)
+	}
+
 	return extractor, len(candidate.values) > 0
+}
+
+func clampFuzzRegexGroup(patterns []string, group int) int {
+	minGroups := -1
+	for _, pattern := range patterns {
+		compiled, err := regexp.Compile(pattern)
+		if err != nil {
+			continue
+		}
+		if groups := compiled.NumSubexp(); minGroups < 0 || groups < minGroups {
+			minGroups = groups
+		}
+	}
+	if minGroups < 0 {
+		return 0
+	}
+	if group > minGroups {
+		return minGroups
+	}
+	return group
 }
 
 func exerciseFuzzExtractor(extractor *Extractor) {


### PR DESCRIPTION
Closes #7611.

### The bug

A `regex` extractor whose `group` exceeds the pattern's capture count compiles, runs, and silently extracts nothing — `ExtractRegex` skips every submatch because `FindAllStringSubmatch` returns exactly `NumSubexp()+1` entries. Same silent-failure class as the negative group already rejected two lines above.

### It affects shipped templates

Scanned `nuclei-templates`: **13,451** yaml files, **2,100** regex extractors with `group > 0`, **4** affected. That ratio matters — it says this is a defect, not behaviour templates depend on.

The clearest is `smtp-credentials-exposure.yaml`, where two patterns share one `group: 1` and only the second captures:

```yaml
regex:
  - smtp_username":".*"                    # 0 capture groups
  - <smtp_username>(.*)</smtp_username>    # 1 capture group
```

Against a body containing both, it extracts `map[bob:{}]` — **the JSON credential is silently missed**, and has been since the template was written.

### Two details worth flagging in review

**Validation runs on the cached branch too.** The compile path short-circuits on a cache hit:

```go
if cached, err := cache.Regex().GetIFPresent(regex); err == nil && cached != nil {
    e.regexCompiled = append(e.regexCompiled, cached)
    continue
}
```

Checking only the freshly-compiled branch would let a pattern through unvalidated as soon as any other template had compiled it first. `TestExtractor_CompileValidatesGroupOnCachedRegex` covers exactly this, and I verified it catches a half-fix: removing *only* the cached-branch check still fails that one test.

**The fuzz harness needed a change.** It picks a group index independently of its patterns, and its own defaults include the group-less `https?://[^\s"']+`, so it would now fail at compile time on inputs it deliberately generates rather than exercising extraction. It clamps the group to what the narrowest pattern captures. I'd rather point this out than have it look like an unexplained edit to test scaffolding.

### Verification

```
go test ./pkg/operators/...   all ok
go vet ./pkg/operators/extractors/   clean
gofmt   clean
```

Tests fail without the fix — removing both call sites gives 2 failures; removing only the cached-branch check gives 1.

### Follow-up, not included here

The four templates need their `group` corrected (or the non-capturing pattern amended) in `nuclei-templates`. I've left that out of this PR since it's a different repo, but they aren't extracting what they claim to today and I'm happy to send it if useful.

---

Separately: the red `Tests (windows-latest)` on my other PR (#7605) is a goleveldb crash that also reproduces on #7598, which isn't mine — details in [that thread](https://github.com/projectdiscovery/nuclei/pull/7605#issuecomment-5083936278). Mentioning it here only because this PR may show the same failure.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid regex capture group selections are now rejected during extractor configuration instead of producing empty or misleading extraction results.
  * Validation is consistently applied, including when compiled regular expressions are reused from cache.
  * Valid capture groups continue to extract values as expected.

* **Tests**
  * Added coverage for valid, invalid, and cached regular expression capture group scenarios.
  * Improved fuzz testing resilience by constraining generated capture group selections to supported ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->