### PR TITLE
fix(sdk): keep baseline ExcludeTags across per-execution filters

### DIFF
--- a/lib/multi.go
+++ b/lib/multi.go
@@ -67,21 +67,27 @@ func createEphemeralObjects(ctx context.Context, base *NucleiEngine, opts *types
 // restoreBaseExcludeTags re-adds any of the engine's baseline excluded tags that
 // a per-execution option dropped, appending only what is missing so the result
 // is order-stable and repeated application is a no-op.
+//
+// The current ExcludeTags slice is cloned before merging so a caller-owned
+// backing array (e.g. a reused WithTemplateFilters ExcludeTags value with spare
+// capacity) is never mutated or shared across concurrent executions.
 func restoreBaseExcludeTags(base []string, opts *types.Options) {
 	if len(base) == 0 {
 		return
 	}
-	present := make(map[string]struct{}, len(opts.ExcludeTags)+len(base))
-	for _, tag := range opts.ExcludeTags {
+	merged := append([]string(nil), opts.ExcludeTags...)
+	present := make(map[string]struct{}, len(merged)+len(base))
+	for _, tag := range merged {
 		present[tag] = struct{}{}
 	}
 	for _, tag := range base {
 		if _, ok := present[tag]; ok {
 			continue
 		}
-		opts.ExcludeTags = append(opts.ExcludeTags, tag)
+		merged = append(merged, tag)
 		present[tag] = struct{}{}
 	}
+	opts.ExcludeTags = merged
 }
 
 // resolveEphemeralOutput combines the base/global writer with any per-call result callbacks.

--- a/lib/multi.go
+++ b/lib/multi.go
@@ -64,6 +64,26 @@ func createEphemeralObjects(ctx context.Context, base *NucleiEngine, opts *types
 	return u, nil
 }
 
+// restoreBaseExcludeTags re-adds any of the engine's baseline excluded tags that
+// a per-execution option dropped, appending only what is missing so the result
+// is order-stable and repeated application is a no-op.
+func restoreBaseExcludeTags(base []string, opts *types.Options) {
+	if len(base) == 0 {
+		return
+	}
+	present := make(map[string]struct{}, len(opts.ExcludeTags)+len(base))
+	for _, tag := range opts.ExcludeTags {
+		present[tag] = struct{}{}
+	}
+	for _, tag := range base {
+		if _, ok := present[tag]; ok {
+			continue
+		}
+		opts.ExcludeTags = append(opts.ExcludeTags, tag)
+		present[tag] = struct{}{}
+	}
+}
+
 // resolveEphemeralOutput combines the base/global writer with any per-call result callbacks.
 // Global callbacks keep working; per-call callbacks are isolated to this execution.
 func resolveEphemeralOutput(base, call *NucleiEngine) output.Writer {
@@ -161,6 +181,18 @@ func (e *ThreadSafeNucleiEngine) ExecuteNucleiWithOptsCtx(ctx context.Context, t
 			return err
 		}
 	}
+	// Per-execution options land on a COPY of the engine's options, so an option
+	// that assigns a whole filter set clears every field it does not name —
+	// WithTemplateFilters does exactly that. ExcludeTags is one of those fields,
+	// and it carries the .nuclei-ignore deny-list that applyRequiredDefaults
+	// installed at construction; nothing re-reads the ignore file afterwards, so
+	// the exclusions would be lost for this execution and templates tagged dos,
+	// bruteforce, fuzz, local or txt-service would run.
+	//
+	// Restore the engine's baseline exclusions so a per-execution filter can add
+	// to them but never silently discard them. IncludeTags remains the explicit
+	// per-tag override for callers who do want an ignored template to run.
+	restoreBaseExcludeTags(e.eng.opts.ExcludeTags, tmpEngine.opts)
 
 	// create ephemeral nuclei objects/instances/types using base nuclei engine
 	unsafeOpts, err := createEphemeralObjects(ctx, e.eng, tmpEngine.opts, resolveEphemeralOutput(e.eng, tmpEngine))

--- a/lib/multi_filters_test.go
+++ b/lib/multi_filters_test.go
@@ -1,0 +1,107 @@
+package nuclei_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	nuclei "github.com/projectdiscovery/nuclei/v3/lib"
+	"github.com/projectdiscovery/nuclei/v3/pkg/output"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestExecuteNucleiWithOptsCtxKeepsBaseExcludeTags covers the case where a
+// per-execution filter that names only Tags used to clear the engine's
+// ExcludeTags — which carry the .nuclei-ignore deny-list installed at
+// construction — letting templates tagged dos (and local, fuzz, bruteforce,
+// txt-service) execute against the target.
+//
+// The engine's construction-time ExcludeTags stand in for that deny-list, and
+// the per-execution filter deliberately asks for the excluded tag: exclusion
+// must still win, because IncludeTags is the documented way to override it.
+func TestExecuteNucleiWithOptsCtxKeepsBaseExcludeTags(t *testing.T) {
+	templatePath := writeSDKDosTaggedTemplate(t)
+
+	var reached atomic.Bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reached.Store(true)
+		_, _ = w.Write([]byte("token-dos"))
+	}))
+	t.Cleanup(srv.Close)
+
+	ne, err := nuclei.NewThreadSafeNucleiEngineCtx(context.Background(),
+		nuclei.WithTemplateFilters(nuclei.TemplateFilters{ExcludeTags: []string{"dos"}}),
+	)
+	require.NoError(t, err, "could not create thread-safe nuclei engine")
+	t.Cleanup(ne.Close)
+
+	var matches atomic.Int64
+	ne.GlobalResultCallback(func(*output.ResultEvent) { matches.Add(1) })
+
+	err = ne.ExecuteNucleiWithOptsCtx(context.Background(), []string{srv.URL},
+		nuclei.WithTemplatesOrWorkflows(nuclei.TemplateSources{Templates: []string{templatePath}}),
+		nuclei.WithTemplateFilters(nuclei.TemplateFilters{Tags: []string{"dos"}}),
+	)
+
+	require.ErrorIs(t, err, nuclei.ErrNoTemplatesAvailable,
+		"the dos-tagged template must stay excluded, leaving nothing to run")
+	assert.Zero(t, matches.Load(), "an excluded template must not report results")
+	assert.False(t, reached.Load(), "an excluded template must not reach the target")
+}
+
+// TestExecuteNucleiWithOptsCtxHonoursIncludeTags is the other half of the
+// contract: restoring the baseline exclusions must not break the documented
+// per-tag override, or callers lose the only way to run an ignored template.
+func TestExecuteNucleiWithOptsCtxHonoursIncludeTags(t *testing.T) {
+	templatePath := writeSDKDosTaggedTemplate(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("token-dos"))
+	}))
+	t.Cleanup(srv.Close)
+
+	ne, err := nuclei.NewThreadSafeNucleiEngineCtx(context.Background(),
+		nuclei.WithTemplateFilters(nuclei.TemplateFilters{ExcludeTags: []string{"dos"}}),
+	)
+	require.NoError(t, err, "could not create thread-safe nuclei engine")
+	t.Cleanup(ne.Close)
+
+	var matches atomic.Int64
+	ne.GlobalResultCallback(func(*output.ResultEvent) { matches.Add(1) })
+
+	err = ne.ExecuteNucleiWithOptsCtx(context.Background(), []string{srv.URL},
+		nuclei.WithTemplatesOrWorkflows(nuclei.TemplateSources{Templates: []string{templatePath}}),
+		nuclei.WithTemplateFilters(nuclei.TemplateFilters{IncludeTags: []string{"dos"}}),
+	)
+
+	require.NoError(t, err)
+	assert.NotZero(t, matches.Load(), "IncludeTags should still override the exclusion")
+}
+
+func writeSDKDosTaggedTemplate(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sdk-dos-tagged.yaml")
+	content := `id: sdk-dos-tagged
+info:
+  name: SDK dos tagged
+  author: nuclei-sdk-test
+  severity: info
+  tags: dos
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+    matchers:
+      - type: word
+        words:
+          - "token-"
+`
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	return path
+}

--- a/lib/multi_filters_test.go
+++ b/lib/multi_filters_test.go
@@ -10,7 +10,9 @@ import (
 	"testing"
 
 	nuclei "github.com/projectdiscovery/nuclei/v3/lib"
+	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/config"
 	"github.com/projectdiscovery/nuclei/v3/pkg/output"
+	"github.com/projectdiscovery/nuclei/v3/pkg/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -104,4 +106,56 @@ http:
 `
 	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
 	return path
+}
+
+// TestExecuteNucleiWithOptsCtxKeepsIgnoreFileExcludeTags is the end-to-end path
+// for #7695 once #7697 is on the tree: tags from a real .nuclei-ignore must
+// survive a per-execution WithTemplateFilters that only sets Tags.
+func TestExecuteNucleiWithOptsCtxKeepsIgnoreFileExcludeTags(t *testing.T) {
+	previousConfigDir := config.DefaultConfig.GetConfigDir()
+	previousTemplatesDir := config.DefaultConfig.TemplatesDirectory
+	previousStateDir := config.DefaultConfig.GetStateDir()
+	t.Cleanup(func() {
+		config.DefaultConfig.SetConfigDir(previousConfigDir)
+		config.DefaultConfig.SetStateDir(previousStateDir)
+		config.DefaultConfig.SetTemplatesDir(previousTemplatesDir)
+	})
+
+	dir := t.TempDir()
+	config.DefaultConfig.SetConfigDir(dir)
+	config.DefaultConfig.SetTemplatesDir(dir)
+
+	require.NoError(t, os.WriteFile(
+		config.DefaultConfig.GetActiveIgnoreFilePath(),
+		[]byte("tags:\n  - dos\n"),
+		0o600,
+	))
+
+	templatePath := writeSDKDosTaggedTemplate(t)
+
+	var reached atomic.Bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reached.Store(true)
+		_, _ = w.Write([]byte("token-dos"))
+	}))
+	t.Cleanup(srv.Close)
+
+	ne, err := nuclei.NewThreadSafeNucleiEngineCtx(context.Background(),
+		nuclei.WithOptions(types.DefaultOptions()),
+		nuclei.DisableUpdateCheck(),
+	)
+	require.NoError(t, err, "could not create thread-safe nuclei engine")
+	t.Cleanup(ne.Close)
+	var matches atomic.Int64
+	ne.GlobalResultCallback(func(*output.ResultEvent) { matches.Add(1) })
+
+	err = ne.ExecuteNucleiWithOptsCtx(context.Background(), []string{srv.URL},
+		nuclei.WithTemplatesOrWorkflows(nuclei.TemplateSources{Templates: []string{templatePath}}),
+		nuclei.WithTemplateFilters(nuclei.TemplateFilters{Tags: []string{"dos"}}),
+	)
+
+	require.ErrorIs(t, err, nuclei.ErrNoTemplatesAvailable,
+		"ignore-file dos exclusion must survive a Tags-only per-execution filter")
+	assert.Zero(t, matches.Load())
+	assert.False(t, reached.Load())
 }

--- a/lib/multi_internal_test.go
+++ b/lib/multi_internal_test.go
@@ -1,0 +1,60 @@
+package nuclei
+
+import (
+	"testing"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRestoreBaseExcludeTags(t *testing.T) {
+	tests := []struct {
+		name     string
+		base     []string
+		current  []string
+		expected []string
+	}{
+		{
+			name:     "per-execution filter cleared the deny-list",
+			base:     []string{"dos", "fuzz"},
+			current:  nil,
+			expected: []string{"dos", "fuzz"},
+		},
+		{
+			name:     "per-execution exclusions are kept alongside the baseline",
+			base:     []string{"dos"},
+			current:  []string{"custom"},
+			expected: []string{"custom", "dos"},
+		},
+		{
+			name:     "entries already present are not duplicated",
+			base:     []string{"dos", "fuzz"},
+			current:  []string{"fuzz"},
+			expected: []string{"fuzz", "dos"},
+		},
+		{
+			name:     "no baseline is a no-op",
+			base:     nil,
+			current:  []string{"custom"},
+			expected: []string{"custom"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := &types.Options{ExcludeTags: tt.current}
+			restoreBaseExcludeTags(tt.base, opts)
+			assert.Equal(t, tt.expected, []string(opts.ExcludeTags))
+		})
+	}
+}
+
+// TestRestoreBaseExcludeTagsIsIdempotent matters because the helper runs on
+// every execution against a long-lived engine.
+func TestRestoreBaseExcludeTagsIsIdempotent(t *testing.T) {
+	opts := &types.Options{}
+	restoreBaseExcludeTags([]string{"dos", "fuzz"}, opts)
+	restoreBaseExcludeTags([]string{"dos", "fuzz"}, opts)
+
+	assert.Equal(t, []string{"dos", "fuzz"}, []string(opts.ExcludeTags))
+}

--- a/lib/multi_internal_test.go
+++ b/lib/multi_internal_test.go
@@ -1,6 +1,7 @@
 package nuclei
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/projectdiscovery/nuclei/v3/pkg/types"
@@ -57,4 +58,31 @@ func TestRestoreBaseExcludeTagsIsIdempotent(t *testing.T) {
 	restoreBaseExcludeTags([]string{"dos", "fuzz"}, opts)
 
 	assert.Equal(t, []string{"dos", "fuzz"}, []string(opts.ExcludeTags))
+}
+
+// TestRestoreBaseExcludeTagsDoesNotMutateCallerSlice guards the concurrent
+// ThreadSafeNucleiEngine case where WithTemplateFilters assigns a caller-owned
+// ExcludeTags slice with spare capacity: a naive append would race and mutate
+// the caller's backing array.
+func TestRestoreBaseExcludeTagsDoesNotMutateCallerSlice(t *testing.T) {
+	shared := make([]string, 1, 8)
+	shared[0] = "custom"
+	base := []string{"dos", "fuzz"}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			opts := &types.Options{ExcludeTags: shared}
+			restoreBaseExcludeTags(base, opts)
+			if got := []string(opts.ExcludeTags); len(got) != 3 || got[0] != "custom" || got[1] != "dos" || got[2] != "fuzz" {
+				panic(got)
+			}
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, []string{"custom"}, shared[:1])
+	assert.Equal(t, make([]string, 7), shared[1:cap(shared)])
 }


### PR DESCRIPTION
## Proposed changes

Fixes #7695.

`applyRequiredDefaults` installs the `.nuclei-ignore` deny-list into `Options.ExcludeTags` once, while the engine is being built (`lib/sdk_private.go`). `ExecuteNucleiWithOptsCtx` then applies per-execution options to a **copy** of those options, afterwards:

```go
baseOpts := e.eng.opts.Copy()
tmpEngine := &NucleiEngine{opts: baseOpts, mode: threadSafe}
for _, option := range opts { ... }
```

`WithTemplateFilters` assigns the whole filter set, so a literal naming only `Tags` clears `ExcludeTags`. Nothing re-reads the ignore file after construction, so every execution that varied tags per call ran with an empty exclude list and executed templates tagged `dos`, `local`, `fuzz`, `bruteforce` and `txt-service`. The failure is silent.

Varying template filters across concurrent `ExecuteNucleiWithOptsCtx` calls is the documented purpose of the thread-safe engine, and `WithTemplateFilters` is the only option that sets tags, so this is reachable through intended use rather than misuse. We hit it in production: `CVE-2019-5544` (VMware ESXi OpenSLP heap overflow, tagged `dos`) executed against 84 hosts.

This restores the engine's baseline exclusions after per-execution options are applied, so a per-execution filter can **add** exclusions but not silently discard them. Chosen over the alternatives because it fixes existing consumers with no code change on their side:

- No extra I/O — the deny-list is already on the base engine's options, so there is no per-execution `ReadIgnoreFile()` call (which would also log an error on every execution for users without an ignore file).
- Only missing entries are appended, so the helper is idempotent across executions against a long-lived engine and the resulting order is stable.
- `IncludeTags` is untouched and remains the explicit per-tag override for callers who *do* want an ignored template to run.

Happy to follow up separately with a narrow per-execution option (e.g. `WithTags`) that sets only the tag allow-list, if you'd like the footgun removed at the source rather than compensated for. Note also that the same assignment clears `Protocols`, so a construction-time protocol-type filter is still lost on per-execution calls that set tags — I left that out to keep this focused, and can address it here or separately, whichever you prefer.

### Proof

Two behavioural tests in `lib/multi_filters_test.go`, following the existing local-template + `httptest` pattern from `lib/result_callback_test.go`, plus a table-driven unit test for the helper in `lib/multi_internal_test.go`.

`TestExecuteNucleiWithOptsCtxKeepsBaseExcludeTags` builds a thread-safe engine with `ExcludeTags: ["dos"]` (standing in for the ignore-file deny-list), then executes with a per-execution `TemplateFilters{Tags: ["dos"]}` against a local server, and asserts the `dos`-tagged template neither runs nor reaches the target.

Without the change:

```
--- FAIL: TestExecuteNucleiWithOptsCtxKeepsBaseExcludeTags (0.36s)
    Error:    Expected error with "cause=\"No templates available\"" in chain but got nil.
    Messages: the dos-tagged template must stay excluded, leaving nothing to run
```

With the change:

```
--- PASS: TestRestoreBaseExcludeTags (0.00s)
--- PASS: TestRestoreBaseExcludeTagsIsIdempotent (0.00s)
--- PASS: TestExecuteNucleiWithOptsCtxKeepsBaseExcludeTags (0.37s)
--- PASS: TestExecuteNucleiWithOptsCtxHonoursIncludeTags (0.09s)
ok  github.com/projectdiscovery/nuclei/v3/lib
```

`TestExecuteNucleiWithOptsCtxHonoursIncludeTags` is the over-correction guard — it passes both with and without the change, confirming the restore does not break the documented `IncludeTags` override.

Full `go test ./lib/` passes apart from `ExampleThreadSafeNucleiEngine`, which fails identically on unmodified `dev` in my environment (a network-dependent example expecting a `caa-fingerprint` result for `honey.scanme.sh`) — unrelated to this change.

## Checklist

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved baseline tag exclusions during per-execution filtering, preventing protected deny-list tags from being unintentionally removed.
  - Ensured explicitly included tags continue to override exclusions as expected.
  - Improved isolation for concurrent executions using different output destinations, preventing shared state from affecting results.

- **Tests**
  - Added coverage for exclusion preservation, inclusion overrides, duplicate prevention, repeated application, and executions without baseline exclusions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->