### PR TITLE
fix: preserve empty query parameter equals

### DIFF
--- a/pkg/protocols/http/build_request.go
+++ b/pkg/protocols/http/build_request.go
@@ -251,6 +251,8 @@ func (r *requestGenerator) Make(ctx context.Context, input *contextargs.Context,
 
 	// while merging parameters first preference is given to target params
 	finalparams := parsed.Params
+	finalparams.IncludeEquals = true
+	reqURL.Params.IncludeEquals = true
 	finalparams.Merge(reqURL.Params.Encode())
 	reqURL.Params = finalparams
 
@@ -382,6 +384,7 @@ func (r *requestGenerator) makeSelfContainedRequest(ctx context.Context, input *
 	if err := r.validateSelfContainedHost(urlx.Hostname()); err != nil {
 		return nil, err
 	}
+	urlx.Params.IncludeEquals = true
 	return r.generateHttpRequest(ctx, urlx, values, payloads)
 }
 

--- a/pkg/protocols/http/build_request_test.go
+++ b/pkg/protocols/http/build_request_test.go
@@ -86,6 +86,31 @@ func TestMakeRequestFromModalTrimSuffixSlash(t *testing.T) {
 	require.Equal(t, "https://example.com/test/?query=example", req.request.String(), "could not get correct request path")
 }
 
+func TestMakeRequestPreservesEmptyQueryEquals(t *testing.T) {
+	options := testutils.DefaultOptions
+
+	testutils.Init(options)
+	templateID := "testing-http-empty-query-equals"
+	request := &Request{
+		ID:     templateID,
+		Name:   "testing",
+		Path:   []string{"{{BaseURL}}/search?xxxx=&next=1"},
+		Method: HTTPMethodTypeHolder{MethodType: HTTPGet},
+	}
+	executerOpts := testutils.NewMockExecuterOptions(options, &testutils.TemplateInfo{
+		ID:   templateID,
+		Info: model.Info{SeverityHolder: severity.Holder{Severity: severity.Low}, Name: "test"},
+	})
+	err := request.Compile(executerOpts)
+	require.Nil(t, err, "could not compile http request")
+
+	generator := request.newGenerator(false)
+	inputData, payloads, _ := generator.nextValue()
+	req, err := generator.Make(context.Background(), contextargs.NewWithInput(context.Background(), "https://example.com"), inputData, payloads, map[string]interface{}{})
+	require.Nil(t, err, "could not make http request")
+	require.Equal(t, "https://example.com/search?xxxx=&next=1", req.request.String(), "empty query parameter must retain equals sign")
+}
+
 func TestMakeRequestFromRawWithPayloads(t *testing.T) {
 	options := testutils.DefaultOptions
 

--- a/pkg/protocols/http/build_request_test.go
+++ b/pkg/protocols/http/build_request_test.go
@@ -111,6 +111,36 @@ func TestMakeRequestPreservesEmptyQueryEquals(t *testing.T) {
 	require.Equal(t, "https://example.com/search?xxxx=&next=1", req.request.String(), "empty query parameter must retain equals sign")
 }
 
+func TestMakeSelfContainedRequestPreservesEmptyQueryEquals(t *testing.T) {
+	templateID := "testing-self-contained-empty-query-equals"
+	options := testutils.DefaultOptions.Copy()
+	options.ExecutionId = templateID
+
+	testutils.Init(options)
+	t.Cleanup(func() {
+		testutils.Cleanup(options)
+	})
+	request := &Request{
+		ID:            templateID,
+		Name:          "testing",
+		SelfContained: true,
+		Path:          []string{"https://93.184.216.34/search?xxxx=&next=1"},
+		Method:        HTTPMethodTypeHolder{MethodType: HTTPGet},
+	}
+	executerOpts := testutils.NewMockExecuterOptions(options, &testutils.TemplateInfo{
+		ID:   templateID,
+		Info: model.Info{SeverityHolder: severity.Holder{Severity: severity.Low}, Name: "test"},
+	})
+	err := request.Compile(executerOpts)
+	require.Nil(t, err, "could not compile self-contained http request")
+
+	generator := request.newGenerator(false)
+	inputData, payloads, _ := generator.nextValue()
+	req, err := generator.Make(context.Background(), contextargs.NewWithInput(context.Background(), ""), inputData, payloads, map[string]interface{}{})
+	require.Nil(t, err, "could not make self-contained http request")
+	require.Equal(t, "https://93.184.216.34/search?xxxx=&next=1", req.request.String(), "self-contained empty query parameter must retain equals sign")
+}
+
 func TestMakeRequestFromRawWithPayloads(t *testing.T) {
 	options := testutils.DefaultOptions
 


### PR DESCRIPTION
## Proposed changes

Fixes #7672.

HTTP template paths that included an empty query value such as `?xxxx=&next=1` were rebuilt as `?xxxx&next=1`, dropping the equals sign from the empty value. This change enables the existing ordered-params empty-value preservation behavior while generating normal HTTP requests, including self-contained HTTP requests.

Before:

`{{BaseURL}}/search?xxxx=&next=1` generated `https://example.com/search?xxxx&next=1`.

After:

`{{BaseURL}}/search?xxxx=&next=1` generates `https://example.com/search?xxxx=&next=1`.

### Proof

Added unit regression tests covering empty query values in HTTP template paths:

`TestMakeRequestPreservesEmptyQueryEquals`

`TestMakeSelfContainedRequestPreservesEmptyQueryEquals`

Ran:

`env GOCACHE=/tmp/nuclei-go-build GOMODCACHE=/tmp/nuclei-go-mod go test ./pkg/protocols/http -run TestMakeRequestPreservesEmptyQueryEquals -count=1`

`env GOCACHE=/home/igorcyber/nuclei/.cache/go-build GOMODCACHE=/home/igorcyber/nuclei/.cache/go-mod GOTMPDIR=/home/igorcyber/nuclei/.cache/go-tmp go test ./pkg/protocols/http -run 'TestMakeRequestPreservesEmptyQueryEquals|TestMakeSelfContainedRequestPreservesEmptyQueryEquals' -count=1`

`env GOCACHE=/home/igorcyber/nuclei/.cache/go-build GOMODCACHE=/home/igorcyber/nuclei/.cache/go-mod GOTMPDIR=/home/igorcyber/nuclei/.cache/go-tmp go test ./pkg/protocols/http -run 'TestMakeRequestFromModal|TestMakeRequestFromModalTrimSuffixSlash|TestMakeRequestPreservesEmptyQueryEquals|TestMakeSelfContainedRequestPreservesEmptyQueryEquals|TestUnsafeRawRequestPreservesAbsoluteRequestTarget' -count=1`

`env GOCACHE=/home/igorcyber/nuclei/.cache/go-build GOMODCACHE=/home/igorcyber/nuclei/.cache/go-mod GOTMPDIR=/home/igorcyber/nuclei/.cache/go-tmp make build`

`env GOCACHE=/home/igorcyber/nuclei/.cache/go-build GOMODCACHE=/home/igorcyber/nuclei/.cache/go-mod GOTMPDIR=/home/igorcyber/nuclei/.cache/go-tmp make vet`

Also attempted `make test`; the full race test suite could not complete in this environment because several packages failed to link with `no space left on device`. The focused HTTP regression test and related HTTP builder tests passed.

## Checklist

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved explicit equals signs for query parameters without values, ensuring URLs such as `?key=` remain unchanged when requests are generated.

* **Tests**
  * Added coverage confirming empty query parameters retain their equals signs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->