### PR TITLE
fix(lib): avoid caching engine state in shared parsers

### DIFF
--- a/lib/parser_lifecycle_test.go
+++ b/lib/parser_lifecycle_test.go
@@ -1,0 +1,70 @@
+package nuclei
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/templates"
+	"github.com/projectdiscovery/nuclei/v3/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCallerParserUsesEngineLocalCompiledCache(t *testing.T) {
+	templatePath := filepath.Join(t.TempDir(), "template.yaml")
+	require.NoError(t, os.WriteFile(templatePath, []byte(`id: parser-lifecycle
+
+info:
+  name: Parser lifecycle
+  author: pdteam
+  severity: info
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+`), 0o600))
+
+	callerParser := templates.NewParser()
+	callerParser.Cache().StoreWithoutRaw("sentinel", &templates.Template{}, nil)
+
+	for range 3 {
+		compiledParser := func() *templates.Parser {
+			opts := types.DefaultOptions()
+			opts.Parser = callerParser
+			opts.Templates = []string{templatePath}
+
+			engine, err := NewNucleiEngineCtx(context.Background(), DisableUpdateCheck(), WithOptions(opts))
+			require.NoError(t, err)
+
+			engineParser := engine.GetParser()
+			require.Same(t, callerParser, engineParser)
+			require.False(t, engine.GetExecuterOptions().DoNotCache)
+
+			compiledParser, ok := engine.GetExecuterOptions().Parser.(*templates.Parser)
+			require.True(t, ok)
+			require.NotSame(t, callerParser, compiledParser)
+			require.Same(t, callerParser.Cache(), compiledParser.Cache())
+
+			require.NoError(t, engine.LoadAllTemplates())
+			require.Len(t, engine.GetTemplates(), 1)
+			require.Equal(t, 0, callerParser.CompiledCount())
+			require.Equal(t, 1, compiledParser.CompiledCount())
+			require.Equal(t, 2, callerParser.ParsedCount())
+			require.NoError(t, engine.LoadAllTemplates())
+			require.Len(t, engine.GetTemplates(), 1)
+			require.Equal(t, 1, compiledParser.CompiledCount())
+
+			engine.Close()
+			return compiledParser
+		}()
+
+		require.Equal(t, 0, callerParser.CompiledCount())
+		require.Equal(t, 0, compiledParser.CompiledCount())
+		require.Equal(t, 2, callerParser.ParsedCount())
+		cached, err := callerParser.Cache().Get("sentinel")
+		require.NoError(t, err)
+		require.NotNil(t, cached)
+	}
+}

--- a/lib/sdk.go
+++ b/lib/sdk.go
@@ -81,6 +81,7 @@ type NucleiEngine struct {
 	browserInstance  *engine.Browser
 	httpClient       *retryablehttp.Client
 	parser           *templates.Parser
+	compiledParser   *templates.Parser
 	ownsParser       bool // true when the engine created the parser and may purge it on Close
 	authprovider     authprovider.AuthProvider
 
@@ -276,10 +277,11 @@ func (e *NucleiEngine) closeInternal() {
 	if e.opts != nil {
 		generators.ClearOptionsPayloadMap(e.opts)
 	}
-	// Purge the template caches (compiled templates are heap-heavy) so a
-	// long-running embedder does not retain them for the process lifetime.
-	// Only do this when the engine created the parser; a caller-supplied
-	// parser is an opt-in shared cache the caller owns.
+	// Purge engine-owned template caches. A caller-supplied parser remains
+	// untouched, while its engine-local compiled cache is always released.
+	if e.compiledParser != nil && e.compiledParser != e.parser {
+		e.compiledParser.CompiledCache().Purge()
+	}
 	if e.ownsParser && e.parser != nil {
 		e.parser.Purge()
 	}

--- a/lib/sdk_private.go
+++ b/lib/sdk_private.go
@@ -172,6 +172,14 @@ func (e *NucleiEngine) init(ctx context.Context) error {
 		e.parser = templates.NewParser()
 		e.ownsParser = true
 	}
+	e.compiledParser = e.parser
+	if !e.ownsParser {
+		// Compiled templates retain engine-local ExecutorOptions. Keep their
+		// cache private while the caller-owned parser provides the parsed cache.
+		e.compiledParser = templates.NewParserWithParsedCache(e.parser.Cache())
+		e.compiledParser.ShouldValidate = e.parser.ShouldValidate
+		e.compiledParser.NoStrictSyntax = e.parser.NoStrictSyntax
+	}
 
 	if protocolstate.ShouldInit(e.opts.ExecutionId) {
 		_ = protocolinit.Init(e.opts)
@@ -250,7 +258,8 @@ func (e *NucleiEngine) init(ctx context.Context) error {
 		Colorizer:          aurora.New(aurora.WithColors(true)),
 		ResumeCfg:          types.NewResumeCfg(),
 		Browser:            e.browserInstance,
-		Parser:             e.parser,
+		Parser:             e.compiledParser,
+		DoNotCache:         e.opts.DoNotCacheTemplates,
 		InputHelper:        input.NewHelper(),
 		TemporaryDirectory: e.tmpDir,
 		Logger:             e.opts.Logger,
@@ -306,8 +315,6 @@ func (e *NucleiEngine) init(ctx context.Context) error {
 		if cachedParser, ok := e.opts.Parser.(*templates.Parser); ok {
 			e.parser = cachedParser
 			e.opts.Parser = cachedParser
-			e.executerOpts.Parser = cachedParser
-			e.executerOpts.Options.Parser = cachedParser
 		}
 	}
 


### PR DESCRIPTION
## Proposed changes

Compiled template cache entries retain mutable
`ExecutorOptions` and can keep closed engines
alive.

Move those entries into an engine-local cache.
Leave the caller-owned parsed cache intact and
purge only compiled entries on `Close`.

Fixes #7656

### Proof

Before:
```console
$ go run lib/poc/7656/main.go ~/nuclei-templates/
load 1: 10629 templates, live heap 213.2 MiB
load 2: 10629 templates, live heap 312.1 MiB
load 3: 10629 templates, live heap 323.8 MiB
load 4: 10629 templates, live heap 323.6 MiB
```

This patch (dc0ebd19a5bddb2d658f1a5e3f0fdb77007ff2e6):
```console
$ go run lib/poc/7656/main.go ~/nuclei-templates/
load 1: 10629 templates, live heap 46.3 MiB
load 2: 10629 templates, live heap 46.6 MiB
load 3: 10629 templates, live heap 46.6 MiB
load 4: 10629 templates, live heap 46.7 MiB
```

Sum:

* Live heap decreased from 323.6 MiB to 46.7 MiB (**85.6% lower**).
* Retained growth decreased from 110.4 MiB to 0.4 MiB.

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved template compilation caching when using a caller-provided parser.
  * Prevented engine cleanup from affecting caller-owned parser state.
  * Preserved cached templates across repeated engine lifecycles.
  * Maintained template caching preferences, including disabled-cache behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->