### PR TITLE
fix(types): give DefaultOptions a usable logger, not the zero value

### DIFF
--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -10,6 +10,9 @@ import (
 
 	"github.com/projectdiscovery/goflags"
 	"github.com/projectdiscovery/gologger"
+	"github.com/projectdiscovery/gologger/formatter"
+	"github.com/projectdiscovery/gologger/levels"
+	"github.com/projectdiscovery/gologger/writer"
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog"
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/config"
 	"github.com/projectdiscovery/nuclei/v3/pkg/model/types/severity"
@@ -823,8 +826,21 @@ func DefaultOptions() *Options {
 		ResponseReadSize:           10 * unitutils.Mega,
 		ResponseSaveSize:           unitutils.Mega,
 		ExecutionId:                xid.New().String(),
-		Logger:                     &gologger.Logger{},
+		Logger:                     defaultLogger(),
 	}
+}
+
+// defaultLogger returns a logger that is safe to raise the level on. A bare
+// &gologger.Logger{} has a nil formatter and writer; it survives only because
+// its zero maxLevel (LevelFatal) filters everything out. Any caller that raises
+// the level -- the SDK does, in lib/sdk_private.go -- then dereferences the nil
+// formatter on the first message that passes the filter.
+func defaultLogger() *gologger.Logger {
+	logger := &gologger.Logger{}
+	logger.SetMaxLevel(levels.LevelInfo)
+	logger.SetFormatter(formatter.NewCLI(false))
+	logger.SetWriter(writer.NewCLI())
+	return logger
 }
 
 func (options *Options) ShouldUseHostError() bool {

--- a/pkg/types/types_test.go
+++ b/pkg/types/types_test.go
@@ -1,11 +1,13 @@
 package types
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
 
+	"github.com/projectdiscovery/gologger/levels"
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/config"
 )
 
@@ -229,4 +231,32 @@ func restoreTemplatesDir(t *testing.T, templatesDir string) {
 	t.Cleanup(func() {
 		config.DefaultConfig.SetTemplatesDir(oldTemplatesDir)
 	})
+}
+
+// The default logger must survive having its level raised. A bare
+// &gologger.Logger{} has a nil formatter and only appears to work because its
+// zero maxLevel (LevelFatal) filters every message out. The SDK raises the
+// level without setting a formatter (lib/sdk_private.go), so the first message
+// that then passes the filter dereferenced nil — aborting the whole lib/tests
+// package through a sync.OnceFunc in the catalog loader.
+func TestDefaultOptionsLoggerSurvivesRaisedLevel(t *testing.T) {
+	for _, level := range []levels.Level{levels.LevelVerbose, levels.LevelDebug, levels.LevelSilent} {
+		t.Run(level.String(), func(t *testing.T) {
+			logger := DefaultOptions().Logger
+			if logger == nil {
+				t.Fatal("DefaultOptions() returned a nil Logger")
+			}
+			logger.SetMaxLevel(level)
+
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("logging at %s panicked: %v", level, r)
+				}
+			}()
+			// The exact call site that crashed: catalog/loader.go, on the
+			// branch where saving the metadata cache returns an error.
+			logger.Warning().Msgf("Could not save metadata cache: %v", errors.New("test"))
+			logger.Verbose().Msgf("Saved %d templates to metadata cache", 0)
+		})
+	}
 }


### PR DESCRIPTION
Fixes #7613 — the nil-formatter panic that aborts the whole `lib/tests` package.

### The mechanism

`DefaultOptions()` handed out `&gologger.Logger{}`, whose formatter and writer are nil. That looks fine because the zero `maxLevel` is `LevelFatal`, and `isCurrentLevelEnabled` is `event.level <= logger.maxLevel`, so every Warning (4), Verbose (6) and Error (2) is filtered out before reaching the formatter:

```
zero-value logger, maxLevel=0:
  Warning   no panic (level filtered)
  Verbose   no panic (level filtered)
  Error     no panic (level filtered)
  Fatal     PANIC                        <- the only level that gets through
```

The SDK then raises the level and never sets a formatter:

```go
// lib/sdk_private.go:153
if e.opts.Verbose {
    e.Logger.SetMaxLevel(levels.LevelVerbose)
}
```

`grep -n SetFormatter lib/*.go` returns nothing. Only `internal/runner/options.go` sets one, and that is the CLI path. So raising the level removes the only thing protecting the nil formatter.

### Where it lands

`saveMetadataIndexOnce` in the catalog loader logs a Warning on the branch where `metadataIndex.Save()` fails — `os.Create` on the cache file, so a full or read-only runner triggers it. Because that closure is a `sync.OnceFunc`, the panic escapes through `once.Do` and takes down the whole test binary rather than failing one test:

```
--- FAIL: TestWithVarsNuclei
panic: runtime error: invalid memory address or nil pointer dereference
  gologger.(*Logger).Log(0xc00084c1c0, ...)   gologger.go:56
  loader.New.func3()                          loader.go:196
  sync/oncefunc.go:33
FAIL github.com/projectdiscovery/nuclei/v3/lib/tests
```

The receiver `0xc00084c1c0` is **non-nil** — the nil is the formatter inside it. I misread that as a nil logger in my first analysis on #7613 and corrected it there.

### The fix

`defaultLogger()` does what gologger's own `init()` does for `DefaultLogger` — level, formatter and writer together — so raising the level afterwards is safe. Three added imports, one changed line, plus the helper.

I chose to fix the constructor rather than add nil guards at the call sites: `store.logger` is used at `loader.go` :196, :211, :393 and :397, and guarding each one leaves the same trap for the next call added.

### Verification

Reproduced the exact production sequence — `DefaultOptions()`, then the SDK's `SetMaxLevel`, then the loader's Warning:

```
without the fix:  RESULT: PANIC - invalid memory address or nil pointer dereference
with the fix:     [WRN] Could not save metadata cache: disk full
                  RESULT: logged cleanly, no panic
```

```
go build ./pkg/...                                    ok
go test ./pkg/types/... ./pkg/catalog/loader/...      ok
go test -race -run TestWithVarsNuclei ./lib/tests/    ok
go vet ./pkg/types/ · gofmt                           clean
```

**The added test fails without the fix**, and the way it fails is the useful part:

```
--- FAIL: TestDefaultOptionsLoggerSurvivesRaisedLevel/verbose
    logging at verbose panicked: runtime error: invalid memory address or nil pointer dereference
--- FAIL: TestDefaultOptionsLoggerSurvivesRaisedLevel/debug
    logging at debug panicked: ...
    (silent passes)
```

`silent` passing on the broken code is correct rather than a gap: `LevelSilent` (1) is still below `LevelWarning` (4), so the filter keeps hiding the bug there. That is exactly why this went unnoticed — the default CLI path never raises the level far enough.

### Scope

Two files. No behaviour change for anything that already supplies its own logger, since `DefaultOptions()` is only the fallback. The one visible difference is that SDK consumers who raise the level now get their warnings on stderr instead of a panic.

---

Found while investigating why `Tests (ubuntu-latest)` was red on #7603 and #7605 — two PRs of mine that share no files and both fail this test identically.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved default logging reliability across information, verbose, debug, and silent modes.
  * Prevented logging operations from causing errors when log-level settings are changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->