### PR TITLE
fix(operators): reject matchers & extractors w/o values

### DIFF
--- a/pkg/operators/extractors/compile.go
+++ b/pkg/operators/extractors/compile.go
@@ -24,6 +24,24 @@ func (e *Extractor) CompileExtractors() error {
 		return fmt.Errorf("regex extractor group must be >= 0, got %d", e.RegexGroup)
 	}
 
+	var requiredField string
+	var valueCount int
+	switch e.extractorType {
+	case RegexExtractor:
+		requiredField, valueCount = "regex", len(e.Regex)
+	case KValExtractor:
+		requiredField, valueCount = "kval", len(e.KVal)
+	case JSONExtractor:
+		requiredField, valueCount = "json", len(e.JSON)
+	case XPathExtractor:
+		requiredField, valueCount = "xpath", len(e.XPath)
+	case DSLExtractor:
+		requiredField, valueCount = "dsl", len(e.DSL)
+	}
+	if valueCount == 0 {
+		return fmt.Errorf("%s extractor requires at least one %s value", e.extractorType, requiredField)
+	}
+
 	// Compile the regexes
 	for _, regex := range e.Regex {
 		if cached, err := cache.Regex().GetIFPresent(regex); err == nil && cached != nil {

--- a/pkg/operators/extractors/compile_test.go
+++ b/pkg/operators/extractors/compile_test.go
@@ -1,0 +1,51 @@
+package extractors
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestCompileExtractorsRequiresValues(t *testing.T) {
+	tests := []struct {
+		typ    string
+		field  string
+		values string
+	}{
+		{"regex", "regex", `["hello"]`},
+		{"kval", "kval", `["header"]`},
+		{"json", "json", `[".value"]`},
+		{"xpath", "xpath", `["//a"]`},
+		{"dsl", "dsl", `["body"]`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.typ, func(t *testing.T) {
+			for _, suffix := range []struct{ name, yaml string }{
+				{"omitted", ""},
+				{"null", tt.field + ": null\n"},
+				{"empty", tt.field + ": []\n"},
+			} {
+				t.Run(suffix.name, func(t *testing.T) {
+					var operator Extractor
+					require.NoError(t, yaml.Unmarshal([]byte("type: "+tt.typ+"\n"+suffix.yaml), &operator))
+					require.ErrorContains(t, operator.CompileExtractors(), fmt.Sprintf("%s extractor requires at least one %s value", tt.typ, tt.field))
+				})
+			}
+			t.Run("valid", func(t *testing.T) {
+				var operator Extractor
+				require.NoError(t, yaml.Unmarshal([]byte("type: "+tt.typ+"\n"+tt.field+": "+tt.values), &operator))
+				require.NoError(t, operator.CompileExtractors())
+			})
+		})
+	}
+}
+
+func TestCompileExtractorsRequiresValuesForSelectedType(t *testing.T) {
+	e := &Extractor{
+		Type: ExtractorTypeHolder{ExtractorType: RegexExtractor},
+		KVal: []string{"header"},
+	}
+	require.ErrorContains(t, e.CompileExtractors(), "regex extractor requires at least one regex value")
+}

--- a/pkg/operators/matchers/compile_test.go
+++ b/pkg/operators/matchers/compile_test.go
@@ -1,0 +1,55 @@
+package matchers
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestCompileMatchersRequiresValues(t *testing.T) {
+	tests := []struct {
+		typ    string
+		field  string
+		values string
+	}{
+		{"word", "words", `["hello"]`},
+		{"regex", "regex", `["hello"]`},
+		{"binary", "binary", `["00"]`},
+		{"status", "status", `[200]`},
+		{"size", "size", `[0]`},
+		{"dsl", "dsl", `["true"]`},
+		{"xpath", "xpath", `["//a"]`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.typ, func(t *testing.T) {
+			for _, suffix := range []struct{ name, yaml string }{
+				{"omitted", ""},
+				{"null", tt.field + ": null\n"},
+				{"empty", tt.field + ": []\n"},
+			} {
+				t.Run(suffix.name, func(t *testing.T) {
+					var operator Matcher
+					require.NoError(t, yaml.Unmarshal([]byte("type: "+tt.typ+"\n"+suffix.yaml), &operator))
+					require.ErrorContains(t, operator.CompileMatchers(), fmt.Sprintf("%s matcher requires at least one %s value", tt.typ, tt.field))
+				})
+			}
+			t.Run("valid", func(t *testing.T) {
+				var operator Matcher
+				require.NoError(t, yaml.Unmarshal([]byte("type: "+tt.typ+"\n"+tt.field+": "+tt.values), &operator))
+				require.NoError(t, operator.CompileMatchers())
+			})
+		})
+	}
+}
+
+func TestCompileMatchersAllowsEmptyStringValue(t *testing.T) {
+	m := &Matcher{
+		Type:  MatcherTypeHolder{MatcherType: WordsMatcher},
+		Words: []string{""},
+	}
+	require.NoError(t, m.CompileMatchers())
+	matched, _ := m.MatchWords("body", nil)
+	require.True(t, matched)
+}

--- a/pkg/operators/matchers/match_test.go
+++ b/pkg/operators/matchers/match_test.go
@@ -100,12 +100,7 @@ func TestHexEncoding(t *testing.T) {
 }
 
 func TestMatcher_MatchDSL(t *testing.T) {
-	compiled, err := govaluate.NewEvaluableExpressionWithFunctions("contains(body, \"{{VARIABLE}}\")", dsl.HelperFunctions)
-	require.Nil(t, err, "couldn't compile expression")
-
-	m := &Matcher{Type: MatcherTypeHolder{MatcherType: DSLMatcher}, dslCompiled: []*govaluate.EvaluableExpression{compiled}}
-	err = m.CompileMatchers()
-	require.Nil(t, err, "could not compile matcher")
+	m := mustCompileDSLMatcher(t, `contains(body, "{{VARIABLE}}")`)
 
 	values := []string{"PING", "pong"}
 
@@ -442,12 +437,7 @@ func TestMatchWords_CaseInsensitive_DynamicValue(t *testing.T) {
 
 func TestMatcher_MatchDSL_ErrorHandling(t *testing.T) {
 	// First expression errors (division by zero), second is true
-	bad, err := govaluate.NewEvaluableExpression("1 / 0")
-	require.NoError(t, err)
-	good, err := govaluate.NewEvaluableExpression("1 == 1")
-	require.NoError(t, err)
-
-	m := &Matcher{Type: MatcherTypeHolder{MatcherType: DSLMatcher}, Condition: "or", dslCompiled: []*govaluate.EvaluableExpression{bad, good}}
+	m := &Matcher{Type: MatcherTypeHolder{MatcherType: DSLMatcher}, Condition: "or", DSL: []string{"1 / 0", "1 == 1"}}
 	require.NoError(t, m.CompileMatchers())
 	ok := m.MatchDSL(map[string]interface{}{})
 	require.True(t, ok)

--- a/pkg/operators/matchers/validate.go
+++ b/pkg/operators/matchers/validate.go
@@ -33,25 +33,38 @@ func (matcher *Matcher) Validate() error {
 	var err error
 
 	var expectedFields []string
+	var requiredField string
+	var valueCount int
 	switch matcher.matcherType {
 	case DSLMatcher:
+		requiredField, valueCount = "dsl", len(matcher.DSL)
 		expectedFields = append(commonExpectedFields, "DSL")
 	case StatusMatcher:
+		requiredField, valueCount = "status", len(matcher.Status)
 		expectedFields = append(commonExpectedFields, "Status", "Part")
 	case SizeMatcher:
+		requiredField, valueCount = "size", len(matcher.Size)
 		expectedFields = append(commonExpectedFields, "Size", "Part")
 	case WordsMatcher:
+		requiredField, valueCount = "words", len(matcher.Words)
 		expectedFields = append(commonExpectedFields, "Words", "Part", "Encoding", "CaseInsensitive")
 	case BinaryMatcher:
+		requiredField, valueCount = "binary", len(matcher.Binary)
 		expectedFields = append(commonExpectedFields, "Binary", "Part", "Encoding", "CaseInsensitive")
 	case RegexMatcher:
+		requiredField, valueCount = "regex", len(matcher.Regex)
 		expectedFields = append(commonExpectedFields, "Regex", "Part", "Encoding", "CaseInsensitive")
 	case XPathMatcher:
+		requiredField, valueCount = "xpath", len(matcher.XPath)
 		expectedFields = append(commonExpectedFields, "XPath", "Part")
 	}
 
 	if err = checkFields(matcher, matcherMap, expectedFields...); err != nil {
 		return err
+	}
+
+	if requiredField != "" && valueCount == 0 {
+		return fmt.Errorf("%s matcher requires at least one %s value", matcher.matcherType, requiredField)
 	}
 
 	// validate the XPath query

--- a/pkg/operators/matchers/validate_test.go
+++ b/pkg/operators/matchers/validate_test.go
@@ -29,3 +29,12 @@ func TestValidate(t *testing.T) {
 	err = m.Validate()
 	require.NotNil(t, err, "Invalid XPath query was correctly validated")
 }
+
+func TestValidateRequiresValues(t *testing.T) {
+	for _, matcherType := range GetSupportedMatcherTypes() {
+		t.Run(matcherType.String(), func(t *testing.T) {
+			m := &Matcher{matcherType: matcherType}
+			require.ErrorContains(t, m.Validate(), "requires at least one")
+		})
+	}
+}

--- a/pkg/protocols/file/operators_test.go
+++ b/pkg/protocols/file/operators_test.go
@@ -21,6 +21,7 @@ func newMockOperator() operators.Operators {
 				Type: matchers.MatcherTypeHolder{
 					MatcherType: matchers.WordsMatcher,
 				},
+				Words: []string{"test-data"},
 			},
 		},
 	}

--- a/pkg/templates/operators_validation_test.go
+++ b/pkg/templates/operators_validation_test.go
@@ -1,0 +1,51 @@
+package templates_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/projectdiscovery/nuclei/v3/internal/tests/testutils"
+	"github.com/projectdiscovery/nuclei/v3/pkg/templates"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseTemplateRejectsOperatorsWithoutValues(t *testing.T) {
+	for _, validationMode := range []bool{false, true} {
+		t.Run(fmt.Sprintf("validation=%t", validationMode), func(t *testing.T) {
+			options := testutils.DefaultOptions.Copy()
+			options.Validate = validationMode
+			options.ExecutionId = t.Name()
+			testutils.Init(options)
+			t.Cleanup(func() { testutils.Cleanup(options) })
+
+			for _, tt := range []struct {
+				kind string
+				typ  string
+			}{
+				{"matcher", "word"},
+				{"extractor", "regex"},
+			} {
+				t.Run(tt.kind, func(t *testing.T) {
+					executerOptions := testutils.NewMockExecuterOptions(options, nil)
+					templateSource := fmt.Sprintf(`id: empty-operator
+info:
+  name: Empty operator
+  author: pdteam
+  severity: info
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    %ss:
+      - type: %s
+`, tt.kind, tt.typ)
+					template, err := templates.ParseTemplateFromReader(strings.NewReader(templateSource), nil, executerOptions)
+					require.ErrorContains(t, err, "could not compile "+tt.kind)
+					require.ErrorContains(t, err, tt.typ+" "+tt.kind+" requires at least one")
+					require.Nil(t, template)
+				})
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Proposed changes

Require at least one value for the selected
operator type during compilation. Empty lists
previously compiled without an error and produced
no results.

Fixes #7604

### Proof

<!-- How has this been tested? Please describe the tests that you ran to verify your changes. -->

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Templates now reject matchers and extractors that do not include at least one value.
  * Validation checks the value field associated with the selected matcher or extractor type.
  * Error messages identify the affected operator and indicate that a value is required.
  * Empty string values remain valid where supported, including word matchers.
* **Tests**
  * Added coverage for missing, null, and empty values across supported matcher and extractor types.
  * Expanded validation coverage for successful compilation and DSL matcher behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->