### PR TITLE
fix(config): reject corrupt active ignore files

### DIFF
--- a/internal/runner/ignorefile_test.go
+++ b/internal/runner/ignorefile_test.go
@@ -1,0 +1,73 @@
+package runner
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/projectdiscovery/gologger"
+	"github.com/projectdiscovery/gologger/formatter"
+	"github.com/projectdiscovery/gologger/levels"
+	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/config"
+	"github.com/projectdiscovery/nuclei/v3/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+type ignoreFileLogRecord struct {
+	message string
+	level   levels.Level
+}
+
+type ignoreFileLogWriter struct {
+	records []ignoreFileLogRecord
+}
+
+func (w *ignoreFileLogWriter) Write(data []byte, level levels.Level) {
+	w.records = append(w.records, ignoreFileLogRecord{message: string(data), level: level})
+}
+
+func newIgnoreFileTestRunner(t *testing.T, root string, writer *ignoreFileLogWriter) *Runner {
+	t.Helper()
+
+	cfg := config.DefaultConfig
+	oldRoot := cfg.TemplatesDirectory
+	t.Cleanup(func() { cfg.SetTemplatesDir(oldRoot) })
+	cfg.SetTemplatesDir(root)
+
+	logger := &gologger.Logger{}
+	logger.SetFormatter(formatter.NewCLI(false))
+	logger.SetWriter(writer)
+	logger.SetMaxLevel(levels.LevelWarning)
+
+	options := types.DefaultOptions()
+	options.Logger = logger
+	return &Runner{options: options, Logger: logger}
+}
+
+func TestLoadIgnoreFileWarnsAndContinuesWhenActiveFileIsMissing(t *testing.T) {
+	root := t.TempDir()
+	writer := &ignoreFileLogWriter{}
+	runner := newIgnoreFileTestRunner(t, root, writer)
+
+	require.NoError(t, runner.loadIgnoreFile())
+	require.Empty(t, runner.options.ExcludeTags)
+	require.Empty(t, runner.options.ExcludedTemplates)
+	require.Len(t, writer.records, 1)
+	require.Equal(t, levels.LevelWarning, writer.records[0].level)
+	require.Contains(t, writer.records[0].message, strconv.Quote(filepath.Join(root, config.NucleiIgnoreFileName)))
+	require.Contains(t, writer.records[0].message, "continuing without ignore exclusions")
+}
+
+func TestLoadIgnoreFileRejectsCorruptActiveFile(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, config.NucleiIgnoreFileName)
+	require.NoError(t, os.WriteFile(path, []byte("tags: ["), 0o600))
+	writer := &ignoreFileLogWriter{}
+	runner := newIgnoreFileTestRunner(t, root, writer)
+
+	err := runner.loadIgnoreFile()
+	require.ErrorContains(t, err, "error parsing")
+	require.ErrorContains(t, err, strconv.Quote(path))
+	require.Empty(t, writer.records)
+}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -604,10 +604,13 @@ func (r *Runner) RunEnumeration() error {
 			OutScope:              r.options.OutOfScope,
 			NucleiExecutorOptions: execurOpts,
 		})
+
 		if err != nil {
 			return err
 		}
+
 		r.dastServer = dastServer
+
 		return dastServer.Start()
 	}
 
@@ -617,16 +620,18 @@ func (r *Runner) RunEnumeration() error {
 			r.options.Templates = append(r.options.Templates, arr...)
 		}
 	}
+
 	if len(r.options.NewTemplatesWithVersion) > 0 {
 		if arr := installer.GetNewTemplatesInVersions(r.options.NewTemplatesWithVersion...); len(arr) > 0 {
 			r.options.Templates = append(r.options.Templates, arr...)
 		}
 	}
-	// Exclude ignored file for validation
+
+	// Apply the active ignore policy only when templates can execute.
 	if !r.options.Validate {
-		ignoreFile := config.ReadIgnoreFile()
-		r.options.ExcludeTags = append(r.options.ExcludeTags, ignoreFile.Tags...)
-		r.options.ExcludedTemplates = append(r.options.ExcludedTemplates, ignoreFile.Files...)
+		if err := r.loadIgnoreFile(); err != nil {
+			return err
+		}
 	}
 
 	fuzzFreqCache := frequency.New(frequency.DefaultMaxTrackCount, r.options.FuzzParamFrequency)
@@ -884,6 +889,24 @@ func (r *Runner) RunEnumeration() error {
 	}
 
 	return err
+}
+
+func (r *Runner) loadIgnoreFile() error {
+	ignoreFile, err := config.ReadIgnoreFile()
+	if errors.Is(err, os.ErrNotExist) {
+		r.Logger.Warning().Msgf("Could not read active .nuclei-ignore file: %s; continuing without ignore exclusions", err)
+
+		return nil
+	}
+
+	if err != nil {
+		return err
+	}
+
+	r.options.ExcludeTags = append(r.options.ExcludeTags, ignoreFile.Tags...)
+	r.options.ExcludedTemplates = append(r.options.ExcludedTemplates, ignoreFile.Files...)
+
+	return nil
 }
 
 func shortDur(d time.Duration) string {

--- a/internal/tests/integration/library_test.go
+++ b/internal/tests/integration/library_test.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -92,7 +93,14 @@ func executeNucleiAsLibrary(templatePath, templateURL string) ([]string, error) 
 		actualTemplatePath = fixturePath(actualTemplatePath)
 	}
 	defaultOpts.Templates = goflags.StringSlice{actualTemplatePath}
-	defaultOpts.ExcludeTags = config.ReadIgnoreFile().Tags
+	ignoreFile, err := config.ReadIgnoreFile()
+	if errors.Is(err, os.ErrNotExist) {
+		defaultOpts.Logger.Warning().Msgf("%s; continuing without ignore exclusions\n", err)
+	} else if err != nil {
+		return nil, err
+	} else {
+		defaultOpts.ExcludeTags = ignoreFile.Tags
+	}
 
 	outputWriter := testutils.NewMockOutputWriter(defaultOpts.OmitTemplate)
 	var results []string

--- a/lib/ignorefile_test.go
+++ b/lib/ignorefile_test.go
@@ -1,0 +1,28 @@
+package nuclei
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewNucleiEngineRejectsCorruptActiveIgnoreFile(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, config.NucleiIgnoreFileName)
+	require.NoError(t, os.WriteFile(path, []byte("tags: ["), 0o600))
+
+	cfg := config.DefaultConfig
+	oldRoot := cfg.TemplatesDirectory
+	t.Cleanup(func() { cfg.SetTemplatesDir(oldRoot) })
+	cfg.SetTemplatesDir(root)
+
+	engine, err := NewNucleiEngineCtx(context.Background())
+	require.Nil(t, engine)
+	require.ErrorContains(t, err, "error parsing")
+	require.ErrorContains(t, err, strconv.Quote(path))
+}

--- a/lib/sdk_private.go
+++ b/lib/sdk_private.go
@@ -135,11 +135,25 @@ func (e *NucleiEngine) applyRequiredDefaults(ctx context.Context) {
 		e.opts.ExcludeTags = []string{}
 	}
 
-	// these templates are known to have weak matchers
-	// and idea is to disable them to avoid false positives
-	e.opts.ExcludeTags = append(e.opts.ExcludeTags, config.ReadIgnoreFile().Tags...)
-
 	e.inputProvider = provider.NewSimpleInputProvider()
+}
+
+func (e *NucleiEngine) loadIgnoreFile() error {
+	ignoreFile, err := config.ReadIgnoreFile()
+	if errors.Is(err, os.ErrNotExist) {
+		e.Logger.Warning().Msgf("Could not read active .nuclei-ignore file: %s; continuing without ignore exclusions", err)
+
+		return nil
+	}
+
+	if err != nil {
+		return err
+	}
+
+	// These templates are known to have weak matchers, so exclude their tags by default.
+	e.opts.ExcludeTags = append(e.opts.ExcludeTags, ignoreFile.Tags...)
+
+	return nil
 }
 
 // init
@@ -162,6 +176,10 @@ func (e *NucleiEngine) init(ctx context.Context) error {
 	}
 
 	if err := runner.ValidateOptions(e.opts); err != nil {
+		return err
+	}
+
+	if err := e.loadIgnoreFile(); err != nil {
 		return err
 	}
 

--- a/pkg/catalog/config/ignorefile.go
+++ b/pkg/catalog/config/ignorefile.go
@@ -2,10 +2,11 @@ package config
 
 import (
 	"crypto/md5"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 
-	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/nuclei/v3/pkg/utils/yaml"
 )
 
@@ -15,25 +16,36 @@ type IgnoreFile struct {
 	Files []string `yaml:"files"`
 }
 
-// ReadIgnoreFile reads the .nuclei-ignore file returning blocked tags and paths.
-func ReadIgnoreFile() IgnoreFile {
+// ReadIgnoreFile reads the active .nuclei-ignore file and returns blocked tags
+// and paths. Callers must decide whether a read error is recoverable. Malformed
+// content is returned as an error to prevent a fail-open scan.
+func ReadIgnoreFile() (IgnoreFile, error) {
 	path := DefaultConfig.GetActiveIgnoreFilePath()
+
 	file, err := os.Open(path)
 	if err != nil {
-		gologger.Error().Msgf("Could not read .nuclei-ignore file %q: %s\n", path, err)
-		return IgnoreFile{}
+		return IgnoreFile{}, fmt.Errorf("error opening %q: %w", path, err)
 	}
 	defer func() {
 		_ = file.Close()
 	}()
 
+	decoder := yaml.NewDecoder(file)
 	ignore := IgnoreFile{}
-	if err := yaml.NewDecoder(file).Decode(&ignore); err != nil {
-		gologger.Error().Msgf("Could not parse .nuclei-ignore file %q: %s\n", path, err)
-		return IgnoreFile{}
+	if err := decoder.Decode(&ignore); err != nil {
+		return IgnoreFile{}, fmt.Errorf("error parsing %q: %w", path, err)
 	}
 
-	return ignore
+	var additionalDocument any
+	if err := decoder.Decode(&additionalDocument); !errors.Is(err, io.EOF) {
+		if err != nil {
+			return IgnoreFile{}, fmt.Errorf("error parsing %q: %w", path, err)
+		}
+
+		return IgnoreFile{}, fmt.Errorf("error parsing %q: multiple YAML documents are not supported", path)
+	}
+
+	return ignore, nil
 }
 
 // WriteActiveIgnoreFile atomically replaces the active root ignore file.

--- a/pkg/catalog/config/ignorefile_test.go
+++ b/pkg/catalog/config/ignorefile_test.go
@@ -1,33 +1,105 @@
 package config
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
 )
 
-func TestReadIgnoreFileAllowsMissingOrInvalidActiveFile(t *testing.T) {
+func setActiveIgnoreFileRoot(t *testing.T) string {
+	t.Helper()
+
 	root := t.TempDir()
 	cfg := DefaultConfig
 	oldRoot := cfg.TemplatesDirectory
 	t.Cleanup(func() { cfg.SetTemplatesDir(oldRoot) })
 	cfg.SetTemplatesDir(root)
+	return root
+}
 
-	if ignore := ReadIgnoreFile(); len(ignore.Tags) != 0 || len(ignore.Files) != 0 {
+func TestReadIgnoreFileReportsMissingActiveFile(t *testing.T) {
+	root := setActiveIgnoreFileRoot(t)
+	path := filepath.Join(root, NucleiIgnoreFileName)
+
+	ignore, err := ReadIgnoreFile()
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("read missing ignore file error = %v, want os.ErrNotExist", err)
+	}
+	if len(ignore.Tags) != 0 || len(ignore.Files) != 0 {
 		t.Fatalf("missing ignore file = %+v, want empty", ignore)
 	}
+	if message := err.Error(); !strings.Contains(message, strconv.Quote(path)) || !strings.Contains(message, "error opening") {
+		t.Fatalf("missing ignore file error = %q, want open failure and active path", message)
+	}
+}
 
-	if err := os.WriteFile(filepath.Join(root, NucleiIgnoreFileName), []byte("tags: ["), 0o600); err != nil {
+func TestReadIgnoreFileRejectsCorruptActiveFile(t *testing.T) {
+	root := setActiveIgnoreFileRoot(t)
+	path := filepath.Join(root, NucleiIgnoreFileName)
+
+	if err := os.WriteFile(path, []byte("tags: ["), 0o600); err != nil {
 		t.Fatalf("write invalid ignore file: %v", err)
 	}
-	if ignore := ReadIgnoreFile(); len(ignore.Tags) != 0 || len(ignore.Files) != 0 {
-		t.Fatalf("invalid ignore file = %+v, want empty", ignore)
+	ignore, err := ReadIgnoreFile()
+	if err == nil {
+		t.Fatalf("read corrupt ignore file = %+v, want error", ignore)
 	}
+	if message := err.Error(); !strings.Contains(message, strconv.Quote(path)) || !strings.Contains(message, "error parsing") {
+		t.Fatalf("corrupt ignore file error = %q, want parse failure and active path", message)
+	}
+}
+
+func TestReadIgnoreFileRejectsMalformedTrailingDocument(t *testing.T) {
+	root := setActiveIgnoreFileRoot(t)
+	path := filepath.Join(root, NucleiIgnoreFileName)
+
+	if err := os.WriteFile(path, []byte("tags: [weak]\n---\ntags: ["), 0o600); err != nil {
+		t.Fatalf("write ignore file: %v", err)
+	}
+	ignore, err := ReadIgnoreFile()
+	if err == nil {
+		t.Fatalf("read ignore file = %+v, want trailing parse error", ignore)
+	}
+	if len(ignore.Tags) != 0 || len(ignore.Files) != 0 {
+		t.Fatalf("ignore file after trailing parse error = %+v, want empty", ignore)
+	}
+	if message := err.Error(); !strings.Contains(message, strconv.Quote(path)) || !strings.Contains(message, "error parsing") {
+		t.Fatalf("trailing parse error = %q, want parse failure and active path", message)
+	}
+}
+
+func TestReadIgnoreFileRejectsAdditionalDocument(t *testing.T) {
+	root := setActiveIgnoreFileRoot(t)
+	path := filepath.Join(root, NucleiIgnoreFileName)
+
+	if err := os.WriteFile(path, []byte("tags: [weak]\n---\nfiles: [blocked.yaml]\n"), 0o600); err != nil {
+		t.Fatalf("write ignore file: %v", err)
+	}
+	ignore, err := ReadIgnoreFile()
+	if err == nil {
+		t.Fatalf("read ignore file = %+v, want multiple-document error", ignore)
+	}
+	if len(ignore.Tags) != 0 || len(ignore.Files) != 0 {
+		t.Fatalf("ignore file with additional document = %+v, want empty", ignore)
+	}
+	if message := err.Error(); !strings.Contains(message, strconv.Quote(path)) || !strings.Contains(message, "multiple YAML documents") {
+		t.Fatalf("multiple-document error = %q, want active path and document count failure", message)
+	}
+}
+
+func TestReadIgnoreFileParsesActiveFile(t *testing.T) {
+	root := setActiveIgnoreFileRoot(t)
 
 	if err := os.WriteFile(filepath.Join(root, NucleiIgnoreFileName), []byte("tags: [weak]\nfiles: [blocked.yaml]\n"), 0o600); err != nil {
 		t.Fatalf("write ignore file: %v", err)
 	}
-	ignore := ReadIgnoreFile()
+	ignore, err := ReadIgnoreFile()
+	if err != nil {
+		t.Fatalf("read ignore file: %v", err)
+	}
 	if len(ignore.Tags) != 1 || ignore.Tags[0] != "weak" {
 		t.Fatalf("ignore tags = %v, want [weak]", ignore.Tags)
 	}

--- a/pkg/catalog/loader/loader.go
+++ b/pkg/catalog/loader/loader.go
@@ -823,7 +823,14 @@ func (store *Store) LoadTemplatesWithTags(templatesList, tags []string) ([]*temp
 	// tags, so it must be matched against the ignore-file tags specifically:
 	// otherwise user-requested -exclude-tags drops would be mislabeled as
 	// .nuclei-ignore exclusions.
-	ignoreFileTags := config.ReadIgnoreFile().Tags
+	ignoreFile, err := config.ReadIgnoreFile()
+	if errors.Is(err, os.ErrNotExist) {
+		store.logger.Warning().Msgf("Could not read active .nuclei-ignore file: %s; continuing without ignore exclusions", err)
+	} else if err != nil {
+		return nil, err
+	}
+	ignoreFileTags := ignoreFile.Tags
+
 	noteExcludedByTag := func(templatePath string, metadata *index.Metadata) {
 		if len(ignoreFileTags) == 0 || !slices.ContainsFunc(ignoreFileTags, metadata.HasTag) {
 			return

--- a/pkg/catalog/loader/loader_test.go
+++ b/pkg/catalog/loader/loader_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"testing"
 	"time"
 
@@ -58,6 +59,37 @@ func TestLoadTemplates(t *testing.T) {
 		require.Nil(t, err, "could not load templates")
 		require.Equal(t, []string{templatesDirectory}, store.finalTemplates, "could not get correct templates")
 	})
+}
+
+func TestLoadTemplatesWithTagsRejectsCorruptIgnoreFileInValidationMode(t *testing.T) {
+	root := t.TempDir()
+	ignoreFilePath := filepath.Join(root, config.NucleiIgnoreFileName)
+	require.NoError(t, os.WriteFile(ignoreFilePath, []byte("tags: ["), 0o600))
+
+	cfg := config.DefaultConfig
+	oldRoot := cfg.TemplatesDirectory
+	t.Cleanup(func() { cfg.SetTemplatesDir(oldRoot) })
+	cfg.SetTemplatesDir(root)
+
+	options := testutils.DefaultOptions.Copy()
+	options.Validate = true
+	metadataIndex, err := metadataindex.NewIndex(t.TempDir())
+	require.NoError(t, err)
+
+	store, err := New(&Config{
+		Catalog: disk.NewCatalog(""),
+		ExecutorOptions: &protocols.ExecutorOptions{
+			Options: options,
+			Parser:  templates.NewParser(),
+		},
+		Logger:        options.Logger,
+		MetadataIndex: metadataIndex,
+	})
+	require.NoError(t, err)
+
+	_, err = store.LoadTemplatesWithTags(nil, nil)
+	require.ErrorContains(t, err, "error parsing")
+	require.ErrorContains(t, err, strconv.Quote(ignoreFilePath))
 }
 
 func TestNewUsesConfiguredMetadataIndex(t *testing.T) {


### PR DESCRIPTION
## Proposed changes

Return .nuclei-ignore read and parse failures to
callers instead of continuing with an empty
exclusion set.

Treat only a missing active ignore file as
recoverable and log it as a warning. Apply this
behavior to the CLI, SDK, and loader paths.

### Proof

<!-- How has this been tested? Please describe the tests that you ran to verify your changes. -->

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Missing `.nuclei-ignore` files now issue a warning and allow execution to continue without exclusions.
  - Malformed, unreadable, or multi-document ignore files now report clear errors, including the affected file path.
  - Ignore-file handling is consistent across standard runs, library initialization, and template loading.
  - Validation now rejects malformed ignore files instead of continuing with invalid configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->