### PR TITLE
feat (http) : expose TLS key exchange metadata

### DIFF
--- a/SYNTAX-REFERENCE.md
+++ b/SYNTAX-REFERENCE.md
@@ -1011,6 +1011,7 @@ Part Definitions:
 - <code>headers_from_response</code> - HTTP response headers in name:value format
 - <code>tls_version</code> - TLS version negotiated for the HTTP connection
 - <code>cipher</code> - TLS cipher suite negotiated for the HTTP connection
+- <code>key_exchange</code> - TLS key exchange group negotiated for the HTTP connection
 - <code>sni</code> - SNI value used in the TLS handshake
 - <code>subject_cn</code> - Leaf certificate subject common name
 - <code>subject_dn</code> - Leaf certificate subject distinguished name

--- a/pkg/protocols/http/http.go
+++ b/pkg/protocols/http/http.go
@@ -296,6 +296,7 @@ var RequestPartDefinitions = map[string]string{
 	"headers_from_response": "HTTP response headers in name:value format",
 	"tls_version":           "TLS version negotiated for the HTTP connection",
 	"cipher":                "TLS cipher suite negotiated for the HTTP connection",
+	"key_exchange":          "TLS key exchange group negotiated for the HTTP connection",
 	"sni":                   "SNI value used in the TLS handshake",
 	"subject_cn":            "Leaf certificate subject common name",
 	"subject_dn":            "Leaf certificate subject distinguished name",

--- a/pkg/protocols/http/tls_metadata.go
+++ b/pkg/protocols/http/tls_metadata.go
@@ -36,6 +36,9 @@ func enrichEventWithTLSMetadata(data output.InternalEvent, resp *http.Response) 
 	if state.ServerName != "" {
 		data["sni"] = state.ServerName
 	}
+	if state.CurveID != 0 {
+		data["key_exchange"] = state.CurveID.String()
+	}
 	if len(state.PeerCertificates) == 0 {
 		return
 	}

--- a/pkg/protocols/http/tls_metadata_test.go
+++ b/pkg/protocols/http/tls_metadata_test.go
@@ -15,9 +15,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/projectdiscovery/nuclei/v3/internal/tests/testutils"
 	"github.com/projectdiscovery/nuclei/v3/pkg/model"
 	"github.com/projectdiscovery/nuclei/v3/pkg/model/types/severity"
-	"github.com/projectdiscovery/nuclei/v3/internal/tests/testutils"
 )
 
 func TestEnrichEventWithTLSMetadata(t *testing.T) {
@@ -28,6 +28,7 @@ func TestEnrichEventWithTLSMetadata(t *testing.T) {
 		TLS: &tls.ConnectionState{
 			Version:          tls.VersionTLS13,
 			CipherSuite:      tls.TLS_AES_128_GCM_SHA256,
+			CurveID:          tls.X25519,
 			ServerName:       "foo.com",
 			PeerCertificates: []*x509.Certificate{cert},
 		},
@@ -38,6 +39,7 @@ func TestEnrichEventWithTLSMetadata(t *testing.T) {
 
 	require.Equal(t, "tls13", event["tls_version"])
 	require.Equal(t, "TLS_AES_128_GCM_SHA256", event["cipher"])
+	require.Equal(t, "X25519", event["key_exchange"])
 	require.Equal(t, "foo.com", event["sni"])
 	require.Equal(t, "example.com", event["subject_cn"])
 	require.Contains(t, event["subject_dn"], "CN=example.com")
@@ -92,6 +94,7 @@ func TestResponseToDSLMapIncludesTLSMetadata(t *testing.T) {
 	resp.TLS = &tls.ConnectionState{
 		Version:          tls.VersionTLS12,
 		CipherSuite:      tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		CurveID:          tls.X25519,
 		ServerName:       "docs.example",
 		PeerCertificates: []*x509.Certificate{cert},
 	}
@@ -101,6 +104,7 @@ func TestResponseToDSLMapIncludesTLSMetadata(t *testing.T) {
 		time.Millisecond, nil)
 
 	require.Equal(t, "tls12", event["tls_version"])
+	require.Equal(t, "X25519", event["key_exchange"])
 	require.Equal(t, "docs.example", event["subject_cn"])
 	require.Equal(t, "docs.example", event["sni"])
 	require.Equal(t, false, event["mismatched"])
@@ -132,4 +136,43 @@ func selfSignedTestCertificate(t *testing.T, cn string, dnsNames []string) (*x50
 		return nil, err
 	}
 	return cert, nil
+}
+
+func TestEnrichEventWithTLSMetadataHybridKeyExchange(t *testing.T) {
+	cert, err := selfSignedTestCertificate(t, "example.com", []string{"example.com"})
+	require.NoError(t, err)
+
+	resp := &http.Response{
+		TLS: &tls.ConnectionState{
+			Version:          tls.VersionTLS13,
+			CipherSuite:      tls.TLS_AES_128_GCM_SHA256,
+			CurveID:          tls.X25519MLKEM768,
+			PeerCertificates: []*x509.Certificate{cert},
+		},
+	}
+
+	event := make(map[string]interface{})
+	enrichEventWithTLSMetadata(event, resp)
+
+	require.Equal(t, "X25519MLKEM768", event["key_exchange"])
+}
+
+func TestEnrichEventWithTLSMetadataWithoutKeyExchange(t *testing.T) {
+	cert, err := selfSignedTestCertificate(t, "example.com", []string{"example.com"})
+	require.NoError(t, err)
+
+	resp := &http.Response{
+		TLS: &tls.ConnectionState{
+			Version:          tls.VersionTLS13,
+			CipherSuite:      tls.TLS_AES_128_GCM_SHA256,
+			CurveID:          0,
+			PeerCertificates: []*x509.Certificate{cert},
+		},
+	}
+
+	event := make(map[string]interface{})
+	enrichEventWithTLSMetadata(event, resp)
+
+	_, ok := event["key_exchange"]
+	require.False(t, ok)
 }


### PR DESCRIPTION
## Proposed changes

Closes #7665

Expose the negotiated TLS key exchange group in HTTP DSL metadata as `key_exchange`.

The value is populated from `tls.ConnectionState.CurveID` using `CurveID.String()`.

When no key exchange group is available (`CurveID == 0`), `key_exchange` is omitted.

No TLS configuration, request handling, or handshake behavior is changed.

## Proof

Tested with:

`go test ./pkg/protocols/http -count=1`

Result:

`ok github.com/projectdiscovery/nuclei/v3/pkg/protocols/http`

Also verified:

`git diff --check`

The tests cover:
- X25519
- X25519MLKEM768 hybrid key exchange
- missing/zero key exchange
- DSL response mapping

`SYNTAX-REFERENCE.md` was regenerated and includes `key_exchange`.

## Checklist

- [x] Pull request is created against the `dev` branch
- [x] Tests passed with my changes
- [ ] Added tests for the feature
- [x] Added necessary documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HTTP request data now includes the negotiated TLS key exchange group, such as `X25519` or `X25519MLKEM768`, when available.
* **Documentation**
  * Updated the syntax reference to document the new `key_exchange` request field.
* **Bug Fixes**
  * Key exchange information is omitted when no negotiated value is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->