### PR TITLE
fix(raw): preserve abs targets in unsafe requests

### DIFF
--- a/pkg/protocols/http/build_request_test.go
+++ b/pkg/protocols/http/build_request_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -198,6 +199,41 @@ Host: {{Hostname}}`},
 	require.Nil(t, parseErr, "could not parse generated unsafe request URL")
 	require.Equal(t, "honey.scanme.sh", parsedURL.Host, "host should be overridden by @Host annotation in unsafe mode")
 	require.Equal(t, "http", parsedURL.Scheme, "scheme should inherit from input when annotation host has no scheme")
+}
+
+func TestUnsafeRawRequestPreservesAbsoluteRequestTarget(t *testing.T) {
+	options := testutils.DefaultOptions
+
+	testutils.Init(options)
+	const requestLine = "GET http://intranet/foo?request=1 HTTP/1.1"
+	request := &Request{
+		ID:     "testing-http-unsafe-absolute-request-target",
+		Name:   "testing",
+		Unsafe: true,
+		Raw: []string{requestLine + `
+Host: {{Hostname}}`},
+	}
+	executerOpts := testutils.NewMockExecuterOptions(options, &testutils.TemplateInfo{
+		ID:   request.ID,
+		Info: model.Info{SeverityHolder: severity.Holder{Severity: severity.Low}, Name: "test"},
+	})
+	require.NoError(t, request.Compile(executerOpts), "could not compile unsafe raw request")
+
+	generator := request.newGenerator(false)
+	inputData, payloads, _ := generator.nextValue()
+	generated, err := generator.Make(context.Background(), contextargs.NewWithInput(context.Background(), "http://example.com/bar?input=1"), inputData, payloads, map[string]interface{}{})
+	require.NoError(t, err, "could not make unsafe raw request")
+	generatedURL, err := urlutil.ParseAbsoluteURL(generated.URL(), true)
+	require.NoError(t, err, "could not parse generated request URL")
+	require.Equal(t, "example.com", generatedURL.Host, "absolute request target must not override the scan target")
+	require.Equal(t, "/foo", generatedURL.Path, "absolute request target path must not merge with the scan target path")
+	require.Equal(t, "1", generatedURL.Params.Get("request"), "generated URL must include the absolute request target query")
+	require.Empty(t, generatedURL.Params.Get("input"), "generated URL must not include the scan target query")
+
+	requestBytes, err := dump(generated, generated.URL())
+	require.NoError(t, err, "could not dump unsafe raw request")
+	actualRequestLine := strings.TrimSuffix(strings.SplitN(string(requestBytes), "\n", 2)[0], "\r")
+	require.Equal(t, requestLine, actualRequestLine, "unsafe raw request line must remain unchanged")
 }
 
 func TestMakeRequestFromModelUniqueInteractsh(t *testing.T) {

--- a/pkg/protocols/http/raw/raw.go
+++ b/pkg/protocols/http/raw/raw.go
@@ -39,22 +39,39 @@ func Parse(request string, inputURL *urlutil.URL, unsafe, disablePathAutomerge b
 	}
 
 	// handle full URLs first (before checking unsafe flag) to extract relative path
-	if strings.HasPrefix(rawrequest.Path, "http://") || strings.HasPrefix(rawrequest.Path, "https://") {
-		urlx, err := urlutil.ParseURL(rawrequest.Path, true)
+	lowerPath := strings.ToLower(rawrequest.Path)
+	hasAbsoluteRequestTarget := strings.HasPrefix(lowerPath, "http://") || strings.HasPrefix(lowerPath, "https://")
+	if hasAbsoluteRequestTarget {
+		var requestTarget string
+		if strings.HasPrefix(lowerPath, "http://") {
+			requestTarget = "http://" + rawrequest.Path[len("http://"):]
+		} else {
+			requestTarget = "https://" + rawrequest.Path[len("https://"):]
+		}
+
+		urlx, err := urlutil.ParseAbsoluteURL(requestTarget, true)
 		if err != nil {
 			return nil, errkit.Wrapf(err, "failed to parse url %v from template", rawrequest.Path)
 		}
-		prevPath := rawrequest.Path
 		relPath := urlx.GetRelativePath()
-
-		// NOTE(dwisiswant0): Use rel path instead if unsafe.
-		// See https://github.com/projectdiscovery/nuclei/issues/6558.
-		if unsafe {
-			rawrequest.UnsafeRawBytes = bytes.Replace(rawrequest.UnsafeRawBytes, []byte(prevPath), []byte(relPath), 1)
-		}
 
 		// rotate full URL with rel path
 		rawrequest.Path = relPath
+		if unsafe {
+			cloned := inputURL.Clone()
+			cloned.Path = ""
+			cloned.Fragment = ""
+			cloned.Params = urlutil.NewOrderedParams()
+			cloned.Params.IncludeEquals = true
+
+			if err := cloned.MergePath(relPath, true); err != nil {
+				return nil, errkit.Wrapf(err, "failed to build request url for absolute target %v", requestTarget)
+			}
+
+			rawrequest.FullURL = cloned.String()
+
+			return rawrequest, nil
+		}
 	}
 
 	switch {

--- a/pkg/protocols/http/raw/raw_test.go
+++ b/pkg/protocols/http/raw/raw_test.go
@@ -297,6 +297,13 @@ Connection: close`, parseURL(t, "http://httpbin.org/bar"), true, true)
 	require.Contains(t, string(request.UnsafeRawBytes), "GET http://127.0.0.1/foo HTTP/1.1", "unsafe request line must preserve the full URL")
 }
 
+func TestUnsafeWithFullURLWithoutPath(t *testing.T) {
+	const requestLine = "GET http://127.0.0.1:22 HTTP/1.1"
+	request, err := Parse(requestLine+"\nHost: {{Hostname}}", parseURL(t, "http://httpbin.org"), true, false)
+	require.NoError(t, err, "could not parse unsafe request with a pathless full URL")
+	require.Contains(t, string(request.UnsafeRawBytes), requestLine, "unsafe request line must preserve the pathless full URL")
+}
+
 func TestUnsafeWithFullURLIgnoresInputPath(t *testing.T) {
 	// The absolute request target supplies the path in unsafe mode.
 	request, err := Parse(`GET http://127.0.0.1/foo HTTP/1.1

--- a/pkg/protocols/http/raw/raw_test.go
+++ b/pkg/protocols/http/raw/raw_test.go
@@ -287,69 +287,74 @@ func TestDisableMergePath(t *testing.T) {
 }
 
 func TestUnsafeWithFullURL(t *testing.T) {
-	// Test unsafe mode with full URL - should extract relative path
+	// The relative path is used internally, but unsafe raw bytes remain unchanged.
 	request, err := Parse(`GET http://127.0.0.1/foo HTTP/1.1
 Host: {{Hostname}}
 User-Agent: Mozilla/5.0
 Connection: close`, parseURL(t, "http://httpbin.org/bar"), true, true)
 	require.Nil(t, err, "could not parse unsafe request with full URL")
 	require.Equal(t, "/foo", request.Path, "Could not extract relative path from full URL in unsafe mode")
-	require.Contains(t, string(request.UnsafeRawBytes), "GET /foo HTTP/1.1", "UnsafeRawBytes should contain relative path, not full URL")
-	require.NotContains(t, string(request.UnsafeRawBytes), "http://127.0.0.1", "UnsafeRawBytes should not contain full URL")
+	require.Contains(t, string(request.UnsafeRawBytes), "GET http://127.0.0.1/foo HTTP/1.1", "unsafe request line must preserve the full URL")
 }
 
-func TestUnsafeWithFullURLAndPath(t *testing.T) {
-	// Test unsafe mode with full URL and target URL that has a path
+func TestUnsafeWithFullURLIgnoresInputPath(t *testing.T) {
+	// The absolute request target supplies the path in unsafe mode.
 	request, err := Parse(`GET http://127.0.0.1/foo HTTP/1.1
 Host: {{Hostname}}
 User-Agent: Mozilla/5.0
 Connection: close`, parseURL(t, "http://httpbin.org/bar"), true, false)
-	require.Nil(t, err, "could not parse unsafe request with full URL and path merge")
-	require.Equal(t, "/bar/foo", request.Path, "Could not merge path correctly from full URL in unsafe mode")
-	require.Contains(t, string(request.UnsafeRawBytes), "GET /bar/foo HTTP/1.1", "UnsafeRawBytes should contain merged relative path")
-	require.NotContains(t, string(request.UnsafeRawBytes), "http://127.0.0.1", "UnsafeRawBytes should not contain full URL")
+	require.Nil(t, err, "could not parse unsafe request with a full URL and input path")
+	require.Equal(t, "/foo", request.Path, "input path must not merge with an absolute request target")
+	require.Contains(t, string(request.UnsafeRawBytes), "GET http://127.0.0.1/foo HTTP/1.1", "unsafe request line must preserve the full URL")
+}
+
+func TestUnsafeWithMixedCaseFullURL(t *testing.T) {
+	request, err := Parse(`GET hTtP://127.0.0.1/foo HTTP/1.1
+Host: {{Hostname}}
+Connection: close`, parseURL(t, "http://httpbin.org/bar"), true, false)
+	require.NoError(t, err, "could not parse unsafe request with a mixed-case full URL")
+	require.Equal(t, "/foo", request.Path, "could not extract the relative path from a mixed-case full URL")
+	require.Contains(t, string(request.UnsafeRawBytes), "GET hTtP://127.0.0.1/foo HTTP/1.1", "unsafe request line must preserve the mixed-case full URL")
 }
 
 func TestUnsafeWithFullURLAndQueryParams(t *testing.T) {
-	// Test unsafe mode with full URL containing query parameters
+	// Query parameters are available internally without changing unsafe raw bytes.
 	request, err := Parse(`GET http://127.0.0.1/foo?id=123&name=test HTTP/1.1
 Host: {{Hostname}}
 User-Agent: Mozilla/5.0
 Connection: close`, parseURL(t, "http://httpbin.org/bar"), true, true)
 	require.Nil(t, err, "could not parse unsafe request with full URL and query params")
 	require.Equal(t, "/foo?id=123&name=test", request.Path, "Could not extract relative path with query params from full URL in unsafe mode")
-	require.Contains(t, string(request.UnsafeRawBytes), "GET /foo?id=123&name=test HTTP/1.1", "UnsafeRawBytes should contain relative path with query params")
-	require.NotContains(t, string(request.UnsafeRawBytes), "http://127.0.0.1", "UnsafeRawBytes should not contain full URL")
+	require.Contains(t, string(request.UnsafeRawBytes), "GET http://127.0.0.1/foo?id=123&name=test HTTP/1.1", "unsafe request line must preserve the full URL")
 }
 
 func TestUnsafeWithHTTPSFullURL(t *testing.T) {
-	// Test unsafe mode with HTTPS full URL
+	// HTTPS absolute request targets follow the same raw-byte rule.
 	request, err := Parse(`GET https://secure.example.com/api/v1/users HTTP/1.1
 Host: {{Hostname}}
 Authorization: Bearer token123
 Connection: close`, parseURL(t, "https://target.com/test"), true, true)
 	require.Nil(t, err, "could not parse unsafe request with HTTPS full URL")
 	require.Equal(t, "/api/v1/users", request.Path, "Could not extract relative path from HTTPS full URL in unsafe mode")
-	require.Contains(t, string(request.UnsafeRawBytes), "GET /api/v1/users HTTP/1.1", "UnsafeRawBytes should contain relative path")
-	require.NotContains(t, string(request.UnsafeRawBytes), "https://secure.example.com", "UnsafeRawBytes should not contain full URL")
+	require.Contains(t, string(request.UnsafeRawBytes), "GET https://secure.example.com/api/v1/users HTTP/1.1", "unsafe request line must preserve the full URL")
 }
 
 func TestUnsafeWithFullURLRootPath(t *testing.T) {
-	// Test unsafe mode with full URL pointing to root path
-	// When disable-path-automerge is true and path is /, it becomes empty string (expected behavior)
+	// Test unsafe mode with full URL pointing to root path.
 	request, err := Parse(`GET http://example.com/ HTTP/1.1
 Host: {{Hostname}}
 Connection: close`, parseURL(t, "http://target.com/api"), true, true)
 	require.Nil(t, err, "could not parse unsafe request with full URL root path")
-	// With disable-path-automerge=true and root path, it becomes empty per existing logic
-	require.Equal(t, "", request.Path, "Root path with disable-path-automerge should be empty")
+	require.Equal(t, "/", request.Path, "absolute root path must remain unchanged when path automerge is disabled")
+	require.Contains(t, string(request.UnsafeRawBytes), "GET http://example.com/ HTTP/1.1", "unsafe request line must preserve the full URL")
 
-	// Test with disable-path-automerge=false
+	// Test with disable-path-automerge=false.
 	request, err = Parse(`GET http://example.com/ HTTP/1.1
 Host: {{Hostname}}
 Connection: close`, parseURL(t, "http://target.com/api"), true, false)
-	require.Nil(t, err, "could not parse unsafe request with full URL root path and merge")
-	require.Equal(t, "/api", request.Path, "Should merge with target path when automerge enabled")
+	require.Nil(t, err, "could not parse unsafe request with a full URL root path and path automerge enabled")
+	require.Equal(t, "/", request.Path, "absolute root path must remain unchanged when path automerge is enabled")
+	require.Contains(t, string(request.UnsafeRawBytes), "GET http://example.com/ HTTP/1.1", "unsafe request line must preserve the full URL")
 }
 
 func TestSafeWithFullURL(t *testing.T) {
@@ -360,6 +365,15 @@ Connection: close`, parseURL(t, "http://target.com/v1"), false, true)
 	require.Nil(t, err, "could not parse safe request with full URL")
 	require.Equal(t, "/api/users", request.Path, "Could not extract path from full URL in safe mode")
 	require.Equal(t, "http://target.com/api/users", request.FullURL, "Could not build correct FullURL in safe mode")
+}
+
+func TestSafeWithSingleLabelFullURL(t *testing.T) {
+	request, err := Parse(`GET http://intranet/foo HTTP/1.1
+Host: {{Hostname}}
+Connection: close`, parseURL(t, "http://target.com/bar"), false, true)
+	require.NoError(t, err, "could not parse safe request with a single-label full URL")
+	require.Equal(t, "/foo", request.Path, "could not extract the path from a single-label full URL")
+	require.Equal(t, "http://target.com/foo", request.FullURL, "single-label request target host must not replace the scan target")
 }
 
 func parseURL(t *testing.T, inputurl string) *urlutil.URL {


### PR DESCRIPTION
## Proposed changes

Keep absolute request targets unchanged on the
wire. Derive the effective URL from the scan
target authority and the raw target path and query,
without merging the input path or query. Also
handle mixed-case schemes and single-label hosts.

Fixes #7382
Fixes #7649

### Proof

<!-- How has this been tested? Please describe the tests that you ran to verify your changes. -->

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of raw HTTP requests that use absolute URLs.
  * Preserved the original request target, including its path and query, while correctly applying the scan target’s host.
  * Added support for mixed-case URL schemes, HTTPS targets, root paths, and single-label hosts.
  * Prevented input URL paths from incorrectly overriding absolute request targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->