### PR TITLE
fix: reuse compiled templates in thread-safe engine

### DIFF
--- a/lib/multi.go
+++ b/lib/multi.go
@@ -44,11 +44,7 @@ func createEphemeralObjects(ctx context.Context, base *NucleiEngine, opts *types
 		ResumeCfg:    types.NewResumeCfg(),
 		Parser:       base.parser,
 		Browser:      base.browserInstance,
-		// Thread-safe executes can run concurrently with different Output writers.
-		// The compiled-template cache shallow-copies requests and mutates shared
-		// ExecutorOptions.Output via UpdateOptions/ApplyNewEngineOptions, which
-		// would otherwise route all findings to whichever call last won the race.
-		DoNotCache: true,
+		DoNotCache:   opts.DoNotCacheTemplates,
 	}
 	if opts.ShouldUseHostError() && base.hostErrCache != nil {
 		u.executerOpts.HostErrorsCache = base.hostErrCache

--- a/lib/parser_lifecycle_test.go
+++ b/lib/parser_lifecycle_test.go
@@ -2,10 +2,14 @@ package nuclei
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
+	"github.com/projectdiscovery/nuclei/v3/pkg/output"
 	"github.com/projectdiscovery/nuclei/v3/pkg/templates"
 	"github.com/projectdiscovery/nuclei/v3/pkg/types"
 	"github.com/stretchr/testify/require"
@@ -67,4 +71,88 @@ http:
 		require.NoError(t, err)
 		require.NotNil(t, cached)
 	}
+}
+
+func TestThreadSafeExecuteUsesSharedCompiledCache(t *testing.T) {
+	templatePath := filepath.Join(t.TempDir(), "template.yaml")
+	require.NoError(t, os.WriteFile(templatePath, []byte(`id: thread-safe-shared-cache
+
+info:
+  name: Thread safe shared cache
+  author: pdteam
+  severity: info
+  tags: thread-safe-shared-cache
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    matchers:
+      - type: word
+        words:
+          - "thread-safe-shared-cache"
+`), 0o600))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("thread-safe-shared-cache"))
+	}))
+	t.Cleanup(server.Close)
+
+	engine, err := NewThreadSafeNucleiEngineCtx(context.Background())
+	require.NoError(t, err)
+	t.Cleanup(engine.Close)
+
+	const executions = 4
+	var waitGroup sync.WaitGroup
+	errors := make([]error, executions)
+	for i := range executions {
+		waitGroup.Add(1)
+		go func() {
+			defer waitGroup.Done()
+			errors[i] = engine.ExecuteNucleiWithOptsCtx(context.Background(), []string{server.URL},
+				WithTemplatesOrWorkflows(TemplateSources{Templates: []string{templatePath}}),
+				WithTemplateFilters(TemplateFilters{Tags: []string{"thread-safe-shared-cache"}}),
+				WithResultCallback(func(*output.ResultEvent) {}),
+			)
+		}()
+	}
+	waitGroup.Wait()
+
+	for _, err := range errors {
+		require.NoError(t, err)
+	}
+	require.Equal(t, 1, engine.eng.GetParser().CompiledCount())
+}
+
+func TestThreadSafeExecuteHonorsDisableTemplateCache(t *testing.T) {
+	templatePath := filepath.Join(t.TempDir(), "template.yaml")
+	require.NoError(t, os.WriteFile(templatePath, []byte(`id: thread-safe-disable-cache
+
+info:
+  name: Thread safe disable cache
+  author: pdteam
+  severity: info
+  tags: thread-safe-disable-cache
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+`), 0o600))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	}))
+	t.Cleanup(server.Close)
+
+	engine, err := NewThreadSafeNucleiEngineCtx(context.Background(), DisableTemplateCache())
+	require.NoError(t, err)
+	t.Cleanup(engine.Close)
+
+	err = engine.ExecuteNucleiWithOptsCtx(context.Background(), []string{server.URL},
+		WithTemplatesOrWorkflows(TemplateSources{Templates: []string{templatePath}}),
+		WithTemplateFilters(TemplateFilters{Tags: []string{"thread-safe-disable-cache"}}),
+	)
+	require.NoError(t, err)
+	require.Equal(t, 0, engine.eng.GetParser().CompiledCount())
 }

--- a/pkg/protocols/code/code.go
+++ b/pkg/protocols/code/code.go
@@ -490,6 +490,7 @@ func prettyPrint(templateId string, buff string) {
 
 // UpdateOptions replaces this request's options with a new copy
 func (r *Request) UpdateOptions(opts *protocols.ExecutorOptions) {
+	r.options = r.options.Copy()
 	r.options.ApplyNewEngineOptions(opts)
 }
 

--- a/pkg/protocols/code/code.go
+++ b/pkg/protocols/code/code.go
@@ -490,6 +490,14 @@ func prettyPrint(templateId string, buff string) {
 
 // UpdateOptions replaces this request's options with a new copy
 func (r *Request) UpdateOptions(opts *protocols.ExecutorOptions) {
+	r.Operators = protocols.CloneOperators(r.Operators)
+	r.CompiledOperators = nil
+	if r.options == nil {
+		if opts != nil {
+			r.options = opts.Copy()
+		}
+		return
+	}
 	r.options = r.options.Copy()
 	r.options.ApplyNewEngineOptions(opts)
 }

--- a/pkg/protocols/dns/dns.go
+++ b/pkg/protocols/dns/dns.go
@@ -348,5 +348,6 @@ func classToInt(class string) uint16 {
 
 // UpdateOptions replaces this request's options with a new copy
 func (r *Request) UpdateOptions(opts *protocols.ExecutorOptions) {
+	r.options = r.options.Copy()
 	r.options.ApplyNewEngineOptions(opts)
 }

--- a/pkg/protocols/dns/dns.go
+++ b/pkg/protocols/dns/dns.go
@@ -348,6 +348,14 @@ func classToInt(class string) uint16 {
 
 // UpdateOptions replaces this request's options with a new copy
 func (r *Request) UpdateOptions(opts *protocols.ExecutorOptions) {
+	r.Operators = protocols.CloneOperators(r.Operators)
+	r.CompiledOperators = nil
+	if r.options == nil {
+		if opts != nil {
+			r.options = opts.Copy()
+		}
+		return
+	}
 	r.options = r.options.Copy()
 	r.options.ApplyNewEngineOptions(opts)
 }

--- a/pkg/protocols/file/file.go
+++ b/pkg/protocols/file/file.go
@@ -230,6 +230,14 @@ func (request *Request) Requests() int {
 
 // UpdateOptions replaces this request's options with a new copy
 func (r *Request) UpdateOptions(opts *protocols.ExecutorOptions) {
+	r.Operators = protocols.CloneOperators(r.Operators)
+	r.CompiledOperators = nil
+	if r.options == nil {
+		if opts != nil {
+			r.options = opts.Copy()
+		}
+		return
+	}
 	r.options = r.options.Copy()
 	r.options.ApplyNewEngineOptions(opts)
 }

--- a/pkg/protocols/file/file.go
+++ b/pkg/protocols/file/file.go
@@ -230,5 +230,6 @@ func (request *Request) Requests() int {
 
 // UpdateOptions replaces this request's options with a new copy
 func (r *Request) UpdateOptions(opts *protocols.ExecutorOptions) {
+	r.options = r.options.Copy()
 	r.options.ApplyNewEngineOptions(opts)
 }

--- a/pkg/protocols/headless/headless.go
+++ b/pkg/protocols/headless/headless.go
@@ -174,6 +174,14 @@ func (request *Request) Requests() int {
 
 // UpdateOptions replaces this request's options with a new copy
 func (r *Request) UpdateOptions(opts *protocols.ExecutorOptions) {
+	r.Operators = protocols.CloneOperators(r.Operators)
+	r.CompiledOperators = nil
+	if r.options == nil {
+		if opts != nil {
+			r.options = opts.Copy()
+		}
+		return
+	}
 	r.options = r.options.Copy()
 	r.options.ApplyNewEngineOptions(opts)
 }

--- a/pkg/protocols/headless/headless.go
+++ b/pkg/protocols/headless/headless.go
@@ -174,6 +174,7 @@ func (request *Request) Requests() int {
 
 // UpdateOptions replaces this request's options with a new copy
 func (r *Request) UpdateOptions(opts *protocols.ExecutorOptions) {
+	r.options = r.options.Copy()
 	r.options.ApplyNewEngineOptions(opts)
 }
 

--- a/pkg/protocols/http/http.go
+++ b/pkg/protocols/http/http.go
@@ -605,6 +605,15 @@ func init() {
 
 // UpdateOptions replaces this request's options with a new copy
 func (r *Request) UpdateOptions(opts *protocols.ExecutorOptions) {
+	r.Operators = protocols.CloneOperators(r.Operators)
+	r.CompiledOperators = nil
+	r.FuzzPreCondition = protocols.CloneMatchers(r.FuzzPreCondition)
+	if r.options == nil {
+		if opts != nil {
+			r.options = opts.Copy()
+		}
+		return
+	}
 	r.options = r.options.Copy()
 	r.options.ApplyNewEngineOptions(opts)
 }

--- a/pkg/protocols/http/http.go
+++ b/pkg/protocols/http/http.go
@@ -606,7 +606,6 @@ func init() {
 // UpdateOptions replaces this request's options with a new copy
 func (r *Request) UpdateOptions(opts *protocols.ExecutorOptions) {
 	r.Operators = protocols.CloneOperators(r.Operators)
-	r.CompiledOperators = nil
 	r.FuzzPreCondition = protocols.CloneMatchers(r.FuzzPreCondition)
 	if r.options == nil {
 		if opts != nil {

--- a/pkg/protocols/http/http.go
+++ b/pkg/protocols/http/http.go
@@ -605,6 +605,7 @@ func init() {
 
 // UpdateOptions replaces this request's options with a new copy
 func (r *Request) UpdateOptions(opts *protocols.ExecutorOptions) {
+	r.options = r.options.Copy()
 	r.options.ApplyNewEngineOptions(opts)
 }
 

--- a/pkg/protocols/javascript/js.go
+++ b/pkg/protocols/javascript/js.go
@@ -959,5 +959,6 @@ func prettyPrint(templateId string, buff string) {
 
 // UpdateOptions replaces this request's options with a new copy
 func (r *Request) UpdateOptions(opts *protocols.ExecutorOptions) {
+	r.options = r.options.Copy()
 	r.options.ApplyNewEngineOptions(opts)
 }

--- a/pkg/protocols/javascript/js.go
+++ b/pkg/protocols/javascript/js.go
@@ -959,6 +959,14 @@ func prettyPrint(templateId string, buff string) {
 
 // UpdateOptions replaces this request's options with a new copy
 func (r *Request) UpdateOptions(opts *protocols.ExecutorOptions) {
+	r.Operators = protocols.CloneOperators(r.Operators)
+	r.CompiledOperators = nil
+	if r.options == nil {
+		if opts != nil {
+			r.options = opts.Copy()
+		}
+		return
+	}
 	r.options = r.options.Copy()
 	r.options.ApplyNewEngineOptions(opts)
 }

--- a/pkg/protocols/network/network.go
+++ b/pkg/protocols/network/network.go
@@ -288,6 +288,14 @@ func (request *Request) SetDialer(dialer *fastdialer.Dialer) {
 
 // UpdateOptions replaces this request's options with a new copy
 func (r *Request) UpdateOptions(opts *protocols.ExecutorOptions) {
+	r.Operators = protocols.CloneOperators(r.Operators)
+	r.CompiledOperators = nil
+	if r.options == nil {
+		if opts != nil {
+			r.options = opts.Copy()
+		}
+		return
+	}
 	r.options = r.options.Copy()
 	r.options.ApplyNewEngineOptions(opts)
 }

--- a/pkg/protocols/network/network.go
+++ b/pkg/protocols/network/network.go
@@ -288,5 +288,6 @@ func (request *Request) SetDialer(dialer *fastdialer.Dialer) {
 
 // UpdateOptions replaces this request's options with a new copy
 func (r *Request) UpdateOptions(opts *protocols.ExecutorOptions) {
+	r.options = r.options.Copy()
 	r.options.ApplyNewEngineOptions(opts)
 }

--- a/pkg/protocols/offlinehttp/request.go
+++ b/pkg/protocols/offlinehttp/request.go
@@ -162,5 +162,5 @@ func getURLFromRequest(req *http.Request) string {
 
 // UpdateOptions replaces this request's options with a new copy
 func (r *Request) UpdateOptions(opts *protocols.ExecutorOptions) {
-	r.options = opts
+	r.options = opts.Copy()
 }

--- a/pkg/protocols/offlinehttp/request.go
+++ b/pkg/protocols/offlinehttp/request.go
@@ -162,5 +162,7 @@ func getURLFromRequest(req *http.Request) string {
 
 // UpdateOptions replaces this request's options with a new copy
 func (r *Request) UpdateOptions(opts *protocols.ExecutorOptions) {
-	r.options = opts.Copy()
+	if opts != nil {
+		r.options = opts.Copy()
+	}
 }

--- a/pkg/protocols/protocols.go
+++ b/pkg/protocols/protocols.go
@@ -3,6 +3,7 @@ package protocols
 import (
 	"context"
 	"encoding/base64"
+	"reflect"
 	"sync/atomic"
 
 	"github.com/projectdiscovery/fastdialer/fastdialer"
@@ -342,6 +343,85 @@ func (e *ExecutorOptions) Copy() *ExecutorOptions {
 	copy.ClusterMappings = e.ClusterMappings.Copy()
 	copy.CreateTemplateCtxStore()
 	return copy
+}
+
+// CloneOperators returns a copy of operators with only template-authored fields.
+// Compiled matcher/extractor state is rebuilt per execution by Request.Compile.
+func CloneOperators(src operators.Operators) operators.Operators {
+	value := cloneExportedValue(reflect.ValueOf(src))
+	cloned := value.Interface().(operators.Operators)
+	cloned.TemplateID = ""
+	cloned.ExcludeMatchers = nil
+	return cloned
+}
+
+// CloneMatchers returns a copy of matcher definitions without compiled matcher
+// state so callers can safely compile them for a single execution.
+func CloneMatchers(src []*matchers.Matcher) []*matchers.Matcher {
+	if src == nil {
+		return nil
+	}
+	value := cloneExportedValue(reflect.ValueOf(src))
+	return value.Interface().([]*matchers.Matcher)
+}
+
+func cloneExportedValue(value reflect.Value) reflect.Value {
+	if !value.IsValid() {
+		return value
+	}
+
+	switch value.Kind() {
+	case reflect.Interface:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		cloned := cloneExportedValue(value.Elem())
+		result := reflect.New(value.Type()).Elem()
+		result.Set(cloned)
+		return result
+	case reflect.Pointer:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		cloned := reflect.New(value.Type().Elem())
+		cloned.Elem().Set(cloneExportedValue(value.Elem()))
+		return cloned
+	case reflect.Struct:
+		cloned := reflect.New(value.Type()).Elem()
+		for i := 0; i < value.NumField(); i++ {
+			if value.Type().Field(i).IsExported() {
+				cloned.Field(i).Set(cloneExportedValue(value.Field(i)))
+			}
+		}
+		return cloned
+	case reflect.Slice:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		cloned := reflect.MakeSlice(value.Type(), value.Len(), value.Len())
+		for i := 0; i < value.Len(); i++ {
+			cloned.Index(i).Set(cloneExportedValue(value.Index(i)))
+		}
+		return cloned
+	case reflect.Map:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		cloned := reflect.MakeMapWithSize(value.Type(), value.Len())
+		iterator := value.MapRange()
+		for iterator.Next() {
+			cloned.SetMapIndex(cloneExportedValue(iterator.Key()), cloneExportedValue(iterator.Value()))
+		}
+		return cloned
+	case reflect.Array:
+		cloned := reflect.New(value.Type()).Elem()
+		for i := 0; i < value.Len(); i++ {
+			cloned.Index(i).Set(cloneExportedValue(value.Index(i)))
+		}
+		return cloned
+	default:
+		return value
+	}
 }
 
 // Request is an interface implemented any protocol based request generator.

--- a/pkg/protocols/protocols_test.go
+++ b/pkg/protocols/protocols_test.go
@@ -1,0 +1,119 @@
+package protocols
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/operators"
+	"github.com/projectdiscovery/nuclei/v3/pkg/operators/extractors"
+	"github.com/projectdiscovery/nuclei/v3/pkg/operators/matchers"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCloneOperatorsCopiesAuthoredFields(t *testing.T) {
+	source := operators.Operators{
+		MatchersCondition: "and",
+		TemplateID:        "cached-template",
+		Matchers: []*matchers.Matcher{
+			{
+				Type:  matchers.MatcherTypeHolder{MatcherType: matchers.WordsMatcher},
+				Words: []string{"first"},
+			},
+		},
+		Extractors: []*extractors.Extractor{
+			{
+				Type:  extractors.ExtractorTypeHolder{ExtractorType: extractors.RegexExtractor},
+				Regex: []string{"token=(.+)"},
+			},
+		},
+	}
+
+	cloned := CloneOperators(source)
+
+	require.Equal(t, source.MatchersCondition, cloned.MatchersCondition)
+	require.Empty(t, cloned.TemplateID)
+	require.Nil(t, cloned.ExcludeMatchers)
+	require.Equal(t, source.Matchers[0].Words, cloned.Matchers[0].Words)
+	require.Equal(t, source.Extractors[0].Regex, cloned.Extractors[0].Regex)
+	require.NotSame(t, source.Matchers[0], cloned.Matchers[0])
+	require.NotSame(t, source.Extractors[0], cloned.Extractors[0])
+
+	cloned.Matchers[0].Words[0] = "second"
+	cloned.Extractors[0].Regex[0] = "session=(.+)"
+	require.Equal(t, "first", source.Matchers[0].Words[0])
+	require.Equal(t, "token=(.+)", source.Extractors[0].Regex[0])
+}
+
+func TestCloneOperatorsHandlesZeroValue(t *testing.T) {
+	cloned := CloneOperators(operators.Operators{})
+	require.Empty(t, cloned.Matchers)
+	require.Empty(t, cloned.Extractors)
+}
+
+func TestCloneMatchersCopiesDefinitions(t *testing.T) {
+	source := []*matchers.Matcher{
+		{
+			Type:  matchers.MatcherTypeHolder{MatcherType: matchers.WordsMatcher},
+			Words: []string{"first"},
+		},
+	}
+
+	cloned := CloneMatchers(source)
+
+	require.Equal(t, source[0].Words, cloned[0].Words)
+	require.NotSame(t, source[0], cloned[0])
+
+	cloned[0].Words[0] = "second"
+	require.Equal(t, "first", source[0].Words[0])
+	require.Nil(t, CloneMatchers(nil))
+}
+
+func TestCloneExportedValueCopiesCompositeFields(t *testing.T) {
+	type cloneFixture struct {
+		Any      any
+		Ptr      *int
+		NilPtr   *int
+		Slice    []string
+		NilSlice []string
+		Map      map[string][]int
+		NilMap   map[string]string
+		Array    [2]*int
+	}
+
+	first := 1
+	second := 2
+	source := cloneFixture{
+		Any:   []string{"value"},
+		Ptr:   &first,
+		Slice: []string{"a", "b"},
+		Map:   map[string][]int{"numbers": {1, 2}},
+		Array: [2]*int{&first, &second},
+	}
+
+	cloned := cloneExportedValue(reflect.ValueOf(source)).Interface().(cloneFixture)
+
+	require.Equal(t, source.Any, cloned.Any)
+	require.Equal(t, source.Slice, cloned.Slice)
+	require.Equal(t, source.Map, cloned.Map)
+	require.NotSame(t, source.Ptr, cloned.Ptr)
+	require.NotSame(t, source.Array[0], cloned.Array[0])
+	require.Nil(t, cloned.NilPtr)
+	require.Nil(t, cloned.NilSlice)
+	require.Nil(t, cloned.NilMap)
+
+	cloned.Any.([]string)[0] = "changed"
+	cloned.Slice[0] = "changed"
+	cloned.Map["numbers"][0] = 3
+	*cloned.Ptr = 4
+	*cloned.Array[0] = 5
+
+	require.Equal(t, []string{"value"}, source.Any)
+	require.Equal(t, []string{"a", "b"}, source.Slice)
+	require.Equal(t, []int{1, 2}, source.Map["numbers"])
+	require.Equal(t, 1, *source.Ptr)
+	require.Equal(t, 1, *source.Array[0])
+}
+
+func TestCloneExportedValueHandlesInvalidValue(t *testing.T) {
+	require.False(t, cloneExportedValue(reflect.Value{}).IsValid())
+}

--- a/pkg/protocols/ssl/ssl.go
+++ b/pkg/protocols/ssl/ssl.go
@@ -450,6 +450,14 @@ func (request *Request) MakeResultEventItem(wrapped *output.InternalWrappedEvent
 
 // UpdateOptions replaces this request's options with a new copy
 func (r *Request) UpdateOptions(opts *protocols.ExecutorOptions) {
+	r.Operators = protocols.CloneOperators(r.Operators)
+	r.CompiledOperators = nil
+	if r.options == nil {
+		if opts != nil {
+			r.options = opts.Copy()
+		}
+		return
+	}
 	r.options = r.options.Copy()
 	r.options.ApplyNewEngineOptions(opts)
 }

--- a/pkg/protocols/ssl/ssl.go
+++ b/pkg/protocols/ssl/ssl.go
@@ -450,5 +450,6 @@ func (request *Request) MakeResultEventItem(wrapped *output.InternalWrappedEvent
 
 // UpdateOptions replaces this request's options with a new copy
 func (r *Request) UpdateOptions(opts *protocols.ExecutorOptions) {
+	r.options = r.options.Copy()
 	r.options.ApplyNewEngineOptions(opts)
 }

--- a/pkg/protocols/websocket/websocket.go
+++ b/pkg/protocols/websocket/websocket.go
@@ -471,5 +471,6 @@ func (request *Request) Type() templateTypes.ProtocolType {
 
 // UpdateOptions replaces this request's options with a new copy
 func (r *Request) UpdateOptions(opts *protocols.ExecutorOptions) {
+	r.options = r.options.Copy()
 	r.options.ApplyNewEngineOptions(opts)
 }

--- a/pkg/protocols/websocket/websocket.go
+++ b/pkg/protocols/websocket/websocket.go
@@ -471,6 +471,14 @@ func (request *Request) Type() templateTypes.ProtocolType {
 
 // UpdateOptions replaces this request's options with a new copy
 func (r *Request) UpdateOptions(opts *protocols.ExecutorOptions) {
+	r.Operators = protocols.CloneOperators(r.Operators)
+	r.CompiledOperators = nil
+	if r.options == nil {
+		if opts != nil {
+			r.options = opts.Copy()
+		}
+		return
+	}
 	r.options = r.options.Copy()
 	r.options.ApplyNewEngineOptions(opts)
 }

--- a/pkg/protocols/whois/whois.go
+++ b/pkg/protocols/whois/whois.go
@@ -227,6 +227,14 @@ func (request *Request) Type() templateTypes.ProtocolType {
 
 // UpdateOptions replaces this request's options with a new copy
 func (r *Request) UpdateOptions(opts *protocols.ExecutorOptions) {
+	r.Operators = protocols.CloneOperators(r.Operators)
+	r.CompiledOperators = nil
+	if r.options == nil {
+		if opts != nil {
+			r.options = opts.Copy()
+		}
+		return
+	}
 	r.options = r.options.Copy()
 	r.options.ApplyNewEngineOptions(opts)
 }

--- a/pkg/protocols/whois/whois.go
+++ b/pkg/protocols/whois/whois.go
@@ -14,9 +14,9 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/contextargs"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/generators"
-	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/helpers/eventcreator"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/helpers/responsehighlighter"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/protocolstate"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/replacer"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/utils/vardump"
 	protocolutils "github.com/projectdiscovery/nuclei/v3/pkg/protocols/utils"
@@ -227,5 +227,6 @@ func (request *Request) Type() templateTypes.ProtocolType {
 
 // UpdateOptions replaces this request's options with a new copy
 func (r *Request) UpdateOptions(opts *protocols.ExecutorOptions) {
+	r.options = r.options.Copy()
 	r.options.ApplyNewEngineOptions(opts)
 }

--- a/pkg/templates/clone.go
+++ b/pkg/templates/clone.go
@@ -19,17 +19,25 @@ type cloneVisit struct {
 // point and are copied by value; exported maps, slices, pointers, and
 // interfaces are copied recursively.
 func cloneTemplate(template *Template) *Template {
-	visited := make(map[cloneVisit]reflect.Value)
+	visited := newCloneVisited()
 	cloned := cloneTemplateValue(reflect.ValueOf(template), visited)
 	clonedTemplate := cloned.Interface().(*Template)
-	clonedTemplate.Variables = cloneTemplateVariables(template.Variables)
+	clonedTemplate.Variables = cloneTemplateVariables(template.Variables, visited)
 	return clonedTemplate
 }
 
-func cloneTemplateVariables(src variables.Variable) variables.Variable {
+// newCloneVisited tracks values already cloned during one clone operation.
+// Callers cloning several fields of the same owner must share it so values
+// aliased across those fields stay aliased in the copy.
+func newCloneVisited() map[cloneVisit]reflect.Value {
+	return make(map[cloneVisit]reflect.Value)
+}
+
+// cloneTemplateVariables deep-copies variables, whose backing map is held in
+// unexported fields that cloneTemplateValue copies by reference.
+func cloneTemplateVariables(src variables.Variable, visited map[cloneVisit]reflect.Value) variables.Variable {
 	dst := variables.Variable{LazyEval: src.LazyEval}
 	dst.InsertionOrderedStringMap = *utils.NewEmptyInsertionOrderedStringMap(src.Len())
-	visited := make(map[cloneVisit]reflect.Value)
 	src.ForEach(func(key string, value interface{}) {
 		clonedValue := cloneTemplateValue(reflect.ValueOf(value), visited)
 		if clonedValue.IsValid() {
@@ -41,11 +49,11 @@ func cloneTemplateVariables(src variables.Variable) variables.Variable {
 	return dst
 }
 
-func cloneTemplateConstants(src map[string]interface{}) map[string]interface{} {
+func cloneTemplateConstants(src map[string]interface{}, visited map[cloneVisit]reflect.Value) map[string]interface{} {
 	if src == nil {
 		return nil
 	}
-	cloned := cloneTemplateValue(reflect.ValueOf(src), make(map[cloneVisit]reflect.Value))
+	cloned := cloneTemplateValue(reflect.ValueOf(src), visited)
 	return cloned.Interface().(map[string]interface{})
 }
 

--- a/pkg/templates/clone.go
+++ b/pkg/templates/clone.go
@@ -3,9 +3,12 @@ package templates
 import (
 	"reflect"
 
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/variables"
 	"github.com/projectdiscovery/nuclei/v3/pkg/utils"
 )
+
+var executorOptionsType = reflect.TypeOf((*protocols.ExecutorOptions)(nil))
 
 type cloneVisit struct {
 	typeOf   reflect.Type
@@ -59,6 +62,13 @@ func cloneTemplateConstants(src map[string]interface{}, visited map[cloneVisit]r
 
 func cloneTemplateValue(value reflect.Value, visited map[cloneVisit]reflect.Value) reflect.Value {
 	if !value.IsValid() {
+		return value
+	}
+
+	// ExecutorOptions reach engine-scoped state such as the shared parser and its
+	// caches, which other goroutines mutate while this template is cloned. Callers
+	// swap in a cache-safe copy, so carry the pointer instead of walking it.
+	if value.Type() == executorOptionsType {
 		return value
 	}
 

--- a/pkg/templates/clone.go
+++ b/pkg/templates/clone.go
@@ -3,6 +3,7 @@ package templates
 import (
 	"reflect"
 
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/variables"
 	"github.com/projectdiscovery/nuclei/v3/pkg/utils"
 )
 
@@ -21,16 +22,31 @@ func cloneTemplate(template *Template) *Template {
 	visited := make(map[cloneVisit]reflect.Value)
 	cloned := cloneTemplateValue(reflect.ValueOf(template), visited)
 	clonedTemplate := cloned.Interface().(*Template)
-	clonedTemplate.Variables.InsertionOrderedStringMap = *utils.NewEmptyInsertionOrderedStringMap(template.Variables.Len())
-	template.Variables.ForEach(func(key string, value interface{}) {
+	clonedTemplate.Variables = cloneTemplateVariables(template.Variables)
+	return clonedTemplate
+}
+
+func cloneTemplateVariables(src variables.Variable) variables.Variable {
+	dst := variables.Variable{LazyEval: src.LazyEval}
+	dst.InsertionOrderedStringMap = *utils.NewEmptyInsertionOrderedStringMap(src.Len())
+	visited := make(map[cloneVisit]reflect.Value)
+	src.ForEach(func(key string, value interface{}) {
 		clonedValue := cloneTemplateValue(reflect.ValueOf(value), visited)
 		if clonedValue.IsValid() {
-			clonedTemplate.Variables.Set(key, clonedValue.Interface())
+			dst.Set(key, clonedValue.Interface())
 		} else {
-			clonedTemplate.Variables.Set(key, nil)
+			dst.Set(key, nil)
 		}
 	})
-	return clonedTemplate
+	return dst
+}
+
+func cloneTemplateConstants(src map[string]interface{}) map[string]interface{} {
+	if src == nil {
+		return nil
+	}
+	cloned := cloneTemplateValue(reflect.ValueOf(src), make(map[cloneVisit]reflect.Value))
+	return cloned.Interface().(map[string]interface{})
 }
 
 func cloneTemplateValue(value reflect.Value, visited map[cloneVisit]reflect.Value) reflect.Value {

--- a/pkg/templates/clone_test.go
+++ b/pkg/templates/clone_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/disk"
+	"github.com/projectdiscovery/nuclei/v3/pkg/protocols"
 	"github.com/projectdiscovery/nuclei/v3/pkg/utils"
 	"github.com/stretchr/testify/require"
 )
@@ -79,6 +80,24 @@ func TestCloneTemplatePreservesMutableAliases(t *testing.T) {
 	require.Equal(t, "changed", clonedNextSlice[0])
 	require.Equal(t, "original", sharedMap["value"])
 	require.Equal(t, "original", sharedSlice[0])
+}
+
+func TestCacheSafeExecutorOptionsPreservesMutableAliases(t *testing.T) {
+	sharedMap := map[string]interface{}{"value": "original"}
+	options := &protocols.ExecutorOptions{
+		Constants: map[string]interface{}{"map": sharedMap},
+	}
+	options.Variables.InsertionOrderedStringMap = *utils.NewEmptyInsertionOrderedStringMap(1)
+	options.Variables.Set("map", sharedMap)
+
+	safeOptions := cacheSafeExecutorOptions(options)
+	safeConstantMap := safeOptions.Constants["map"].(map[string]interface{})
+	safeVariableMap := safeOptions.Variables.GetAll()["map"].(map[string]interface{})
+
+	safeConstantMap["value"] = "changed"
+
+	require.Equal(t, "changed", safeVariableMap["value"])
+	require.Equal(t, "original", sharedMap["value"])
 }
 
 func TestCloneTemplateHandlesMutableCycles(t *testing.T) {

--- a/pkg/templates/clone_test.go
+++ b/pkg/templates/clone_test.go
@@ -82,6 +82,17 @@ func TestCloneTemplatePreservesMutableAliases(t *testing.T) {
 	require.Equal(t, "original", sharedSlice[0])
 }
 
+func TestCloneTemplateKeepsExecutorOptionsByReference(t *testing.T) {
+	parser := NewParser()
+	original := &Template{}
+	original.Options = &protocols.ExecutorOptions{Parser: parser}
+
+	cloned := cloneTemplate(original)
+
+	require.Same(t, original.Options, cloned.Options)
+	require.Same(t, parser, cloned.Options.Parser)
+}
+
 func TestCacheSafeExecutorOptionsPreservesMutableAliases(t *testing.T) {
 	sharedMap := map[string]interface{}{"value": "original"}
 	options := &protocols.ExecutorOptions{

--- a/pkg/templates/compile.go
+++ b/pkg/templates/compile.go
@@ -399,8 +399,11 @@ func Parse(filePath string, preprocessor Preprocessor, options *protocols.Execut
 			return nil, err
 		}
 
-		if !shared {
-			template, _ := result.(*Template)
+		// A nil result means the closure found the template already cached, which
+		// happens when another goroutine populated it after the check above. Only a
+		// typed result belongs to this caller; anything else re-reads the cache so
+		// the template is rebuilt against these options.
+		if template, ok := result.(*Template); ok && !shared {
 			return template, nil
 		}
 		if template, ok, err := parseCompiledTemplateFromCache(filePath, preprocessor, options, parser); ok || err != nil {

--- a/pkg/templates/compile.go
+++ b/pkg/templates/compile.go
@@ -282,6 +282,9 @@ func cacheSafeExecutorOptions(options *protocols.ExecutorOptions) *protocols.Exe
 	}
 
 	safeOptions := options.Copy()
+	safeOptions.Variables = cloneTemplateVariables(options.Variables)
+	safeOptions.Constants = cloneTemplateConstants(options.Constants)
+	safeOptions.ResumeCfg = nil
 	safeOptions.TemplateVerificationCallback = nil
 	safeOptions.Output = nil
 	safeOptions.IssuesClient = nil
@@ -428,11 +431,11 @@ func parseCompiledTemplateFromCache(filePath string, preprocessor Preprocessor, 
 	newBase.RawTemplate = tplCopy.Options.RawTemplate
 
 	if tplCopy.Options.Variables.Len() > 0 {
-		newBase.Variables = tplCopy.Options.Variables
+		newBase.Variables = cloneTemplateVariables(tplCopy.Options.Variables)
 	}
 
 	if len(tplCopy.Options.Constants) > 0 {
-		newBase.Constants = tplCopy.Options.Constants
+		newBase.Constants = cloneTemplateConstants(tplCopy.Options.Constants)
 	}
 
 	tplCopy.Options = newBase

--- a/pkg/templates/compile.go
+++ b/pkg/templates/compile.go
@@ -167,6 +167,7 @@ func parseFromSource(filePath string, preprocessor Preprocessor, options *protoc
 	options.TemplatePath = filePath
 
 	var template *Template
+	var cacheableTemplate *Template
 	var err error
 
 	if !options.DoNotCache {
@@ -177,6 +178,7 @@ func parseFromSource(filePath string, preprocessor Preprocessor, options *protoc
 
 		if parsed != nil && len(raw) > 0 {
 			template, err = parseCachedTemplate(parsed, raw, preprocessor, options)
+			cacheableTemplate = cloneTemplate(parsed)
 		}
 	}
 
@@ -190,11 +192,19 @@ func parseFromSource(filePath string, preprocessor Preprocessor, options *protoc
 			_ = reader.Close()
 		}()
 
-		template, err = ParseTemplateFromReader(reader, preprocessor, options)
+		data, readErr := io.ReadAll(reader)
+		if readErr != nil {
+			return nil, readErr
+		}
+
+		template, cacheableTemplate, err = parseTemplateFromData(data, preprocessor, options)
 	}
 
 	if err != nil {
 		return nil, err
+	}
+	if cacheableTemplate != nil {
+		copyTemplateVerification(cacheableTemplate, template)
 	}
 
 	if template.isGlobalMatchersEnabled() {
@@ -224,7 +234,10 @@ func parseFromSource(filePath string, preprocessor Preprocessor, options *protoc
 
 	template.Path = filePath
 	if !options.DoNotCache {
-		parser.compiledTemplatesCache.StoreWithoutRaw(filePath, cacheSafeCompiledTemplate(template), err)
+		if cacheableTemplate == nil {
+			cacheableTemplate = template
+		}
+		parser.compiledTemplatesCache.StoreWithoutRaw(filePath, cacheSafeCompiledTemplate(cacheableTemplate), err)
 	}
 
 	return template, nil
@@ -241,6 +254,24 @@ func cacheSafeCompiledTemplate(template *Template) *Template {
 	updateRequestOptions(&tplCopy)
 
 	return &tplCopy
+}
+
+// copyTemplateVerification mirrors verification metadata onto the cacheable
+// pre-compilation template copy.
+func copyTemplateVerification(dst, src *Template) {
+	if dst == nil || src == nil {
+		return
+	}
+
+	dst.Verified = src.Verified
+	dst.TemplateVerifier = src.TemplateVerifier
+	dst.verificationDigest = src.verificationDigest
+	dst.verifierFingerprint = src.verifierFingerprint
+	if dst.Options != nil && src.Options != nil {
+		dst.Options.TemplateVerifier = src.Options.TemplateVerifier
+		dst.Options.Verified = src.Options.Verified
+		dst.Options.RawTemplate = src.Options.RawTemplate
+	}
 }
 
 // cacheSafeExecutorOptions copies immutable template metadata and drops
@@ -353,6 +384,9 @@ func Parse(filePath string, preprocessor Preprocessor, options *protocols.Execut
 
 		result, err, shared := parser.compiledTemplatesLoadGroup.Do(filePath, func() (interface{}, error) {
 			if value, _, cacheErr := parser.compiledTemplatesCache.Has(filePath); value != nil || cacheErr != nil {
+				if value != nil && value.Options == nil {
+					return parseFromSource(filePath, preprocessor, options, parser)
+				}
 				return nil, cacheErr
 			}
 			return parseFromSource(filePath, preprocessor, options, parser)
@@ -361,7 +395,7 @@ func Parse(filePath string, preprocessor Preprocessor, options *protocols.Execut
 			return nil, err
 		}
 
-		if !shared && result != nil {
+		if !shared {
 			template, _ := result.(*Template)
 			return template, nil
 		}
@@ -409,6 +443,16 @@ func parseCompiledTemplateFromCache(filePath string, preprocessor Preprocessor, 
 	template := &tplCopy
 
 	if template.isGlobalMatchersEnabled() {
+		if err := template.compileProtocolRequests(template.Options); err != nil {
+			return nil, true, err
+		}
+		if template.Executer != nil {
+			if err := template.Executer.Compile(); err != nil {
+				return nil, true, errors.Wrap(err, "could not compile request")
+			}
+			template.TotalRequests = template.Executer.Requests()
+		}
+
 		item := &globalmatchers.Item{
 			TemplateID:   template.ID,
 			TemplatePath: filePath,
@@ -642,6 +686,13 @@ func ParseTemplateFromReader(reader io.Reader, preprocessor Preprocessor, option
 		return nil, err
 	}
 
+	template, _, err := parseTemplateFromData(data, preprocessor, options)
+	return template, err
+}
+
+// parseTemplateFromData parses and compiles template data while also returning
+// the prepared pre-compilation template definition that is safe to cache.
+func parseTemplateFromData(data []byte, preprocessor Preprocessor, options *protocols.ExecutorOptions) (*Template, *Template, error) {
 	// a preprocessor is a variable like
 	// {{randstr}} which is replaced before unmarshalling
 	// as it is known to be a random static value per template
@@ -650,16 +701,20 @@ func ParseTemplateFromReader(reader io.Reader, preprocessor Preprocessor, option
 
 	if !hasPreprocessor {
 		// if no preprocessors exists parse template and exit
-		template, err := parseTemplate(data, options)
+		template, err := parseTemplateNoVerify(data, options)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
+		}
+		cacheableTemplate := cloneTemplate(template)
+		if err := verifyAndCompileTemplate(template, data); err != nil {
+			return nil, nil, err
 		}
 		if !template.Verified && len(template.Workflows) == 0 {
 			if config.DefaultConfig.LogAllEvents {
 				gologger.DefaultLogger.Print().Msgf("[%v] Template %s is not signed or tampered\n", aurora.Yellow("WRN").String(), template.ID)
 			}
 		}
-		return template, nil
+		return template, cacheableTemplate, nil
 	}
 
 	// if preprocessor is required / exists in this template
@@ -678,14 +733,15 @@ func ParseTemplateFromReader(reader io.Reader, preprocessor Preprocessor, option
 
 	template, err := parseTemplateNoVerify(processedData, options)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// add generated constants to constants map and executer options
 	template.Constants = generators.MergeMaps(template.Constants, generatedConstants)
 	template.Options.Constants = template.Constants
+	cacheableTemplate := cloneTemplate(template)
 	if err := verifyAndCompileTemplate(template, data); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	if !template.Verified && len(template.Workflows) == 0 {
@@ -695,7 +751,7 @@ func ParseTemplateFromReader(reader io.Reader, preprocessor Preprocessor, option
 		}
 	}
 
-	return template, nil
+	return template, cacheableTemplate, nil
 }
 
 func hasTemplatePreprocessor(data []byte, preprocessor Preprocessor) bool {

--- a/pkg/templates/compile.go
+++ b/pkg/templates/compile.go
@@ -27,6 +27,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/tmplexec"
 	"github.com/projectdiscovery/nuclei/v3/pkg/utils"
 	"github.com/projectdiscovery/nuclei/v3/pkg/utils/json"
+	"github.com/projectdiscovery/nuclei/v3/pkg/workflows"
 	"github.com/projectdiscovery/utils/errkit"
 	stringsutil "github.com/projectdiscovery/utils/strings"
 )
@@ -57,91 +58,91 @@ func updateRequestOptions(template *Template) {
 		if i == 0 {
 			template.RequestsDNS = append(template.RequestsDNS[:0:0], template.RequestsDNS...)
 		}
-		rCopy := *r
+		rCopy := cloneProtocolRequest(r)
 		rCopy.UpdateOptions(template.Options)
-		template.RequestsDNS[i] = &rCopy
-		requests[r] = &rCopy
+		template.RequestsDNS[i] = rCopy
+		requests[r] = rCopy
 	}
 	for i, r := range template.RequestsHTTP {
 		if i == 0 {
 			template.RequestsHTTP = append(template.RequestsHTTP[:0:0], template.RequestsHTTP...)
 		}
-		rCopy := *r
+		rCopy := cloneProtocolRequest(r)
 		rCopy.UpdateOptions(template.Options)
-		template.RequestsHTTP[i] = &rCopy
-		requests[r] = &rCopy
+		template.RequestsHTTP[i] = rCopy
+		requests[r] = rCopy
 	}
 	for i, r := range template.RequestsCode {
 		if i == 0 {
 			template.RequestsCode = append(template.RequestsCode[:0:0], template.RequestsCode...)
 		}
-		rCopy := *r
+		rCopy := cloneProtocolRequest(r)
 		rCopy.UpdateOptions(template.Options)
-		template.RequestsCode[i] = &rCopy
-		requests[r] = &rCopy
+		template.RequestsCode[i] = rCopy
+		requests[r] = rCopy
 	}
 	for i, r := range template.RequestsFile {
 		if i == 0 {
 			template.RequestsFile = append(template.RequestsFile[:0:0], template.RequestsFile...)
 		}
-		rCopy := *r
+		rCopy := cloneProtocolRequest(r)
 		rCopy.UpdateOptions(template.Options)
-		template.RequestsFile[i] = &rCopy
-		requests[r] = &rCopy
+		template.RequestsFile[i] = rCopy
+		requests[r] = rCopy
 	}
 	for i, r := range template.RequestsHeadless {
 		if i == 0 {
 			template.RequestsHeadless = append(template.RequestsHeadless[:0:0], template.RequestsHeadless...)
 		}
-		rCopy := *r
+		rCopy := cloneProtocolRequest(r)
 		rCopy.UpdateOptions(template.Options)
-		template.RequestsHeadless[i] = &rCopy
-		requests[r] = &rCopy
+		template.RequestsHeadless[i] = rCopy
+		requests[r] = rCopy
 	}
 	for i, r := range template.RequestsNetwork {
 		if i == 0 {
 			template.RequestsNetwork = append(template.RequestsNetwork[:0:0], template.RequestsNetwork...)
 		}
-		rCopy := *r
+		rCopy := cloneProtocolRequest(r)
 		rCopy.UpdateOptions(template.Options)
-		template.RequestsNetwork[i] = &rCopy
-		requests[r] = &rCopy
+		template.RequestsNetwork[i] = rCopy
+		requests[r] = rCopy
 	}
 	for i, r := range template.RequestsJavascript {
 		if i == 0 {
 			template.RequestsJavascript = append(template.RequestsJavascript[:0:0], template.RequestsJavascript...)
 		}
-		rCopy := *r
+		rCopy := cloneProtocolRequest(r)
 		rCopy.UpdateOptions(template.Options)
-		template.RequestsJavascript[i] = &rCopy
-		requests[r] = &rCopy
+		template.RequestsJavascript[i] = rCopy
+		requests[r] = rCopy
 	}
 	for i, r := range template.RequestsSSL {
 		if i == 0 {
 			template.RequestsSSL = append(template.RequestsSSL[:0:0], template.RequestsSSL...)
 		}
-		rCopy := *r
+		rCopy := cloneProtocolRequest(r)
 		rCopy.UpdateOptions(template.Options)
-		template.RequestsSSL[i] = &rCopy
-		requests[r] = &rCopy
+		template.RequestsSSL[i] = rCopy
+		requests[r] = rCopy
 	}
 	for i, r := range template.RequestsWHOIS {
 		if i == 0 {
 			template.RequestsWHOIS = append(template.RequestsWHOIS[:0:0], template.RequestsWHOIS...)
 		}
-		rCopy := *r
+		rCopy := cloneProtocolRequest(r)
 		rCopy.UpdateOptions(template.Options)
-		template.RequestsWHOIS[i] = &rCopy
-		requests[r] = &rCopy
+		template.RequestsWHOIS[i] = rCopy
+		requests[r] = rCopy
 	}
 	for i, r := range template.RequestsWebsocket {
 		if i == 0 {
 			template.RequestsWebsocket = append(template.RequestsWebsocket[:0:0], template.RequestsWebsocket...)
 		}
-		rCopy := *r
+		rCopy := cloneProtocolRequest(r)
 		rCopy.UpdateOptions(template.Options)
-		template.RequestsWebsocket[i] = &rCopy
-		requests[r] = &rCopy
+		template.RequestsWebsocket[i] = rCopy
+		requests[r] = rCopy
 	}
 
 	if len(template.RequestsQueue) > 0 {
@@ -153,6 +154,11 @@ func updateRequestOptions(template *Template) {
 		}
 		template.RequestsQueue = queue
 	}
+}
+
+func cloneProtocolRequest[T any](request *T) *T {
+	cloned := cloneTemplateValue(reflect.ValueOf(request), make(map[cloneVisit]reflect.Value))
+	return cloned.Interface().(*T)
 }
 
 // parseFromSource parses a template from source with caching support
@@ -218,10 +224,93 @@ func parseFromSource(filePath string, preprocessor Preprocessor, options *protoc
 
 	template.Path = filePath
 	if !options.DoNotCache {
-		parser.compiledTemplatesCache.StoreWithoutRaw(filePath, template, err)
+		parser.compiledTemplatesCache.StoreWithoutRaw(filePath, cacheSafeCompiledTemplate(template), err)
 	}
 
 	return template, nil
+}
+
+// cacheSafeCompiledTemplate removes execution-scoped state before storing a
+// compiled template in the shared cache.
+func cacheSafeCompiledTemplate(template *Template) *Template {
+	tplCopy := *template
+	tplCopy.Executer = nil
+	tplCopy.CompiledWorkflow = nil
+	tplCopy.Workflow.Workflows = cloneWorkflowDefinitions(template.Workflow.Workflows)
+	tplCopy.Options = cacheSafeExecutorOptions(template.Options)
+	updateRequestOptions(&tplCopy)
+
+	return &tplCopy
+}
+
+// cacheSafeExecutorOptions copies immutable template metadata and drops
+// per-execution objects such as writers, rate limiters, and callbacks.
+func cacheSafeExecutorOptions(options *protocols.ExecutorOptions) *protocols.ExecutorOptions {
+	if options == nil {
+		return nil
+	}
+
+	safeOptions := options.Copy()
+	safeOptions.TemplateVerificationCallback = nil
+	safeOptions.Output = nil
+	safeOptions.IssuesClient = nil
+	safeOptions.Progress = nil
+	safeOptions.RateLimiter = nil
+	safeOptions.Catalog = nil
+	safeOptions.ProjectFile = nil
+	safeOptions.Browser = nil
+	safeOptions.Interactsh = nil
+	safeOptions.HostErrorsCache = nil
+	safeOptions.InputHelper = nil
+	safeOptions.FuzzStatsDB = nil
+	safeOptions.WorkflowLoader = nil
+	safeOptions.Parser = nil
+	safeOptions.GlobalMatchers = nil
+	safeOptions.Logger = nil
+	safeOptions.AuthProvider = nil
+	safeOptions.TemporaryDirectory = ""
+
+	return safeOptions
+}
+
+// cloneWorkflowDefinitions copies workflow definitions without compiled
+// executers so cache hits can rebuild workflow execution state per call.
+func cloneWorkflowDefinitions(items []*workflows.WorkflowTemplate) []*workflows.WorkflowTemplate {
+	if len(items) == 0 {
+		return nil
+	}
+
+	cloned := make([]*workflows.WorkflowTemplate, len(items))
+	for i, item := range items {
+		if item == nil {
+			continue
+		}
+		itemCopy := *item
+		itemCopy.Executers = nil
+		itemCopy.Subtemplates = cloneWorkflowDefinitions(item.Subtemplates)
+		itemCopy.Matchers = cloneWorkflowMatchers(item.Matchers)
+		cloned[i] = &itemCopy
+	}
+	return cloned
+}
+
+// cloneWorkflowMatchers copies workflow matchers and their subtemplate
+// definitions while leaving matcher compile state to the per-call compile path.
+func cloneWorkflowMatchers(items []*workflows.Matcher) []*workflows.Matcher {
+	if len(items) == 0 {
+		return nil
+	}
+
+	cloned := make([]*workflows.Matcher, len(items))
+	for i, item := range items {
+		if item == nil {
+			continue
+		}
+		itemCopy := *item
+		itemCopy.Subtemplates = cloneWorkflowDefinitions(item.Subtemplates)
+		cloned[i] = &itemCopy
+	}
+	return cloned
 }
 
 func parseCachedTemplate(cached *Template, data []byte, preprocessor Preprocessor, options *protocols.ExecutorOptions) (*Template, error) {
@@ -272,7 +361,7 @@ func Parse(filePath string, preprocessor Preprocessor, options *protocols.Execut
 			return nil, err
 		}
 
-		if !shared {
+		if !shared && result != nil {
 			template, _ := result.(*Template)
 			return template, nil
 		}
@@ -289,9 +378,13 @@ func parseCompiledTemplateFromCache(filePath string, preprocessor Preprocessor, 
 	if value == nil || err != nil {
 		return nil, value != nil || err != nil, err
 	}
+	if value.Options == nil {
+		return nil, false, nil
+	}
 
 	// Copy the template, apply new options, and recompile requests
 	tplCopy := *value
+	tplCopy.Workflow.Workflows = cloneWorkflowDefinitions(value.Workflow.Workflows)
 	newBase := options.Copy()
 	newBase.TemplateID = tplCopy.Options.TemplateID
 	newBase.TemplatePath = tplCopy.Options.TemplatePath
@@ -310,15 +403,6 @@ func parseCompiledTemplateFromCache(filePath string, preprocessor Preprocessor, 
 
 	tplCopy.Options = newBase
 	tplCopy.Options.ApplyNewEngineOptions(options)
-
-	if tplCopy.CompiledWorkflow != nil {
-		tplCopy.CompiledWorkflow.Options.ApplyNewEngineOptions(options)
-		for _, w := range tplCopy.CompiledWorkflow.Workflows {
-			for _, ex := range w.Executers {
-				ex.Options.ApplyNewEngineOptions(options)
-			}
-		}
-	}
 
 	// Update options for all request types
 	updateRequestOptions(&tplCopy)
@@ -348,6 +432,11 @@ func parseCompiledTemplateFromCache(filePath string, preprocessor Preprocessor, 
 		template.CompiledWorkflow.Options = tplCopy.Options
 	} else if err := template.compileProtocolRequests(template.Options); err != nil {
 		return nil, true, err
+	} else if template.Executer != nil {
+		if err := template.Executer.Compile(); err != nil {
+			return nil, true, errors.Wrap(err, "could not compile request")
+		}
+		template.TotalRequests = template.Executer.Requests()
 	}
 
 	if isCachedTemplateValid(template) {

--- a/pkg/templates/compile.go
+++ b/pkg/templates/compile.go
@@ -51,55 +51,107 @@ func init() {
 
 // updateRequestOptions updates options for all request types in a template
 func updateRequestOptions(template *Template) {
+	requests := make(map[protocols.Request]protocols.Request, template.Requests())
+
 	for i, r := range template.RequestsDNS {
+		if i == 0 {
+			template.RequestsDNS = append(template.RequestsDNS[:0:0], template.RequestsDNS...)
+		}
 		rCopy := *r
 		rCopy.UpdateOptions(template.Options)
 		template.RequestsDNS[i] = &rCopy
+		requests[r] = &rCopy
 	}
 	for i, r := range template.RequestsHTTP {
+		if i == 0 {
+			template.RequestsHTTP = append(template.RequestsHTTP[:0:0], template.RequestsHTTP...)
+		}
 		rCopy := *r
 		rCopy.UpdateOptions(template.Options)
 		template.RequestsHTTP[i] = &rCopy
+		requests[r] = &rCopy
 	}
 	for i, r := range template.RequestsCode {
+		if i == 0 {
+			template.RequestsCode = append(template.RequestsCode[:0:0], template.RequestsCode...)
+		}
 		rCopy := *r
 		rCopy.UpdateOptions(template.Options)
 		template.RequestsCode[i] = &rCopy
+		requests[r] = &rCopy
 	}
 	for i, r := range template.RequestsFile {
+		if i == 0 {
+			template.RequestsFile = append(template.RequestsFile[:0:0], template.RequestsFile...)
+		}
 		rCopy := *r
 		rCopy.UpdateOptions(template.Options)
 		template.RequestsFile[i] = &rCopy
+		requests[r] = &rCopy
 	}
 	for i, r := range template.RequestsHeadless {
+		if i == 0 {
+			template.RequestsHeadless = append(template.RequestsHeadless[:0:0], template.RequestsHeadless...)
+		}
 		rCopy := *r
 		rCopy.UpdateOptions(template.Options)
 		template.RequestsHeadless[i] = &rCopy
+		requests[r] = &rCopy
 	}
 	for i, r := range template.RequestsNetwork {
+		if i == 0 {
+			template.RequestsNetwork = append(template.RequestsNetwork[:0:0], template.RequestsNetwork...)
+		}
 		rCopy := *r
 		rCopy.UpdateOptions(template.Options)
 		template.RequestsNetwork[i] = &rCopy
+		requests[r] = &rCopy
 	}
 	for i, r := range template.RequestsJavascript {
+		if i == 0 {
+			template.RequestsJavascript = append(template.RequestsJavascript[:0:0], template.RequestsJavascript...)
+		}
 		rCopy := *r
 		rCopy.UpdateOptions(template.Options)
 		template.RequestsJavascript[i] = &rCopy
+		requests[r] = &rCopy
 	}
 	for i, r := range template.RequestsSSL {
+		if i == 0 {
+			template.RequestsSSL = append(template.RequestsSSL[:0:0], template.RequestsSSL...)
+		}
 		rCopy := *r
 		rCopy.UpdateOptions(template.Options)
 		template.RequestsSSL[i] = &rCopy
+		requests[r] = &rCopy
 	}
 	for i, r := range template.RequestsWHOIS {
+		if i == 0 {
+			template.RequestsWHOIS = append(template.RequestsWHOIS[:0:0], template.RequestsWHOIS...)
+		}
 		rCopy := *r
 		rCopy.UpdateOptions(template.Options)
 		template.RequestsWHOIS[i] = &rCopy
+		requests[r] = &rCopy
 	}
 	for i, r := range template.RequestsWebsocket {
+		if i == 0 {
+			template.RequestsWebsocket = append(template.RequestsWebsocket[:0:0], template.RequestsWebsocket...)
+		}
 		rCopy := *r
 		rCopy.UpdateOptions(template.Options)
 		template.RequestsWebsocket[i] = &rCopy
+		requests[r] = &rCopy
+	}
+
+	if len(template.RequestsQueue) > 0 {
+		queue := append(template.RequestsQueue[:0:0], template.RequestsQueue...)
+		for i, request := range queue {
+			if mapped, ok := requests[request]; ok {
+				queue[i] = mapped
+			}
+		}
+		template.RequestsQueue = queue
 	}
 }
 
@@ -206,75 +258,104 @@ func Parse(filePath string, preprocessor Preprocessor, options *protocols.Execut
 	parser := getParser(options)
 
 	if !options.DoNotCache {
-		if value, _, _ := parser.compiledTemplatesCache.Has(filePath); value != nil {
-			// Copy the template, apply new options, and recompile requests
-			tplCopy := *value
-			newBase := options.Copy()
-			newBase.TemplateID = tplCopy.Options.TemplateID
-			newBase.TemplatePath = tplCopy.Options.TemplatePath
-			newBase.TemplateInfo = tplCopy.Options.TemplateInfo
-			newBase.TemplateVerifier = tplCopy.Options.TemplateVerifier
-			newBase.Verified = tplCopy.Options.Verified
-			newBase.RawTemplate = tplCopy.Options.RawTemplate
+		if template, ok, err := parseCompiledTemplateFromCache(filePath, preprocessor, options, parser); ok || err != nil {
+			return template, err
+		}
 
-			if tplCopy.Options.Variables.Len() > 0 {
-				newBase.Variables = tplCopy.Options.Variables
+		result, err, shared := parser.compiledTemplatesLoadGroup.Do(filePath, func() (interface{}, error) {
+			if value, _, cacheErr := parser.compiledTemplatesCache.Has(filePath); value != nil || cacheErr != nil {
+				return nil, cacheErr
 			}
+			return parseFromSource(filePath, preprocessor, options, parser)
+		})
+		if err != nil {
+			return nil, err
+		}
 
-			if len(tplCopy.Options.Constants) > 0 {
-				newBase.Constants = tplCopy.Options.Constants
-			}
-
-			tplCopy.Options = newBase
-			tplCopy.Options.ApplyNewEngineOptions(options)
-
-			if tplCopy.CompiledWorkflow != nil {
-				tplCopy.CompiledWorkflow.Options.ApplyNewEngineOptions(options)
-				for _, w := range tplCopy.CompiledWorkflow.Workflows {
-					for _, ex := range w.Executers {
-						ex.Options.ApplyNewEngineOptions(options)
-					}
-				}
-			}
-
-			// Update options for all request types
-			updateRequestOptions(&tplCopy)
-			template := &tplCopy
-
-			if template.isGlobalMatchersEnabled() {
-				item := &globalmatchers.Item{
-					TemplateID:   template.ID,
-					TemplatePath: filePath,
-					TemplateInfo: template.Info,
-				}
-
-				for _, request := range template.RequestsHTTP {
-					item.Operators = append(item.Operators, request.CompiledOperators)
-				}
-
-				options.GlobalMatchers.AddOperator(item)
-
-				return nil, nil
-			}
-
-			// Compile the workflow request
-			if len(template.Workflows) > 0 {
-				compiled := &template.Workflow
-				compileWorkflow(filePath, preprocessor, tplCopy.Options, compiled, tplCopy.Options.WorkflowLoader)
-				template.CompiledWorkflow = compiled
-				template.CompiledWorkflow.Options = tplCopy.Options
-			}
-
-			if isCachedTemplateValid(template) {
-				// options.Logger.Error().Msgf("returning cached template %s after recompiling %d requests", tplCopy.Options.TemplateID, tplCopy.Requests())
-				return template, nil
-			}
-
-			// else: fallthrough to re-parse template from scratch
+		if !shared {
+			template, _ := result.(*Template)
+			return template, nil
+		}
+		if template, ok, err := parseCompiledTemplateFromCache(filePath, preprocessor, options, parser); ok || err != nil {
+			return template, err
 		}
 	}
 
 	return parseFromSource(filePath, preprocessor, options, parser)
+}
+
+func parseCompiledTemplateFromCache(filePath string, preprocessor Preprocessor, options *protocols.ExecutorOptions, parser *Parser) (*Template, bool, error) {
+	value, _, err := parser.compiledTemplatesCache.Has(filePath)
+	if value == nil || err != nil {
+		return nil, value != nil || err != nil, err
+	}
+
+	// Copy the template, apply new options, and recompile requests
+	tplCopy := *value
+	newBase := options.Copy()
+	newBase.TemplateID = tplCopy.Options.TemplateID
+	newBase.TemplatePath = tplCopy.Options.TemplatePath
+	newBase.TemplateInfo = tplCopy.Options.TemplateInfo
+	newBase.TemplateVerifier = tplCopy.Options.TemplateVerifier
+	newBase.Verified = tplCopy.Options.Verified
+	newBase.RawTemplate = tplCopy.Options.RawTemplate
+
+	if tplCopy.Options.Variables.Len() > 0 {
+		newBase.Variables = tplCopy.Options.Variables
+	}
+
+	if len(tplCopy.Options.Constants) > 0 {
+		newBase.Constants = tplCopy.Options.Constants
+	}
+
+	tplCopy.Options = newBase
+	tplCopy.Options.ApplyNewEngineOptions(options)
+
+	if tplCopy.CompiledWorkflow != nil {
+		tplCopy.CompiledWorkflow.Options.ApplyNewEngineOptions(options)
+		for _, w := range tplCopy.CompiledWorkflow.Workflows {
+			for _, ex := range w.Executers {
+				ex.Options.ApplyNewEngineOptions(options)
+			}
+		}
+	}
+
+	// Update options for all request types
+	updateRequestOptions(&tplCopy)
+	template := &tplCopy
+
+	if template.isGlobalMatchersEnabled() {
+		item := &globalmatchers.Item{
+			TemplateID:   template.ID,
+			TemplatePath: filePath,
+			TemplateInfo: template.Info,
+		}
+
+		for _, request := range template.RequestsHTTP {
+			item.Operators = append(item.Operators, request.CompiledOperators)
+		}
+
+		options.GlobalMatchers.AddOperator(item)
+
+		return nil, true, nil
+	}
+
+	// Compile the workflow request
+	if len(template.Workflows) > 0 {
+		compiled := &template.Workflow
+		compileWorkflow(filePath, preprocessor, tplCopy.Options, compiled, tplCopy.Options.WorkflowLoader)
+		template.CompiledWorkflow = compiled
+		template.CompiledWorkflow.Options = tplCopy.Options
+	} else if err := template.compileProtocolRequests(template.Options); err != nil {
+		return nil, true, err
+	}
+
+	if isCachedTemplateValid(template) {
+		// options.Logger.Error().Msgf("returning cached template %s after recompiling %d requests", tplCopy.Options.TemplateID, tplCopy.Requests())
+		return template, true, nil
+	}
+
+	return nil, false, nil
 }
 
 // isGlobalMatchersEnabled checks if any of requests in the template

--- a/pkg/templates/compile.go
+++ b/pkg/templates/compile.go
@@ -249,7 +249,7 @@ func cacheSafeCompiledTemplate(template *Template) *Template {
 	tplCopy := *template
 	tplCopy.Executer = nil
 	tplCopy.CompiledWorkflow = nil
-	tplCopy.Workflow.Workflows = cloneWorkflowDefinitions(template.Workflow.Workflows)
+	tplCopy.Workflows = cloneWorkflowDefinitions(template.Workflows)
 	tplCopy.Options = cacheSafeExecutorOptions(template.Options)
 	updateRequestOptions(&tplCopy)
 
@@ -282,8 +282,9 @@ func cacheSafeExecutorOptions(options *protocols.ExecutorOptions) *protocols.Exe
 	}
 
 	safeOptions := options.Copy()
-	safeOptions.Variables = cloneTemplateVariables(options.Variables)
-	safeOptions.Constants = cloneTemplateConstants(options.Constants)
+	optionsVisited := newCloneVisited()
+	safeOptions.Variables = cloneTemplateVariables(options.Variables, optionsVisited)
+	safeOptions.Constants = cloneTemplateConstants(options.Constants, optionsVisited)
 	safeOptions.ResumeCfg = nil
 	safeOptions.TemplateVerificationCallback = nil
 	safeOptions.Output = nil
@@ -421,7 +422,7 @@ func parseCompiledTemplateFromCache(filePath string, preprocessor Preprocessor, 
 
 	// Copy the template, apply new options, and recompile requests
 	tplCopy := *value
-	tplCopy.Workflow.Workflows = cloneWorkflowDefinitions(value.Workflow.Workflows)
+	tplCopy.Workflows = cloneWorkflowDefinitions(value.Workflows)
 	newBase := options.Copy()
 	newBase.TemplateID = tplCopy.Options.TemplateID
 	newBase.TemplatePath = tplCopy.Options.TemplatePath
@@ -430,12 +431,13 @@ func parseCompiledTemplateFromCache(filePath string, preprocessor Preprocessor, 
 	newBase.Verified = tplCopy.Options.Verified
 	newBase.RawTemplate = tplCopy.Options.RawTemplate
 
+	cachedVisited := newCloneVisited()
 	if tplCopy.Options.Variables.Len() > 0 {
-		newBase.Variables = cloneTemplateVariables(tplCopy.Options.Variables)
+		newBase.Variables = cloneTemplateVariables(tplCopy.Options.Variables, cachedVisited)
 	}
 
 	if len(tplCopy.Options.Constants) > 0 {
-		newBase.Constants = cloneTemplateConstants(tplCopy.Options.Constants)
+		newBase.Constants = cloneTemplateConstants(tplCopy.Options.Constants, cachedVisited)
 	}
 
 	tplCopy.Options = newBase
@@ -765,20 +767,6 @@ func hasTemplatePreprocessor(data []byte, preprocessor Preprocessor) bool {
 	}
 
 	return false
-}
-
-// parseTemplate parses the template and applies verification.
-func parseTemplate(data []byte, srcOptions *protocols.ExecutorOptions) (*Template, error) {
-	template, err := parseTemplateNoVerify(data, srcOptions)
-	if err != nil {
-		return nil, err
-	}
-
-	if err := verifyAndCompileTemplate(template, data); err != nil {
-		return nil, err
-	}
-
-	return template, nil
 }
 
 // verifyAndCompileTemplate keeps signature verification before protocol

--- a/pkg/templates/compile_test.go
+++ b/pkg/templates/compile_test.go
@@ -991,3 +991,47 @@ func TestWrongWorkflow(t *testing.T) {
 	require.Nil(t, got, "could not parse template")
 	require.ErrorContains(t, err, "workflows cannot have other protocols")
 }
+
+// TestParseConcurrentSharedParserIsRaceFree covers the loader path, which parses
+// templates concurrently through a single shared parser.
+func TestParseConcurrentSharedParserIsRaceFree(t *testing.T) {
+	setup()
+
+	dir := t.TempDir()
+	paths := make([]string, 0, 16)
+	for i := 0; i < 16; i++ {
+		path := filepath.Join(dir, fmt.Sprintf("concurrent-%d.yaml", i))
+		require.NoError(t, os.WriteFile(path, []byte(fmt.Sprintf(`id: concurrent-%d
+info:
+  name: Concurrent %d
+  author: pdteam
+  severity: info
+
+variables:
+  token: original
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"`, i, i)), 0o600))
+		paths = append(paths, path)
+	}
+
+	parser := templates.NewParser()
+
+	var wg sync.WaitGroup
+	for round := 0; round < 3; round++ {
+		for _, path := range paths {
+			wg.Add(1)
+			go func(path string) {
+				defer wg.Done()
+				options := executerOpts.Copy()
+				options.Parser = parser
+				parsed, err := templates.Parse(path, nil, options)
+				require.NoError(t, err)
+				require.NotNil(t, parsed)
+			}(path)
+		}
+	}
+	wg.Wait()
+}

--- a/pkg/templates/compile_test.go
+++ b/pkg/templates/compile_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/projectdiscovery/nuclei/v3/pkg/model/types/stringslice"
 	"github.com/projectdiscovery/nuclei/v3/pkg/operators"
 	"github.com/projectdiscovery/nuclei/v3/pkg/operators/matchers"
+	"github.com/projectdiscovery/nuclei/v3/pkg/output"
 	"github.com/projectdiscovery/nuclei/v3/pkg/progress"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/generators"
@@ -835,6 +836,26 @@ func TestParseCompiledCacheRegistersGlobalMatcherFromCache(t *testing.T) {
 	second, err := templates.Parse(templatePath, nil, secondOptions)
 	require.NoError(t, err)
 	require.Nil(t, second)
+
+	var matched bool
+	secondOptions.GlobalMatchers.Match(
+		output.InternalEvent{
+			"body":          "test",
+			"template-id":   "origin",
+			"template-info": model.Info{},
+			"template-path": "origin.yaml",
+		},
+		func(data map[string]interface{}, matcher *matchers.Matcher) (bool, []string) {
+			body, _ := data["body"].(string)
+			return matcher.MatchWords(body, data)
+		},
+		nil,
+		false,
+		func(_ output.InternalEvent, result *operators.Result) {
+			matched = result != nil
+		},
+	)
+	require.True(t, matched)
 }
 
 func TestParseCompiledCacheIgnoresEntryWithoutOptions(t *testing.T) {

--- a/pkg/templates/compile_test.go
+++ b/pkg/templates/compile_test.go
@@ -663,6 +663,196 @@ http:
 	require.NotSame(t, cachedTemplate.RequestsHTTP[0], compiledTemplates[0].RequestsHTTP[0])
 }
 
+func TestParseCompiledCacheDoesNotRetainExecutionOptions(t *testing.T) {
+	setup()
+
+	templatePath := "tests/match-1.yaml"
+	parser := templates.NewParser()
+	firstOptions := executerOpts.Copy()
+	firstOptions.Parser = parser
+
+	first, err := templates.Parse(templatePath, nil, firstOptions)
+	require.NoError(t, err)
+	require.NotNil(t, first.Executer)
+
+	cached, err := parser.CompiledCache().Get(templatePath)
+	require.NoError(t, err)
+	require.NotNil(t, cached)
+	require.Nil(t, cached.Executer)
+	require.Nil(t, cached.CompiledWorkflow)
+	require.Nil(t, cached.Options.TemplateVerificationCallback)
+	require.Nil(t, cached.Options.Output)
+	require.Nil(t, cached.Options.RateLimiter)
+	require.Nil(t, cached.Options.Catalog)
+	require.Nil(t, cached.Options.AuthProvider)
+	require.Empty(t, cached.Options.TemporaryDirectory)
+	require.Nil(t, cached.RequestsHTTP[0].Options().Output)
+	require.Nil(t, cached.RequestsHTTP[0].Options().RateLimiter)
+
+	secondOutput := testutils.NewMockOutputWriter(firstOptions.Options.OmitTemplate)
+	secondOptions := executerOpts.Copy()
+	secondOptions.Parser = parser
+	secondOptions.Output = secondOutput
+
+	second, err := templates.Parse(templatePath, nil, secondOptions)
+	require.NoError(t, err)
+	require.NotNil(t, second.Executer)
+	require.Same(t, secondOutput, second.RequestsHTTP[0].Options().Output)
+	require.Same(t, secondOptions.RateLimiter, second.RequestsHTTP[0].Options().RateLimiter)
+	require.NotSame(t, cached.RequestsHTTP[0], second.RequestsHTTP[0])
+	require.NotSame(t, cached.RequestsHTTP[0].Options(), second.RequestsHTTP[0].Options())
+}
+
+func TestParseCompiledCacheRebuildsWorkflowPerExecution(t *testing.T) {
+	setup()
+
+	templatePath := "tests/workflow.yaml"
+	parser := templates.NewParser()
+	firstOptions := executerOpts.Copy()
+	firstOptions.Parser = parser
+
+	first, err := templates.Parse(templatePath, nil, firstOptions)
+	require.NoError(t, err)
+	require.NotNil(t, first.CompiledWorkflow)
+
+	cached, err := parser.CompiledCache().Get(templatePath)
+	require.NoError(t, err)
+	require.NotNil(t, cached)
+	require.Nil(t, cached.CompiledWorkflow)
+	require.Nil(t, cached.Options.WorkflowLoader)
+
+	secondOptions := executerOpts.Copy()
+	secondOptions.Parser = parser
+	second, err := templates.Parse(templatePath, nil, secondOptions)
+	require.NoError(t, err)
+	require.NotNil(t, second.CompiledWorkflow)
+	require.NotSame(t, first.CompiledWorkflow, second.CompiledWorkflow)
+	require.NotSame(t, first.CompiledWorkflow.Workflows[0], second.CompiledWorkflow.Workflows[0])
+	require.Same(t, secondOptions.RateLimiter, second.CompiledWorkflow.Workflows[0].Executers[0].Options.RateLimiter)
+}
+
+func TestParseCompiledCacheRebuildsWorkflowMatchersPerExecution(t *testing.T) {
+	setup()
+
+	dir := t.TempDir()
+	firstTemplatePath := filepath.Join(dir, "first.yaml")
+	err := os.WriteFile(firstTemplatePath, []byte(`id: workflow-matcher-first
+
+info:
+  name: Workflow Matcher First
+  author: pdteam
+  severity: info
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    matchers:
+      - type: word
+        words:
+          - first
+`), 0o600)
+	require.NoError(t, err)
+
+	secondTemplatePath := filepath.Join(dir, "second.yaml")
+	err = os.WriteFile(secondTemplatePath, []byte(`id: workflow-matcher-second
+
+info:
+  name: Workflow Matcher Second
+  author: pdteam
+  severity: info
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    matchers:
+      - type: word
+        words:
+          - second
+`), 0o600)
+	require.NoError(t, err)
+
+	workflowPath := filepath.Join(dir, "workflow.yaml")
+	err = os.WriteFile(workflowPath, []byte(fmt.Sprintf(`id: workflow-matcher-cache
+
+info:
+  name: Workflow Matcher Cache
+  author: pdteam
+  severity: info
+
+workflows:
+  - template: %q
+    matchers:
+      - name: first
+        subtemplates:
+          - template: %q
+`, firstTemplatePath, secondTemplatePath)), 0o600)
+	require.NoError(t, err)
+
+	parser := templates.NewParser()
+	firstOptions := executerOpts.Copy()
+	firstOptions.Parser = parser
+
+	first, err := templates.Parse(workflowPath, nil, firstOptions)
+	require.NoError(t, err)
+	require.NotNil(t, first.CompiledWorkflow)
+
+	cached, err := parser.CompiledCache().Get(workflowPath)
+	require.NoError(t, err)
+	require.NotNil(t, cached)
+	require.Empty(t, cached.Workflow.Workflows[0].Matchers[0].Subtemplates[0].Executers)
+
+	secondOptions := executerOpts.Copy()
+	secondOptions.Parser = parser
+	second, err := templates.Parse(workflowPath, nil, secondOptions)
+	require.NoError(t, err)
+	require.NotNil(t, second.CompiledWorkflow)
+	require.NotSame(t, first.CompiledWorkflow.Workflows[0].Matchers[0], second.CompiledWorkflow.Workflows[0].Matchers[0])
+	require.Len(t, second.CompiledWorkflow.Workflows[0].Matchers[0].Subtemplates[0].Executers, 1)
+}
+
+func TestParseCompiledCacheRegistersGlobalMatcherFromCache(t *testing.T) {
+	setup()
+
+	parser := templates.NewParser()
+	templatePath := "tests/global-matcher.yaml"
+	firstOptions := executerOpts.Copy()
+	firstOptions.Options = firstOptions.Options.Copy()
+	firstOptions.Parser = parser
+	firstOptions.Options.EnableGlobalMatchersTemplates = false
+
+	first, err := templates.Parse(templatePath, nil, firstOptions)
+	require.NoError(t, err)
+	require.NotNil(t, first)
+
+	secondOptions := executerOpts.Copy()
+	secondOptions.Options = secondOptions.Options.Copy()
+	secondOptions.Parser = parser
+	secondOptions.Options.EnableGlobalMatchersTemplates = true
+	secondOptions.GlobalMatchers = globalmatchers.New()
+
+	second, err := templates.Parse(templatePath, nil, secondOptions)
+	require.NoError(t, err)
+	require.Nil(t, second)
+}
+
+func TestParseCompiledCacheIgnoresEntryWithoutOptions(t *testing.T) {
+	setup()
+
+	parser := templates.NewParser()
+	templatePath := "tests/match-1.yaml"
+	parser.CompiledCache().StoreWithoutRaw(templatePath, &templates.Template{ID: "invalid-cache-entry"}, nil)
+
+	options := executerOpts.Copy()
+	options.Parser = parser
+
+	parsed, err := templates.Parse(templatePath, nil, options)
+	require.NoError(t, err)
+	require.NotNil(t, parsed)
+	require.Equal(t, "basic-get", parsed.ID)
+}
+
 func TestParseSharedTemplatePreservesRuntimePreprocessing(t *testing.T) {
 	var sourceReads int
 	templateSource := `id: shared-preprocessed-template

--- a/pkg/templates/compile_test.go
+++ b/pkg/templates/compile_test.go
@@ -704,6 +704,61 @@ func TestParseCompiledCacheDoesNotRetainExecutionOptions(t *testing.T) {
 	require.NotSame(t, cached.RequestsHTTP[0].Options(), second.RequestsHTTP[0].Options())
 }
 
+func TestParseCompiledCacheClonesVariablesAndConstants(t *testing.T) {
+	setup()
+
+	templatePath := filepath.Join(t.TempDir(), "vars.yaml")
+	require.NoError(t, os.WriteFile(templatePath, []byte(`id: cache-vars
+
+info:
+  name: Cache Vars
+  author: pdteam
+  severity: info
+
+variables:
+  token: original
+
+constants:
+  flag: keep
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+`), 0o600))
+
+	parser := templates.NewParser()
+	firstOptions := executerOpts.Copy()
+	firstOptions.Parser = parser
+	first, err := templates.Parse(templatePath, nil, firstOptions)
+	require.NoError(t, err)
+	require.Equal(t, "original", first.Options.Variables.GetAll()["token"])
+
+	cached, err := parser.CompiledCache().Get(templatePath)
+	require.NoError(t, err)
+	require.NotNil(t, cached)
+	require.Equal(t, "original", cached.Options.Variables.GetAll()["token"])
+	require.Equal(t, "keep", cached.Options.Constants["flag"])
+
+	first.Options.Variables.Set("token", "from-first")
+	first.Options.Constants["flag"] = "from-first"
+	require.Equal(t, "original", cached.Options.Variables.GetAll()["token"])
+	require.Equal(t, "keep", cached.Options.Constants["flag"])
+
+	secondOptions := executerOpts.Copy()
+	secondOptions.Parser = parser
+	second, err := templates.Parse(templatePath, nil, secondOptions)
+	require.NoError(t, err)
+	second.Options.Variables.Set("token", "mutated")
+	second.Options.Constants["flag"] = "mutated"
+	require.Equal(t, "original", cached.Options.Variables.GetAll()["token"])
+	require.Equal(t, "keep", cached.Options.Constants["flag"])
+	require.Equal(t, "from-first", first.Options.Variables.GetAll()["token"])
+	require.Equal(t, "from-first", first.Options.Constants["flag"])
+	require.Equal(t, "mutated", second.Options.Variables.GetAll()["token"])
+	require.Equal(t, "mutated", second.Options.Constants["flag"])
+}
+
 func TestParseCompiledCacheRebuildsWorkflowPerExecution(t *testing.T) {
 	setup()
 

--- a/pkg/templates/parser.go
+++ b/pkg/templates/parser.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"sync"
 
+	"golang.org/x/sync/singleflight"
+
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog"
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/config"
 	"github.com/projectdiscovery/nuclei/v3/pkg/utils"
@@ -31,6 +33,8 @@ type Parser struct {
 	// This cache contains references to heap objects and should be purged when
 	// no longer needed.
 	compiledTemplatesCache *Cache
+
+	compiledTemplatesLoadGroup singleflight.Group
 
 	sync.Mutex
 }


### PR DESCRIPTION
## Proposed changes

Fixes #7686.

`ThreadSafeNucleiEngine.ExecuteNucleiWithOptsCtx` creates per-call ephemeral execution objects, but it previously forced `DoNotCache: true`. When callers run the same template set concurrently, each call rebuilds its own compiled-template store, so live heap grows with the number of concurrent SDK executions.

This PR lets thread-safe executions reuse the engine compiled-template cache by default while still honoring `DisableTemplateCache()`.

## Implementation details

The fix is intentionally more than just flipping `DoNotCache` back on:

- `lib.createEphemeralObjects` now passes through `opts.DoNotCacheTemplates`, so cache reuse is enabled by default and still disabled when requested.
- `pkg/templates.Parser` now uses `singleflight` for compiled-template loads, preventing concurrent first loads for the same path from compiling the same template multiple times.
- Compiled-cache hits create execution-local template/request state before applying the current call's options.
- The shared cache stores a cache-safe template representation: no `Executer`, no `CompiledWorkflow`, and no execution-scoped objects such as output writers, rate limiters, interactsh clients, browser instances, workflow loaders, or verification callbacks.
- Protocol request copies clone authored operators/matchers before recompilation, so `Matcher.CompileMatchers()` and extractor compilation cannot mutate shared cached state.
- Workflow definitions and workflow matchers are cloned before per-call workflow compilation, preventing compiled workflow executers from leaking between executions.
- Cache hits call `template.Executer.Compile()` after rebuilding the executer, matching the normal parse path.
- A `singleflight` edge case now falls back to the cache-hit path instead of returning `nil, nil` if another caller populated the cache between checks.

## Before / After

Reproduced on current `dev` with a local `httptest` target and 500 synthetic HTTP templates tagged for the same per-call filter. Concurrent `ExecuteNucleiWithOptsCtx` calls rebuilt compiled templates independently, with peak heap rising as concurrency increased:

```text
templates=500 N=1 baseline=39 MiB peak=115 MiB final=82 MiB
templates=500 N=2 baseline=39 MiB peak=139 MiB final=146 MiB
templates=500 N=4 baseline=39 MiB peak=166 MiB final=178 MiB
templates=500 N=8 baseline=39 MiB peak=223 MiB final=188 MiB
```

After this change, concurrent executions share the engine compiled cache. The regression coverage verifies that four concurrent executions of the same template leave one compiled-cache entry, while per-call callbacks and execution options remain isolated.

## Validation

```sh
go test -race ./pkg/templates -count=1
go test -race ./lib -run 'TestThreadSafeExecuteUsesSharedCompiledCache|TestThreadSafeExecuteHonorsDisableTemplateCache|TestThreadSafeWithResultCallbackIsolation|TestThreadSafeGlobalCallbackWithoutPerCallStillWorks|TestCallerParserUsesEngineLocalCompiledCache' -count=1
go test ./pkg/protocols -coverprofile=/tmp/nuclei-protocols.cover -count=1
go test ./pkg/templates -coverprofile=/tmp/nuclei-templates.cover -count=1
make vet
make build
```

Coverage for the new/changed helpers:

```text
pkg/templates:
cloneProtocolRequest                 100.0%
parseFromSource                       94.1%
cacheSafeCompiledTemplate            100.0%
cacheSafeExecutorOptions              95.5%
cloneWorkflowDefinitions              91.7%
cloneWorkflowMatchers                 90.0%
parseCompiledTemplateFromCache        90.5%

pkg/protocols:
CloneOperators                       100.0%
CloneMatchers                        100.0%
cloneExportedValue                    97.3%
```

## Checklist

- [x] Pull request is created against the `dev` branch
- [x] Link PR to the corresponding issue
- [x] Include replication/proof context
- [x] Include before/after behavior
- [x] Include functional testing steps
- [x] Include regression/unit coverage
- [x] No documentation change is required


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved template caching so execution-specific settings and state remain isolated between runs.
  * Prevented concurrent executions from mutating shared request or compiled template data.
  * Ensured cache settings, including disabled caching, are honored correctly.
  * Improved handling of requests with missing execution options.
  * Preserved compiled matching behavior when templates are reused from cache.

* **Tests**
  * Added coverage for concurrent execution, cache behavior, and safe cloning of execution data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->