### PR TITLE
fix: add timeout to network connectivity checks in healthcheck

### DIFF
--- a/internal/runner/healthcheck.go
+++ b/internal/runner/healthcheck.go
@@ -1,15 +1,19 @@
 package runner
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/config"
 	"github.com/projectdiscovery/nuclei/v3/pkg/types"
 	fileutil "github.com/projectdiscovery/utils/file"
 )
+
+const defaultNetworkTimeout = 5 * time.Second
 
 // DoHealthCheck performs self-diagnostic checks
 func DoHealthCheck(options *types.Options) string {
@@ -46,7 +50,11 @@ func DoHealthCheck(options *types.Options) string {
 		}
 		fmt.Fprintf(&test, "File \"%s\" Write => %s\n", filename, testResult)
 	}
-	c4, err := net.Dial("tcp4", "scanme.sh:80")
+	ctx, cancel := context.WithTimeout(context.Background(), defaultNetworkTimeout)
+	defer cancel()
+
+	var d net.Dialer
+	c4, err := d.DialContext(ctx, "tcp4", "scanme.sh:80")
 	if err == nil && c4 != nil {
 		_ = c4.Close()
 	}
@@ -55,7 +63,10 @@ func DoHealthCheck(options *types.Options) string {
 		testResult = fmt.Sprintf("Ko (%s)", err)
 	}
 	fmt.Fprintf(&test, "IPv4 connectivity to scanme.sh:80 => %s\n", testResult)
-	c6, err := net.Dial("tcp6", "scanme.sh:80")
+
+	ctx2, cancel2 := context.WithTimeout(context.Background(), defaultNetworkTimeout)
+	defer cancel2()
+	c6, err := d.DialContext(ctx2, "tcp6", "scanme.sh:80")
 	if err == nil && c6 != nil {
 		_ = c6.Close()
 	}
@@ -64,7 +75,10 @@ func DoHealthCheck(options *types.Options) string {
 		testResult = fmt.Sprintf("Ko (%s)", err)
 	}
 	fmt.Fprintf(&test, "IPv6 connectivity to scanme.sh:80 => %s\n", testResult)
-	u4, err := net.Dial("udp4", "scanme.sh:53")
+
+	ctx3, cancel3 := context.WithTimeout(context.Background(), defaultNetworkTimeout)
+	defer cancel3()
+	u4, err := d.DialContext(ctx3, "udp4", "scanme.sh:53")
 	if err == nil && u4 != nil {
 		_ = u4.Close()
 	}


### PR DESCRIPTION
## Description
This PR adds a 5-second timeout to the network connectivity checks in the healthcheck functionality to prevent the healthcheck from hanging indefinitely when network issues occur.

## Changes
- Added \context.WithTimeout\ to TCP/UDP network dial operations
- Prevents healthcheck from blocking indefinitely on network connectivity issues
- Uses proper context cancellation for resource cleanup

## Testing
- Verified that healthcheck completes within timeout period even when network is unreachable
- Ensures proper error reporting when connectivity checks fail

This change improves the reliability of the healthcheck feature, especially in environments with intermittent network connectivity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a five-second timeout to network health checks.
  * Health checks now prevent stalled connections across TCP and UDP protocols.
  * Existing connectivity reporting remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->