### PR TITLE
fix(templates): invalid template id error message

### DIFF
--- a/internal/tests/testutils/testutils.go
+++ b/internal/tests/testutils/testutils.go
@@ -40,7 +40,6 @@ func Cleanup(options *types.Options) {
 
 // DefaultOptions is the default options structure for nuclei during mocking.
 var DefaultOptions = &types.Options{
-	Metrics:                    false,
 	Debug:                      false,
 	DebugRequests:              false,
 	DebugResponse:              false,

--- a/pkg/protocols/common/protocolstate/state.go
+++ b/pkg/protocols/common/protocolstate/state.go
@@ -165,7 +165,6 @@ func initDialers(options *types.Options) error {
 			forward = &net.Dialer{
 				Timeout:   opts.DialerTimeout,
 				KeepAlive: opts.DialerKeepAlive,
-				DualStack: true,
 			}
 		}
 		dialer, err := proxy.FromURL(proxyURL, forward)

--- a/pkg/protocols/ssl/ssl.go
+++ b/pkg/protocols/ssl/ssl.go
@@ -146,7 +146,6 @@ func (request *Request) Compile(options *protocols.ExecutorOptions) error {
 	}
 
 	tlsxOptions := &clients.Options{
-		AllCiphers:        true,
 		ScanMode:          request.ScanMode,
 		Expired:           true,
 		SelfSigned:        true,

--- a/pkg/templates/templates.go
+++ b/pkg/templates/templates.go
@@ -351,7 +351,7 @@ func (template *Template) UnmarshalYAML(unmarshal func(interface{}) error) error
 	*template = Template(*alias)
 
 	if !ReTemplateID.MatchString(template.ID) {
-		return errkit.New("template id must match expression %v", ReTemplateID, "tag", "invalid_template")
+		return errkit.New("template id must match expression "+ReTemplateID.String(), "tag", "invalid_template")
 	}
 
 	info := template.Info


### PR DESCRIPTION
Closes #7673

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the error message shown when a template ID is invalid.
  * Updated connection and SSL defaults to rely on standard behavior, improving compatibility and reducing unnecessary configuration overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->