### PR TITLE
Update Dockerfile to golang 1.27

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build
-FROM golang:1.24-alpine AS builder
+FROM golang:1.27-alpine AS builder
 
 RUN apk add build-base
 WORKDIR /app


### PR DESCRIPTION
## Proposed changes

Resolve #7668 by bumping the pinned golang version in the Dockerfile

### Proof

`docker build --tag nuclei .` succeeds.

## Checklist

- [X] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build environment to use Go 1.27 on Alpine.
  * No user-facing functionality or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->