### PR TITLE
feat: evaluate DSL helpers in -H values per request

### DIFF
--- a/pkg/operators/common/dsl/dsl.go
+++ b/pkg/operators/common/dsl/dsl.go
@@ -10,6 +10,7 @@ import (
 	"github.com/projectdiscovery/govaluate"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/dns/dnsclientpool"
 	"github.com/projectdiscovery/nuclei/v3/pkg/types"
+	"github.com/projectdiscovery/useragent"
 	sliceutil "github.com/projectdiscovery/utils/slice"
 	stringsutil "github.com/projectdiscovery/utils/strings"
 )
@@ -112,6 +113,14 @@ func init() {
 			return defaultPort, nil
 		}
 		return port, nil
+	}))
+	// cacheable is false on purpose: a cached result would return the same
+	// user agent for the rest of the run, defeating the randomization.
+	_ = dsl.AddFunction(dsl.NewWithSingleSignature("rand_user_agent", "() string", false, func(args ...interface{}) (interface{}, error) {
+		if len(args) != 0 {
+			return nil, dsl.ErrInvalidDslFunction
+		}
+		return useragent.PickRandom().Raw, nil
 	}))
 
 	dsl.PrintDebugCallback = func(args ...interface{}) error {

--- a/pkg/operators/common/dsl/rand_user_agent_test.go
+++ b/pkg/operators/common/dsl/rand_user_agent_test.go
@@ -1,0 +1,33 @@
+package dsl
+
+import (
+	"testing"
+
+	"github.com/projectdiscovery/govaluate"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRandUserAgentIsNotCached guards the cacheable=false registration: a
+// cached helper would hand back one frozen user agent for the whole run.
+func TestRandUserAgentIsNotCached(t *testing.T) {
+	compiled, err := govaluate.NewEvaluableExpressionWithFunctions("rand_user_agent()", HelperFunctions)
+	require.NoError(t, err, "could not compile rand_user_agent()")
+
+	seen := make(map[string]struct{})
+	for i := 0; i < 50; i++ {
+		result, err := compiled.Evaluate(make(map[string]interface{}))
+		require.NoError(t, err, "could not evaluate rand_user_agent()")
+		require.NotEmpty(t, result, "rand_user_agent() returned an empty user agent")
+		seen[result.(string)] = struct{}{}
+	}
+
+	require.Greater(t, len(seen), 1, "rand_user_agent() returned a cached value")
+}
+
+func TestRandUserAgentRejectsArguments(t *testing.T) {
+	compiled, err := govaluate.NewEvaluableExpressionWithFunctions(`rand_user_agent("chrome")`, HelperFunctions)
+	require.NoError(t, err, "could not compile rand_user_agent() with an argument")
+
+	_, err = compiled.Evaluate(make(map[string]interface{}))
+	require.Error(t, err, "rand_user_agent() should reject arguments")
+}

--- a/pkg/protocols/http/build_request.go
+++ b/pkg/protocols/http/build_request.go
@@ -453,7 +453,11 @@ func (r *requestGenerator) generateRawRequest(ctx context.Context, rawRequest st
 		}
 
 		if len(r.options.Options.CustomHeaders) > 0 {
-			_ = rawRequestData.TryFillCustomHeaders(r.options.Options.CustomHeaders)
+			customHeaders := make([]string, 0, len(r.options.Options.CustomHeaders))
+			for _, header := range r.options.Options.CustomHeaders {
+				customHeaders = append(customHeaders, evaluateCustomHeaderExpressions(r.options.TemplateID, header, finalVars))
+			}
+			_ = rawRequestData.TryFillCustomHeaders(customHeaders)
 		}
 
 		if rawRequestData.Data != "" && !stringsutil.EqualFoldAny(rawRequestData.Method, http.MethodHead, http.MethodGet) && rawRequestData.Headers["Transfer-Encoding"] != "chunked" {

--- a/pkg/protocols/http/custom_headers_dsl_test.go
+++ b/pkg/protocols/http/custom_headers_dsl_test.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"context"
 	"net/http"
 	"strings"
 	"testing"
@@ -10,6 +11,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/internal/tests/testutils"
 	"github.com/projectdiscovery/nuclei/v3/pkg/model"
 	"github.com/projectdiscovery/nuclei/v3/pkg/model/types/severity"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/contextargs"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/marker"
 	"github.com/projectdiscovery/retryablehttp-go"
 )
@@ -69,22 +71,59 @@ func TestCustomHeaderWithoutExpressionIsUnchanged(t *testing.T) {
 	require.Equal(t, "abc", generateCustomHeader(t, request, "X-Scan-Id"))
 }
 
-// TestUnsafeRawCustomHeaderIsEvaluated covers the unsafe raw path, which
-// splices the -H line into the request bytes via TryFillCustomHeaders and so
-// never reaches setCustomHeaders. Without this the literal {{...}} marker would
-// go out on the wire.
+// TestUnsafeRawCustomHeaderIsEvaluated covers the unsafe raw path, which splices
+// the -H line into UnsafeRawBytes via TryFillCustomHeaders and so never takes
+// the header from setCustomHeaders. It drives real request generation and reads
+// the resulting wire bytes, otherwise it would not guard that wiring.
 func TestUnsafeRawCustomHeaderIsEvaluated(t *testing.T) {
+	options := testutils.DefaultOptions
+	options.CustomHeaders = []string{"User-Agent: {{rand_user_agent()}} myprop/value"}
+	testutils.Init(options)
+
+	templateID := "testing-unsafe-raw-header"
+	request := &Request{
+		ID:     templateID,
+		Name:   "testing",
+		Unsafe: true,
+		Raw:    []string{"GET /unsafe HTTP/1.1\nHost: {{Hostname}}\n\n"},
+	}
+	executerOpts := testutils.NewMockExecuterOptions(options, &testutils.TemplateInfo{
+		ID:   templateID,
+		Info: model.Info{SeverityHolder: severity.Holder{Severity: severity.Low}, Name: "test"},
+	})
+	require.Nil(t, request.Compile(executerOpts), "could not compile http request")
+
 	seen := make(map[string]struct{})
 	for i := 0; i < 20; i++ {
-		value := evaluateCustomHeaderExpressions("testing-unsafe-raw",
-			"User-Agent: {{rand_user_agent()}} myprop/value", map[string]interface{}{})
-		require.True(t, strings.HasPrefix(value, "User-Agent: "), "header name was mangled")
-		require.NotContains(t, value, marker.ParenthesisOpen, "expression was left unevaluated")
-		require.Contains(t, value, "myprop/value", "tag was dropped")
-		seen[value] = struct{}{}
+		generator := request.newGenerator(false)
+		inputData, payloads, ok := generator.nextValue()
+		require.True(t, ok, "could not get next value from generator")
+
+		req, err := generator.Make(context.Background(),
+			contextargs.NewWithInput(context.Background(), "https://example.com"),
+			inputData, payloads, map[string]interface{}{})
+		require.Nil(t, err, "could not make http request")
+		require.NotNil(t, req.rawRequest, "expected an unsafe raw request")
+
+		wire := string(req.rawRequest.UnsafeRawBytes)
+		require.NotContains(t, wire, marker.ParenthesisOpen+"rand_user_agent", "expression reached the wire unevaluated")
+		require.Contains(t, wire, "myprop/value", "tag was dropped from the wire bytes")
+
+		userAgent, found := rawUserAgentLine(wire)
+		require.True(t, found, "no User-Agent header in the wire bytes")
+		seen[userAgent] = struct{}{}
 	}
 
 	require.Greater(t, len(seen), 1, "user agent was frozen instead of evaluated per request")
+}
+
+func rawUserAgentLine(wire string) (string, bool) {
+	for _, line := range strings.Split(wire, "\r\n") {
+		if after, ok := strings.CutPrefix(line, "User-Agent: "); ok {
+			return after, true
+		}
+	}
+	return "", false
 }
 
 // TestCustomHeaderWithBrokenExpressionKeepsOriginal keeps a typo in -H from

--- a/pkg/protocols/http/custom_headers_dsl_test.go
+++ b/pkg/protocols/http/custom_headers_dsl_test.go
@@ -1,0 +1,78 @@
+package http
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/projectdiscovery/nuclei/v3/internal/tests/testutils"
+	"github.com/projectdiscovery/nuclei/v3/pkg/model"
+	"github.com/projectdiscovery/nuclei/v3/pkg/model/types/severity"
+	"github.com/projectdiscovery/retryablehttp-go"
+)
+
+func newCustomHeaderTestRequest(t *testing.T, headers map[string]string) *Request {
+	t.Helper()
+
+	options := testutils.DefaultOptions
+	testutils.Init(options)
+
+	return &Request{
+		customHeaders: headers,
+		options: testutils.NewMockExecuterOptions(options, &testutils.TemplateInfo{
+			ID:   "testing-custom-header-dsl",
+			Info: model.Info{SeverityHolder: severity.Holder{Severity: severity.Low}, Name: "test"},
+		}),
+	}
+}
+
+func generateCustomHeader(t *testing.T, request *Request, header string) string {
+	t.Helper()
+
+	req, err := retryablehttp.NewRequest(http.MethodGet, "https://example.com", nil)
+	require.Nil(t, err, "could not create request")
+
+	request.setCustomHeaders(&generatedRequest{request: req})
+
+	return req.Header.Get(header)
+}
+
+// TestCustomHeaderDSLEvaluatedPerRequest is the whole point of the feature: a
+// -H value carrying rand_user_agent() must resolve again on every generated
+// request, so the UA keeps rotating while the operator's tag stays attached.
+func TestCustomHeaderDSLEvaluatedPerRequest(t *testing.T) {
+	request := newCustomHeaderTestRequest(t, map[string]string{
+		"User-Agent": "{{rand_user_agent()}} myprop/value",
+	})
+
+	seen := make(map[string]struct{})
+	for i := 0; i < 20; i++ {
+		value := generateCustomHeader(t, request, "User-Agent")
+		require.Contains(t, value, "myprop/value", "tag was dropped from the user agent")
+		require.NotEqual(t, "{{rand_user_agent()}} myprop/value", value, "expression was not evaluated")
+		seen[value] = struct{}{}
+	}
+
+	require.Greater(t, len(seen), 1, "user agent was frozen instead of evaluated per request")
+}
+
+func TestCustomHeaderWithoutExpressionIsUnchanged(t *testing.T) {
+	request := newCustomHeaderTestRequest(t, map[string]string{
+		"User-Agent": "myprop/value",
+		"X-Scan-Id":  "abc",
+	})
+
+	require.Equal(t, "myprop/value", generateCustomHeader(t, request, "User-Agent"))
+	require.Equal(t, "abc", generateCustomHeader(t, request, "X-Scan-Id"))
+}
+
+// TestCustomHeaderWithBrokenExpressionKeepsOriginal keeps a typo in -H from
+// killing the scan: the raw value goes out and the error is only logged.
+func TestCustomHeaderWithBrokenExpressionKeepsOriginal(t *testing.T) {
+	request := newCustomHeaderTestRequest(t, map[string]string{
+		"User-Agent": "{{no_such_helper()}} myprop",
+	})
+
+	require.Equal(t, "{{no_such_helper()}} myprop", generateCustomHeader(t, request, "User-Agent"))
+}

--- a/pkg/protocols/http/custom_headers_dsl_test.go
+++ b/pkg/protocols/http/custom_headers_dsl_test.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -9,6 +10,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/internal/tests/testutils"
 	"github.com/projectdiscovery/nuclei/v3/pkg/model"
 	"github.com/projectdiscovery/nuclei/v3/pkg/model/types/severity"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/marker"
 	"github.com/projectdiscovery/retryablehttp-go"
 )
 
@@ -65,6 +67,24 @@ func TestCustomHeaderWithoutExpressionIsUnchanged(t *testing.T) {
 
 	require.Equal(t, "myprop/value", generateCustomHeader(t, request, "User-Agent"))
 	require.Equal(t, "abc", generateCustomHeader(t, request, "X-Scan-Id"))
+}
+
+// TestUnsafeRawCustomHeaderIsEvaluated covers the unsafe raw path, which
+// splices the -H line into the request bytes via TryFillCustomHeaders and so
+// never reaches setCustomHeaders. Without this the literal {{...}} marker would
+// go out on the wire.
+func TestUnsafeRawCustomHeaderIsEvaluated(t *testing.T) {
+	seen := make(map[string]struct{})
+	for i := 0; i < 20; i++ {
+		value := evaluateCustomHeaderExpressions("testing-unsafe-raw",
+			"User-Agent: {{rand_user_agent()}} myprop/value", map[string]interface{}{})
+		require.True(t, strings.HasPrefix(value, "User-Agent: "), "header name was mangled")
+		require.NotContains(t, value, marker.ParenthesisOpen, "expression was left unevaluated")
+		require.Contains(t, value, "myprop/value", "tag was dropped")
+		seen[value] = struct{}{}
+	}
+
+	require.Greater(t, len(seen), 1, "user agent was frozen instead of evaluated per request")
 }
 
 // TestCustomHeaderWithBrokenExpressionKeepsOriginal keeps a typo in -H from

--- a/pkg/protocols/http/request.go
+++ b/pkg/protocols/http/request.go
@@ -1323,13 +1323,20 @@ func (request *Request) setCustomHeaders(req *generatedRequest) {
 // compile time. A bad expression degrades the header instead of failing the
 // scan.
 func (request *Request) evaluateCustomHeaderValue(req *generatedRequest, value string) string {
+	values := generators.MergeMaps(req.dynamicValues, req.meta)
+	return evaluateCustomHeaderExpressions(request.options.TemplateID, value, values)
+}
+
+// evaluateCustomHeaderExpressions resolves helper expressions in a global custom
+// header string. Unsafe raw requests splice the -H line straight into the
+// request bytes, so they resolve it here instead of in setCustomHeaders.
+func evaluateCustomHeaderExpressions(templateID, value string, values map[string]interface{}) string {
 	if !strings.Contains(value, marker.ParenthesisOpen) {
 		return value
 	}
-	values := generators.MergeMaps(req.dynamicValues, req.meta)
 	evaluated, err := expressions.Evaluate(value, values)
 	if err != nil {
-		gologger.Debug().Msgf("[%s] could not evaluate custom header value %q: %s", request.options.TemplateID, value, err)
+		gologger.Debug().Msgf("[%s] could not evaluate custom header value %q: %s", templateID, value, err)
 		return value
 	}
 	return evaluated

--- a/pkg/protocols/http/request.go
+++ b/pkg/protocols/http/request.go
@@ -32,6 +32,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/helpers/eventcreator"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/helpers/responsehighlighter"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/interactsh"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/marker"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/http/httpclientpool"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/http/httputils"
@@ -1298,6 +1299,7 @@ func (request *Request) handleSignature(generatedRequest *generatedRequest) erro
 // setCustomHeaders sets the custom headers for generated request
 func (request *Request) setCustomHeaders(req *generatedRequest) {
 	for k, v := range request.customHeaders {
+		v = request.evaluateCustomHeaderValue(req, v)
 		if req.rawRequest != nil {
 			req.rawRequest.Headers[k] = v
 		} else {
@@ -1313,6 +1315,24 @@ func (request *Request) setCustomHeaders(req *generatedRequest) {
 			req.request.Header[kk] = []string{vv}
 		}
 	}
+}
+
+// evaluateCustomHeaderValue resolves helper expressions inside a global custom
+// header value. It runs once per generated request, so helpers such as
+// rand_user_agent() yield a fresh value per request instead of being frozen at
+// compile time. A bad expression degrades the header instead of failing the
+// scan.
+func (request *Request) evaluateCustomHeaderValue(req *generatedRequest, value string) string {
+	if !strings.Contains(value, marker.ParenthesisOpen) {
+		return value
+	}
+	values := generators.MergeMaps(req.dynamicValues, req.meta)
+	evaluated, err := expressions.Evaluate(value, values)
+	if err != nil {
+		gologger.Debug().Msgf("[%s] could not evaluate custom header value %q: %s", request.options.TemplateID, value, err)
+		return value
+	}
+	return evaluated
 }
 
 const CRLF = "\r\n"


### PR DESCRIPTION
Closes #7617

### What

1. `rand_user_agent()` DSL helper, backed by `projectdiscovery/useragent` (already a direct dependency, already used for UA randomization). Registered with `cacheable=false`, since a cached result would freeze the UA for the whole run.
2. `setCustomHeaders` now resolves `{{...}}` in global header values. It already runs once per generated request, so this gives per-request evaluation with no new plumbing.

33 lines of non-test code across 2 files.

### Why this shape

Implements @dwisiswant0's suggestion from #7446 rather than the `-ua-tag` flag from #7445 (closed). No new CLI flag, no new dependency.

Note that `{{rand_ua}}` as written in #7446 does not exist yet: nuclei wires only `dsl.HelperFunctions()`, and the faker generators from projectdiscovery/dsl#234 sit in a separate `dsl.FakerFunctions()` that nuclei never merges. Hence piece 1. If you would rather merge `FakerFunctions()` wholesale, I will swap it.

### Behaviour

- Values with no `{{` skip evaluation entirely, so the common path is unaffected
- Compile or evaluation errors keep the original value and log at debug, so a typo degrades one header instead of failing the scan
- Values come from the operator's own `-H` flag or config file, the same trust boundary as a template. Response data is not evaluated on this path.
- Both request paths are covered. Unsafe raw requests take their headers from `UnsafeRawBytes` via
  `TryFillCustomHeaders` rather than from `setCustomHeaders`, so they are evaluated at the splice
  point instead; both paths share one evaluation helper so they cannot drift

### Verification

Unit tests cover per-request rotation, tag retention, no-expression passthrough, broken-expression fallback, the non-cached helper, and argument rejection.

Live run, 4 requests against a local server with `-H "User-Agent: {{rand_user_agent()}} myprop/value"`:

```
Mozilla/5.0 (X11; Linux i686; rv:1.9.5.20) Gecko/ Firefox/3.6.20 myprop/value
Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_1) AppleWebKit/604.3.5 (KHTML, like Gecko) Version/11.0.1 Safari/604.3.5 myprop/value
Mozilla/5.0 (Knoppix; Linux i686) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.36 myprop/value
Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_6; en-en) AppleWebKit/533.19.4 (KHTML, like Gecko) Version/5.0.3 Safari/533.19.4 myprop/value
```

Four distinct UAs, tag on each.

`go build ./...`, `go vet`, and `go test ./pkg/protocols/http/...` pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `rand_user_agent()` helper for generating random user-agent values in expressions.
  * Custom HTTP header values can now include dynamic expressions evaluated separately for each request.
* **Bug Fixes**
  * Header values safely retain their original content when expression evaluation fails.
  * Dynamic expressions now work for unsafe raw HTTP requests.
* **Tests**
  * Added coverage for randomization, argument validation, and per-request header evaluation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
