### PR TITLE
Stop reusing hosts after idle leftovers

### DIFF
--- a/pkg/protocols/common/protocolstate/dialers.go
+++ b/pkg/protocols/common/protocolstate/dialers.go
@@ -16,6 +16,7 @@ type Dialers struct {
 	HTTPClientPool             *HTTPPool
 	PerHostRateLimitPool       any // *httpclientpool.PerHostRateLimitPool
 	HTTPToHTTPSPortTracker     any // *httpclientpool.HTTPToHTTPSPortTracker
+	HTTPDesyncHosts            *ExpiringSet
 	NetworkPolicy              *networkpolicy.NetworkPolicy
 	LocalFileAccessAllowed     bool
 	RestrictLocalNetworkAccess bool

--- a/pkg/protocols/common/protocolstate/expiring_set.go
+++ b/pkg/protocols/common/protocolstate/expiring_set.go
@@ -1,0 +1,89 @@
+package protocolstate
+
+import (
+	"slices"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// ExpiringSet is a lock-free-read set of string keys with per-entry expiry.
+// Cleanup is amortized across writes and also performed by Keys.
+type ExpiringSet struct {
+	values          sync.Map // string -> expiry UnixNano
+	cleanupInterval time.Duration
+	lastCleanup     atomic.Int64
+}
+
+func NewExpiringSet(cleanupInterval time.Duration) *ExpiringSet {
+	set := &ExpiringSet{cleanupInterval: cleanupInterval}
+	set.lastCleanup.Store(time.Now().UnixNano())
+	return set
+}
+
+func (s *ExpiringSet) Store(key string, ttl time.Duration) {
+	s.StoreUntil(key, time.Now().Add(ttl))
+}
+
+func (s *ExpiringSet) StoreUntil(key string, expiry time.Time) {
+	if s == nil || key == "" {
+		return
+	}
+	s.values.Store(key, expiry.UnixNano())
+	s.maybeCleanup(time.Now())
+}
+
+func (s *ExpiringSet) Contains(key string) bool {
+	return s.containsAt(key, time.Now())
+}
+
+func (s *ExpiringSet) containsAt(key string, now time.Time) bool {
+	if s == nil || key == "" {
+		return false
+	}
+	value, ok := s.values.Load(key)
+	if !ok {
+		return false
+	}
+	expiresAt, ok := value.(int64)
+	if !ok || now.UnixNano() >= expiresAt {
+		s.values.CompareAndDelete(key, value)
+		return false
+	}
+	return true
+}
+
+func (s *ExpiringSet) Keys() []string {
+	return s.keysAt(time.Now())
+}
+
+func (s *ExpiringSet) keysAt(now time.Time) []string {
+	if s == nil {
+		return nil
+	}
+	var keys []string
+	s.values.Range(func(key, value any) bool {
+		name, keyOK := key.(string)
+		expiresAt, expiryOK := value.(int64)
+		if keyOK && expiryOK && now.UnixNano() < expiresAt {
+			keys = append(keys, name)
+		} else {
+			s.values.CompareAndDelete(key, value)
+		}
+		return true
+	})
+	slices.Sort(keys)
+	return keys
+}
+
+func (s *ExpiringSet) maybeCleanup(now time.Time) {
+	if s.cleanupInterval <= 0 {
+		return
+	}
+	last := s.lastCleanup.Load()
+	if now.UnixNano()-last < s.cleanupInterval.Nanoseconds() ||
+		!s.lastCleanup.CompareAndSwap(last, now.UnixNano()) {
+		return
+	}
+	s.keysAt(now)
+}

--- a/pkg/protocols/common/protocolstate/expiring_set_test.go
+++ b/pkg/protocols/common/protocolstate/expiring_set_test.go
@@ -1,0 +1,102 @@
+package protocolstate
+
+import (
+	"fmt"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExpiringSetContainsAndExpires(t *testing.T) {
+	set := NewExpiringSet(time.Minute)
+	now := time.Now()
+	set.StoreUntil("active", now.Add(time.Minute))
+	set.StoreUntil("expired", now.Add(-time.Second))
+
+	require.True(t, set.containsAt("active", now))
+	require.False(t, set.containsAt("expired", now))
+	_, exists := set.values.Load("expired")
+	require.False(t, exists)
+}
+
+func TestExpiringSetKeysSortsAndCleans(t *testing.T) {
+	set := NewExpiringSet(time.Minute)
+	now := time.Now()
+	set.StoreUntil("b", now.Add(time.Minute))
+	set.StoreUntil("a", now.Add(time.Minute))
+	set.StoreUntil("expired", now.Add(-time.Second))
+
+	require.Equal(t, []string{"a", "b"}, set.keysAt(now))
+	_, exists := set.values.Load("expired")
+	require.False(t, exists)
+}
+
+func TestExpiringSetRefreshesTTL(t *testing.T) {
+	set := NewExpiringSet(time.Minute)
+	now := time.Now()
+	set.StoreUntil("host", now.Add(time.Minute))
+	set.StoreUntil("host", now.Add(2*time.Minute))
+
+	require.True(t, set.containsAt("host", now.Add(90*time.Second)))
+	require.False(t, set.containsAt("host", now.Add(3*time.Minute)))
+}
+
+func TestExpiringSetEmptyAndNil(t *testing.T) {
+	var nilSet *ExpiringSet
+	require.False(t, nilSet.Contains("host"))
+	require.Empty(t, nilSet.Keys())
+
+	set := NewExpiringSet(time.Minute)
+	set.Store("", time.Minute)
+	require.False(t, set.Contains(""))
+	require.Empty(t, set.Keys())
+}
+
+func TestExpiringSetConcurrentAccess(t *testing.T) {
+	set := NewExpiringSet(time.Minute)
+	var done atomic.Int64
+
+	t.Run("parallel", func(t *testing.T) {
+		for i := range 100 {
+			i := i
+			t.Run(strconv.Itoa(i), func(t *testing.T) {
+				t.Parallel()
+				key := fmt.Sprintf("host-%d", i%10)
+				set.Store(key, time.Minute)
+				require.True(t, set.Contains(key))
+				done.Add(1)
+			})
+		}
+	})
+	require.Equal(t, int64(100), done.Load())
+}
+
+func TestExpiringSetConcurrentRefreshSurvivesExpiredCleanup(t *testing.T) {
+	for range 1000 {
+		set := NewExpiringSet(time.Minute)
+		now := time.Now()
+		set.StoreUntil("host", now.Add(-time.Second))
+
+		start := make(chan struct{})
+		done := make(chan struct{}, 2)
+		go func() {
+			<-start
+			_ = set.containsAt("host", now)
+			done <- struct{}{}
+		}()
+		go func() {
+			<-start
+			set.StoreUntil("host", now.Add(time.Minute))
+			done <- struct{}{}
+		}()
+		close(start)
+		<-done
+		<-done
+
+		require.True(t, set.containsAt("host", now),
+			"cleanup of the expired value must not delete a concurrent refresh")
+	}
+}

--- a/pkg/protocols/common/protocolstate/state.go
+++ b/pkg/protocols/common/protocolstate/state.go
@@ -216,6 +216,7 @@ func initDialers(options *types.Options) error {
 		Fastdialer:                 dialer,
 		NetworkPolicy:              networkPolicy,
 		HTTPClientPool:             httpClientPool,
+		HTTPDesyncHosts:            NewExpiringSet(time.Minute),
 		LocalFileAccessAllowed:     options.AllowLocalFileAccess,
 		RestrictLocalNetworkAccess: options.RestrictLocalNetworkAccess,
 		ExcludeTargets:             options.ExcludeTargets,

--- a/pkg/protocols/http/httpclientpool/clientpool.go
+++ b/pkg/protocols/http/httpclientpool/clientpool.go
@@ -124,6 +124,7 @@ func (t *connTrackingTransport) RoundTrip(req *http.Request) (*http.Response, er
 	// Compute the host key once (URL is already parsed) so the GotConn hook can
 	// update both the global counters and the per-host bucket from one trace.
 	host := normalizeHost(req.URL)
+	var used atomic.Pointer[desyncConn]
 	trace := &httptrace.ClientTrace{
 		GotConn: func(info httptrace.GotConnInfo) {
 			if info.Reused {
@@ -132,6 +133,18 @@ func (t *connTrackingTransport) RoundTrip(req *http.Request) (*http.Response, er
 				connStats.New.Add(1)
 			}
 			recordHostConn(host, info.Reused)
+			if tracked, ok := info.Conn.(*desyncConn); ok {
+				tracked.markBusy()
+				used.Store(tracked)
+			}
+		},
+		PutIdleConn: func(err error) {
+			if err != nil {
+				return
+			}
+			if tracked := used.Load(); tracked != nil {
+				tracked.markIdle()
+			}
 		},
 	}
 	req = req.WithContext(httptrace.WithClientTrace(req.Context(), trace))
@@ -303,6 +316,13 @@ func wrappedGet(options *types.Options, configuration *Configuration, host strin
 		clientKey += ":" + host
 	}
 
+	// A host caught sending unsolicited idle responses gets its own cache
+	// entry, so the keep-alive client already cached for it is not reused.
+	noReuse := IsHostDesynced(options, host)
+	if noReuse {
+		clientKey += ":noreuse"
+	}
+
 	// Fast path: lock-free cache hit.
 	if !hasExplicitJar {
 		if client, ok := pool.GetClient(clientKey); ok {
@@ -330,7 +350,8 @@ func wrappedGet(options *types.Options, configuration *Configuration, host strin
 		maxIdleConns = configuration.Threads
 	}
 
-	disableKeepAlives := configuration.Connection != nil && configuration.Connection.DisableKeepAlive
+	disableKeepAlives := noReuse ||
+		(configuration.Connection != nil && configuration.Connection.DisableKeepAlive)
 
 	responseHeaderTimeout := options.GetTimeouts().HttpResponseHeaderTimeout
 	if configuration.ResponseHeaderTimeout != 0 {
@@ -367,10 +388,32 @@ func wrappedGet(options *types.Options, configuration *Configuration, host strin
 			return nil, errors.Wrap(err, "could not create client certificate")
 		}
 
+		// Wrap keep-alive dials so an idle leftover can close the connection
+		// and quarantine the host. Proxies are left alone: CONNECT is performed
+		// by net/http outside a round trip we can mark busy/idle.
+		proxied := options.AliveHttpProxy != "" || options.AliveSocksProxy != ""
+		trackDesync := func(dial func(context.Context, string, string) (net.Conn, error)) func(context.Context, string, string) (net.Conn, error) {
+			if disableKeepAlives || proxied {
+				return dial
+			}
+			return func(ctx context.Context, network, addr string) (net.Conn, error) {
+				conn, err := dial(ctx, network, addr)
+				if err != nil {
+					return conn, err
+				}
+				return newDesyncConn(conn, addr, func(host string) {
+					if dialers.HTTPDesyncHosts != nil {
+						dialers.HTTPDesyncHosts.Store(host, desyncedHostTTL)
+					}
+					countDesyncedResponse()
+				}), nil
+			}
+		}
+
 		transport := &http.Transport{
 			ForceAttemptHTTP2: options.ForceAttemptHTTP2,
-			DialContext:       dialers.Fastdialer.Dial,
-			DialTLSContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			DialContext:       trackDesync(dialers.Fastdialer.Dial),
+			DialTLSContext: trackDesync(func(ctx context.Context, network, addr string) (net.Conn, error) {
 				if options.TlsImpersonate {
 					return dialers.Fastdialer.DialTLSWithConfigImpersonate(ctx, network, addr, tlsConfig, impersonate.Random, nil)
 				}
@@ -378,7 +421,7 @@ func wrappedGet(options *types.Options, configuration *Configuration, host strin
 					return dialers.Fastdialer.DialTLSWithConfig(ctx, network, addr, tlsConfig)
 				}
 				return dialers.Fastdialer.DialTLS(ctx, network, addr)
-			},
+			}),
 			MaxIdleConns:          maxIdleConns,
 			MaxIdleConnsPerHost:   maxIdleConnsPerHost,
 			MaxConnsPerHost:       maxConnsPerHost,

--- a/pkg/protocols/http/httpclientpool/desync_conn.go
+++ b/pkg/protocols/http/httpclientpool/desync_conn.go
@@ -1,0 +1,83 @@
+package httpclientpool
+
+import (
+	"crypto/tls"
+	"net"
+	"sync"
+	"sync/atomic"
+)
+
+// desyncConn watches for bytes that arrive from a server while the connection is
+// not serving any request. A server has nothing to answer at that point, so
+// whatever it sends belongs to an earlier exchange.
+//
+// Idleness comes from net/http: GotConn fires when a request takes the
+// connection and PutIdleConn fires when it returns to the pool. Bytes in that
+// window are unsolicited by the same criterion net/http uses internally. The
+// check is one atomic load in Read, identical over plaintext and TLS because
+// the wrapper sits above the handshake.
+//
+// net/http already closes a connection when it notices this, but only logs it.
+// Observing it here is what lets the pool stop reusing connections to that host.
+// A leftover that arrives while a request is outstanding is indistinguishable
+// from that request's real reply, so this cannot save the first wrong response.
+// Closing and quarantining only stops the host from doing it again.
+type desyncConn struct {
+	net.Conn
+	host      string
+	onPoison  func(host string)
+	idle      atomic.Bool
+	poisoned  atomic.Bool
+	closeOnce sync.Once
+}
+
+func newDesyncConn(conn net.Conn, addr string, onPoison func(host string)) net.Conn {
+	if conn == nil || negotiatedHTTP2(conn) {
+		return conn
+	}
+	return &desyncConn{
+		Conn:     conn,
+		host:     desyncedHostKey(addr),
+		onPoison: onPoison,
+	}
+}
+
+func (c *desyncConn) Read(b []byte) (int, error) {
+	n, err := c.Conn.Read(b)
+	if n > 0 && c.idle.Load() {
+		c.poison()
+	}
+	return n, err
+}
+
+func (c *desyncConn) markBusy() {
+	c.idle.Store(false)
+}
+
+func (c *desyncConn) markIdle() {
+	c.idle.Store(true)
+}
+
+func (c *desyncConn) Close() error {
+	c.idle.Store(false)
+	return c.Conn.Close()
+}
+
+func (c *desyncConn) poison() {
+	if !c.poisoned.CompareAndSwap(false, true) {
+		return
+	}
+	c.idle.Store(false)
+	if c.onPoison != nil {
+		c.onPoison(c.host)
+	}
+	c.closeOnce.Do(func() { _ = c.Conn.Close() })
+}
+
+func negotiatedHTTP2(conn net.Conn) bool {
+	handshaked, ok := conn.(interface{ ConnectionState() tls.ConnectionState })
+	if !ok {
+		return false
+	}
+	return handshaked.ConnectionState().NegotiatedProtocol == "h2"
+}

--- a/pkg/protocols/http/httpclientpool/desync_conn_test.go
+++ b/pkg/protocols/http/httpclientpool/desync_conn_test.go
@@ -1,0 +1,353 @@
+package httpclientpool
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/projectdiscovery/retryablehttp-go"
+)
+
+type quarantineRecorder struct {
+	hosts chan string
+}
+
+func newQuarantineRecorder() *quarantineRecorder {
+	return &quarantineRecorder{hosts: make(chan string, 8)}
+}
+
+func (q *quarantineRecorder) record(host string) {
+	select {
+	case q.hosts <- host:
+	default:
+	}
+}
+
+func (q *quarantineRecorder) await(t *testing.T) string {
+	t.Helper()
+	select {
+	case host := <-q.hosts:
+		return host
+	case <-time.After(5 * time.Second):
+		t.Fatal("idle leftover never quarantined the host")
+		return ""
+	}
+}
+
+func (q *quarantineRecorder) requireQuiet(t *testing.T) {
+	t.Helper()
+	select {
+	case host := <-q.hosts:
+		t.Fatalf("healthy traffic was quarantined: %s", host)
+	default:
+	}
+}
+
+func trackedDialer(record func(string)) func(context.Context, string, string) (net.Conn, error) {
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		var dialer net.Dialer
+		conn, err := dialer.DialContext(ctx, network, addr)
+		if err != nil {
+			return nil, err
+		}
+		return newDesyncConn(conn, addr, record), nil
+	}
+}
+
+func trackedTLSDialer(record func(string)) func(context.Context, string, string) (net.Conn, error) {
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		var dialer net.Dialer
+		raw, err := dialer.DialContext(ctx, network, addr)
+		if err != nil {
+			return nil, err
+		}
+		conn := tls.Client(raw, &tls.Config{InsecureSkipVerify: true})
+		if err := conn.HandshakeContext(ctx); err != nil {
+			_ = raw.Close()
+			return nil, err
+		}
+		return newDesyncConn(conn, addr, record), nil
+	}
+}
+
+func countingClient(t *testing.T, transport *http.Transport) *http.Client {
+	t.Helper()
+	t.Cleanup(transport.CloseIdleConnections)
+	return &http.Client{Transport: &connTrackingTransport{base: transport}}
+}
+
+// surplusHandler answers the first request, then emits a leftover response timed
+// to land while the second request is outstanding. net/http attributes that
+// leftover to the second request. The genuine reply then arrives with nothing
+// outstanding, which is the idle-byte signal.
+func surplusHandler() http.HandlerFunc {
+	const (
+		straySentAfter   = 50 * time.Millisecond
+		realReplyDelayed = 400 * time.Millisecond
+		stale            = "HTTP/1.1 200 OK\r\nContent-Length: 5\r\nX-Tag: stale\r\n\r\nstale"
+	)
+	answer := func(exchange int) string {
+		return fmt.Sprintf("HTTP/1.1 200 OK\r\nContent-Length: 5\r\nX-Tag: ok-%d\r\n\r\nbody%d", exchange, exchange)
+	}
+
+	return func(w http.ResponseWriter, _ *http.Request) {
+		hijacker, ok := w.(http.Hijacker)
+		if !ok {
+			return
+		}
+		conn, buffered, err := hijacker.Hijack()
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+
+		if _, err := io.WriteString(conn, answer(1)); err != nil {
+			return
+		}
+		go func() {
+			time.Sleep(straySentAfter)
+			_, _ = io.WriteString(conn, stale)
+		}()
+
+		for exchange := 2; ; exchange++ {
+			req, err := http.ReadRequest(buffered.Reader)
+			if err != nil {
+				return
+			}
+			_, _ = io.Copy(io.Discard, req.Body)
+			time.Sleep(realReplyDelayed)
+			if _, err := io.WriteString(conn, answer(exchange)); err != nil {
+				return
+			}
+		}
+	}
+}
+
+func requireSurplusDetected(t *testing.T, server *httptest.Server, transport *http.Transport) {
+	t.Helper()
+	client := countingClient(t, transport)
+	for range 2 {
+		resp, err := client.Get(server.URL)
+		if err != nil {
+			break
+		}
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}
+}
+
+func TestDesyncConnDetectsSurplusResponseOverHTTP(t *testing.T) {
+	server := httptest.NewServer(surplusHandler())
+	t.Cleanup(server.Close)
+
+	recorder := newQuarantineRecorder()
+	transport := &http.Transport{MaxIdleConnsPerHost: 1, DialContext: trackedDialer(recorder.record)}
+	requireSurplusDetected(t, server, transport)
+
+	require.Equal(t, strings.TrimPrefix(server.URL, "http://"), recorder.await(t))
+}
+
+func TestDesyncConnDetectsSurplusResponseOverHTTPS(t *testing.T) {
+	server := httptest.NewTLSServer(surplusHandler())
+	t.Cleanup(server.Close)
+
+	recorder := newQuarantineRecorder()
+	transport := &http.Transport{MaxIdleConnsPerHost: 1, DialTLSContext: trackedTLSDialer(recorder.record)}
+	requireSurplusDetected(t, server, transport)
+
+	require.Equal(t, strings.TrimPrefix(server.URL, "https://"), recorder.await(t))
+}
+
+func TestDesyncConnAllowsHealthyKeepAliveTraffic(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "ok")
+	}))
+	t.Cleanup(server.Close)
+
+	recorder := newQuarantineRecorder()
+	client := countingClient(t, &http.Transport{
+		MaxIdleConnsPerHost: 1, DialContext: trackedDialer(recorder.record),
+	})
+
+	for range 25 {
+		resp, err := client.Get(server.URL)
+		require.NoError(t, err)
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Equal(t, "ok", string(body))
+		require.NoError(t, resp.Body.Close())
+	}
+	recorder.requireQuiet(t)
+}
+
+func TestDesyncConnIgnoresBytesWhileBusy(t *testing.T) {
+	client, server := net.Pipe()
+	t.Cleanup(func() { _ = server.Close() })
+
+	recorder := newQuarantineRecorder()
+	tracked := newDesyncConn(client, "busy.test:80", recorder.record).(*desyncConn)
+	t.Cleanup(func() { _ = tracked.Close() })
+	tracked.markBusy()
+
+	go func() { _, _ = io.WriteString(server, "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok") }()
+
+	buffer := make([]byte, 128)
+	_, err := tracked.Read(buffer)
+	require.NoError(t, err)
+	require.False(t, tracked.poisoned.Load())
+	recorder.requireQuiet(t)
+}
+
+func TestDesyncConnStartsBusy(t *testing.T) {
+	client, server := net.Pipe()
+	t.Cleanup(func() { _ = server.Close() })
+
+	recorder := newQuarantineRecorder()
+	tracked := newDesyncConn(client, "fresh.test:80", recorder.record).(*desyncConn)
+	t.Cleanup(func() { _ = tracked.Close() })
+
+	go func() { _, _ = io.WriteString(server, "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n") }()
+
+	buffer := make([]byte, 128)
+	_, err := tracked.Read(buffer)
+	require.NoError(t, err)
+	require.False(t, tracked.poisoned.Load())
+	recorder.requireQuiet(t)
+}
+
+func TestDesyncConnPoisonsOnBytesWhileIdleAndClosesConnection(t *testing.T) {
+	client, server := net.Pipe()
+	t.Cleanup(func() { _ = server.Close() })
+
+	recorder := newQuarantineRecorder()
+	tracked := newDesyncConn(client, "idle.test:80", recorder.record).(*desyncConn)
+	tracked.markBusy()
+	tracked.markIdle()
+
+	go func() { _, _ = io.WriteString(server, "HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nstale") }()
+
+	buffer := make([]byte, 128)
+	_, err := tracked.Read(buffer)
+	require.NoError(t, err)
+	require.Equal(t, "idle.test:80", recorder.await(t))
+	require.True(t, tracked.poisoned.Load())
+
+	_, err = tracked.Read(buffer)
+	require.Error(t, err, "a poisoned connection must not stay usable")
+}
+
+func TestDesyncConnSkipsNegotiatedHTTP2(t *testing.T) {
+	plain, _ := net.Pipe()
+	t.Cleanup(func() { _ = plain.Close() })
+
+	overHTTP2 := stubTLSConn{Conn: plain, protocol: "h2"}
+	require.Equal(t, overHTTP2, newDesyncConn(overHTTP2, "h2.test:443", nil))
+
+	overHTTP1 := stubTLSConn{Conn: plain, protocol: "http/1.1"}
+	require.IsType(t, &desyncConn{}, newDesyncConn(overHTTP1, "h1.test:443", nil))
+}
+
+type stubTLSConn struct {
+	net.Conn
+	protocol string
+}
+
+func (s stubTLSConn) ConnectionState() tls.ConnectionState {
+	return tls.ConnectionState{NegotiatedProtocol: s.protocol}
+}
+
+func TestMarkHostDesyncedStopsReuse(t *testing.T) {
+	opts := newTestOptions(t, "test-desynced-host-no-reuse")
+	cfg := &Configuration{}
+
+	var conns atomic.Int64
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "ok")
+	}))
+	server.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+		if state == http.StateNew {
+			conns.Add(1)
+		}
+	}
+	server.Start()
+	t.Cleanup(server.Close)
+
+	host := hostOf(t, server.URL)
+
+	pooled, err := Get(opts, cfg, host)
+	require.NoError(t, err)
+	requestTwice(t, pooled, server.URL)
+	require.Equal(t, int64(1), conns.Load(), "an unmarked host must reuse its connection")
+
+	MarkHostDesynced(opts, server.URL)
+	require.True(t, IsHostDesynced(opts, host))
+
+	guarded, err := Get(opts, cfg, host)
+	require.NoError(t, err)
+	require.NotSame(t, pooled, guarded)
+
+	conns.Store(0)
+	requestTwice(t, guarded, server.URL)
+	require.Equal(t, int64(2), conns.Load(), "a marked host must not reuse connections")
+}
+
+func TestIsHostDesyncedEmptyHost(t *testing.T) {
+	opts := newTestOptions(t, "test-desync-empty-host")
+	MarkHostDesynced(opts, "")
+	require.False(t, IsHostDesynced(opts, ""))
+}
+
+func requestTwice(t *testing.T, client *retryablehttp.Client, target string) {
+	t.Helper()
+	for range 2 {
+		resp, err := client.Get(target)
+		require.NoError(t, err)
+		_, err = io.Copy(io.Discard, resp.Body)
+		require.NoError(t, err)
+		require.NoError(t, resp.Body.Close())
+	}
+}
+
+func hostOf(t *testing.T, raw string) string {
+	t.Helper()
+	parsed, err := url.Parse(raw)
+	require.NoError(t, err)
+	return parsed.Host
+}
+
+func TestDesyncedHostKey(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{"https://example.com:8443/admin?a=1", "example.com:8443"},
+		{"http://example.com/", "example.com"},
+		{"https://EXAMPLE.COM:443/", "example.com:443"},
+		{"https://[2001:db8::1]:8443/", "[2001:db8::1]:8443"},
+		{"example.com:8443", "example.com:8443"},
+		{"  example.com  ", "example.com"},
+		{"", ""},
+	} {
+		require.Equal(t, tc.want, desyncedHostKey(tc.in), tc.in)
+	}
+	require.NotEqual(t, desyncedHostKey("example.com:80"), desyncedHostKey("example.com:8080"))
+}
+
+func TestDesyncTrackersAreExecutionScoped(t *testing.T) {
+	first := newTestOptions(t, "test-desync-scope-first")
+	second := newTestOptions(t, "test-desync-scope-second")
+
+	MarkHostDesynced(first, "example.com:443")
+	require.True(t, IsHostDesynced(first, "example.com:443"))
+	require.False(t, IsHostDesynced(second, "example.com:443"))
+	require.Equal(t, []string{"example.com:443"}, DesyncedHosts(first))
+	require.Empty(t, DesyncedHosts(second))
+}

--- a/pkg/protocols/http/httpclientpool/desynced_hosts.go
+++ b/pkg/protocols/http/httpclientpool/desynced_hosts.go
@@ -1,0 +1,86 @@
+package httpclientpool
+
+import (
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
+	"github.com/projectdiscovery/nuclei/v3/pkg/types"
+)
+
+// Some servers answer a request and then send another, unsolicited response on
+// the same keep-alive connection. net/http already discards that connection when
+// the leftover lands while the connection is idle, but it only logs the event.
+// Under back-to-back load a leftover can still be attributed to the next request,
+// corrupting a small number of responses before the stream resynchronizes.
+//
+// Once a leftover is observed on an idle connection, reuse for that host is
+// disabled for a while so the same listener cannot keep costing wrong results.
+const desyncedHostTTL = 15 * time.Minute
+
+var desyncedResponses atomic.Int64
+
+// DesyncedResponses reports how many idle connections were closed after receiving
+// unsolicited bytes since the process started.
+func DesyncedResponses() int64 {
+	return desyncedResponses.Load()
+}
+
+func countDesyncedResponse() {
+	desyncedResponses.Add(1)
+}
+
+func desyncHostsFor(options *types.Options) *protocolstate.ExpiringSet {
+	if options == nil {
+		return nil
+	}
+	dialers := protocolstate.GetDialersWithId(options.ExecutionId)
+	if dialers == nil {
+		return nil
+	}
+	return dialers.HTTPDesyncHosts
+}
+
+// MarkHostDesynced disables connection reuse for a target until the mark expires.
+func MarkHostDesynced(options *types.Options, target string) {
+	hosts := desyncHostsFor(options)
+	if hosts == nil {
+		return
+	}
+	key := desyncedHostKey(target)
+	if key == "" {
+		return
+	}
+	hosts.Store(key, desyncedHostTTL)
+}
+
+// IsHostDesynced reports whether connection reuse for a target is disabled.
+func IsHostDesynced(options *types.Options, target string) bool {
+	hosts := desyncHostsFor(options)
+	key := desyncedHostKey(target)
+	return hosts != nil && key != "" && hosts.Contains(key)
+}
+
+// DesyncedHosts returns the hosts connection reuse is currently disabled for.
+func DesyncedHosts(options *types.Options) []string {
+	hosts := desyncHostsFor(options)
+	if hosts == nil {
+		return nil
+	}
+	return hosts.Keys()
+}
+
+func desyncedHostKey(target string) string {
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return ""
+	}
+
+	if parsed, err := url.Parse(target); err == nil && parsed.Host != "" {
+		return strings.ToLower(parsed.Host)
+	}
+
+	return strings.ToLower(strings.TrimSuffix(target, "/"))
+}


### PR DESCRIPTION
## Summary
- Close a keep-alive connection that receives bytes while idle, then disable reuse for that host (HTTP and HTTPS).
- `net/http` already drops the connection; this observes the event so a host that keeps emitting leftovers cannot keep costing wrong results under back-to-back load.
- Does not detect a leftover that arrives while a request is outstanding. That reply is indistinguishable from a real one. Slimmer alternative to #7671.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved detection of HTTP connection desynchronization caused by unsolicited server responses.
  * Automatically quarantines affected hosts, disables unsafe connection reuse, and expires tracking entries over time.
  * Added reporting for desynchronized hosts and connections closed after unexpected responses.
* **Bug Fixes**
  * Prevents poisoned pooled connections from being reused.
  * Preserves safe connection reuse for healthy traffic and HTTP/2 connections.
* **Tests**
  * Added coverage for HTTP/HTTPS behavior, host tracking, expiration, concurrency, and connection reuse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->