### PR TITLE
fix(http): honor disable-cookie with shared jars

### DIFF
--- a/internal/tests/integration/http_test.go
+++ b/internal/tests/integration/http_test.go
@@ -905,7 +905,6 @@ type httpRawCookieReuse struct{}
 
 type httpDisableCookieReuse struct{}
 
-// Execute executes a test case and returns an error if occurred
 func (h *httpDisableCookieReuse) Execute(filePath string) error {
 	router := httprouter.New()
 	router.GET("/login", func(w http.ResponseWriter, _ *http.Request, _ httprouter.Params) {

--- a/internal/tests/integration/http_test.go
+++ b/internal/tests/integration/http_test.go
@@ -43,6 +43,7 @@ var httpTestcases = []integrationCase{
 	{Path: "protocols/http/post-json-body.yaml", TestCase: &httpPostJSONBody{}},
 	{Path: "protocols/http/post-multipart-body.yaml", TestCase: &httpPostMultipartBody{}},
 	{Path: "protocols/http/raw-cookie-reuse.yaml", TestCase: &httpRawCookieReuse{}},
+	{Path: "protocols/http/disable-cookie-reuse.yaml", TestCase: &httpDisableCookieReuse{}},
 	{Path: "protocols/http/raw-dynamic-extractor.yaml", TestCase: &httpRawDynamicExtractor{}},
 	{Path: "protocols/http/raw-get-query.yaml", TestCase: &httpRawGetQuery{}},
 	{Path: "protocols/http/raw-get.yaml", TestCase: &httpRawGet{}},
@@ -901,6 +902,30 @@ func (h *httpPaths) Execute(filepath string) error {
 }
 
 type httpRawCookieReuse struct{}
+
+type httpDisableCookieReuse struct{}
+
+// Execute executes a test case and returns an error if occurred
+func (h *httpDisableCookieReuse) Execute(filePath string) error {
+	router := httprouter.New()
+	router.GET("/login", func(w http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
+		http.SetCookie(w, &http.Cookie{Name: "nuclei", Value: "test"})
+		_, _ = fmt.Fprint(w, "logged in")
+	})
+	router.GET("/anonymous", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+		if _, err := r.Cookie("nuclei"); errors.Is(err, http.ErrNoCookie) {
+			_, _ = fmt.Fprint(w, "anonymous")
+		}
+	})
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+
+	results, err := testutils.RunNucleiTemplateAndGetResults(filePath, ts.URL, debug)
+	if err != nil {
+		return err
+	}
+	return expectResultsCount(results, 1)
+}
 
 // Execute executes a test case and returns an error if occurred
 func (h *httpRawCookieReuse) Execute(filePath string) error {

--- a/internal/tests/integration/testdata/protocols/http/disable-cookie-reuse.yaml
+++ b/internal/tests/integration/testdata/protocols/http/disable-cookie-reuse.yaml
@@ -1,0 +1,27 @@
+id: disable-cookie-reuse
+
+info:
+  name: Disable Cookie Reuse
+  author: pdteam
+  severity: info
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/login"
+
+    matchers:
+      - type: word
+        words:
+          - "logged in"
+        internal: true
+
+  - method: GET
+    path:
+      - "{{BaseURL}}/anonymous"
+    disable-cookie: true
+
+    matchers:
+      - type: word
+        words:
+          - "anonymous"

--- a/pkg/protocols/http/request.go
+++ b/pkg/protocols/http/request.go
@@ -846,7 +846,7 @@ func (request *Request) executeRequest(input *contextargs.Context, generatedRequ
 			}
 
 			connConfig := request.connConfiguration
-			if input.CookieJar != nil {
+			if input.CookieJar != nil && !request.DisableCookie {
 				connConfig = connConfig.Clone()
 				connConfig.Connection.SetCookieJar(input.CookieJar)
 			}


### PR DESCRIPTION
## Proposed changes

Fixes #7670.

When a workflow context supplied a shared cookie jar, `executeRequest` attached it after request options were prepared, even when `disable-cookie: true` was set. Guard the shared-jar attachment with `!request.DisableCookie`.

### Proof

Added an integration case that:

1. receives a session cookie from `/login`;
2. sends a second request with `disable-cookie: true`;
3. only matches when `/anonymous` receives no session cookie.

Executed:

`go test -tags integration ./internal/tests/integration -run TestIntegrationSuites -family http -template disable-cookie-reuse`

Result: passed.

## Checklist

- [x] Pull request is created against the dev branch
- [x] Targeted integration checks passed with my changes
- [x] I have added a test that proves the fix is effective
- [x] No documentation change is required

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP cookie handling so cookie jars are not reused when cookie reuse is disabled.
  * Ensured requests without cookie reuse do not carry cookies from previous requests, helping preserve request isolation and expected anonymous access behavior.

* **Tests**
  * Added integration coverage verifying that cookies set during login are absent from subsequent anonymous requests when reuse is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->