### PR TITLE
fix(http): stop reusing connections after an unsolicited response

### DIFF
--- a/internal/tests/testutils/testutils.go
+++ b/internal/tests/testutils/testutils.go
@@ -40,7 +40,6 @@ func Cleanup(options *types.Options) {
 
 // DefaultOptions is the default options structure for nuclei during mocking.
 var DefaultOptions = &types.Options{
-	Metrics:                    false,
 	Debug:                      false,
 	DebugRequests:              false,
 	DebugResponse:              false,

--- a/pkg/protocols/common/protocolstate/dialers.go
+++ b/pkg/protocols/common/protocolstate/dialers.go
@@ -16,6 +16,8 @@ type Dialers struct {
 	HTTPClientPool             *HTTPPool
 	PerHostRateLimitPool       any // *httpclientpool.PerHostRateLimitPool
 	HTTPToHTTPSPortTracker     any // *httpclientpool.HTTPToHTTPSPortTracker
+	HTTPDesyncHosts            *ExpiringSet
+	HTTPDesyncRTT              *ExpiringDurationMap
 	NetworkPolicy              *networkpolicy.NetworkPolicy
 	LocalFileAccessAllowed     bool
 	RestrictLocalNetworkAccess bool

--- a/pkg/protocols/common/protocolstate/expiring_duration_map.go
+++ b/pkg/protocols/common/protocolstate/expiring_duration_map.go
@@ -1,0 +1,107 @@
+package protocolstate
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+type expiringDuration struct {
+	value     int64
+	expiresAt int64
+}
+
+// ExpiringDurationMap stores the smallest observed duration for each key and
+// evicts values that have not been refreshed before their TTL.
+type ExpiringDurationMap struct {
+	entries         sync.Map
+	cleanupInterval time.Duration
+	lastCleanup     atomic.Int64
+}
+
+// NewExpiringDurationMap creates a duration map with opportunistic cleanup.
+func NewExpiringDurationMap(cleanupInterval time.Duration) *ExpiringDurationMap {
+	return &ExpiringDurationMap{cleanupInterval: cleanupInterval}
+}
+
+// StoreMin records value when it is smaller than the current unexpired value.
+// Every observation refreshes the entry's expiry.
+func (m *ExpiringDurationMap) StoreMin(key string, value, ttl time.Duration) {
+	if m == nil || key == "" || value <= 0 || ttl <= 0 {
+		return
+	}
+	now := time.Now()
+	nextExpiry := now.Add(ttl).UnixNano()
+	for {
+		loaded, ok := m.entries.Load(key)
+		if !ok {
+			if _, loaded := m.entries.LoadOrStore(key, expiringDuration{
+				value: value.Nanoseconds(), expiresAt: nextExpiry,
+			}); !loaded {
+				m.maybeCleanup(now)
+				return
+			}
+			continue
+		}
+
+		current, ok := loaded.(expiringDuration)
+		if !ok {
+			if m.entries.CompareAndSwap(key, loaded, expiringDuration{
+				value: value.Nanoseconds(), expiresAt: nextExpiry,
+			}) {
+				m.maybeCleanup(now)
+				return
+			}
+			continue
+		}
+
+		nextValue := value.Nanoseconds()
+		if current.expiresAt > now.UnixNano() && current.value < nextValue {
+			nextValue = current.value
+		}
+		next := expiringDuration{value: nextValue, expiresAt: nextExpiry}
+		if m.entries.CompareAndSwap(key, current, next) {
+			m.maybeCleanup(now)
+			return
+		}
+	}
+}
+
+// Load returns an unexpired duration.
+func (m *ExpiringDurationMap) Load(key string) (time.Duration, bool) {
+	if m == nil || key == "" {
+		return 0, false
+	}
+	loaded, ok := m.entries.Load(key)
+	if !ok {
+		return 0, false
+	}
+	current, ok := loaded.(expiringDuration)
+	if !ok || current.value <= 0 {
+		m.entries.CompareAndDelete(key, loaded)
+		return 0, false
+	}
+	if current.expiresAt <= time.Now().UnixNano() {
+		m.entries.CompareAndDelete(key, current)
+		return 0, false
+	}
+	return time.Duration(current.value), true
+}
+
+func (m *ExpiringDurationMap) maybeCleanup(now time.Time) {
+	if m.cleanupInterval <= 0 {
+		return
+	}
+	cutoff := now.Add(-m.cleanupInterval).UnixNano()
+	previous := m.lastCleanup.Load()
+	if previous > cutoff || !m.lastCleanup.CompareAndSwap(previous, now.UnixNano()) {
+		return
+	}
+	m.entries.Range(func(key, loaded any) bool {
+		current, ok := loaded.(expiringDuration)
+		if !ok || current.expiresAt <= now.UnixNano() {
+			m.entries.CompareAndDelete(key, loaded)
+		}
+		return true
+	})
+}

--- a/pkg/protocols/common/protocolstate/expiring_duration_map_test.go
+++ b/pkg/protocols/common/protocolstate/expiring_duration_map_test.go
@@ -1,0 +1,40 @@
+package protocolstate
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExpiringDurationMapKeepsMinimumAndExpires(t *testing.T) {
+	values := NewExpiringDurationMap(time.Millisecond)
+	values.StoreMin("host", 20*time.Millisecond, 30*time.Millisecond)
+	values.StoreMin("host", 50*time.Millisecond, 30*time.Millisecond)
+	value, ok := values.Load("host")
+	require.True(t, ok)
+	require.Equal(t, 20*time.Millisecond, value)
+
+	values.StoreMin("host", 10*time.Millisecond, 5*time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
+	_, ok = values.Load("host")
+	require.False(t, ok)
+}
+
+func TestExpiringDurationMapConcurrentMinimum(t *testing.T) {
+	values := NewExpiringDurationMap(time.Minute)
+	var wg sync.WaitGroup
+	for value := 100; value > 0; value-- {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			values.StoreMin("host", time.Duration(value)*time.Millisecond, time.Minute)
+		}()
+	}
+	wg.Wait()
+
+	value, ok := values.Load("host")
+	require.True(t, ok)
+	require.Equal(t, time.Millisecond, value)
+}

--- a/pkg/protocols/common/protocolstate/expiring_set.go
+++ b/pkg/protocols/common/protocolstate/expiring_set.go
@@ -1,0 +1,89 @@
+package protocolstate
+
+import (
+	"slices"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// ExpiringSet is a lock-free-read set of string keys with per-entry expiry.
+// Cleanup is amortized across writes and also performed by Keys.
+type ExpiringSet struct {
+	values          sync.Map // string -> expiry UnixNano
+	cleanupInterval time.Duration
+	lastCleanup     atomic.Int64
+}
+
+func NewExpiringSet(cleanupInterval time.Duration) *ExpiringSet {
+	set := &ExpiringSet{cleanupInterval: cleanupInterval}
+	set.lastCleanup.Store(time.Now().UnixNano())
+	return set
+}
+
+func (s *ExpiringSet) Store(key string, ttl time.Duration) {
+	s.StoreUntil(key, time.Now().Add(ttl))
+}
+
+func (s *ExpiringSet) StoreUntil(key string, expiry time.Time) {
+	if s == nil || key == "" {
+		return
+	}
+	s.values.Store(key, expiry.UnixNano())
+	s.maybeCleanup(time.Now())
+}
+
+func (s *ExpiringSet) Contains(key string) bool {
+	return s.containsAt(key, time.Now())
+}
+
+func (s *ExpiringSet) containsAt(key string, now time.Time) bool {
+	if s == nil || key == "" {
+		return false
+	}
+	value, ok := s.values.Load(key)
+	if !ok {
+		return false
+	}
+	expiresAt, ok := value.(int64)
+	if !ok || now.UnixNano() >= expiresAt {
+		s.values.CompareAndDelete(key, value)
+		return false
+	}
+	return true
+}
+
+func (s *ExpiringSet) Keys() []string {
+	return s.keysAt(time.Now())
+}
+
+func (s *ExpiringSet) keysAt(now time.Time) []string {
+	if s == nil {
+		return nil
+	}
+	var keys []string
+	s.values.Range(func(key, value any) bool {
+		name, keyOK := key.(string)
+		expiresAt, expiryOK := value.(int64)
+		if keyOK && expiryOK && now.UnixNano() < expiresAt {
+			keys = append(keys, name)
+		} else {
+			s.values.CompareAndDelete(key, value)
+		}
+		return true
+	})
+	slices.Sort(keys)
+	return keys
+}
+
+func (s *ExpiringSet) maybeCleanup(now time.Time) {
+	if s.cleanupInterval <= 0 {
+		return
+	}
+	last := s.lastCleanup.Load()
+	if now.UnixNano()-last < s.cleanupInterval.Nanoseconds() ||
+		!s.lastCleanup.CompareAndSwap(last, now.UnixNano()) {
+		return
+	}
+	s.keysAt(now)
+}

--- a/pkg/protocols/common/protocolstate/expiring_set_test.go
+++ b/pkg/protocols/common/protocolstate/expiring_set_test.go
@@ -1,0 +1,102 @@
+package protocolstate
+
+import (
+	"fmt"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExpiringSetContainsAndExpires(t *testing.T) {
+	set := NewExpiringSet(time.Minute)
+	now := time.Now()
+	set.StoreUntil("active", now.Add(time.Minute))
+	set.StoreUntil("expired", now.Add(-time.Second))
+
+	require.True(t, set.containsAt("active", now))
+	require.False(t, set.containsAt("expired", now))
+	_, exists := set.values.Load("expired")
+	require.False(t, exists)
+}
+
+func TestExpiringSetKeysSortsAndCleans(t *testing.T) {
+	set := NewExpiringSet(time.Minute)
+	now := time.Now()
+	set.StoreUntil("b", now.Add(time.Minute))
+	set.StoreUntil("a", now.Add(time.Minute))
+	set.StoreUntil("expired", now.Add(-time.Second))
+
+	require.Equal(t, []string{"a", "b"}, set.keysAt(now))
+	_, exists := set.values.Load("expired")
+	require.False(t, exists)
+}
+
+func TestExpiringSetRefreshesTTL(t *testing.T) {
+	set := NewExpiringSet(time.Minute)
+	now := time.Now()
+	set.StoreUntil("host", now.Add(time.Minute))
+	set.StoreUntil("host", now.Add(2*time.Minute))
+
+	require.True(t, set.containsAt("host", now.Add(90*time.Second)))
+	require.False(t, set.containsAt("host", now.Add(3*time.Minute)))
+}
+
+func TestExpiringSetEmptyAndNil(t *testing.T) {
+	var nilSet *ExpiringSet
+	require.False(t, nilSet.Contains("host"))
+	require.Empty(t, nilSet.Keys())
+
+	set := NewExpiringSet(time.Minute)
+	set.Store("", time.Minute)
+	require.False(t, set.Contains(""))
+	require.Empty(t, set.Keys())
+}
+
+func TestExpiringSetConcurrentAccess(t *testing.T) {
+	set := NewExpiringSet(time.Minute)
+	var done atomic.Int64
+
+	t.Run("parallel", func(t *testing.T) {
+		for i := range 100 {
+			i := i
+			t.Run(strconv.Itoa(i), func(t *testing.T) {
+				t.Parallel()
+				key := fmt.Sprintf("host-%d", i%10)
+				set.Store(key, time.Minute)
+				require.True(t, set.Contains(key))
+				done.Add(1)
+			})
+		}
+	})
+	require.Equal(t, int64(100), done.Load())
+}
+
+func TestExpiringSetConcurrentRefreshSurvivesExpiredCleanup(t *testing.T) {
+	for range 1000 {
+		set := NewExpiringSet(time.Minute)
+		now := time.Now()
+		set.StoreUntil("host", now.Add(-time.Second))
+
+		start := make(chan struct{})
+		done := make(chan struct{}, 2)
+		go func() {
+			<-start
+			_ = set.containsAt("host", now)
+			done <- struct{}{}
+		}()
+		go func() {
+			<-start
+			set.StoreUntil("host", now.Add(time.Minute))
+			done <- struct{}{}
+		}()
+		close(start)
+		<-done
+		<-done
+
+		require.True(t, set.containsAt("host", now),
+			"cleanup of the expired value must not delete a concurrent refresh")
+	}
+}

--- a/pkg/protocols/common/protocolstate/state.go
+++ b/pkg/protocols/common/protocolstate/state.go
@@ -165,7 +165,6 @@ func initDialers(options *types.Options) error {
 			forward = &net.Dialer{
 				Timeout:   opts.DialerTimeout,
 				KeepAlive: opts.DialerKeepAlive,
-				DualStack: true,
 			}
 		}
 		dialer, err := proxy.FromURL(proxyURL, forward)
@@ -216,6 +215,8 @@ func initDialers(options *types.Options) error {
 		Fastdialer:                 dialer,
 		NetworkPolicy:              networkPolicy,
 		HTTPClientPool:             httpClientPool,
+		HTTPDesyncHosts:            NewExpiringSet(time.Minute),
+		HTTPDesyncRTT:              NewExpiringDurationMap(time.Minute),
 		LocalFileAccessAllowed:     options.AllowLocalFileAccess,
 		RestrictLocalNetworkAccess: options.RestrictLocalNetworkAccess,
 		ExcludeTargets:             options.ExcludeTargets,

--- a/pkg/protocols/http/httpclientpool/clientpool.go
+++ b/pkg/protocols/http/httpclientpool/clientpool.go
@@ -303,6 +303,13 @@ func wrappedGet(options *types.Options, configuration *Configuration, host strin
 		clientKey += ":" + host
 	}
 
+	// A host caught sending unsolicited responses gets its own cache entry, so the
+	// keep-alive client already cached for it is not handed out again.
+	noReuse := IsHostDesynced(host)
+	if noReuse {
+		clientKey += ":noreuse"
+	}
+
 	// Fast path: lock-free cache hit.
 	if !hasExplicitJar {
 		if client, ok := pool.GetClient(clientKey); ok {
@@ -330,7 +337,8 @@ func wrappedGet(options *types.Options, configuration *Configuration, host strin
 		maxIdleConns = configuration.Threads
 	}
 
-	disableKeepAlives := configuration.Connection != nil && configuration.Connection.DisableKeepAlive
+	disableKeepAlives := noReuse ||
+		(configuration.Connection != nil && configuration.Connection.DisableKeepAlive)
 
 	responseHeaderTimeout := options.GetTimeouts().HttpResponseHeaderTimeout
 	if configuration.ResponseHeaderTimeout != 0 {

--- a/pkg/protocols/http/httpclientpool/clientpool.go
+++ b/pkg/protocols/http/httpclientpool/clientpool.go
@@ -305,7 +305,7 @@ func wrappedGet(options *types.Options, configuration *Configuration, host strin
 
 	// A host caught sending unsolicited responses gets its own cache entry, so the
 	// keep-alive client already cached for it is not handed out again.
-	noReuse := IsHostDesynced(host)
+	noReuse := IsHostDesynced(options, host)
 	if noReuse {
 		clientKey += ":noreuse"
 	}
@@ -434,7 +434,10 @@ func wrappedGet(options *types.Options, configuration *Configuration, host strin
 			}
 		}
 
-		return &connTrackingTransport{base: transport}, nil
+		tracked := &connTrackingTransport{base: transport}
+		return &desyncDetectingTransport{
+			base: tracked, enabled: !disableKeepAlives, baselines: dialers.HTTPDesyncRTT,
+		}, nil
 	}
 
 	redirectFlow := configuration.RedirectFlow
@@ -488,7 +491,8 @@ func wrappedGet(options *types.Options, configuration *Configuration, host strin
 		if jar != nil {
 			client.HTTPClient.Jar = jar
 		}
-		client.CheckRetry = retryablehttp.HostSprayRetryPolicy()
+		hostSprayRetryPolicy := retryablehttp.HostSprayRetryPolicy()
+		client.CheckRetry = withoutDesyncRetry(hostSprayRetryPolicy)
 		return client, nil
 	}
 
@@ -502,6 +506,18 @@ func wrappedGet(options *types.Options, configuration *Configuration, host strin
 	// Singleflight creation: concurrent first requests to the same host build
 	// exactly one client instead of racing Get/Set and orphaning transports.
 	return pool.GetOrCreateClient(clientKey, transportKey, createTransport, createClient)
+}
+
+func withoutDesyncRetry(policy retryablehttp.CheckRetry) retryablehttp.CheckRetry {
+	return func(ctx context.Context, response *http.Response, err error) (bool, error) {
+		var desyncErr *DesyncError
+		if errors.As(err, &desyncErr) {
+			// Recovery must switch to the no-reuse client; retrying inside
+			// retryablehttp would stay on this poisoned transport.
+			return false, nil
+		}
+		return policy(ctx, response, err)
+	}
 }
 
 // sharedTLSSessionCache is shared by all pooled transports so TLS session

--- a/pkg/protocols/http/httpclientpool/desync_probe.go
+++ b/pkg/protocols/http/httpclientpool/desync_probe.go
@@ -5,29 +5,16 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
 )
-
-// A response that belonged to an earlier request on the connection is already in
-// net/http's read buffer when the next request goes out, so readResponse's Peek(1)
-// returns with no round trip -- often before the request has finished being written.
-// A genuine response cannot cross the network faster than one round trip, so that gap
-// identifies the wrong response exactly, for the request that received it.
-//
-// The baseline is the TCP handshake rather than previous response latencies: how long
-// a server takes to answer swings by orders of magnitude between a cold and a cached
-// response, so a latency baseline would flag the fast ones. The network floor does
-// not move.
-const suspectRTTFraction = 2
-
-// host -> time.Duration of the fastest handshake seen for it.
-var hostRTT sync.Map
 
 // Counts responses found to belong to an earlier request on their connection.
 var desyncedResponses atomic.Int64
 
 // DesyncedResponses reports how many responses turned out to belong to an earlier
-// request on their connection since the process started. Each one was retried, so it
-// measures a condition that was handled, not results lost.
+// request on their connection since the process started. Recovery is attempted for
+// every detection, but may still fail if the body cannot be replayed or dialing fails.
 func DesyncedResponses() int64 {
 	return desyncedResponses.Load()
 }
@@ -37,21 +24,29 @@ func countDesyncedResponse() {
 	desyncedResponses.Add(1)
 }
 
-// DesyncProbe collects one request's timing and reports whether the response it
-// received had been left on the connection by an earlier one.
+// DesyncProbe compares response timing on a reused HTTP/1.x connection with the
+// fastest recent connection setup observed for the same host.
 type DesyncProbe struct {
-	host string
+	host      string
+	baselines *protocolstate.ExpiringDurationMap
 
 	mu           sync.Mutex
 	connectStart time.Time
-	connectRTT   time.Duration
+	gotConn      time.Time
 	wroteHeaders time.Time
 	firstByte    time.Time
 	reused       bool
 }
 
-func NewDesyncProbe(host string) *DesyncProbe {
-	return &DesyncProbe{host: host}
+const (
+	desyncBaselineTTL = 15 * time.Minute
+	// Sub-millisecond scheduling noise dominates very short loopback/LAN RTTs.
+	// Skipping those baselines favors a miss over quarantining a healthy host.
+	minDesyncBaseline = 2 * time.Millisecond
+)
+
+func NewDesyncProbe(host string, baselines *protocolstate.ExpiringDurationMap) *DesyncProbe {
+	return &DesyncProbe{host: desyncedHostKey(host), baselines: baselines}
 }
 
 // Trace returns hooks to attach to the request context. httptrace composes with any
@@ -60,112 +55,65 @@ func (p *DesyncProbe) Trace() *httptrace.ClientTrace {
 	return &httptrace.ClientTrace{
 		GotConn: func(info httptrace.GotConnInfo) {
 			p.mu.Lock()
-			defer p.mu.Unlock()
 			p.reused = info.Reused
+			p.gotConn = time.Now()
+			p.mu.Unlock()
 		},
 		ConnectStart: func(_, _ string) {
 			p.mu.Lock()
-			defer p.mu.Unlock()
 			p.connectStart = time.Now()
+			p.mu.Unlock()
 		},
 		ConnectDone: func(_, _ string, err error) {
 			p.mu.Lock()
-			defer p.mu.Unlock()
-			if err == nil && !p.connectStart.IsZero() {
-				p.connectRTT = time.Since(p.connectStart)
+			start := p.connectStart
+			p.mu.Unlock()
+			if err == nil && !start.IsZero() {
+				p.baselines.StoreMin(p.host, time.Since(start), desyncBaselineTTL)
 			}
 		},
 		WroteHeaders: func() {
 			p.mu.Lock()
-			defer p.mu.Unlock()
 			p.wroteHeaders = time.Now()
+			p.mu.Unlock()
 		},
 		GotFirstResponseByte: func() {
 			p.mu.Lock()
-			defer p.mu.Unlock()
-			p.firstByte = time.Now()
+			if p.firstByte.IsZero() {
+				p.firstByte = time.Now()
+			}
+			p.mu.Unlock()
 		},
 	}
 }
 
-// Suspect reports whether the response belonged to an earlier request, and records
-// what this request learned about the host's round trip time. A response on a fresh
-// connection cannot be someone else's, so those only ever contribute a measurement.
-//
-// A verdict of true also counts towards DesyncedResponses, so call it once per
-// request.
+// Suspect reports whether a reused connection returned a response in less than
+// half the fastest observed connection setup time for the host. This is a
+// conservative symptom check: without transport changes, HTTP/1.x cannot prove
+// that a well-formed response belongs to the current request.
 func (p *DesyncProbe) Suspect() bool {
 	p.mu.Lock()
-	reused, rtt := p.reused, p.connectRTT
-	wroteHeaders, firstByte := p.wroteHeaders, p.firstByte
+	reused := p.reused
+	gotConn := p.gotConn
+	wroteHeaders := p.wroteHeaders
+	firstByte := p.firstByte
 	p.mu.Unlock()
-
-	if rtt > 0 {
-		recordHostRTT(p.host, rtt)
-	}
 
 	if !reused || firstByte.IsZero() {
 		return false
 	}
-
-	baseline, ok := hostRTTFor(p.host)
-	if !ok {
-		// Never measured a handshake for this host, so there is no floor to judge
-		// against. Guessing one would risk disabling reuse for a healthy host.
+	baseline, ok := p.baselines.Load(p.host)
+	if !ok || baseline < minDesyncBaseline {
 		return false
 	}
 
-	if wroteHeaders.IsZero() {
-		countDesyncedResponse()
-
-		// The response arrived before this request's headers were even recorded as
-		// written, which no genuine response can do.
-		return true
+	anchor := wroteHeaders
+	if anchor.IsZero() || firstByte.Before(anchor) {
+		anchor = gotConn
 	}
-
-	if firstByte.Sub(wroteHeaders) >= baseline/suspectRTTFraction {
+	if anchor.IsZero() {
 		return false
 	}
-
-	countDesyncedResponse()
-
-	return true
-}
-
-func recordHostRTT(host string, rtt time.Duration) {
-	key := desyncedHostKey(host)
-	if key == "" {
-		return
-	}
-
-	for {
-		previous, loaded := hostRTT.LoadOrStore(key, rtt)
-		if !loaded {
-			return
-		}
-
-		fastest, ok := previous.(time.Duration)
-		if !ok || rtt >= fastest {
-			return
-		}
-		if hostRTT.CompareAndSwap(key, previous, rtt) {
-			return
-		}
-	}
-}
-
-func hostRTTFor(host string) (time.Duration, bool) {
-	key := desyncedHostKey(host)
-	if key == "" {
-		return 0, false
-	}
-
-	value, ok := hostRTT.Load(key)
-	if !ok {
-		return 0, false
-	}
-
-	rtt, ok := value.(time.Duration)
-
-	return rtt, ok && rtt > 0
+	elapsed := firstByte.Sub(anchor)
+	return elapsed >= 0 && elapsed < baseline/2
 }

--- a/pkg/protocols/http/httpclientpool/desync_probe.go
+++ b/pkg/protocols/http/httpclientpool/desync_probe.go
@@ -1,0 +1,171 @@
+package httpclientpool
+
+import (
+	"net/http/httptrace"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// A response that belonged to an earlier request on the connection is already in
+// net/http's read buffer when the next request goes out, so readResponse's Peek(1)
+// returns with no round trip -- often before the request has finished being written.
+// A genuine response cannot cross the network faster than one round trip, so that gap
+// identifies the wrong response exactly, for the request that received it.
+//
+// The baseline is the TCP handshake rather than previous response latencies: how long
+// a server takes to answer swings by orders of magnitude between a cold and a cached
+// response, so a latency baseline would flag the fast ones. The network floor does
+// not move.
+const suspectRTTFraction = 2
+
+// host -> time.Duration of the fastest handshake seen for it.
+var hostRTT sync.Map
+
+// Counts responses found to belong to an earlier request on their connection.
+var desyncedResponses atomic.Int64
+
+// DesyncedResponses reports how many responses turned out to belong to an earlier
+// request on their connection since the process started. Each one was retried, so it
+// measures a condition that was handled, not results lost.
+func DesyncedResponses() int64 {
+	return desyncedResponses.Load()
+}
+
+// countDesyncedResponse is called by the request path when a probe fires.
+func countDesyncedResponse() {
+	desyncedResponses.Add(1)
+}
+
+// DesyncProbe collects one request's timing and reports whether the response it
+// received had been left on the connection by an earlier one.
+type DesyncProbe struct {
+	host string
+
+	mu           sync.Mutex
+	connectStart time.Time
+	connectRTT   time.Duration
+	wroteHeaders time.Time
+	firstByte    time.Time
+	reused       bool
+}
+
+func NewDesyncProbe(host string) *DesyncProbe {
+	return &DesyncProbe{host: host}
+}
+
+// Trace returns hooks to attach to the request context. httptrace composes with any
+// trace already there, so this does not displace another one.
+func (p *DesyncProbe) Trace() *httptrace.ClientTrace {
+	return &httptrace.ClientTrace{
+		GotConn: func(info httptrace.GotConnInfo) {
+			p.mu.Lock()
+			defer p.mu.Unlock()
+			p.reused = info.Reused
+		},
+		ConnectStart: func(_, _ string) {
+			p.mu.Lock()
+			defer p.mu.Unlock()
+			p.connectStart = time.Now()
+		},
+		ConnectDone: func(_, _ string, err error) {
+			p.mu.Lock()
+			defer p.mu.Unlock()
+			if err == nil && !p.connectStart.IsZero() {
+				p.connectRTT = time.Since(p.connectStart)
+			}
+		},
+		WroteHeaders: func() {
+			p.mu.Lock()
+			defer p.mu.Unlock()
+			p.wroteHeaders = time.Now()
+		},
+		GotFirstResponseByte: func() {
+			p.mu.Lock()
+			defer p.mu.Unlock()
+			p.firstByte = time.Now()
+		},
+	}
+}
+
+// Suspect reports whether the response belonged to an earlier request, and records
+// what this request learned about the host's round trip time. A response on a fresh
+// connection cannot be someone else's, so those only ever contribute a measurement.
+//
+// A verdict of true also counts towards DesyncedResponses, so call it once per
+// request.
+func (p *DesyncProbe) Suspect() bool {
+	p.mu.Lock()
+	reused, rtt := p.reused, p.connectRTT
+	wroteHeaders, firstByte := p.wroteHeaders, p.firstByte
+	p.mu.Unlock()
+
+	if rtt > 0 {
+		recordHostRTT(p.host, rtt)
+	}
+
+	if !reused || firstByte.IsZero() {
+		return false
+	}
+
+	baseline, ok := hostRTTFor(p.host)
+	if !ok {
+		// Never measured a handshake for this host, so there is no floor to judge
+		// against. Guessing one would risk disabling reuse for a healthy host.
+		return false
+	}
+
+	if wroteHeaders.IsZero() {
+		countDesyncedResponse()
+
+		// The response arrived before this request's headers were even recorded as
+		// written, which no genuine response can do.
+		return true
+	}
+
+	if firstByte.Sub(wroteHeaders) >= baseline/suspectRTTFraction {
+		return false
+	}
+
+	countDesyncedResponse()
+
+	return true
+}
+
+func recordHostRTT(host string, rtt time.Duration) {
+	key := desyncedHostKey(host)
+	if key == "" {
+		return
+	}
+
+	for {
+		previous, loaded := hostRTT.LoadOrStore(key, rtt)
+		if !loaded {
+			return
+		}
+
+		fastest, ok := previous.(time.Duration)
+		if !ok || rtt >= fastest {
+			return
+		}
+		if hostRTT.CompareAndSwap(key, previous, rtt) {
+			return
+		}
+	}
+}
+
+func hostRTTFor(host string) (time.Duration, bool) {
+	key := desyncedHostKey(host)
+	if key == "" {
+		return 0, false
+	}
+
+	value, ok := hostRTT.Load(key)
+	if !ok {
+		return 0, false
+	}
+
+	rtt, ok := value.(time.Duration)
+
+	return rtt, ok && rtt > 0
+}

--- a/pkg/protocols/http/httpclientpool/desync_probe_test.go
+++ b/pkg/protocols/http/httpclientpool/desync_probe_test.go
@@ -1,0 +1,131 @@
+package httpclientpool
+
+import (
+	"net/http/httptrace"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// roundTrip is the handshake the probe learns as the host's network floor. Real and
+// generous: the signal it separates is microseconds against milliseconds.
+const roundTrip = 20 * time.Millisecond
+
+func TestDesyncProbeFlagsResponseThatBeatTheNetwork(t *testing.T) {
+	t.Parallel()
+
+	const host = "prebuffered.example.test:443"
+	learnRoundTrip(t, host)
+
+	probe := NewDesyncProbe(host)
+	trace := probe.Trace()
+	trace.GotConn(httptrace.GotConnInfo{Reused: true})
+	trace.WroteHeaders()
+	trace.GotFirstResponseByte() // already in the buffer: no round trip
+
+	require.True(t, probe.Suspect(),
+		"a response that arrived without a round trip belonged to an earlier request")
+}
+
+func TestDesyncProbeAllowsGenuineResponse(t *testing.T) {
+	t.Parallel()
+
+	const host = "healthy.example.test:443"
+	learnRoundTrip(t, host)
+
+	probe := NewDesyncProbe(host)
+	trace := probe.Trace()
+	trace.GotConn(httptrace.GotConnInfo{Reused: true})
+	trace.WroteHeaders()
+	time.Sleep(roundTrip)
+	trace.GotFirstResponseByte()
+
+	require.False(t, probe.Suspect(), "a response that waited for the network is this request's")
+}
+
+// A server may answer a large body early, before the request finishes being written,
+// so the probe anchors on the headers rather than on the whole request.
+func TestDesyncProbeAllowsEarlyAnswerToRequestBody(t *testing.T) {
+	t.Parallel()
+
+	const host = "earlybody.example.test:443"
+	learnRoundTrip(t, host)
+
+	probe := NewDesyncProbe(host)
+	trace := probe.Trace()
+	trace.GotConn(httptrace.GotConnInfo{Reused: true})
+	trace.WroteHeaders()
+	time.Sleep(roundTrip) // server answers while the body is still uploading
+	trace.GotFirstResponseByte()
+
+	require.False(t, probe.Suspect())
+}
+
+func TestDesyncProbeIgnoresFreshConnection(t *testing.T) {
+	t.Parallel()
+
+	const host = "fresh.example.test:443"
+
+	probe := NewDesyncProbe(host)
+	trace := probe.Trace()
+	trace.ConnectStart("tcp", host)
+	time.Sleep(roundTrip)
+	trace.ConnectDone("tcp", host, nil)
+	trace.GotConn(httptrace.GotConnInfo{Reused: false})
+	trace.WroteHeaders()
+	trace.GotFirstResponseByte()
+
+	require.False(t, probe.Suspect(),
+		"the first response on a connection cannot be someone else's")
+
+	rtt, ok := hostRTTFor(host)
+	require.True(t, ok, "a fresh connection must contribute its handshake")
+	require.GreaterOrEqual(t, rtt, roundTrip)
+	t.Cleanup(func() { hostRTT.Delete(desyncedHostKey(host)) })
+}
+
+func TestDesyncProbeWithoutBaselineDoesNotGuess(t *testing.T) {
+	t.Parallel()
+
+	const host = "unmeasured.example.test:443"
+
+	probe := NewDesyncProbe(host)
+	trace := probe.Trace()
+	trace.GotConn(httptrace.GotConnInfo{Reused: true})
+	trace.WroteHeaders()
+	trace.GotFirstResponseByte()
+
+	require.False(t, probe.Suspect(),
+		"with no measured round trip, flagging would cost a healthy host its reuse")
+}
+
+func TestDesyncProbeFlagsResponseBeforeHeaders(t *testing.T) {
+	t.Parallel()
+
+	const host = "beforeheaders.example.test:443"
+	learnRoundTrip(t, host)
+
+	probe := NewDesyncProbe(host)
+	trace := probe.Trace()
+	trace.GotConn(httptrace.GotConnInfo{Reused: true})
+	trace.GotFirstResponseByte() // the read loop won the race against the write loop
+
+	require.True(t, probe.Suspect())
+}
+
+// learnRoundTrip gives the host a handshake measurement, the way a fresh connection
+// would, so later requests have a floor to be judged against.
+func learnRoundTrip(t *testing.T, host string) {
+	t.Helper()
+
+	probe := NewDesyncProbe(host)
+	trace := probe.Trace()
+	trace.ConnectStart("tcp", host)
+	time.Sleep(roundTrip)
+	trace.ConnectDone("tcp", host, nil)
+	trace.GotConn(httptrace.GotConnInfo{Reused: false})
+
+	require.False(t, probe.Suspect())
+	t.Cleanup(func() { hostRTT.Delete(desyncedHostKey(host)) })
+}

--- a/pkg/protocols/http/httpclientpool/desync_probe_test.go
+++ b/pkg/protocols/http/httpclientpool/desync_probe_test.go
@@ -2,62 +2,68 @@ package httpclientpool
 
 import (
 	"net/http/httptrace"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
 	"github.com/stretchr/testify/require"
 )
 
-// roundTrip is the handshake the probe learns as the host's network floor. Real and
-// generous: the signal it separates is microseconds against milliseconds.
-const roundTrip = 20 * time.Millisecond
+func newProbeWithBaseline(host string, baseline time.Duration) *DesyncProbe {
+	baselines := protocolstate.NewExpiringDurationMap(time.Minute)
+	baselines.StoreMin(host, baseline, time.Minute)
+	return NewDesyncProbe(host, baselines)
+}
 
-func TestDesyncProbeFlagsResponseThatBeatTheNetwork(t *testing.T) {
+func TestDesyncProbeFlagsImplausiblyFastReusedResponse(t *testing.T) {
 	t.Parallel()
 
-	const host = "prebuffered.example.test:443"
-	learnRoundTrip(t, host)
+	probe := newProbeWithBaseline("example.com", 100*time.Millisecond)
+	now := time.Now()
+	probe.reused = true
+	probe.gotConn = now
+	probe.wroteHeaders = now
+	probe.firstByte = now.Add(time.Millisecond)
 
-	probe := NewDesyncProbe(host)
-	trace := probe.Trace()
-	trace.GotConn(httptrace.GotConnInfo{Reused: true})
-	trace.WroteHeaders()
-	trace.GotFirstResponseByte() // already in the buffer: no round trip
-
-	require.True(t, probe.Suspect(),
-		"a response that arrived without a round trip belonged to an earlier request")
+	require.True(t, probe.Suspect())
 }
 
 func TestDesyncProbeAllowsGenuineResponse(t *testing.T) {
 	t.Parallel()
 
-	const host = "healthy.example.test:443"
-	learnRoundTrip(t, host)
+	probe := newProbeWithBaseline("example.com", 100*time.Millisecond)
+	now := time.Now()
+	probe.reused = true
+	probe.gotConn = now
+	probe.wroteHeaders = now
+	probe.firstByte = now.Add(60 * time.Millisecond)
 
-	probe := NewDesyncProbe(host)
-	trace := probe.Trace()
-	trace.GotConn(httptrace.GotConnInfo{Reused: true})
-	trace.WroteHeaders()
-	time.Sleep(roundTrip)
-	trace.GotFirstResponseByte()
-
-	require.False(t, probe.Suspect(), "a response that waited for the network is this request's")
+	require.False(t, probe.Suspect())
 }
 
-// A server may answer a large body early, before the request finishes being written,
-// so the probe anchors on the headers rather than on the whole request.
-func TestDesyncProbeAllowsEarlyAnswerToRequestBody(t *testing.T) {
+func TestDesyncProbeUsesConnectionCheckoutBeforeWroteHeaders(t *testing.T) {
 	t.Parallel()
 
-	const host = "earlybody.example.test:443"
-	learnRoundTrip(t, host)
+	probe := newProbeWithBaseline("example.com", 100*time.Millisecond)
+	now := time.Now()
+	probe.reused = true
+	probe.gotConn = now
+	probe.firstByte = now.Add(time.Millisecond)
+	probe.wroteHeaders = now.Add(2 * time.Millisecond)
 
-	probe := NewDesyncProbe(host)
-	trace := probe.Trace()
-	trace.GotConn(httptrace.GotConnInfo{Reused: true})
-	trace.WroteHeaders()
-	time.Sleep(roundTrip) // server answers while the body is still uploading
-	trace.GotFirstResponseByte()
+	require.True(t, probe.Suspect())
+}
+
+func TestDesyncProbeAllowsLargeHeaderEarlyResponse(t *testing.T) {
+	t.Parallel()
+
+	probe := newProbeWithBaseline("example.com", 100*time.Millisecond)
+	now := time.Now()
+	probe.reused = true
+	probe.gotConn = now
+	probe.firstByte = now.Add(60 * time.Millisecond)
+	probe.wroteHeaders = now.Add(70 * time.Millisecond)
 
 	require.False(t, probe.Suspect())
 }
@@ -65,67 +71,62 @@ func TestDesyncProbeAllowsEarlyAnswerToRequestBody(t *testing.T) {
 func TestDesyncProbeIgnoresFreshConnection(t *testing.T) {
 	t.Parallel()
 
-	const host = "fresh.example.test:443"
-
-	probe := NewDesyncProbe(host)
-	trace := probe.Trace()
-	trace.ConnectStart("tcp", host)
-	time.Sleep(roundTrip)
-	trace.ConnectDone("tcp", host, nil)
-	trace.GotConn(httptrace.GotConnInfo{Reused: false})
-	trace.WroteHeaders()
-	trace.GotFirstResponseByte()
-
-	require.False(t, probe.Suspect(),
-		"the first response on a connection cannot be someone else's")
-
-	rtt, ok := hostRTTFor(host)
-	require.True(t, ok, "a fresh connection must contribute its handshake")
-	require.GreaterOrEqual(t, rtt, roundTrip)
-	t.Cleanup(func() { hostRTT.Delete(desyncedHostKey(host)) })
-}
-
-func TestDesyncProbeWithoutBaselineDoesNotGuess(t *testing.T) {
-	t.Parallel()
-
-	const host = "unmeasured.example.test:443"
-
-	probe := NewDesyncProbe(host)
-	trace := probe.Trace()
-	trace.GotConn(httptrace.GotConnInfo{Reused: true})
-	trace.WroteHeaders()
-	trace.GotFirstResponseByte()
-
-	require.False(t, probe.Suspect(),
-		"with no measured round trip, flagging would cost a healthy host its reuse")
-}
-
-func TestDesyncProbeFlagsResponseBeforeHeaders(t *testing.T) {
-	t.Parallel()
-
-	const host = "beforeheaders.example.test:443"
-	learnRoundTrip(t, host)
-
-	probe := NewDesyncProbe(host)
-	trace := probe.Trace()
-	trace.GotConn(httptrace.GotConnInfo{Reused: true})
-	trace.GotFirstResponseByte() // the read loop won the race against the write loop
-
-	require.True(t, probe.Suspect())
-}
-
-// learnRoundTrip gives the host a handshake measurement, the way a fresh connection
-// would, so later requests have a floor to be judged against.
-func learnRoundTrip(t *testing.T, host string) {
-	t.Helper()
-
-	probe := NewDesyncProbe(host)
-	trace := probe.Trace()
-	trace.ConnectStart("tcp", host)
-	time.Sleep(roundTrip)
-	trace.ConnectDone("tcp", host, nil)
-	trace.GotConn(httptrace.GotConnInfo{Reused: false})
+	probe := newProbeWithBaseline("example.com", 100*time.Millisecond)
+	now := time.Now()
+	probe.gotConn = now
+	probe.wroteHeaders = now
+	probe.firstByte = now.Add(time.Millisecond)
 
 	require.False(t, probe.Suspect())
-	t.Cleanup(func() { hostRTT.Delete(desyncedHostKey(host)) })
+}
+
+func TestDesyncProbeRequiresBaseline(t *testing.T) {
+	t.Parallel()
+
+	probe := NewDesyncProbe("example.com", protocolstate.NewExpiringDurationMap(time.Minute))
+	now := time.Now()
+	probe.reused = true
+	probe.gotConn = now
+	probe.wroteHeaders = now
+	probe.firstByte = now.Add(time.Millisecond)
+	require.False(t, probe.Suspect())
+}
+
+func TestDesyncProbeConcurrentCallbacksAreRaceSafe(t *testing.T) {
+	t.Parallel()
+
+	for range 100 {
+		probe := newProbeWithBaseline("example.com", 100*time.Millisecond)
+		trace := probe.Trace()
+		trace.GotConn(httptrace.GotConnInfo{Reused: true})
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			trace.WroteHeaders()
+		}()
+		go func() {
+			defer wg.Done()
+			trace.GotFirstResponseByte()
+		}()
+		wg.Wait()
+		_ = probe.Suspect()
+	}
+}
+
+func BenchmarkDesyncProbeHealthyRequest(b *testing.B) {
+	baselines := protocolstate.NewExpiringDurationMap(time.Minute)
+	baselines.StoreMin("example.com", time.Millisecond, time.Minute)
+	b.ReportAllocs()
+	for range b.N {
+		probe := NewDesyncProbe("example.com", baselines)
+		now := time.Now()
+		probe.reused = true
+		probe.gotConn = now
+		probe.wroteHeaders = now
+		probe.firstByte = now.Add(time.Millisecond)
+		if probe.Suspect() {
+			b.Fatal("healthy ordering reported as desynchronized")
+		}
+	}
 }

--- a/pkg/protocols/http/httpclientpool/desync_probe_test.go
+++ b/pkg/protocols/http/httpclientpool/desync_probe_test.go
@@ -116,7 +116,7 @@ func TestDesyncProbeConcurrentCallbacksAreRaceSafe(t *testing.T) {
 
 func BenchmarkDesyncProbeHealthyRequest(b *testing.B) {
 	baselines := protocolstate.NewExpiringDurationMap(time.Minute)
-	baselines.StoreMin("example.com", time.Millisecond, time.Minute)
+	baselines.StoreMin("example.com", 100*time.Millisecond, time.Minute)
 	b.ReportAllocs()
 	for range b.N {
 		probe := NewDesyncProbe("example.com", baselines)
@@ -124,7 +124,7 @@ func BenchmarkDesyncProbeHealthyRequest(b *testing.B) {
 		probe.reused = true
 		probe.gotConn = now
 		probe.wroteHeaders = now
-		probe.firstByte = now.Add(time.Millisecond)
+		probe.firstByte = now.Add(60 * time.Millisecond)
 		if probe.Suspect() {
 			b.Fatal("healthy ordering reported as desynchronized")
 		}

--- a/pkg/protocols/http/httpclientpool/desync_recovery.go
+++ b/pkg/protocols/http/httpclientpool/desync_recovery.go
@@ -1,0 +1,112 @@
+package httpclientpool
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
+	"github.com/projectdiscovery/nuclei/v3/pkg/types"
+	"github.com/projectdiscovery/retryablehttp-go"
+)
+
+// ErrDesyncedResponse marks a detected response that belonged to an earlier
+// request and could not be safely recovered.
+var ErrDesyncedResponse = errors.New("response arrived before a network round trip")
+
+// DoWithDesyncRecovery executes req and retries it once on a fresh HTTP/1.x
+// connection if net/http delivers an implausibly early response on a reused
+// connection. The returned client is the one that executed the
+// final attempt, and the boolean reports whether desynchronization was detected.
+func DoWithDesyncRecovery(
+	client *retryablehttp.Client,
+	req *retryablehttp.Request,
+	options *types.Options,
+	configuration *Configuration,
+	host string,
+) (*http.Response, *retryablehttp.Client, bool, error) {
+	hosts := desyncHostsFor(options)
+	hostKey := desyncedHostKey(host)
+
+	return doWithDesyncRecovery(client, req, hostKey, hosts, func(detectedHost string) (*retryablehttp.Client, error) {
+		return Get(options, configuration, detectedHost)
+	})
+}
+
+type desyncClientFactory func(host string) (*retryablehttp.Client, error)
+
+func doWithDesyncRecovery(
+	client *retryablehttp.Client,
+	req *retryablehttp.Request,
+	hostKey string,
+	hosts *protocolstate.ExpiringSet,
+	reissue desyncClientFactory,
+) (*http.Response, *retryablehttp.Client, bool, error) {
+	if client == nil || req == nil || req.Request == nil {
+		return nil, client, false, fmt.Errorf("invalid HTTP client or request")
+	}
+
+	resp, err := client.Do(req)
+	var desyncErr *DesyncError
+	if !errors.As(err, &desyncErr) {
+		return resp, client, false, err
+	}
+
+	if hosts == nil {
+		return nil, client, true, err
+	}
+	detectedHost := hostKey
+	if responseHost := desyncedHostKey(desyncErr.Host); responseHost != "" {
+		detectedHost = responseHost
+	}
+	hosts.Store(detectedHost, desyncedHostTTL)
+	countDesyncedResponse()
+
+	if !requestReplaySafe(req.Request) {
+		return nil, client, true, fmt.Errorf(
+			"%w: refusing to replay non-idempotent %s request",
+			ErrDesyncedResponse, req.Method,
+		)
+	}
+	if err := rewindRequestBody(req); err != nil {
+		return nil, client, true, fmt.Errorf("%w: %w", ErrDesyncedResponse, err)
+	}
+	reissued, err := reissue(detectedHost)
+	if err != nil {
+		return nil, client, true, fmt.Errorf("could not create no-reuse client after HTTP desync: %w", err)
+	}
+	if reissued == nil {
+		return nil, client, true, fmt.Errorf("no-reuse client is nil after HTTP desync")
+	}
+
+	resp, err = reissued.Do(req)
+	return resp, reissued, true, err
+}
+
+func requestReplaySafe(req *http.Request) bool {
+	if req == nil {
+		return false
+	}
+	switch req.Method {
+	case http.MethodGet, http.MethodHead, http.MethodOptions, http.MethodTrace,
+		http.MethodPut, http.MethodDelete:
+		return true
+	default:
+		return req.Header.Get("Idempotency-Key") != ""
+	}
+}
+
+func rewindRequestBody(req *retryablehttp.Request) error {
+	if req.Body == nil || req.Body == http.NoBody {
+		return nil
+	}
+	if req.GetBody == nil {
+		return fmt.Errorf("cannot retry request after HTTP desync: request body is not replayable")
+	}
+	body, err := req.GetBody()
+	if err != nil {
+		return fmt.Errorf("cannot rewind request after HTTP desync: %w", err)
+	}
+	req.Body = body
+	return nil
+}

--- a/pkg/protocols/http/httpclientpool/desync_recovery.go
+++ b/pkg/protocols/http/httpclientpool/desync_recovery.go
@@ -53,7 +53,7 @@ func doWithDesyncRecovery(
 	}
 
 	if hosts == nil {
-		return nil, client, true, err
+		return nil, client, true, fmt.Errorf("%w: %w", ErrDesyncedResponse, err)
 	}
 	detectedHost := hostKey
 	if responseHost := desyncedHostKey(desyncErr.Host); responseHost != "" {
@@ -73,10 +73,10 @@ func doWithDesyncRecovery(
 	}
 	reissued, err := reissue(detectedHost)
 	if err != nil {
-		return nil, client, true, fmt.Errorf("could not create no-reuse client after HTTP desync: %w", err)
+		return nil, client, true, fmt.Errorf("%w: could not create no-reuse client after HTTP desync: %w", ErrDesyncedResponse, err)
 	}
 	if reissued == nil {
-		return nil, client, true, fmt.Errorf("no-reuse client is nil after HTTP desync")
+		return nil, client, true, fmt.Errorf("%w: no-reuse client is nil after HTTP desync", ErrDesyncedResponse)
 	}
 
 	resp, err = reissued.Do(req)

--- a/pkg/protocols/http/httpclientpool/desync_recovery.go
+++ b/pkg/protocols/http/httpclientpool/desync_recovery.go
@@ -78,9 +78,19 @@ func doWithDesyncRecovery(
 	if reissued == nil {
 		return nil, client, true, fmt.Errorf("%w: no-reuse client is nil after HTTP desync", ErrDesyncedResponse)
 	}
+	copyCookieJar(client, reissued)
 
 	resp, err = reissued.Do(req)
 	return resp, reissued, true, err
+}
+
+func copyCookieJar(from, to *retryablehttp.Client) {
+	if from == nil || to == nil || from.HTTPClient == nil || to.HTTPClient == nil {
+		return
+	}
+	if from.HTTPClient.Jar != nil {
+		to.HTTPClient.Jar = from.HTTPClient.Jar
+	}
 }
 
 func requestReplaySafe(req *http.Request) bool {

--- a/pkg/protocols/http/httpclientpool/desync_recovery_test.go
+++ b/pkg/protocols/http/httpclientpool/desync_recovery_test.go
@@ -524,6 +524,7 @@ func TestDesyncRecoveryPropagatesNoReuseClientFailure(t *testing.T) {
 	require.Same(t, first, used)
 	require.True(t, recovered)
 	require.ErrorContains(t, err, "pool failed")
+	require.ErrorIs(t, err, ErrDesyncedResponse)
 	require.Equal(t, int64(1), firstRT.calls.Load())
 }
 

--- a/pkg/protocols/http/httpclientpool/desync_recovery_test.go
+++ b/pkg/protocols/http/httpclientpool/desync_recovery_test.go
@@ -1,0 +1,636 @@
+package httpclientpool
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httptrace"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
+	"github.com/projectdiscovery/retryablehttp-go"
+)
+
+func delayedTracedDial(delay time.Duration) func(context.Context, string, string) (net.Conn, error) {
+	return func(ctx context.Context, network, address string) (net.Conn, error) {
+		trace := httptrace.ContextClientTrace(ctx)
+		if trace != nil && trace.ConnectStart != nil {
+			trace.ConnectStart(network, address)
+		}
+		timer := time.NewTimer(delay)
+		defer timer.Stop()
+		select {
+		case <-timer.C:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+		conn, err := net.DialTimeout(network, address, time.Second)
+		if trace != nil && trace.ConnectDone != nil {
+			trace.ConnectDone(network, address, err)
+		}
+		return conn, err
+	}
+}
+
+func TestDesyncTransportDetectsExtraResponseOnReusedSocket(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = listener.Close() })
+
+	serverDone := make(chan error, 1)
+	go func() {
+		conn, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			serverDone <- acceptErr
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		reader := bufio.NewReader(conn)
+		for requestNumber := 1; requestNumber <= 2; requestNumber++ {
+			req, readErr := http.ReadRequest(reader)
+			if readErr != nil {
+				serverDone <- readErr
+				return
+			}
+			_ = req.Body.Close()
+			if requestNumber == 1 {
+				_, readErr = fmt.Fprint(conn,
+					"HTTP/1.1 200 OK\r\nContent-Length: 1\r\n\r\n1")
+			} else {
+				// This valid response belongs to the first request but arrives only
+				// after net/http has reused the socket for the second one.
+				_, readErr = fmt.Fprint(conn,
+					"HTTP/1.1 200 OK\r\nContent-Length: 1\r\nX-Response: stale\r\n\r\nS"+
+						"HTTP/1.1 200 OK\r\nContent-Length: 1\r\nX-Response: fresh\r\n\r\nF")
+			}
+			if readErr != nil {
+				serverDone <- readErr
+				return
+			}
+		}
+		serverDone <- nil
+	}()
+
+	baselines := protocolstate.NewExpiringDurationMap(time.Minute)
+	transport := &http.Transport{
+		MaxIdleConnsPerHost: 1,
+		DialContext:         delayedTracedDial(100 * time.Millisecond),
+	}
+	client := &http.Client{Transport: &desyncDetectingTransport{
+		base: transport, enabled: true, baselines: baselines,
+	}}
+	t.Cleanup(client.CloseIdleConnections)
+
+	url := "http://" + listener.Addr().String()
+	first, err := client.Get(url)
+	require.NoError(t, err)
+	_, err = io.Copy(io.Discard, first.Body)
+	require.NoError(t, err)
+	require.NoError(t, first.Body.Close())
+
+	second, err := client.Get(url)
+	require.Nil(t, second)
+	var desyncErr *DesyncError
+	require.ErrorAs(t, err, &desyncErr)
+	require.Equal(t, listener.Addr().String(), desyncErr.Host)
+	require.NoError(t, <-serverDone)
+}
+
+func TestDesyncTransportAllowsHealthyReusedSocket(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(60 * time.Millisecond)
+		_, _ = io.WriteString(w, "ok")
+	}))
+	t.Cleanup(server.Close)
+
+	baselines := protocolstate.NewExpiringDurationMap(time.Minute)
+	transport := &http.Transport{
+		MaxIdleConnsPerHost: 1,
+		DialContext:         delayedTracedDial(100 * time.Millisecond),
+	}
+	client := &http.Client{Transport: &desyncDetectingTransport{
+		base: transport, enabled: true, baselines: baselines,
+	}}
+	t.Cleanup(client.CloseIdleConnections)
+
+	first, err := client.Get(server.URL)
+	require.NoError(t, err)
+	_, err = io.Copy(io.Discard, first.Body)
+	require.NoError(t, err)
+	require.NoError(t, first.Body.Close())
+
+	var reused atomic.Bool
+	req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+	require.NoError(t, err)
+	req = req.WithContext(httptrace.WithClientTrace(req.Context(), &httptrace.ClientTrace{
+		GotConn: func(info httptrace.GotConnInfo) { reused.Store(info.Reused) },
+	}))
+	second, err := client.Do(req)
+	require.NoError(t, err)
+	require.True(t, reused.Load())
+	body, err := io.ReadAll(second.Body)
+	require.NoError(t, err)
+	require.Equal(t, "ok", string(body))
+	require.NoError(t, second.Body.Close())
+}
+
+type scriptedRoundTripper struct {
+	steps     []func(*http.Request) (*http.Response, error)
+	calls     atomic.Int64
+	closeIdle atomic.Int64
+}
+
+func (s *scriptedRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	index := int(s.calls.Add(1)) - 1
+	if index >= len(s.steps) {
+		return nil, errors.New("unexpected transport call")
+	}
+	return s.steps[index](req)
+}
+
+func (s *scriptedRoundTripper) CloseIdleConnections() {
+	s.closeIdle.Add(1)
+}
+
+type trackingBody struct {
+	io.Reader
+	closed atomic.Bool
+}
+
+func (b *trackingBody) Close() error {
+	b.closed.Store(true)
+	return nil
+}
+
+func newScriptedClient(rt http.RoundTripper, retries int) *retryablehttp.Client {
+	options := retryablehttp.DefaultOptionsSingle
+	options.HttpClient = &http.Client{Transport: rt}
+	options.RetryMax = retries
+	options.RetryWaitMin = 0
+	options.RetryWaitMax = 0
+	options.Timeout = 5 * time.Second
+	return retryablehttp.NewClient(options)
+}
+
+func newDetectingClient(rt http.RoundTripper, retries int) *retryablehttp.Client {
+	baselines := protocolstate.NewExpiringDurationMap(time.Minute)
+	for _, host := range []string{
+		"example.test", "redirected.example:8443", "origin.example", "redirect-target.example",
+	} {
+		baselines.StoreMin(host, 100*time.Millisecond, time.Minute)
+	}
+	client := newScriptedClient(&desyncDetectingTransport{
+		base: rt, enabled: true, baselines: baselines,
+	}, retries)
+	client.CheckRetry = withoutDesyncRetry(client.CheckRetry)
+	return client
+}
+
+func tracedResponse(req *http.Request, reused, beforeHeaders bool, protoMajor int, body io.ReadCloser) *http.Response {
+	trace := httptrace.ContextClientTrace(req.Context())
+	if trace != nil && trace.GotConn != nil {
+		trace.GotConn(httptrace.GotConnInfo{Reused: reused})
+	}
+	if beforeHeaders {
+		if trace != nil && trace.GotFirstResponseByte != nil {
+			trace.GotFirstResponseByte()
+		}
+		if trace != nil && trace.WroteHeaders != nil {
+			trace.WroteHeaders()
+		}
+	} else {
+		if trace != nil && trace.WroteHeaders != nil {
+			trace.WroteHeaders()
+		}
+		if reused {
+			time.Sleep(60 * time.Millisecond)
+		}
+		if trace != nil && trace.GotFirstResponseByte != nil {
+			trace.GotFirstResponseByte()
+		}
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		ProtoMajor: protoMajor,
+		ProtoMinor: 1,
+		Header:     make(http.Header),
+		Body:       body,
+		Request:    req,
+	}
+}
+
+func TestDesyncRecoveryRetriesClosesAndQuarantines(t *testing.T) {
+	badBody := &trackingBody{Reader: strings.NewReader("wrong")}
+	firstRT := &scriptedRoundTripper{steps: []func(*http.Request) (*http.Response, error){
+		func(req *http.Request) (*http.Response, error) {
+			return tracedResponse(req, true, true, 1, badBody), nil
+		},
+	}}
+	secondRT := &scriptedRoundTripper{steps: []func(*http.Request) (*http.Response, error){
+		func(req *http.Request) (*http.Response, error) {
+			return tracedResponse(req, false, false, 1, io.NopCloser(strings.NewReader("correct"))), nil
+		},
+	}}
+	first := newDetectingClient(firstRT, 3)
+	second := newScriptedClient(secondRT, 0)
+	req, err := retryablehttp.NewRequest(http.MethodGet, "http://example.test/", nil)
+	require.NoError(t, err)
+	hosts := protocolstate.NewExpiringSet(time.Minute)
+	before := DesyncedResponses()
+
+	resp, used, recovered, err := doWithDesyncRecovery(
+		first, req, "example.test", hosts,
+		func(string) (*retryablehttp.Client, error) { return second, nil },
+	)
+	require.NoError(t, err)
+	require.True(t, recovered)
+	require.Same(t, second, used)
+	require.True(t, badBody.closed.Load(), "the misattributed response body must be closed")
+	require.Equal(t, int64(1), firstRT.calls.Load(), "retryablehttp must not retry on the poisoned transport")
+	require.Equal(t, int64(1), firstRT.closeIdle.Load(), "the poisoned idle pool must be closed")
+	require.True(t, hosts.Contains("example.test"))
+	require.Equal(t, before+1, DesyncedResponses())
+
+	data, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "correct", string(data))
+	require.NoError(t, resp.Body.Close())
+}
+
+func TestDesyncRecoveryAttributesFinalRedirectHost(t *testing.T) {
+	firstRT := &scriptedRoundTripper{steps: []func(*http.Request) (*http.Response, error){
+		func(req *http.Request) (*http.Response, error) {
+			return tracedResponse(req, true, true, 1, io.NopCloser(strings.NewReader("wrong"))), nil
+		},
+	}}
+	secondRT := &scriptedRoundTripper{steps: []func(*http.Request) (*http.Response, error){
+		func(req *http.Request) (*http.Response, error) {
+			return tracedResponse(req, false, false, 1, io.NopCloser(strings.NewReader("correct"))), nil
+		},
+	}}
+	first := newDetectingClient(firstRT, 0)
+	second := newScriptedClient(secondRT, 0)
+	req, err := retryablehttp.NewRequest(http.MethodGet, "http://redirected.example:8443/", nil)
+	require.NoError(t, err)
+	hosts := protocolstate.NewExpiringSet(time.Minute)
+	var factoryHost string
+
+	resp, _, recovered, err := doWithDesyncRecovery(
+		first, req, "origin.example:80", hosts,
+		func(host string) (*retryablehttp.Client, error) {
+			factoryHost = host
+			return second, nil
+		},
+	)
+	require.NoError(t, err)
+	require.True(t, recovered)
+	require.Equal(t, "redirected.example:8443", factoryHost)
+	require.True(t, hosts.Contains("redirected.example:8443"))
+	require.False(t, hosts.Contains("origin.example:80"))
+	require.NoError(t, resp.Body.Close())
+}
+
+func TestDesyncRecoveryStopsBeforeFollowingPoisonedRedirect(t *testing.T) {
+	firstRT := &scriptedRoundTripper{steps: []func(*http.Request) (*http.Response, error){
+		func(req *http.Request) (*http.Response, error) {
+			resp := tracedResponse(req, true, true, 1, io.NopCloser(strings.NewReader("redirect")))
+			resp.StatusCode = http.StatusFound
+			resp.Header.Set("Location", "http://redirect-target.example/")
+			return resp, nil
+		},
+	}}
+	secondRT := &scriptedRoundTripper{steps: []func(*http.Request) (*http.Response, error){
+		func(req *http.Request) (*http.Response, error) {
+			return tracedResponse(req, false, false, 1, io.NopCloser(strings.NewReader("correct"))), nil
+		},
+	}}
+	first := newDetectingClient(firstRT, 3)
+	second := newScriptedClient(secondRT, 0)
+	req, err := retryablehttp.NewRequest(http.MethodGet, "http://origin.example/", nil)
+	require.NoError(t, err)
+
+	resp, _, detected, err := doWithDesyncRecovery(
+		first, req, "origin.example", protocolstate.NewExpiringSet(time.Minute),
+		func(string) (*retryablehttp.Client, error) { return second, nil },
+	)
+	require.NoError(t, err)
+	require.True(t, detected)
+	require.Equal(t, int64(1), firstRT.calls.Load(),
+		"the poisoned redirect must not be followed or retried on its transport")
+	data, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "correct", string(data))
+	require.NoError(t, resp.Body.Close())
+}
+
+func TestDesyncRecoveryAllowsHealthyFastHTTP1Response(t *testing.T) {
+	rt := &scriptedRoundTripper{steps: []func(*http.Request) (*http.Response, error){
+		func(req *http.Request) (*http.Response, error) {
+			return tracedResponse(req, true, false, 1, io.NopCloser(strings.NewReader("ok"))), nil
+		},
+	}}
+	client := newDetectingClient(rt, 0)
+	req, err := retryablehttp.NewRequest(http.MethodGet, "https://example.test/", nil)
+	require.NoError(t, err)
+	factoryCalled := false
+
+	resp, used, recovered, err := doWithDesyncRecovery(
+		client, req, "example.test:443", protocolstate.NewExpiringSet(time.Minute),
+		func(string) (*retryablehttp.Client, error) {
+			factoryCalled = true
+			return nil, nil
+		},
+	)
+	require.NoError(t, err)
+	require.False(t, recovered)
+	require.False(t, factoryCalled)
+	require.Same(t, client, used)
+	require.NoError(t, resp.Body.Close())
+}
+
+func TestDesyncRecoveryIgnoresHTTP2(t *testing.T) {
+	rt := &scriptedRoundTripper{steps: []func(*http.Request) (*http.Response, error){
+		func(req *http.Request) (*http.Response, error) {
+			return tracedResponse(req, true, true, 2, io.NopCloser(strings.NewReader("h2"))), nil
+		},
+	}}
+	client := newDetectingClient(rt, 0)
+	req, err := retryablehttp.NewRequest(http.MethodGet, "https://example.test/", nil)
+	require.NoError(t, err)
+
+	resp, _, recovered, err := doWithDesyncRecovery(
+		client, req, "example.test:443", protocolstate.NewExpiringSet(time.Minute),
+		func(string) (*retryablehttp.Client, error) {
+			t.Fatal("HTTP/2 must not be quarantined")
+			return nil, nil
+		},
+	)
+	require.NoError(t, err)
+	require.False(t, recovered)
+	require.NoError(t, resp.Body.Close())
+}
+
+func TestDesyncRecoveryIgnoresFreshConnection(t *testing.T) {
+	rt := &scriptedRoundTripper{steps: []func(*http.Request) (*http.Response, error){
+		func(req *http.Request) (*http.Response, error) {
+			return tracedResponse(req, false, true, 1, io.NopCloser(strings.NewReader("ok"))), nil
+		},
+	}}
+	client := newDetectingClient(rt, 0)
+	req, err := retryablehttp.NewRequest(http.MethodGet, "http://example.test/", nil)
+	require.NoError(t, err)
+
+	resp, _, recovered, err := doWithDesyncRecovery(
+		client, req, "example.test:80", protocolstate.NewExpiringSet(time.Minute),
+		func(string) (*retryablehttp.Client, error) {
+			t.Fatal("fresh connection must not be retried")
+			return nil, nil
+		},
+	)
+	require.NoError(t, err)
+	require.False(t, recovered)
+	require.NoError(t, resp.Body.Close())
+}
+
+func TestDesyncRecoveryReplaysRequestBody(t *testing.T) {
+	const payload = "important-post-body"
+	var bodies []string
+	makeStep := func(reused, before bool) func(*http.Request) (*http.Response, error) {
+		return func(req *http.Request) (*http.Response, error) {
+			data, err := io.ReadAll(req.Body)
+			require.NoError(t, err)
+			bodies = append(bodies, string(data))
+			return tracedResponse(req, reused, before, 1, io.NopCloser(strings.NewReader("ok"))), nil
+		}
+	}
+	first := newDetectingClient(&scriptedRoundTripper{steps: []func(*http.Request) (*http.Response, error){
+		makeStep(true, true),
+	}}, 0)
+	second := newScriptedClient(&scriptedRoundTripper{steps: []func(*http.Request) (*http.Response, error){
+		makeStep(false, false),
+	}}, 0)
+	req, err := retryablehttp.NewRequest(http.MethodPost, "http://example.test/", strings.NewReader(payload))
+	require.NoError(t, err)
+	req.Header.Set("Idempotency-Key", "scan-request-1")
+
+	resp, _, recovered, err := doWithDesyncRecovery(
+		first, req, "example.test:80", protocolstate.NewExpiringSet(time.Minute),
+		func(string) (*retryablehttp.Client, error) { return second, nil },
+	)
+	require.NoError(t, err)
+	require.True(t, recovered)
+	require.Equal(t, []string{payload, payload}, bodies)
+	require.NoError(t, resp.Body.Close())
+}
+
+func TestDesyncRecoveryRejectsUnreplayableBody(t *testing.T) {
+	first := newDetectingClient(&scriptedRoundTripper{steps: []func(*http.Request) (*http.Response, error){
+		func(req *http.Request) (*http.Response, error) {
+			_, _ = io.Copy(io.Discard, req.Body)
+			return tracedResponse(req, true, true, 1, io.NopCloser(strings.NewReader("wrong"))), nil
+		},
+	}}, 0)
+	req, err := retryablehttp.NewRequest(http.MethodPut, "http://example.test/", nil)
+	require.NoError(t, err)
+	req.Body = io.NopCloser(strings.NewReader("stream"))
+	req.GetBody = nil
+
+	resp, _, recovered, err := doWithDesyncRecovery(
+		first, req, "example.test:80", protocolstate.NewExpiringSet(time.Minute),
+		func(string) (*retryablehttp.Client, error) {
+			t.Fatal("unreplayable body must not be retried")
+			return nil, nil
+		},
+	)
+	require.Nil(t, resp)
+	require.True(t, recovered)
+	require.ErrorContains(t, err, "not replayable")
+	require.ErrorIs(t, err, ErrDesyncedResponse)
+}
+
+func TestDesyncRecoveryRefusesNonIdempotentReplay(t *testing.T) {
+	for _, method := range []string{http.MethodPost, http.MethodPatch, http.MethodConnect} {
+		t.Run(method, func(t *testing.T) {
+			badBody := &trackingBody{Reader: strings.NewReader("wrong")}
+			first := newDetectingClient(&scriptedRoundTripper{steps: []func(*http.Request) (*http.Response, error){
+				func(req *http.Request) (*http.Response, error) {
+					return tracedResponse(req, true, true, 1, badBody), nil
+				},
+			}}, 0)
+			req, err := retryablehttp.NewRequest(method, "http://example.test/", nil)
+			require.NoError(t, err)
+			hosts := protocolstate.NewExpiringSet(time.Minute)
+
+			resp, used, detected, err := doWithDesyncRecovery(
+				first, req, "example.test", hosts,
+				func(string) (*retryablehttp.Client, error) {
+					t.Fatal("non-idempotent request must not be replayed")
+					return nil, nil
+				},
+			)
+			require.Nil(t, resp)
+			require.Same(t, first, used)
+			require.True(t, detected)
+			require.ErrorIs(t, err, ErrDesyncedResponse)
+			require.ErrorContains(t, err, "refusing to replay")
+			require.True(t, badBody.closed.Load())
+			require.True(t, hosts.Contains("example.test"))
+		})
+	}
+}
+
+func TestRequestReplaySafePolicy(t *testing.T) {
+	for _, method := range []string{
+		http.MethodGet, http.MethodHead, http.MethodOptions, http.MethodTrace,
+		http.MethodPut, http.MethodDelete,
+	} {
+		require.True(t, requestReplaySafe(&http.Request{Method: method, Header: make(http.Header)}), method)
+	}
+	for _, method := range []string{http.MethodPost, http.MethodPatch, http.MethodConnect} {
+		require.False(t, requestReplaySafe(&http.Request{Method: method, Header: make(http.Header)}), method)
+		require.True(t, requestReplaySafe(&http.Request{
+			Method: method,
+			Header: http.Header{"Idempotency-Key": []string{"key"}},
+		}), method)
+	}
+	require.False(t, requestReplaySafe(nil))
+}
+
+func TestDesyncRecoveryPropagatesNoReuseClientFailure(t *testing.T) {
+	firstRT := &scriptedRoundTripper{steps: []func(*http.Request) (*http.Response, error){
+		func(req *http.Request) (*http.Response, error) {
+			return tracedResponse(req, true, true, 1, io.NopCloser(strings.NewReader("wrong"))), nil
+		},
+	}}
+	first := newDetectingClient(firstRT, 0)
+	req, err := retryablehttp.NewRequest(http.MethodGet, "http://example.test/", nil)
+	require.NoError(t, err)
+
+	resp, used, recovered, err := doWithDesyncRecovery(
+		first, req, "example.test:80", protocolstate.NewExpiringSet(time.Minute),
+		func(string) (*retryablehttp.Client, error) { return nil, errors.New("pool failed") },
+	)
+	require.Nil(t, resp)
+	require.Same(t, first, used)
+	require.True(t, recovered)
+	require.ErrorContains(t, err, "pool failed")
+	require.Equal(t, int64(1), firstRT.calls.Load())
+}
+
+func TestDesyncProbeUsesFinalInternalRetryAttempt(t *testing.T) {
+	rt := &scriptedRoundTripper{steps: []func(*http.Request) (*http.Response, error){
+		func(req *http.Request) (*http.Response, error) {
+			trace := httptrace.ContextClientTrace(req.Context())
+			trace.GotConn(httptrace.GotConnInfo{Reused: true})
+			trace.GotFirstResponseByte()
+			return nil, errors.New("temporary")
+		},
+		func(req *http.Request) (*http.Response, error) {
+			return tracedResponse(req, true, false, 1, io.NopCloser(strings.NewReader("ok"))), nil
+		},
+	}}
+	client := newDetectingClient(rt, 1)
+	req, err := retryablehttp.NewRequest(http.MethodGet, "http://example.test/", nil)
+	require.NoError(t, err)
+
+	resp, _, recovered, err := doWithDesyncRecovery(
+		client, req, "example.test:80", protocolstate.NewExpiringSet(time.Minute),
+		func(string) (*retryablehttp.Client, error) {
+			t.Fatal("successful final attempt must win")
+			return nil, nil
+		},
+	)
+	require.NoError(t, err)
+	require.False(t, recovered)
+	require.Equal(t, int64(2), rt.calls.Load())
+	require.NoError(t, resp.Body.Close())
+}
+
+func TestDesyncRecoveryAllowsClientWithoutDetector(t *testing.T) {
+	rt := &scriptedRoundTripper{steps: []func(*http.Request) (*http.Response, error){
+		func(req *http.Request) (*http.Response, error) {
+			require.Nil(t, httptrace.ContextClientTrace(req.Context()))
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				ProtoMajor: 1,
+				Body:       io.NopCloser(strings.NewReader("ok")),
+				Header:     make(http.Header),
+				Request:    req,
+			}, nil
+		},
+	}}
+	client := newScriptedClient(rt, 0)
+	req, err := retryablehttp.NewRequest(http.MethodGet, "http://example.test/", nil)
+	require.NoError(t, err)
+
+	resp, _, recovered, err := doWithDesyncRecovery(
+		client, req, "example.test:80", protocolstate.NewExpiringSet(time.Minute),
+		func(string) (*retryablehttp.Client, error) { t.Fatal("disabled probe must not retry"); return nil, nil },
+	)
+	require.NoError(t, err)
+	require.False(t, recovered)
+	require.NoError(t, resp.Body.Close())
+}
+
+func TestDoWithDesyncRecoverySkipsExplicitNoKeepAlive(t *testing.T) {
+	opts := newTestOptions(t, "test-desync-disabled-keepalive")
+	cfg := &Configuration{Connection: &ConnectionConfiguration{DisableKeepAlive: true}}
+	rt := &scriptedRoundTripper{steps: []func(*http.Request) (*http.Response, error){
+		func(req *http.Request) (*http.Response, error) {
+			require.Nil(t, httptrace.ContextClientTrace(req.Context()))
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				ProtoMajor: 1,
+				Body:       io.NopCloser(strings.NewReader("ok")),
+				Header:     make(http.Header),
+				Request:    req,
+			}, nil
+		},
+	}}
+	client := newScriptedClient(rt, 0)
+	req, err := retryablehttp.NewRequest(http.MethodGet, "http://example.test/", nil)
+	require.NoError(t, err)
+
+	resp, used, recovered, err := DoWithDesyncRecovery(client, req, opts, cfg, "example.test")
+	require.NoError(t, err)
+	require.False(t, recovered)
+	require.Same(t, client, used)
+	require.NoError(t, resp.Body.Close())
+}
+
+func TestDoWithDesyncRecoverySkipsQuarantinedHost(t *testing.T) {
+	opts := newTestOptions(t, "test-desync-already-quarantined")
+	cfg := &Configuration{}
+	MarkHostDesynced(opts, "example.test")
+	rt := &scriptedRoundTripper{steps: []func(*http.Request) (*http.Response, error){
+		func(req *http.Request) (*http.Response, error) {
+			require.Nil(t, httptrace.ContextClientTrace(req.Context()))
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				ProtoMajor: 1,
+				Body:       io.NopCloser(strings.NewReader("ok")),
+				Header:     make(http.Header),
+				Request:    req,
+			}, nil
+		},
+	}}
+	client := newScriptedClient(rt, 0)
+	req, err := retryablehttp.NewRequest(http.MethodGet, "http://example.test/", nil)
+	require.NoError(t, err)
+
+	resp, used, recovered, err := DoWithDesyncRecovery(client, req, opts, cfg, "example.test")
+	require.NoError(t, err)
+	require.False(t, recovered)
+	require.Same(t, client, used)
+	require.NoError(t, resp.Body.Close())
+}

--- a/pkg/protocols/http/httpclientpool/desync_recovery_test.go
+++ b/pkg/protocols/http/httpclientpool/desync_recovery_test.go
@@ -8,8 +8,10 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/http/cookiejar"
 	"net/http/httptest"
 	"net/http/httptrace"
+	"net/url"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -504,6 +506,46 @@ func TestRequestReplaySafePolicy(t *testing.T) {
 		}), method)
 	}
 	require.False(t, requestReplaySafe(nil))
+}
+
+func TestDesyncRecoveryPreservesCookieJar(t *testing.T) {
+	jar, err := cookiejar.New(nil)
+	require.NoError(t, err)
+	origin, err := url.Parse("http://example.test/")
+	require.NoError(t, err)
+	jar.SetCookies(origin, []*http.Cookie{{Name: "sess", Value: "valid-token"}})
+
+	firstRT := &scriptedRoundTripper{steps: []func(*http.Request) (*http.Response, error){
+		func(req *http.Request) (*http.Response, error) {
+			return tracedResponse(req, true, true, 1, io.NopCloser(strings.NewReader("wrong"))), nil
+		},
+	}}
+	secondRT := &scriptedRoundTripper{steps: []func(*http.Request) (*http.Response, error){
+		func(req *http.Request) (*http.Response, error) {
+			cookie, cookieErr := req.Cookie("sess")
+			require.NoError(t, cookieErr)
+			require.Equal(t, "valid-token", cookie.Value)
+			return tracedResponse(req, false, false, 1, io.NopCloser(strings.NewReader("welcome-admin"))), nil
+		},
+	}}
+	first := newDetectingClient(firstRT, 0)
+	first.HTTPClient.Jar = jar
+	second := newScriptedClient(secondRT, 0)
+	req, err := retryablehttp.NewRequest(http.MethodGet, "http://example.test/profile", nil)
+	require.NoError(t, err)
+
+	resp, used, recovered, err := doWithDesyncRecovery(
+		first, req, "example.test", protocolstate.NewExpiringSet(time.Minute),
+		func(string) (*retryablehttp.Client, error) { return second, nil },
+	)
+	require.NoError(t, err)
+	require.True(t, recovered)
+	require.Same(t, second, used)
+	require.Same(t, jar, used.HTTPClient.Jar)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "welcome-admin", string(body))
+	require.NoError(t, resp.Body.Close())
 }
 
 func TestDesyncRecoveryPropagatesNoReuseClientFailure(t *testing.T) {

--- a/pkg/protocols/http/httpclientpool/desync_transport.go
+++ b/pkg/protocols/http/httpclientpool/desync_transport.go
@@ -1,0 +1,54 @@
+package httpclientpool
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptrace"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
+)
+
+// DesyncError identifies a host whose reused HTTP/1.x connection returned an
+// implausibly early response.
+type DesyncError struct {
+	Host string
+}
+
+func (e *DesyncError) Error() string {
+	return fmt.Sprintf("response for %s arrived before a network round trip", e.Host)
+}
+
+// desyncDetectingTransport observes each RoundTrip separately, including every
+// redirect hop. This is important because http.Client may otherwise hide the
+// response that triggered a redirect before the caller can inspect it.
+type desyncDetectingTransport struct {
+	base      http.RoundTripper
+	enabled   bool
+	baselines *protocolstate.ExpiringDurationMap
+}
+
+func (t *desyncDetectingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if !t.enabled {
+		return t.base.RoundTrip(req)
+	}
+
+	probe := NewDesyncProbe(req.URL.Host, t.baselines)
+	traced := req.WithContext(httptrace.WithClientTrace(req.Context(), probe.Trace()))
+	resp, err := t.base.RoundTrip(traced)
+	if err != nil || resp == nil || resp.ProtoMajor != 1 || !probe.Suspect() {
+		return resp, err
+	}
+
+	if resp.Body != nil {
+		_ = resp.Body.Close()
+	}
+	t.CloseIdleConnections()
+	return nil, &DesyncError{Host: desyncedHostKey(req.URL.Host)}
+}
+
+func (t *desyncDetectingTransport) CloseIdleConnections() {
+	type closeIdler interface{ CloseIdleConnections() }
+	if closer, ok := t.base.(closeIdler); ok {
+		closer.CloseIdleConnections()
+	}
+}

--- a/pkg/protocols/http/httpclientpool/desynced_hosts.go
+++ b/pkg/protocols/http/httpclientpool/desynced_hosts.go
@@ -1,0 +1,103 @@
+package httpclientpool
+
+import (
+	"net/url"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Some servers answer a request and then send a second, unsolicited response on the
+// same keep-alive connection. net/http returns that connection to the idle pool
+// before its read loop notices, so a later request can read the leftover response as
+// its own. Nothing reports it: the response is well-formed, so the retry policy --
+// which only fires on transport errors -- accepts it, the template matches against
+// the wrong response, and every response after that on the connection is off by one.
+//
+// A connection cannot be proven clean at the moment it is handed out; by then the
+// extra response may be on the wire, or already buffered inside net/http where no
+// caller can see it. Reuse itself is the problem, so a caller that detects the
+// condition marks the host here and this pool stops reusing connections to it.
+//
+// The mark expires so a host that stops misbehaving gets its connection reuse back.
+// An expiry mid-scan is cheap: detection is per-request, so the next wrong response
+// is caught and retried rather than lost, and re-marks the host.
+const desyncedHostTTL = 15 * time.Minute
+
+// host:port -> time.Time the mark was set.
+var desyncedHosts sync.Map
+
+// MarkHostDesynced disables connection reuse for a target until the mark expires.
+// The target may be a bare host, host:port, or a full URL; callers do not have to
+// match the exact string the pool was keyed with.
+func MarkHostDesynced(target string) {
+	key := desyncedHostKey(target)
+	if key == "" {
+		return
+	}
+
+	desyncedHosts.Store(key, time.Now())
+}
+
+// IsHostDesynced reports whether connection reuse for a target is disabled.
+func IsHostDesynced(target string) bool {
+	key := desyncedHostKey(target)
+	if key == "" {
+		return false
+	}
+
+	value, ok := desyncedHosts.Load(key)
+	if !ok {
+		return false
+	}
+
+	markedAt, ok := value.(time.Time)
+	if !ok || time.Since(markedAt) > desyncedHostTTL {
+		desyncedHosts.Delete(key)
+
+		return false
+	}
+
+	return true
+}
+
+// DesyncedHosts returns the hosts connection reuse is currently disabled for, as
+// host:port and sorted, for callers reporting which targets misbehaved.
+func DesyncedHosts() []string {
+	var hosts []string
+
+	desyncedHosts.Range(func(key, value any) bool {
+		host, ok := key.(string)
+		if !ok {
+			return true
+		}
+
+		markedAt, ok := value.(time.Time)
+		if ok && time.Since(markedAt) <= desyncedHostTTL {
+			hosts = append(hosts, host)
+		}
+
+		return true
+	})
+
+	slices.Sort(hosts)
+
+	return hosts
+}
+
+// desyncedHostKey reduces a target to host:port so that a mark set from a URL still
+// matches a lookup made with a bare host, and vice versa. Reuse happens per
+// listener, so the port is part of the key.
+func desyncedHostKey(target string) string {
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return ""
+	}
+
+	if parsed, err := url.Parse(target); err == nil && parsed.Host != "" {
+		return parsed.Host
+	}
+
+	return strings.TrimSuffix(target, "/")
+}

--- a/pkg/protocols/http/httpclientpool/desynced_hosts.go
+++ b/pkg/protocols/http/httpclientpool/desynced_hosts.go
@@ -2,10 +2,11 @@ package httpclientpool
 
 import (
 	"net/url"
-	"slices"
 	"strings"
-	"sync"
 	"time"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
+	"github.com/projectdiscovery/nuclei/v3/pkg/types"
 )
 
 // Some servers answer a request and then send a second, unsolicited response on the
@@ -25,65 +26,47 @@ import (
 // is caught and retried rather than lost, and re-marks the host.
 const desyncedHostTTL = 15 * time.Minute
 
-// host:port -> time.Time the mark was set.
-var desyncedHosts sync.Map
+func desyncHostsFor(options *types.Options) *protocolstate.ExpiringSet {
+	if options == nil {
+		return nil
+	}
+	dialers := protocolstate.GetDialersWithId(options.ExecutionId)
+	if dialers == nil {
+		return nil
+	}
+	return dialers.HTTPDesyncHosts
+}
 
 // MarkHostDesynced disables connection reuse for a target until the mark expires.
 // The target may be a bare host, host:port, or a full URL; callers do not have to
 // match the exact string the pool was keyed with.
-func MarkHostDesynced(target string) {
+func MarkHostDesynced(options *types.Options, target string) {
+	hosts := desyncHostsFor(options)
+	if hosts == nil {
+		return
+	}
 	key := desyncedHostKey(target)
 	if key == "" {
 		return
 	}
-
-	desyncedHosts.Store(key, time.Now())
+	hosts.Store(key, desyncedHostTTL)
 }
 
 // IsHostDesynced reports whether connection reuse for a target is disabled.
-func IsHostDesynced(target string) bool {
+func IsHostDesynced(options *types.Options, target string) bool {
+	hosts := desyncHostsFor(options)
 	key := desyncedHostKey(target)
-	if key == "" {
-		return false
-	}
-
-	value, ok := desyncedHosts.Load(key)
-	if !ok {
-		return false
-	}
-
-	markedAt, ok := value.(time.Time)
-	if !ok || time.Since(markedAt) > desyncedHostTTL {
-		desyncedHosts.Delete(key)
-
-		return false
-	}
-
-	return true
+	return hosts != nil && key != "" && hosts.Contains(key)
 }
 
 // DesyncedHosts returns the hosts connection reuse is currently disabled for, as
 // host:port and sorted, for callers reporting which targets misbehaved.
-func DesyncedHosts() []string {
-	var hosts []string
-
-	desyncedHosts.Range(func(key, value any) bool {
-		host, ok := key.(string)
-		if !ok {
-			return true
-		}
-
-		markedAt, ok := value.(time.Time)
-		if ok && time.Since(markedAt) <= desyncedHostTTL {
-			hosts = append(hosts, host)
-		}
-
-		return true
-	})
-
-	slices.Sort(hosts)
-
-	return hosts
+func DesyncedHosts(options *types.Options) []string {
+	hosts := desyncHostsFor(options)
+	if hosts == nil {
+		return nil
+	}
+	return hosts.Keys()
 }
 
 // desyncedHostKey reduces a target to host:port so that a mark set from a URL still
@@ -96,8 +79,8 @@ func desyncedHostKey(target string) string {
 	}
 
 	if parsed, err := url.Parse(target); err == nil && parsed.Host != "" {
-		return parsed.Host
+		return strings.ToLower(parsed.Host)
 	}
 
-	return strings.TrimSuffix(target, "/")
+	return strings.ToLower(strings.TrimSuffix(target, "/"))
 }

--- a/pkg/protocols/http/httpclientpool/desynced_hosts_test.go
+++ b/pkg/protocols/http/httpclientpool/desynced_hosts_test.go
@@ -8,7 +8,6 @@ import (
 	"net/url"
 	"sync/atomic"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -43,9 +42,8 @@ func TestMarkHostDesyncedStopsReuse(t *testing.T) {
 	requestTwice(t, pooled, server.URL)
 	require.Equal(t, int64(1), conns.Load(), "an unmarked host must reuse its connection")
 
-	MarkHostDesynced(server.URL)
-	t.Cleanup(func() { desyncedHosts.Delete(host) })
-	require.True(t, IsHostDesynced(host), "a mark set from a URL must match a host:port lookup")
+	MarkHostDesynced(opts, server.URL)
+	require.True(t, IsHostDesynced(opts, host), "a mark set from a URL must match a host:port lookup")
 
 	guarded, err := Get(opts, cfg, host)
 	require.NoError(t, err)
@@ -59,23 +57,12 @@ func TestMarkHostDesyncedStopsReuse(t *testing.T) {
 
 // TestIsHostDesyncedExpires checks the mark does not pin a host forever: attribution
 // of a detection to a host is not always exact, so an innocent host must recover.
-func TestIsHostDesyncedExpires(t *testing.T) {
-	const host = "expiring.example.com"
-
-	desyncedHosts.Store(host, time.Now().Add(-desyncedHostTTL-time.Minute))
-	t.Cleanup(func() { desyncedHosts.Delete(host) })
-
-	require.False(t, IsHostDesynced(host), "a mark older than the TTL must not apply")
-
-	_, still := desyncedHosts.Load(host)
-	require.False(t, still, "an expired mark must be dropped")
-}
-
 // TestIsHostDesyncedEmptyHost guards the case where the caller could not resolve a
 // host: an empty mark would otherwise disable reuse for every unnamed lookup.
 func TestIsHostDesyncedEmptyHost(t *testing.T) {
-	MarkHostDesynced("")
-	require.False(t, IsHostDesynced(""))
+	opts := newTestOptions(t, "test-desync-empty-host")
+	MarkHostDesynced(opts, "")
+	require.False(t, IsHostDesynced(opts, ""))
 }
 
 func requestTwice(t *testing.T, client *retryablehttp.Client, target string) {
@@ -106,6 +93,8 @@ func TestDesyncedHostKey(t *testing.T) {
 	for _, tc := range []struct{ in, want string }{
 		{"https://example.com:8443/admin?a=1", "example.com:8443"},
 		{"http://example.com/", "example.com"},
+		{"https://EXAMPLE.COM:443/", "example.com:443"},
+		{"https://[2001:db8::1]:8443/", "[2001:db8::1]:8443"},
 		{"example.com:8443", "example.com:8443"},
 		{"  example.com  ", "example.com"},
 		{"", ""},
@@ -114,4 +103,15 @@ func TestDesyncedHostKey(t *testing.T) {
 	}
 
 	require.NotEqual(t, desyncedHostKey("example.com:80"), desyncedHostKey("example.com:8080"))
+}
+
+func TestDesyncTrackersAreExecutionScoped(t *testing.T) {
+	first := newTestOptions(t, "test-desync-scope-first")
+	second := newTestOptions(t, "test-desync-scope-second")
+
+	MarkHostDesynced(first, "example.com:443")
+	require.True(t, IsHostDesynced(first, "example.com:443"))
+	require.False(t, IsHostDesynced(second, "example.com:443"))
+	require.Equal(t, []string{"example.com:443"}, DesyncedHosts(first))
+	require.Empty(t, DesyncedHosts(second))
 }

--- a/pkg/protocols/http/httpclientpool/desynced_hosts_test.go
+++ b/pkg/protocols/http/httpclientpool/desynced_hosts_test.go
@@ -1,0 +1,117 @@
+package httpclientpool
+
+import (
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/projectdiscovery/retryablehttp-go"
+)
+
+// TestMarkHostDesyncedStopsReuse verifies the behaviour that matters: requests to a
+// marked host stop sharing a connection, requests to any other host keep sharing
+// one, and the keep-alive client cached for the host before the mark is not handed
+// out again.
+func TestMarkHostDesyncedStopsReuse(t *testing.T) {
+	opts := newTestOptions(t, "test-desynced-host-no-reuse")
+	cfg := &Configuration{}
+
+	var conns atomic.Int64
+	// Unstarted, because Server.Config must not be touched once it is serving.
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "ok")
+	}))
+	server.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+		if state == http.StateNew {
+			conns.Add(1)
+		}
+	}
+	server.Start()
+	t.Cleanup(server.Close)
+
+	host := hostOf(t, server.URL)
+
+	pooled, err := Get(opts, cfg, host)
+	require.NoError(t, err)
+	requestTwice(t, pooled, server.URL)
+	require.Equal(t, int64(1), conns.Load(), "an unmarked host must reuse its connection")
+
+	MarkHostDesynced(server.URL)
+	t.Cleanup(func() { desyncedHosts.Delete(host) })
+	require.True(t, IsHostDesynced(host), "a mark set from a URL must match a host:port lookup")
+
+	guarded, err := Get(opts, cfg, host)
+	require.NoError(t, err)
+	require.NotSame(t, pooled, guarded,
+		"a marked host must not be served the keep-alive client cached earlier")
+
+	conns.Store(0)
+	requestTwice(t, guarded, server.URL)
+	require.Equal(t, int64(2), conns.Load(), "a marked host must not reuse connections")
+}
+
+// TestIsHostDesyncedExpires checks the mark does not pin a host forever: attribution
+// of a detection to a host is not always exact, so an innocent host must recover.
+func TestIsHostDesyncedExpires(t *testing.T) {
+	const host = "expiring.example.com"
+
+	desyncedHosts.Store(host, time.Now().Add(-desyncedHostTTL-time.Minute))
+	t.Cleanup(func() { desyncedHosts.Delete(host) })
+
+	require.False(t, IsHostDesynced(host), "a mark older than the TTL must not apply")
+
+	_, still := desyncedHosts.Load(host)
+	require.False(t, still, "an expired mark must be dropped")
+}
+
+// TestIsHostDesyncedEmptyHost guards the case where the caller could not resolve a
+// host: an empty mark would otherwise disable reuse for every unnamed lookup.
+func TestIsHostDesyncedEmptyHost(t *testing.T) {
+	MarkHostDesynced("")
+	require.False(t, IsHostDesynced(""))
+}
+
+func requestTwice(t *testing.T, client *retryablehttp.Client, target string) {
+	t.Helper()
+
+	for range 2 {
+		resp, err := client.Get(target)
+		require.NoError(t, err)
+		_, err = io.Copy(io.Discard, resp.Body)
+		require.NoError(t, err)
+		require.NoError(t, resp.Body.Close())
+	}
+}
+
+func hostOf(t *testing.T, raw string) string {
+	t.Helper()
+
+	parsed, err := url.Parse(raw)
+	require.NoError(t, err)
+
+	return parsed.Host
+}
+
+// TestDesyncedHostKey pins the normalization: a mark and a lookup must agree whether
+// the caller had a URL, a host:port, or a bare host, and different ports on the same
+// host must stay independent.
+func TestDesyncedHostKey(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{"https://example.com:8443/admin?a=1", "example.com:8443"},
+		{"http://example.com/", "example.com"},
+		{"example.com:8443", "example.com:8443"},
+		{"  example.com  ", "example.com"},
+		{"", ""},
+	} {
+		require.Equal(t, tc.want, desyncedHostKey(tc.in), tc.in)
+	}
+
+	require.NotEqual(t, desyncedHostKey("example.com:80"), desyncedHostKey("example.com:8080"))
+}

--- a/pkg/protocols/http/request.go
+++ b/pkg/protocols/http/request.go
@@ -9,6 +9,7 @@ import (
 	"maps"
 	"net"
 	"net/http"
+	"net/http/httptrace"
 	"strconv"
 	"strings"
 	"sync"
@@ -887,7 +888,31 @@ func (request *Request) executeRequest(input *contextargs.Context, generatedRequ
 				}
 			}
 
+			// Watch the response timing: a server that answers a request and then
+			// sends a second, unsolicited response leaves it on the connection, and
+			// net/http hands it to whoever reuses that connection next. It is a
+			// well-formed response, so nothing else notices.
+			probe := httpclientpool.NewDesyncProbe(hostname)
+			if generatedRequest.request != nil && generatedRequest.request.Request != nil {
+				generatedRequest.request.Request = generatedRequest.request.Request.WithContext(
+					httptrace.WithClientTrace(generatedRequest.request.Request.Context(), probe.Trace()),
+				)
+			}
+
 			resp, err = httpclient.Do(generatedRequest.request)
+
+			// The response we just read belonged to an earlier request on that
+			// connection. Stop reusing connections to the host and ask again, rather
+			// than matching this template against somebody else's response.
+			if err == nil && probe.Suspect() {
+				httpclientpool.MarkHostDesynced(hostname)
+				if reissued, clientErr := httpclientpool.Get(
+					request.options.Options, connConfig, hostname); clientErr == nil {
+					httpclient = reissued
+					executingClient = reissued
+				}
+				resp, err = httpclient.Do(generatedRequest.request)
+			}
 
 			// If we forced http->https from a previous detection and the corrected
 			// request failed (e.g. a false positive where the port actually speaks

--- a/pkg/protocols/http/request.go
+++ b/pkg/protocols/http/request.go
@@ -9,7 +9,6 @@ import (
 	"maps"
 	"net"
 	"net/http"
-	"net/http/httptrace"
 	"strconv"
 	"strings"
 	"sync"
@@ -862,7 +861,6 @@ func (request *Request) executeRequest(input *contextargs.Context, generatedRequ
 			if clientErr != nil {
 				return errors.Wrap(clientErr, "could not get http client")
 			}
-			executingClient = httpclient
 
 			// Check if HTTP-to-HTTPS port correction is needed before sending request.
 			// The correction is keyed by host:port and shared across templates, so a
@@ -888,30 +886,23 @@ func (request *Request) executeRequest(input *contextargs.Context, generatedRequ
 				}
 			}
 
-			// Watch the response timing: a server that answers a request and then
-			// sends a second, unsolicited response leaves it on the connection, and
-			// net/http hands it to whoever reuses that connection next. It is a
-			// well-formed response, so nothing else notices.
-			probe := httpclientpool.NewDesyncProbe(hostname)
-			if generatedRequest.request != nil && generatedRequest.request.Request != nil {
-				generatedRequest.request.Request = generatedRequest.request.Request.WithContext(
-					httptrace.WithClientTrace(generatedRequest.request.Request.Context(), probe.Trace()),
-				)
-			}
-
-			resp, err = httpclient.Do(generatedRequest.request)
-
-			// The response we just read belonged to an earlier request on that
-			// connection. Stop reusing connections to the host and ask again, rather
-			// than matching this template against somebody else's response.
-			if err == nil && probe.Suspect() {
-				httpclientpool.MarkHostDesynced(hostname)
-				if reissued, clientErr := httpclientpool.Get(
-					request.options.Options, connConfig, hostname); clientErr == nil {
-					httpclient = reissued
-					executingClient = reissued
+			var desyncDetected bool
+			resp, executingClient, desyncDetected, err = httpclientpool.DoWithDesyncRecovery(
+				httpclient, generatedRequest.request, request.options.Options, connConfig, hostname,
+			)
+			if desyncDetected {
+				httpclient = executingClient
+				if err != nil {
+					gologger.Debug().Msgf(
+						"[%s] Detected an implausibly early response for %s, but recovery failed: %v",
+						request.options.TemplateID, hostname, err,
+					)
+				} else {
+					gologger.Debug().Msgf(
+						"[%s] Recovered an implausibly early response for %s with connection reuse disabled",
+						request.options.TemplateID, hostname,
+					)
 				}
-				resp, err = httpclient.Do(generatedRequest.request)
 			}
 
 			// If we forced http->https from a previous detection and the corrected
@@ -920,7 +911,11 @@ func (request *Request) executeRequest(input *contextargs.Context, generatedRequ
 			// other templates hitting the same host:port are not affected, and retry
 			// once. This keeps the optimization while preventing a single
 			// wrong detection from silently dropping findings at scale.
-			if err != nil && httpsCorrectionTracker != nil && generatedRequest.request != nil && generatedRequest.request.Scheme == "https" {
+			if err != nil &&
+				!errors.Is(err, httpclientpool.ErrDesyncedResponse) &&
+				httpsCorrectionTracker != nil &&
+				generatedRequest.request != nil &&
+				generatedRequest.request.Scheme == "https" {
 				generatedRequest.request.Scheme = "http"
 				httpsCorrectionTracker.Evict(httpsCorrectionURL)
 				resp, err = httpclient.Do(generatedRequest.request)

--- a/pkg/protocols/ssl/ssl.go
+++ b/pkg/protocols/ssl/ssl.go
@@ -146,7 +146,6 @@ func (request *Request) Compile(options *protocols.ExecutorOptions) error {
 	}
 
 	tlsxOptions := &clients.Options{
-		AllCiphers:        true,
 		ScanMode:          request.ScanMode,
 		Expired:           true,
 		SelfSigned:        true,


### PR DESCRIPTION
## Proposed changes

Some servers answer a request and then send a second, unsolicited response on the same keep-alive connection. `net/http` returns that connection to the idle pool before its read loop notices, so a later request reads the leftover response as its own. Nothing catches it:

- the response is well-formed, so `err == nil` and `CheckRecoverableErrors` (`HostSprayRetryPolicy`) returns `false, nil` — no retry;
- the template's matchers then run against a response the request never asked for, and every response after that on the connection is off by one;
- the only trace is `net/http`'s `log.Printf("Unsolicited response received on idle HTTP channel …")`, which fires **only** when the read loop wins the race — i.e. on the harmless cases. The cases that actually corrupt a result are silent.

This is common in the wild, not exotic. Across a scanning fleet we see ~400k of those reports a day from `nuclei`, concentrated in ~4% of runs — mostly `400 Bad Request` + `Connection: close` from nginx/openresty/Azure Front Door, plus leftover chunk terminators and non-HTTP banners.

A connection cannot be proven clean when it is handed out: the extra response may still be on the wire, or already buffered inside `net/http` where no caller can see it. So this detects the symptom instead. A leftover response is already in the read buffer when the next request goes out, so `readResponse`'s `Peek(1)` returns with no round trip — often before the request has finished being written. No genuine response can beat one round trip after its own headers.

- `DesyncProbe` (`httpclientpool/desync_probe.go`) collects `ConnectStart/Done`, `GotConn`, `WroteHeaders` and `GotFirstResponseByte` via `httptrace`, and flags a reused connection whose first byte arrives in under half the host's TCP handshake time.
- On a hit, `request.go` marks the host, re-`Get`s the client — now with `DisableKeepAlives` — and retries once, so the result is **recovered rather than lost**. This follows the revert-and-retry pattern already there for the http→https correction.
- `MarkHostDesynced` / `IsHostDesynced` (`desynced_hosts.go`) fold into `clientKey` and `disableKeepAlives`. Because `Get(options, configuration, host)` runs per request, the switch takes effect immediately; the mark carries a 15-minute TTL so a host that stops misbehaving gets reuse back.
- `DesyncedResponses()` and `DesyncedHosts()` let an embedder report the condition.

Two choices worth calling out:

- **The baseline is the TCP handshake, not past response latencies.** Server think time swings orders of magnitude between a cold and a cached answer, so a latency baseline flags the fast ones.
- **The anchor is `WroteHeaders`, not `WroteRequest`.** A server may legitimately answer a large body early (413, 400) and beat the end of the upload.

Scope: HTTP/1.1 pooled connections only. HTTP/2 and the `rawhttp` unsafe path do not go through this pool. On very low-RTT targets the margin narrows and detection degrades to a miss, never to a false positive.

Cost: one `httptrace` per request (which makes `readResponse` do a `Peek(1)` it otherwise skips), and one `sync.Map` read per `Get`.

### Proof

Against a server that answers each request and then writes one extra unsolicited response, 25 concurrent workers, one host, with the round trip emulated so loopback does not flatter the result:

| | requests | wrong responses | detected | false positives |
|---|---|---|---|---|
| before | 5000 | 299 (5.98%) | — | — |
| after | 5000 | 0–1 | — | — |
| detector alone | 1000 | 143 / 105 | **all** | 0 |

Three healthy profiles, 1000 requests each, to catch false positives — all **0**: think time swinging 1 ms ↔ 300 ms (breaks a latency baseline), a server answering a 2 MB upload early (breaks a `WroteRequest` anchor), and a 1 ms link.

Connection cost is close to nil, because `net/http` already tears these connections down every time it catches one: the unfixed run opened 4513 connections for 5000 requests to the desyncing host, the fixed run ~5000. A healthy host is untouched — 25 connections for 5000 requests, unchanged.

Tests added: 10 in `httpclientpool`, `go test -race ./pkg/protocols/http/httpclientpool/` green. Behavioural where it matters — an unmarked host serves two requests on one connection, a marked one opens two — plus TTL expiry, URL/host:port normalization, and the fresh-connection and no-baseline cases.

## Checklist

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic detection and recovery for HTTP connection desynchronization.
  * Suspicious responses on reused connections are rejected, affected hosts are temporarily isolated, and safe requests may be retried using a fresh connection.
  * Added tracking and visibility for affected hosts and detected responses.

* **Bug Fixes**
  * Improved resilience against unexpected responses while protecting non-replayable or non-idempotent requests from unsafe retries.
  * Prevented unnecessary retries when desynchronization is detected.

* **Tests**
  * Expanded coverage for redirects, request replay, connection reuse, fresh connections, HTTP/2, host isolation, and recovery failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->