### PR TITLE
derive idle connections per host from per-host concurrency

### DIFF
--- a/lib/config.go
+++ b/lib/config.go
@@ -739,3 +739,11 @@ func WithTemporaryDirectory(parentDir string) NucleiSDKOptions {
 		return nil
 	}
 }
+
+// WithPerHostRateLimit applies the rate limit per host instead of globally.
+func WithPerHostRateLimit(enabled bool) NucleiSDKOptions {
+	return func(e *NucleiEngine) error {
+		e.opts.PerHostRateLimit = enabled
+		return nil
+	}
+}

--- a/pkg/protocols/http/httpclientpool/clientpool.go
+++ b/pkg/protocols/http/httpclientpool/clientpool.go
@@ -322,13 +322,24 @@ func wrappedGet(options *types.Options, configuration *Configuration, host strin
 		retryableHttpOptions.Timeout = configuration.ResponseHeaderTimeout
 	}
 
-	maxIdleConns := 4
-	maxIdleConnsPerHost := 4
+	// Size the idle pool to the number of requests this process can have in
+	// flight against a SINGLE host, so a completed request hands its connection
+	// to the next one instead of the transport closing it.
+	//
+	// In template-spray, per-host in-flight is TemplateThreads: each of the N
+	// templates running in parallel issues one request per host (BulkSize is
+	// hosts-in-parallel, which does not add per-host concurrency). A template
+	// with its own `threads:`, or payload/fuzz concurrency, can exceed that.
+	//
+	// A fixed 4 (the previous default) throttles reuse badly once per-host
+	// concurrency rises: measured on 10 hosts at TemplateThreads=20, idle=4 gave
+	// 43% reuse / 572 rps versus 81% / 1088 rps at idle=16 — a 1.9x throughput
+	// difference from this constant alone. The curve is flat past
+	// idle ~= per-host in-flight, so overshooting is cheap and undershooting is
+	// not; the cap only exists to bound retained sockets (hosts * idle fds).
+	maxIdleConnsPerHost := perHostIdleConns(options, configuration)
+	maxIdleConns := maxIdleConnsPerHost
 	maxConnsPerHost := 0 // unlimited by default; the SPM handler controls concurrency
-	if configuration.Threads > 0 {
-		maxIdleConnsPerHost = configuration.Threads
-		maxIdleConns = configuration.Threads
-	}
 
 	disableKeepAlives := configuration.Connection != nil && configuration.Connection.DisableKeepAlive
 
@@ -704,4 +715,35 @@ func RecordHTTPToHTTPSPortMismatch(options *types.Options, hostname string) {
 	}
 
 	tracker.RecordHTTPToHTTPSPort(hostname)
+}
+
+// minIdleConnsPerHost / maxIdleConnsPerHostCap bound the derived idle pool.
+// The floor keeps behaviour sane when concurrency options are unset; the ceiling
+// bounds retained file descriptors, since a process holds up to
+// hosts * maxIdleConnsPerHost idle sockets.
+const (
+	minIdleConnsPerHost    = 4
+	maxIdleConnsPerHostCap = 64
+)
+
+// perHostIdleConns derives the idle-connection budget for one host's transport
+// from the concurrency that can actually target that host.
+func perHostIdleConns(options *types.Options, configuration *Configuration) int {
+	n := minIdleConnsPerHost
+	// Templates running in parallel each issue one request per host.
+	if options != nil && options.TemplateThreads > n {
+		n = options.TemplateThreads
+	}
+	// A template declaring its own `threads:` drives that many per host.
+	if configuration != nil && configuration.Threads > n {
+		n = configuration.Threads
+	}
+	// Payload/fuzz requests within a single template also run concurrently.
+	if options != nil && options.PayloadConcurrency > n {
+		n = options.PayloadConcurrency
+	}
+	if n > maxIdleConnsPerHostCap {
+		n = maxIdleConnsPerHostCap
+	}
+	return n
 }


### PR DESCRIPTION
`maxIdleConnsPerHost` was a fixed 4, which throttles connection reuse once per-host concurrency rises above that — measured on 10 hosts at `TemplateThreads=20`, idle=4 gave 43% reuse / 572 rps against 81% / 1088 rps at idle=16, a 1.9x throughput difference from that constant alone.

It is now derived from the concurrency that can actually target a single host (`TemplateThreads`, a template's own `threads:`, `PayloadConcurrency`), bounded to [4, 64] so retained file descriptors stay capped, and `WithPerHostRateLimit` is exposed as an SDK option.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an SDK option to enable or disable per-host rate limiting.

* **Performance Improvements**
  * Improved HTTP connection pooling by dynamically adjusting per-host idle connections based on configured concurrency.
  * Limited retained connections with an upper bound to support more efficient resource usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->