### PR TITLE
fix(http): avoid proxy stalls from keep-alive reuse

### DIFF
--- a/pkg/protocols/http/http.go
+++ b/pkg/protocols/http/http.go
@@ -23,6 +23,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/http/httpclientpool"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/network/networkclientpool"
+	"github.com/projectdiscovery/nuclei/v3/pkg/types/scanstrategy"
 	"github.com/projectdiscovery/nuclei/v3/pkg/utils/json"
 	"github.com/projectdiscovery/nuclei/v3/pkg/utils/stats"
 	"github.com/projectdiscovery/rawhttp"
@@ -558,6 +559,11 @@ func (request *Request) Compile(options *protocols.ExecutorOptions) error {
 			request.Threads = options.GetThreadsForNPayloadRequests(request.Requests(), request.Threads)
 		}
 	}
+
+	// Avoid reusing client-side HTTP proxy connections for the legacy non-threaded spray path.
+	if shouldDisableKeepAliveForHTTPProxy(request, options) {
+		request.connConfiguration.Connection.DisableKeepAlive = true
+	}
 	return nil
 }
 
@@ -605,6 +611,15 @@ func (r *Request) UpdateOptions(opts *protocols.ExecutorOptions) {
 // HasFuzzing indicates whether the request has fuzzing rules defined.
 func (request *Request) HasFuzzing() bool {
 	return len(request.Fuzzing) > 0
+}
+
+// shouldDisableKeepAliveForHTTPProxy preserves the pre-pooling behavior only for
+// standard HTTP proxies in non-threaded template/auto spray scans.
+func shouldDisableKeepAliveForHTTPProxy(request *Request, options *protocols.ExecutorOptions) bool {
+	if request == nil || options == nil || options.Options == nil || options.Options.AliveHttpProxy == "" {
+		return false
+	}
+	return request.Threads <= 0 && options.Options.ScanStrategy != scanstrategy.HostSpray.String()
 }
 
 // AnalyzeConnectionReuse determines if a request can safely reuse connections.

--- a/pkg/protocols/http/proxy_keepalive_test.go
+++ b/pkg/protocols/http/proxy_keepalive_test.go
@@ -1,0 +1,20 @@
+package http
+
+import (
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols"
+	"github.com/projectdiscovery/nuclei/v3/pkg/types"
+	"github.com/projectdiscovery/nuclei/v3/pkg/types/scanstrategy"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestShouldDisableKeepAliveForHTTPProxy(t *testing.T) {
+	opts := types.DefaultOptions()
+	opts.AliveHttpProxy = "http://127.0.0.1:8080"
+	opts.ScanStrategy = scanstrategy.TemplateSpray.String()
+	require.True(t, shouldDisableKeepAliveForHTTPProxy(&Request{}, &protocols.ExecutorOptions{Options: opts}))
+
+	opts.ScanStrategy = scanstrategy.HostSpray.String()
+	require.False(t, shouldDisableKeepAliveForHTTPProxy(&Request{}, &protocols.ExecutorOptions{Options: opts}))
+	require.False(t, shouldDisableKeepAliveForHTTPProxy(&Request{Threads: 10}, &protocols.ExecutorOptions{Options: opts}))
+}


### PR DESCRIPTION
## Summary

Fixes #7654.

This PR avoids reusing HTTP proxy connections in the legacy non-threaded spray path, which can cause long stalls when scanning through heavyweight MITM proxies such as Burp Suite.

The change is intentionally scoped to:
- HTTP proxies
- non-threaded requests
- auto/template-spray strategies

Host-spray, threaded requests, SOCKS proxies, and direct scans keep the existing connection reuse behavior.

## Why

After the HTTP client pooling changes, keep-alive became enabled more broadly. With some heavyweight MITM proxies, reusing the client-side proxy connection can leave requests waiting for long periods before the scan exits.

This restores the previous non-threaded proxy behavior without reverting the broader connection pooling improvements.

## Changes

- disable keep-alive for non-threaded HTTP proxy scans outside host-spray
- keep the decision after thread normalization in `Compile()`
- add a regression test covering the proxy keep-alive decision

## Validation

- `go test ./pkg/protocols/http/... -count=1`
- `make test`
- `make vet`
- `make build`

All passed successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP proxy connection handling for non-threaded scans.
  * Proxy connection reuse is now disabled for template-spray scans while remaining available for host-spray scans.
  * Added safeguards for requests with missing scan strategy information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->