### PR TITLE
perf(templates): reuse parsed templates across engines

### DIFF
--- a/pkg/templates/clone.go
+++ b/pkg/templates/clone.go
@@ -1,0 +1,98 @@
+package templates
+
+import (
+	"reflect"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/utils"
+)
+
+type cloneVisit struct {
+	typeOf  reflect.Type
+	pointer uintptr
+}
+
+// cloneTemplate copies a clean parsed template before protocol compilation
+// adds engine-local state. Unexported fields hold immutable parse state at this
+// point and are copied by value; exported maps, slices, pointers, and
+// interfaces are copied recursively.
+func cloneTemplate(template *Template) *Template {
+	cloned := cloneTemplateValue(reflect.ValueOf(template), make(map[cloneVisit]reflect.Value))
+	clonedTemplate := cloned.Interface().(*Template)
+	clonedTemplate.Variables.InsertionOrderedStringMap = *utils.NewEmptyInsertionOrderedStringMap(template.Variables.Len())
+	template.Variables.ForEach(func(key string, value interface{}) {
+		clonedValue := cloneTemplateValue(reflect.ValueOf(value), make(map[cloneVisit]reflect.Value))
+		if clonedValue.IsValid() {
+			clonedTemplate.Variables.Set(key, clonedValue.Interface())
+		} else {
+			clonedTemplate.Variables.Set(key, nil)
+		}
+	})
+	return clonedTemplate
+}
+
+func cloneTemplateValue(value reflect.Value, visited map[cloneVisit]reflect.Value) reflect.Value {
+	if !value.IsValid() {
+		return value
+	}
+
+	switch value.Kind() {
+	case reflect.Interface:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		cloned := cloneTemplateValue(value.Elem(), visited)
+		result := reflect.New(value.Type()).Elem()
+		result.Set(cloned)
+		return result
+	case reflect.Pointer:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		visit := cloneVisit{typeOf: value.Type(), pointer: value.Pointer()}
+		if cloned, ok := visited[visit]; ok {
+			return cloned
+		}
+		cloned := reflect.New(value.Type().Elem())
+		visited[visit] = cloned
+		cloned.Elem().Set(cloneTemplateValue(value.Elem(), visited))
+		return cloned
+	case reflect.Struct:
+		cloned := reflect.New(value.Type()).Elem()
+		cloned.Set(value)
+		for i := 0; i < value.NumField(); i++ {
+			if value.Type().Field(i).IsExported() {
+				cloned.Field(i).Set(cloneTemplateValue(value.Field(i), visited))
+			}
+		}
+		return cloned
+	case reflect.Slice:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		cloned := reflect.MakeSlice(value.Type(), value.Len(), value.Len())
+		for i := 0; i < value.Len(); i++ {
+			cloned.Index(i).Set(cloneTemplateValue(value.Index(i), visited))
+		}
+		return cloned
+	case reflect.Map:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		cloned := reflect.MakeMapWithSize(value.Type(), value.Len())
+		iterator := value.MapRange()
+		for iterator.Next() {
+			key := cloneTemplateValue(iterator.Key(), visited)
+			item := cloneTemplateValue(iterator.Value(), visited)
+			cloned.SetMapIndex(key, item)
+		}
+		return cloned
+	case reflect.Array:
+		cloned := reflect.New(value.Type()).Elem()
+		for i := 0; i < value.Len(); i++ {
+			cloned.Index(i).Set(cloneTemplateValue(value.Index(i), visited))
+		}
+		return cloned
+	default:
+		return value
+	}
+}

--- a/pkg/templates/clone.go
+++ b/pkg/templates/clone.go
@@ -7,8 +7,10 @@ import (
 )
 
 type cloneVisit struct {
-	typeOf  reflect.Type
-	pointer uintptr
+	typeOf   reflect.Type
+	pointer  uintptr
+	length   int
+	capacity int
 }
 
 // cloneTemplate copies a clean parsed template before protocol compilation
@@ -16,11 +18,12 @@ type cloneVisit struct {
 // point and are copied by value; exported maps, slices, pointers, and
 // interfaces are copied recursively.
 func cloneTemplate(template *Template) *Template {
-	cloned := cloneTemplateValue(reflect.ValueOf(template), make(map[cloneVisit]reflect.Value))
+	visited := make(map[cloneVisit]reflect.Value)
+	cloned := cloneTemplateValue(reflect.ValueOf(template), visited)
 	clonedTemplate := cloned.Interface().(*Template)
 	clonedTemplate.Variables.InsertionOrderedStringMap = *utils.NewEmptyInsertionOrderedStringMap(template.Variables.Len())
 	template.Variables.ForEach(func(key string, value interface{}) {
-		clonedValue := cloneTemplateValue(reflect.ValueOf(value), make(map[cloneVisit]reflect.Value))
+		clonedValue := cloneTemplateValue(reflect.ValueOf(value), visited)
 		if clonedValue.IsValid() {
 			clonedTemplate.Variables.Set(key, clonedValue.Interface())
 		} else {
@@ -69,7 +72,17 @@ func cloneTemplateValue(value reflect.Value, visited map[cloneVisit]reflect.Valu
 		if value.IsNil() {
 			return reflect.Zero(value.Type())
 		}
+		visit := cloneVisit{
+			typeOf:   value.Type(),
+			pointer:  value.Pointer(),
+			length:   value.Len(),
+			capacity: value.Cap(),
+		}
+		if cloned, ok := visited[visit]; ok {
+			return cloned
+		}
 		cloned := reflect.MakeSlice(value.Type(), value.Len(), value.Len())
+		visited[visit] = cloned
 		for i := 0; i < value.Len(); i++ {
 			cloned.Index(i).Set(cloneTemplateValue(value.Index(i), visited))
 		}
@@ -78,7 +91,12 @@ func cloneTemplateValue(value reflect.Value, visited map[cloneVisit]reflect.Valu
 		if value.IsNil() {
 			return reflect.Zero(value.Type())
 		}
+		visit := cloneVisit{typeOf: value.Type(), pointer: value.Pointer()}
+		if cloned, ok := visited[visit]; ok {
+			return cloned
+		}
 		cloned := reflect.MakeMapWithSize(value.Type(), value.Len())
+		visited[visit] = cloned
 		iterator := value.MapRange()
 		for iterator.Next() {
 			key := cloneTemplateValue(iterator.Key(), visited)

--- a/pkg/templates/clone_test.go
+++ b/pkg/templates/clone_test.go
@@ -1,0 +1,53 @@
+package templates
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/disk"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCloneTemplatePreservesCleanTemplateIsolation(t *testing.T) {
+	templatePath := filepath.Join(t.TempDir(), "multi-protocol.yaml")
+	require.NoError(t, os.WriteFile(templatePath, []byte(`id: clone-isolation
+
+info:
+  name: Clone isolation
+  author: pdteam
+  severity: info
+
+variables:
+  shared: original
+
+dns:
+  - name: "{{FQDN}}"
+    type: A
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    matchers:
+      - type: word
+        words:
+          - original
+`), 0o600))
+
+	parsed, err := NewParser().ParseTemplate(templatePath, disk.NewCatalog(""))
+	require.NoError(t, err)
+	original := parsed.(*Template)
+	cloned := cloneTemplate(original)
+
+	require.NotSame(t, original, cloned)
+	require.NotSame(t, original.RequestsDNS[0], cloned.RequestsDNS[0])
+	require.NotSame(t, original.RequestsHTTP[0], cloned.RequestsHTTP[0])
+	require.Same(t, cloned.RequestsDNS[0], cloned.RequestsQueue[0])
+	require.Same(t, cloned.RequestsHTTP[0], cloned.RequestsQueue[1])
+
+	cloned.RequestsHTTP[0].Matchers[0].Words[0] = "changed"
+	cloned.Variables.Set("shared", "changed")
+	require.Equal(t, "original", original.RequestsHTTP[0].Matchers[0].Words[0])
+	require.Equal(t, map[string]interface{}{"shared": "original"}, original.Variables.GetAll())
+}

--- a/pkg/templates/clone_test.go
+++ b/pkg/templates/clone_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/disk"
+	"github.com/projectdiscovery/nuclei/v3/pkg/utils"
 	"github.com/stretchr/testify/require"
 )
 
@@ -50,4 +51,54 @@ http:
 	cloned.Variables.Set("shared", "changed")
 	require.Equal(t, "original", original.RequestsHTTP[0].Matchers[0].Words[0])
 	require.Equal(t, map[string]interface{}{"shared": "original"}, original.Variables.GetAll())
+}
+
+func TestCloneTemplatePreservesMutableAliases(t *testing.T) {
+	sharedMap := map[string]interface{}{"value": "original"}
+	sharedSlice := []interface{}{"original"}
+	original := &Template{
+		Constants: map[string]interface{}{
+			"map":         sharedMap,
+			"first-slice": sharedSlice,
+			"next-slice":  sharedSlice,
+		},
+	}
+	original.Variables.InsertionOrderedStringMap = *utils.NewEmptyInsertionOrderedStringMap(1)
+	original.Variables.Set("map", sharedMap)
+
+	cloned := cloneTemplate(original)
+	clonedMap := cloned.Constants["map"].(map[string]interface{})
+	clonedVariableMap := cloned.Variables.GetAll()["map"].(map[string]interface{})
+	clonedFirstSlice := cloned.Constants["first-slice"].([]interface{})
+	clonedNextSlice := cloned.Constants["next-slice"].([]interface{})
+
+	clonedMap["value"] = "changed"
+	clonedFirstSlice[0] = "changed"
+
+	require.Equal(t, "changed", clonedVariableMap["value"])
+	require.Equal(t, "changed", clonedNextSlice[0])
+	require.Equal(t, "original", sharedMap["value"])
+	require.Equal(t, "original", sharedSlice[0])
+}
+
+func TestCloneTemplateHandlesMutableCycles(t *testing.T) {
+	cyclicMap := make(map[string]interface{})
+	cyclicMap["self"] = cyclicMap
+	cyclicSlice := make([]interface{}, 1)
+	cyclicSlice[0] = cyclicSlice
+	original := &Template{Constants: map[string]interface{}{
+		"map":   cyclicMap,
+		"slice": cyclicSlice,
+	}}
+
+	cloned := cloneTemplate(original)
+	clonedMap := cloned.Constants["map"].(map[string]interface{})
+	clonedMap["self"].(map[string]interface{})["changed"] = true
+	clonedSlice := cloned.Constants["slice"].([]interface{})
+	clonedSlice[0].([]interface{})[0] = "changed"
+
+	require.True(t, clonedMap["changed"].(bool))
+	require.Equal(t, "changed", clonedSlice[0])
+	require.NotContains(t, cyclicMap, "changed")
+	require.IsType(t, []interface{}{}, cyclicSlice[0])
 }

--- a/pkg/templates/compile.go
+++ b/pkg/templates/compile.go
@@ -1,6 +1,7 @@
 package templates
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"fmt"
 	"io"
@@ -104,19 +105,36 @@ func updateRequestOptions(template *Template) {
 
 // parseFromSource parses a template from source with caching support
 func parseFromSource(filePath string, preprocessor Preprocessor, options *protocols.ExecutorOptions, parser *Parser) (*Template, error) {
-	reader, err := utils.ReaderFromPathOrURL(filePath, options.Catalog)
-	if err != nil {
-		return nil, err
-	}
-
-	defer func() {
-		_ = reader.Close()
-	}()
-
 	options = options.Copy()
 	options.TemplatePath = filePath
 
-	template, err := ParseTemplateFromReader(reader, preprocessor, options)
+	var template *Template
+	var err error
+
+	if !options.DoNotCache {
+		parsed, raw, cachedErr := parser.parsedTemplatesCache.Has(filePath)
+		if cachedErr != nil {
+			return nil, cachedErr
+		}
+
+		if parsed != nil && len(raw) > 0 {
+			template, err = parseCachedTemplate(parsed, raw, preprocessor, options)
+		}
+	}
+
+	if template == nil && err == nil {
+		reader, openErr := utils.ReaderFromPathOrURL(filePath, options.Catalog)
+		if openErr != nil {
+			return nil, openErr
+		}
+
+		defer func() {
+			_ = reader.Close()
+		}()
+
+		template, err = ParseTemplateFromReader(reader, preprocessor, options)
+	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -154,6 +172,25 @@ func parseFromSource(filePath string, preprocessor Preprocessor, options *protoc
 	return template, nil
 }
 
+func parseCachedTemplate(cached *Template, data []byte, preprocessor Preprocessor, options *protocols.ExecutorOptions) (*Template, error) {
+	if hasTemplatePreprocessor(data, preprocessor) {
+		return ParseTemplateFromReader(bytes.NewReader(data), preprocessor, options)
+	}
+
+	template, err := prepareTemplate(cloneTemplate(cached), options)
+	if err != nil {
+		return nil, err
+	}
+	if err := verifyAndCompileTemplate(template, data); err != nil {
+		return nil, err
+	}
+
+	if !template.Verified && len(template.Workflows) == 0 && config.DefaultConfig.LogAllEvents {
+		gologger.DefaultLogger.Print().Msgf("[%v] Template %s is not signed or tampered\n", aurora.Yellow("WRN").String(), template.ID)
+	}
+	return template, nil
+}
+
 // getParser returns a cached parser instance
 func getParser(options *protocols.ExecutorOptions) *Parser {
 	parser, ok := options.Parser.(*Parser)
@@ -165,7 +202,6 @@ func getParser(options *protocols.ExecutorOptions) *Parser {
 }
 
 // Parse parses a yaml request template file
-// TODO make sure reading from the disk the template parsing happens once: see parsers.ParseTemplate vs templates.Parse
 func Parse(filePath string, preprocessor Preprocessor, options *protocols.ExecutorOptions) (*Template, error) {
 	parser := getParser(options)
 
@@ -439,14 +475,8 @@ func ParseTemplateFromReader(reader io.Reader, preprocessor Preprocessor, option
 	// a preprocessor is a variable like
 	// {{randstr}} which is replaced before unmarshalling
 	// as it is known to be a random static value per template
-	hasPreprocessor := false
+	hasPreprocessor := hasTemplatePreprocessor(data, preprocessor)
 	allPreprocessors := getPreprocessors(preprocessor)
-	for _, preprocessor := range allPreprocessors {
-		if preprocessor.Exists(data) {
-			hasPreprocessor = true
-			break
-		}
-	}
 
 	if !hasPreprocessor {
 		// if no preprocessors exists parse template and exit
@@ -498,6 +528,16 @@ func ParseTemplateFromReader(reader io.Reader, preprocessor Preprocessor, option
 	return template, nil
 }
 
+func hasTemplatePreprocessor(data []byte, preprocessor Preprocessor) bool {
+	for _, candidate := range getPreprocessors(preprocessor) {
+		if candidate.Exists(data) {
+			return true
+		}
+	}
+
+	return false
+}
+
 // parseTemplate parses the template and applies verification.
 func parseTemplate(data []byte, srcOptions *protocols.ExecutorOptions) (*Template, error) {
 	template, err := parseTemplateNoVerify(data, srcOptions)
@@ -522,8 +562,6 @@ func verifyAndCompileTemplate(template *Template, data []byte) error {
 
 // parseTemplateNoVerify parses the template without applying any verification.
 func parseTemplateNoVerify(data []byte, srcOptions *protocols.ExecutorOptions) (*Template, error) {
-	// Create a copy of the options specifically for this template
-	options := srcOptions.Copy()
 	template := &Template{}
 
 	var err error
@@ -543,6 +581,13 @@ func parseTemplateNoVerify(data []byte, srcOptions *protocols.ExecutorOptions) (
 	if err != nil {
 		return nil, errkit.Wrapf(err, "failed to parse %s", template.Path)
 	}
+
+	return prepareTemplate(template, srcOptions)
+}
+
+func prepareTemplate(template *Template, srcOptions *protocols.ExecutorOptions) (*Template, error) {
+	// Create a copy of the options specifically for this template.
+	options := srcOptions.Copy()
 
 	if utils.IsBlank(template.Info.Name) {
 		return nil, errors.New("no template name field provided")

--- a/pkg/templates/compile_bench_test.go
+++ b/pkg/templates/compile_bench_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols"
 	"github.com/projectdiscovery/nuclei/v3/pkg/templates"
 )
 
@@ -20,6 +21,43 @@ func BenchmarkParse(b *testing.B) {
 		_, err := templates.Parse(filePath, nil, executerOpts)
 		if err != nil {
 			b.Fatalf("could not parse template: %s", err)
+		}
+	}
+}
+
+func BenchmarkParseAcrossEngineLocalCaches(b *testing.B) {
+	const engineCount = 5
+
+	filePath := "tests/match-1.yaml"
+	setup()
+
+	sharedParser := templates.NewParser()
+	_, err := sharedParser.ParseTemplate(filePath, executerOpts.Catalog)
+	if err != nil {
+		b.Fatalf("could not warm parsed template cache: %s", err)
+	}
+
+	engineOptions := make([]*protocols.ExecutorOptions, engineCount)
+	engineParsers := make([]*templates.Parser, engineCount)
+	for i := range engineCount {
+		engineParsers[i] = templates.NewParserWithParsedCache(sharedParser.Cache())
+		engineOptions[i] = executerOpts.Copy()
+		engineOptions[i].Parser = engineParsers[i]
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for b.Loop() {
+		for _, options := range engineOptions {
+			_, err := templates.Parse(filePath, nil, options)
+			if err != nil {
+				b.Fatalf("could not parse template: %s", err)
+			}
+		}
+
+		for _, parser := range engineParsers {
+			parser.CompiledCache().Purge()
 		}
 	}
 }

--- a/pkg/templates/compile_test.go
+++ b/pkg/templates/compile_test.go
@@ -11,6 +11,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -595,6 +597,110 @@ javascript:
 	require.NoError(t, err)
 	require.True(t, cached.Verified)
 	require.True(t, cached.Options.Verified)
+}
+
+func TestParseReusesSharedParsedTemplateAcrossEngineCaches(t *testing.T) {
+	var sourceReads atomic.Int32
+	templateSource := `id: shared-parsed-template
+
+info:
+  name: Shared parsed template
+  author: pdteam
+  severity: info
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    body: |
+      first line
+      second line
+`
+	server := httptest.NewServer(netHttp.HandlerFunc(func(w netHttp.ResponseWriter, _ *netHttp.Request) {
+		sourceReads.Add(1)
+		_, _ = w.Write([]byte(templateSource))
+	}))
+	t.Cleanup(server.Close)
+
+	setup()
+	templatePath := server.URL + "/template.yaml"
+	sharedParser := templates.NewParser()
+	_, err := sharedParser.ParseTemplate(templatePath, executerOpts.Catalog)
+	require.NoError(t, err)
+
+	compiledTemplates := make([]*templates.Template, 5)
+	parseErrors := make([]error, len(compiledTemplates))
+	var waitGroup sync.WaitGroup
+	for i := range compiledTemplates {
+		engineOptions := executerOpts.Copy()
+		engineOptions.Parser = templates.NewParserWithParsedCache(sharedParser.Cache())
+		engineOptions.TemplateVerificationCallback = func(string) *protocols.TemplateVerification {
+			return trustedVerificationForTest(templateSource)
+		}
+		waitGroup.Add(1)
+		go func() {
+			defer waitGroup.Done()
+			compiledTemplates[i], parseErrors[i] = templates.Parse(templatePath, nil, engineOptions)
+		}()
+	}
+	waitGroup.Wait()
+
+	for i := range compiledTemplates {
+		require.NoError(t, parseErrors[i])
+		require.True(t, compiledTemplates[i].Verified)
+	}
+
+	require.Equal(t, int32(1), sourceReads.Load())
+	cachedTemplate, err := sharedParser.Cache().Get(templatePath)
+	require.NoError(t, err)
+	require.NotNil(t, cachedTemplate)
+	require.NotContains(t, cachedTemplate.RequestsHTTP[0].Body, "\r\n")
+	for i := 1; i < len(compiledTemplates); i++ {
+		require.NotSame(t, compiledTemplates[0], compiledTemplates[i])
+		require.NotSame(t, compiledTemplates[0].RequestsHTTP[0], compiledTemplates[i].RequestsHTTP[0])
+		require.NotSame(t, compiledTemplates[0].RequestsHTTP[0].Options(), compiledTemplates[i].RequestsHTTP[0].Options())
+	}
+	require.NotSame(t, cachedTemplate.RequestsHTTP[0], compiledTemplates[0].RequestsHTTP[0])
+}
+
+func TestParseSharedTemplatePreservesRuntimePreprocessing(t *testing.T) {
+	var sourceReads int
+	templateSource := `id: shared-preprocessed-template
+
+info:
+  name: Shared preprocessed template
+  author: pdteam
+  severity: info
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/{{randstr}}"
+`
+	server := httptest.NewServer(netHttp.HandlerFunc(func(w netHttp.ResponseWriter, _ *netHttp.Request) {
+		sourceReads++
+		_, _ = w.Write([]byte(templateSource))
+	}))
+	t.Cleanup(server.Close)
+
+	setup()
+	templatePath := server.URL + "/template.yaml"
+	sharedParser := templates.NewParser()
+	_, err := sharedParser.ParseTemplate(templatePath, executerOpts.Catalog)
+	require.NoError(t, err)
+
+	compiledPaths := make([]string, 2)
+	for i := range compiledPaths {
+		engineOptions := executerOpts.Copy()
+		engineOptions.Parser = templates.NewParserWithParsedCache(sharedParser.Cache())
+		compiled, parseErr := templates.Parse(templatePath, nil, engineOptions)
+		require.NoError(t, parseErr)
+		compiledPaths[i] = compiled.RequestsHTTP[0].Path[0]
+		require.NotContains(t, compiledPaths[i], "{{randstr}}")
+	}
+
+	require.Equal(t, 1, sourceReads)
+	require.NotEqual(t, compiledPaths[0], compiledPaths[1])
 }
 
 func Test_WrongTemplate(t *testing.T) {

--- a/pkg/templates/parser.go
+++ b/pkg/templates/parser.go
@@ -1,6 +1,7 @@
 package templates
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"strings"
@@ -20,10 +21,9 @@ type Parser struct {
 	ShouldValidate bool
 	NoStrictSyntax bool
 
-	// parsedTemplatesCache stores lightweight parsed template structures
-	// (without raw bytes).
-	// Used for validation and filtering. This cache can be copied safely
-	// between ephemeral instances.
+	// parsedTemplatesCache stores clean parsed template structures used for
+	// validation, filtering, and engine-local compilation. Entries also retain
+	// source bytes when they exactly match the parsed structure.
 	parsedTemplatesCache *Cache
 
 	// compiledTemplatesCache stores fully compiled templates with all protocol
@@ -149,49 +149,38 @@ func (p *Parser) ParseTemplate(templatePath string, catalog catalog.Catalog) (an
 		_ = reader.Close()
 	}()
 
-	// For local YAML files, check if preprocessing is needed
-	var data []byte
+	sourceData, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, err
+	}
+
+	data := sourceData
+	cacheSource := true
+
+	// For local YAML files, check if preprocessing is needed.
 	if fileutil.FileExists(templatePath) && config.GetTemplateFormatFromExt(templatePath) == config.YAML {
-		data, err = io.ReadAll(reader)
-		if err != nil {
-			return nil, err
-		}
 		data, err = yamlutil.PreProcess(data, templatePath)
 		if err != nil {
 			return nil, err
 		}
+
+		cacheSource = bytes.Equal(data, sourceData)
 	}
 
 	template := &Template{}
 
 	switch config.GetTemplateFormatFromExt(templatePath) {
 	case config.JSON:
-		if data == nil {
-			data, err = io.ReadAll(reader)
-			if err != nil {
-				return nil, err
-			}
-		}
 		if p.NoStrictSyntax {
 			err = json.Unmarshal(data, template)
 		} else {
 			err = template.unmarshalJSONStrict(data)
 		}
 	case config.YAML:
-		if data != nil {
-			// Already read and preprocessed
-			if p.NoStrictSyntax {
-				err = yamlutil.Unmarshal(data, template)
-			} else {
-				err = yamlutil.UnmarshalStrict(data, template)
-			}
+		if p.NoStrictSyntax {
+			err = yamlutil.Unmarshal(data, template)
 		} else {
-			// Stream directly from reader
-			decoder := yamlutil.NewDecoder(reader)
-			if !p.NoStrictSyntax {
-				decoder.SetStrict(true)
-			}
-			err = decoder.Decode(template)
+			err = yamlutil.UnmarshalStrict(data, template)
 		}
 	default:
 		err = fmt.Errorf("failed to identify template format expected JSON or YAML but got %v", templatePath)
@@ -200,7 +189,11 @@ func (p *Parser) ParseTemplate(templatePath string, catalog catalog.Catalog) (an
 		return nil, err
 	}
 
-	p.parsedTemplatesCache.StoreWithoutRaw(templatePath, template, nil)
+	if cacheSource {
+		p.parsedTemplatesCache.Store(templatePath, template, sourceData, nil)
+	} else {
+		p.parsedTemplatesCache.StoreWithoutRaw(templatePath, template, nil)
+	}
 
 	return template, nil
 }


### PR DESCRIPTION
## Proposed changes

Clone cached parsed templates before compiling
them with engine-local options to avoid reopening
and decoding the same source for every engine
without sharing mutable compiled state.

Follow-up work (2/3) of #7656

### Proof

```console
$ gh pr checkout 7661
$ go test -run=^$ -count=10 -benchmem -bench ^BenchmarkParseAcrossEngineLocalCaches$ ./pkg/templates > patch
$ git checkout dev
Switched to branch 'dev'
$ git cherry-pick cd6e8ef2
[dev 93d3d0b2] test(templates): add parse across engine local caches bench test
 Date: Sat Aug 15 23:23:49 2026 +0700
 1 file changed, 38 insertions(+)
$ go test -run=^$ -count=10 -benchmem -bench ^BenchmarkParseAcrossEngineLocalCaches$ ./pkg/templates > dev
$ benchstat dev patch
goos: linux
goarch: amd64
pkg: github.com/projectdiscovery/nuclei/v3/pkg/templates
cpu: 11th Gen Intel(R) Core(TM) i9-11900H @ 2.50GHz
                               │     dev     │                patch                │
                               │   sec/op    │   sec/op     vs base                │
ParseAcrossEngineLocalCaches-4   371.2µ ± 3%   146.6µ ± 6%  -60.51% (p=0.000 n=10)

                               │      dev      │                patch                 │
                               │     B/op      │     B/op      vs base                │
ParseAcrossEngineLocalCaches-4   125.77Ki ± 0%   44.86Ki ± 0%  -64.33% (p=0.000 n=10)

                               │     dev     │               patch                │
                               │  allocs/op  │ allocs/op   vs base                │
ParseAcrossEngineLocalCaches-4   1535.0 ± 0%   520.0 ± 0%  -66.12% (p=0.000 n=10)
```

Sum: **1.5x faster**, with **~2.8x less memory** and **~3x fewer allocs**.

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved template parsing efficiency by reusing parsed templates across engine caches.
  * Added benchmarking for shared template-cache performance.

* **Reliability**
  * Ensured cloned templates remain isolated while preserving shared references and cyclic data.
  * Improved concurrent parsing consistency and cache behavior.
  * Preserved runtime preprocessing and template verification when using cached templates.

* **Bug Fixes**
  * Improved YAML preprocessing and source handling during template parsing.
  * Preserved request body data correctly when loading templates from cache.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->