### PR TITLE
fix(sdk): read .nuclei-ignore after init finishes managing it

### DIFF
--- a/lib/ignorefile_test.go
+++ b/lib/ignorefile_test.go
@@ -8,9 +8,15 @@ import (
 	"testing"
 
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/config"
+	"github.com/projectdiscovery/nuclei/v3/pkg/types"
 	"github.com/stretchr/testify/require"
 )
 
+// Update checks are disabled explicitly so this pins corrupt-file rejection on
+// its own. The ignore file is read after init's update block, which may replace
+// a corrupt file via UpdateIgnoreFile — with update checks left on, this test
+// would assert rejection or repair depending on whether the process could reach
+// the network.
 func TestNewNucleiEngineRejectsCorruptActiveIgnoreFile(t *testing.T) {
 	root := t.TempDir()
 	path := filepath.Join(root, config.NucleiIgnoreFileName)
@@ -21,8 +27,58 @@ func TestNewNucleiEngineRejectsCorruptActiveIgnoreFile(t *testing.T) {
 	t.Cleanup(func() { cfg.SetTemplatesDir(oldRoot) })
 	cfg.SetTemplatesDir(root)
 
-	engine, err := NewNucleiEngineCtx(context.Background())
+	engine, err := NewNucleiEngineCtx(context.Background(), DisableUpdateCheck())
 	require.Nil(t, engine)
 	require.ErrorContains(t, err, "error parsing")
 	require.ErrorContains(t, err, strconv.Quote(path))
+}
+
+// TestIgnoreFileSurvivesAuthTemplateStore pins the ordering of the ignore-file
+// read within init.
+//
+// GetAuthTmplStore scopes its own template store by nilling every filter field
+// on the shared *types.Options — ExcludeTags and ExcludedTemplates included —
+// and does not restore them. It runs whenever SecretsFile is set, so reading
+// .nuclei-ignore before it leaves the engine with no deny-list for the rest of
+// its lifetime, ExcludeTags never being re-read after init.
+//
+// A static-only secrets file is enough: the store is built, and the fields
+// nilled, regardless of whether any dynamic templates are present.
+func TestIgnoreFileSurvivesAuthTemplateStore(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(root, config.NucleiIgnoreFileName),
+		[]byte("tags:\n  - dos\nfiles:\n  - dns/soa-detect.yaml\n"),
+		0o600,
+	))
+
+	cfg := config.DefaultConfig
+	oldRoot := cfg.TemplatesDirectory
+	t.Cleanup(func() { cfg.SetTemplatesDir(oldRoot) })
+	cfg.SetTemplatesDir(root)
+
+	secrets := filepath.Join(root, "secrets.yaml")
+	require.NoError(t, os.WriteFile(secrets, []byte(`static:
+  - type: header
+    domains:
+      - example.com
+    headers:
+      - key: x-api-key
+        value: not-a-real-secret
+`), 0o600))
+
+	opts := types.DefaultOptions()
+	opts.SecretsFile = []string{secrets}
+
+	engine, err := NewNucleiEngineCtx(context.Background(),
+		WithOptions(opts),
+		DisableUpdateCheck(),
+	)
+	require.NoError(t, err)
+	t.Cleanup(engine.Close)
+
+	require.Contains(t, []string(engine.Options().ExcludeTags), "dos",
+		"the .nuclei-ignore deny-list must survive GetAuthTmplStore nilling the filter fields")
+	require.Contains(t, []string(engine.Options().ExcludedTemplates), "dns/soa-detect.yaml",
+		"the files section must survive it too")
 }

--- a/lib/sdk_private.go
+++ b/lib/sdk_private.go
@@ -184,10 +184,6 @@ func (e *NucleiEngine) init(ctx context.Context) error {
 		return err
 	}
 
-	if err := e.loadIgnoreFile(); err != nil {
-		return err
-	}
-
 	if e.opts.Parser != nil {
 		if op, ok := e.opts.Parser.(*templates.Parser); ok {
 			e.parser = op
@@ -380,6 +376,27 @@ func (e *NucleiEngine) init(ctx context.Context) error {
 				e.opts.Logger.Warning().Msgf("failed to update nuclei ignore file: %s\n", err)
 			}
 		}
+	}
+
+	// Read .nuclei-ignore LAST, once init has finished managing that file and
+	// the options it writes into.
+	//
+	// It must come after the update block above: init creates or replaces the
+	// ignore file there (UpdateIgnoreFile), so reading earlier reads a file this
+	// same call is about to write. On a host without a pre-existing ignore file
+	// — a fresh install, or any container whose filesystem was reset — the read
+	// found nothing, warned, and left the engine with an empty deny-list for its
+	// whole lifetime, because ExcludeTags is never re-read after init. Reading
+	// afterwards also makes the corrupt-file check recoverable rather than fatal:
+	// a malformed local file that IgnoreFileNeedsUpdate replaces no longer fails
+	// the scan.
+	//
+	// It must also come after GetAuthTmplStore above, which nils ExcludeTags and
+	// ExcludedTemplates on the shared options to scope its own template store and
+	// does not restore them. Loading here keeps the deny-list intact for callers
+	// that pass SecretsFile.
+	if err := e.loadIgnoreFile(); err != nil {
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
## Proposed changes

Fixes #7704.

`init()` manages the ignore file itself — `installer.UpdateIgnoreFile()` in the `CanCheckForUpdates()` block — but read it near the top of the same function. The read therefore saw a file that the same call was about to write.

On a host with no pre-existing ignore file (fresh install, or any container whose filesystem was reset) the read found nothing, warned, and left the engine with an empty deny-list. `ExcludeTags` is never re-read after `init`, so that engine executed `dos`, `bruteforce`, `fuzz`, `local` and `txt-service` templates for its whole lifetime — while the file it wanted appeared moments later in the same `init` call. Consumers that build one engine per protocol group and reuse it across a scan can lose the deny-list for the entire scan that way.

This moves the load to the end of `init`, after the update block.

**Why that position is safe.** Nothing in `init` consumes `ExcludeTags` or `ExcludedTemplates`, and the components that receive `e.opts` (`core.New`, `protocolinit.Init`, `httpclientpool.Get`) hold it by pointer, so populating those fields later is visible to them. When `CanCheckForUpdates()` is false the behaviour is unchanged: read whatever exists, warn and continue if absent.

**A second bug it fixes as a consequence.** The new position is also after `GetAuthTmplStore` (`internal/runner/lazy.go`), which scopes its own template store by nilling every filter field on the shared `*types.Options` — `ExcludeTags` and `ExcludedTemplates` included — and never restores them. It runs whenever `SecretsFile` is set, so any such caller previously lost the deny-list. Worth noting it also nils `Tags`, `Severities`, `Protocols`, `IncludeIds` and the rest, which this PR does **not** address — that looks like it wants a copy of the options rather than mutation of the shared one, and I'm happy to file it separately if you agree it's a bug.

### One deliberate semantics change, please sanity-check it

A corrupt ignore file that the installer **successfully replaces** no longer fails engine construction, since the read now happens after the replacement. Rejection of a corrupt file the installer does *not* replace is unchanged.

I think that is the better behaviour — failing a scan over a file that was just repaired seems gratuitous — but it does soften what #7691 introduced, so I would rather flag it than slip it through. If you prefer corrupt-always-fatal, the alternative is to validate early and apply late, at the cost of two reads.

`TestNewNucleiEngineRejectsCorruptActiveIgnoreFile` now passes `DisableUpdateCheck()` so it pins corrupt-file rejection deterministically instead of depending on whether the test process can reach the network. It passed before only because the read preceded the installer.

### Proof

`TestIgnoreFileSurvivesAuthTemplateStore` in `lib/ignorefile_test.go` is the regression test. It writes an ignore file plus a static-only secrets file (enough to trigger `GetAuthTmplStore`, no dynamic templates or network needed) and asserts the deny-list survives engine construction.

Without the change:

```
--- FAIL: TestIgnoreFileSurvivesAuthTemplateStore
    Error:    []string(nil) does not contain "dos"
    Messages: the .nuclei-ignore deny-list must survive GetAuthTmplStore nilling the filter fields
```

With the change:

```
--- PASS: TestNewNucleiEngineRejectsCorruptActiveIgnoreFile (0.04s)
--- PASS: TestIgnoreFileSurvivesAuthTemplateStore (0.07s)
--- PASS: TestIgnoreFileFilesSectionIsApplied (0.05s)
ok  github.com/projectdiscovery/nuclei/v3/lib
```

Full `go test ./lib/` passes apart from `ExampleThreadSafeNucleiEngine`, which fails identically on unmodified `dev` in my environment (network-dependent example expecting a `caa-fingerprint` result for `honey.scanme.sh`) — unrelated to this change.

Field evidence for the original bug is in #7704: a controlled A/B on one host, same binary and config, where the run with the ignore file absent at engine construction produced 8 `fuzz`-tagged detections across 4 hosts and the run with it present produced 0, with those hosts still returning non-deny-listed detections so they were demonstrably scanned.

## Checklist

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery when the ignore file is corrupted, allowing it to be recreated instead of causing initialization to fail.
  - Preserved ignore-file exclusions when authentication templates are loaded from a static secrets file.
  - Prevented update-check behavior from interfering with ignore-file parsing and recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->