### PR TITLE
verify template signatures independently of cached metadata

### DIFF
--- a/pkg/catalog/loader/loader_test.go
+++ b/pkg/catalog/loader/loader_test.go
@@ -2,6 +2,7 @@ package loader
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -662,7 +663,132 @@ http:
 	loaded := loadSingleTemplateForTest(t, templatePath, "loader-unsigned-flow-template")
 	require.Len(t, loaded, 1)
 	require.Equal(t, "unsigned-flow-template", loaded[0].ID)
+	require.False(t, loaded[0].Verified)
 	require.Equal(t, initialUnverifiedJavascript, stats.GetValue(templates.SkippedUnverifiedJavascriptTemplateStats))
+}
+
+func contentDigestForLoaderTest(data []byte) [32]byte {
+	dataDigest := sha256.Sum256(data)
+	return sha256.Sum256(dataDigest[:])
+}
+
+func loadTemplateWithPoisonedMetadata(t *testing.T, templatePath, executionID string, source []byte, disableUnsigned bool) []*templates.Template {
+	t.Helper()
+
+	fileInfo, err := os.Stat(templatePath)
+	require.NoError(t, err)
+
+	metadataIndex, err := metadataindex.NewIndex(t.TempDir())
+	require.NoError(t, err)
+	metadataIndex.Set(templatePath, &metadataindex.Metadata{
+		ID:               "poisoned",
+		FilePath:         templatePath,
+		ModTime:          fileInfo.ModTime(),
+		Name:             "Poisoned",
+		Authors:          []string{"pdteam"},
+		Severity:         "info",
+		Verified:         true,
+		TemplateVerifier: "projectdiscovery/nuclei-templates",
+		ContentDigest:    contentDigestForLoaderTest(source),
+		Validation:       metadataindex.ValidationStrict,
+	})
+
+	options := testutils.DefaultOptions.Copy()
+	options.Logger = &gologger.Logger{}
+	options.ExecutionId = executionID
+	options.DisableUnsignedTemplates = disableUnsigned
+	options.TemplateLoadingConcurrency = 1
+	testutils.Init(options)
+	t.Cleanup(func() {
+		testutils.Cleanup(options)
+	})
+
+	catalog := disk.NewCatalog("")
+	executerOpts := testutils.NewMockExecuterOptions(options, nil)
+	executerOpts.Catalog = catalog
+	executerOpts.Parser = templates.NewParser()
+	executerOpts.Logger = options.Logger
+
+	workflowLoader, err := workflow.NewLoader(executerOpts)
+	require.NoError(t, err)
+	executerOpts.WorkflowLoader = workflowLoader
+
+	loaderConfig := NewConfig(options, catalog, executerOpts)
+	loaderConfig.MetadataIndex = metadataIndex
+	store, err := New(loaderConfig)
+	require.NoError(t, err)
+
+	loaded, err := store.LoadTemplates([]string{templatePath})
+	require.NoError(t, err)
+	return loaded
+}
+
+func TestLoadTemplatesIgnoresSelfConsistentCacheForJavascript(t *testing.T) {
+	templatePath := filepath.Join(t.TempDir(), "poisoned-javascript.yaml")
+	source := []byte(`id: poisoned-cached-javascript
+
+info:
+  name: Poisoned Cached Javascript
+  author: pdteam
+  severity: info
+
+javascript:
+  - init: |
+      set("init-status", "executed")
+    code: |
+      Export("poisoned-cached-javascript")
+`)
+	require.NoError(t, os.WriteFile(templatePath, source, 0o600))
+
+	loaded := loadTemplateWithPoisonedMetadata(t, templatePath, "loader-poisoned-javascript", source, false)
+	require.Empty(t, loaded)
+}
+
+func TestLoadTemplatesAllowsUnsignedFlowDespitePoisonedCache(t *testing.T) {
+	templatePath := filepath.Join(t.TempDir(), "poisoned-flow.yaml")
+	source := []byte(`id: poisoned-cached-flow
+
+info:
+  name: Poisoned Cached Flow
+  author: pdteam
+  severity: info
+
+flow: http(1)
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+`)
+	require.NoError(t, os.WriteFile(templatePath, source, 0o600))
+
+	loaded := loadTemplateWithPoisonedMetadata(t, templatePath, "loader-poisoned-flow", source, false)
+	require.Len(t, loaded, 1)
+	require.Equal(t, "poisoned-cached-flow", loaded[0].ID)
+	require.False(t, loaded[0].Verified)
+	require.True(t, loaded[0].IsFlowTemplate())
+}
+
+func TestLoadTemplatesSkipsPoisonedHttpWhenUnsignedDisabled(t *testing.T) {
+	templatePath := filepath.Join(t.TempDir(), "poisoned-http.yaml")
+	source := []byte(`id: poisoned-cached-http
+
+info:
+  name: Poisoned Cached HTTP
+  author: pdteam
+  severity: info
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+`)
+	require.NoError(t, os.WriteFile(templatePath, source, 0o600))
+
+	initialUnverified := stats.GetValue(templates.SkippedUnverifiedTemplateStats)
+	loaded := loadTemplateWithPoisonedMetadata(t, templatePath, "loader-poisoned-http-dut", source, true)
+	require.Empty(t, loaded)
+	require.Equal(t, initialUnverified+1, stats.GetValue(templates.SkippedUnverifiedTemplateStats))
 }
 
 func TestLoadTemplatesDoesNotRequireGlobalMatchersFlagToLoadTemplate(t *testing.T) {

--- a/pkg/templates/compile.go
+++ b/pkg/templates/compile.go
@@ -690,7 +690,22 @@ func applyTemplateVerification(template *Template, data []byte) {
 	// check if the template is verified
 	// only valid templates can be verified or signed
 	if digestErr == nil && options.TemplateVerificationCallback != nil && options.TemplatePath != "" {
-		if cached := options.TemplateVerificationCallback(options.TemplatePath); cached != nil {
+		// The metadata cache (index.gob) is an unauthenticated local file:
+		// anyone who can write to the cache directory can forge a
+		// self-consistent entry (Verified=true, a trusted verifier
+		// fingerprint, and a digest computed over their own payload) and
+		// have unsigned templates treated as verified. Execution of code and
+		// javascript templates is gated on this flag at runtime, so
+		// templates using those protocols always re-run signature
+		// verification against the real keys instead of trusting the cache.
+		// The same applies to every protocol when unsigned templates are
+		// explicitly disabled.
+		cacheVerificationTrusted := !template.HasCodeRequest() && !template.HasJavascriptRequest()
+		if template.Options.Options != nil && template.Options.Options.DisableUnsignedTemplates {
+			cacheVerificationTrusted = false
+		}
+
+		if cached := options.TemplateVerificationCallback(options.TemplatePath); cached != nil && cacheVerificationTrusted {
 			if cached.ContentDigest == verificationDigest && cached.ContentDigest != ([sha256.Size]byte{}) && cachedTemplateVerificationIsTrusted(cached) {
 				template.Verified = cached.Verified
 				template.TemplateVerifier = cached.Verifier

--- a/pkg/templates/compile.go
+++ b/pkg/templates/compile.go
@@ -684,44 +684,14 @@ func applyTemplateVerification(template *Template, data []byte) {
 	}
 
 	options := template.Options
-	verificationDigest, digestErr := templateVerificationDigest(data, template)
+	verificationDigest, _ := templateVerificationDigest(data, template)
 	template.verificationDigest = verificationDigest
 
-	// check if the template is verified
-	// only valid templates can be verified or signed
-	if digestErr == nil && options.TemplateVerificationCallback != nil && options.TemplatePath != "" {
-		// The metadata cache (index.gob) is an unauthenticated local file:
-		// anyone who can write to the cache directory can forge a
-		// self-consistent entry (Verified=true, a trusted verifier
-		// fingerprint, and a digest computed over their own payload) and
-		// have unsigned templates treated as verified. Execution of code and
-		// javascript templates is gated on this flag at runtime, so
-		// templates using those protocols always re-run signature
-		// verification against the real keys instead of trusting the cache.
-		// The same applies to every protocol when unsigned templates are
-		// explicitly disabled.
-		cacheVerificationTrusted := !template.HasCodeRequest() && !template.HasJavascriptRequest()
-		if template.Options.Options != nil && template.Options.Options.DisableUnsignedTemplates {
-			cacheVerificationTrusted = false
-		}
-
-		if cached := options.TemplateVerificationCallback(options.TemplatePath); cached != nil && cacheVerificationTrusted {
-			if cached.ContentDigest == verificationDigest && cached.ContentDigest != ([sha256.Size]byte{}) && cachedTemplateVerificationIsTrusted(cached) {
-				template.Verified = cached.Verified
-				template.TemplateVerifier = cached.Verifier
-				template.verifierFingerprint = cached.VerifierFingerprint
-				options.TemplateVerifier = cached.Verifier
-				// Mirror verification onto options for execution-time checks.
-				options.Verified = cached.Verified
-				//nolint
-				if !(template.Verified && template.TemplateVerifier == "projectdiscovery/nuclei-templates") {
-					template.Options.RawTemplate = data
-				}
-
-				return
-			}
-		}
-	}
+	// index.gob is an unauthenticated local file. A forged entry can pair
+	// Verified=true with a trusted fingerprint and a digest of the
+	// unsigned payload, so never copy a cached verdict. Always verify
+	// against DefaultTemplateVerifiers. Unsigned templates still
+	// short-circuit in ExtractSignatureAndContent with no ECDSA.
 
 	var verifier *signer.TemplateSigner
 
@@ -758,20 +728,6 @@ func (template *Template) ContentDigest() [sha256.Size]byte {
 // authenticated this template.
 func (template *Template) VerifierFingerprint() [sha256.Size]byte {
 	return template.verifierFingerprint
-}
-
-func cachedTemplateVerificationIsTrusted(cached *protocols.TemplateVerification) bool {
-	if !cached.Verified || cached.VerifierFingerprint == ([sha256.Size]byte{}) {
-		return false
-	}
-
-	for _, verifier := range signer.DefaultTemplateVerifiers {
-		if verifier.Identifier() == cached.Verifier && verifier.Fingerprint() == cached.VerifierFingerprint {
-			return true
-		}
-	}
-
-	return false
 }
 
 func templateVerificationDigest(data []byte, template *Template) ([sha256.Size]byte, error) {

--- a/pkg/templates/compile_test.go
+++ b/pkg/templates/compile_test.go
@@ -640,6 +640,216 @@ http:
 	require.False(t, template.Options.Verified)
 }
 
+func parseUnsignedWithPoisonedCache(t *testing.T, source, templatePath string) *templates.Template {
+	t.Helper()
+
+	options := testutils.DefaultOptions.Copy()
+	testutils.Init(options)
+	t.Cleanup(func() {
+		testutils.Cleanup(options)
+	})
+
+	executerOptions := testutils.NewMockExecuterOptions(options, nil)
+	executerOptions.TemplatePath = templatePath
+	executerOptions.TemplateVerificationCallback = func(gotPath string) *protocols.TemplateVerification {
+		require.Equal(t, templatePath, gotPath)
+		return trustedVerificationForTest(source)
+	}
+
+	template, err := templates.ParseTemplateFromReader(strings.NewReader(source), nil, executerOptions)
+	require.NoError(t, err)
+	require.False(t, template.Verified)
+	require.False(t, template.Options.Verified)
+	return template
+}
+
+func TestParseTemplateIgnoresCachedVerificationForFlowTemplates(t *testing.T) {
+	template := parseUnsignedWithPoisonedCache(t, `id: poisoned-flow-template
+
+info:
+  name: Poisoned Flow Template
+  author: pdteam
+  severity: info
+
+flow: http(1)
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+`, "poisoned-flow-template.yaml")
+	require.True(t, template.IsFlowTemplate())
+	require.Equal(t, "http(1)", template.Options.Flow)
+	require.NotNil(t, template.Executer)
+	require.False(t, template.HasJavascriptRequest())
+}
+
+func TestParseTemplateIgnoresCachedVerificationForWorkflowTemplates(t *testing.T) {
+	setup()
+
+	source, err := os.ReadFile("tests/workflow.yaml")
+	require.NoError(t, err)
+
+	executerOptions := executerOpts.Copy()
+	executerOptions.Parser = templates.NewParser()
+	executerOptions.TemplatePath = "tests/workflow.yaml"
+	executerOptions.TemplateVerificationCallback = func(templatePath string) *protocols.TemplateVerification {
+		require.Equal(t, executerOptions.TemplatePath, templatePath)
+		return trustedVerificationForTest(string(source))
+	}
+
+	template, err := templates.Parse("tests/workflow.yaml", nil, executerOptions)
+	require.NoError(t, err)
+	require.False(t, template.Verified)
+	require.False(t, template.Options.Verified)
+	require.NotNil(t, template.CompiledWorkflow)
+	require.Len(t, template.CompiledWorkflow.Workflows, 2)
+}
+
+func TestParseTemplateIgnoresCachedVerificationForPreprocessedHttpTemplates(t *testing.T) {
+	template := parseUnsignedWithPoisonedCache(t, `id: poisoned-preprocessed-http
+
+info:
+  name: Poisoned Preprocessed HTTP
+  author: pdteam
+  severity: info
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/{{randstr}}"
+`, "poisoned-preprocessed-http.yaml")
+	require.True(t, template.HasHTTPRequest())
+	require.NotContains(t, template.RequestsHTTP[0].Path[0], "{{randstr}}")
+}
+
+func TestParseTemplateIgnoresCachedVerificationFromDisk(t *testing.T) {
+	options := testutils.DefaultOptions.Copy()
+	testutils.Init(options)
+	t.Cleanup(func() {
+		testutils.Cleanup(options)
+	})
+
+	templateSource := `id: poisoned-disk-http
+
+info:
+  name: Poisoned Disk HTTP
+  author: pdteam
+  severity: info
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+`
+	templatePath := filepath.Join(t.TempDir(), "poisoned-disk-http.yaml")
+	require.NoError(t, os.WriteFile(templatePath, []byte(templateSource), 0o600))
+
+	executerOptions := testutils.NewMockExecuterOptions(options, nil)
+	executerOptions.Parser = templates.NewParser()
+	executerOptions.TemplateVerificationCallback = func(gotPath string) *protocols.TemplateVerification {
+		require.Equal(t, templatePath, gotPath)
+		return trustedVerificationForTest(templateSource)
+	}
+
+	template, err := templates.Parse(templatePath, nil, executerOptions)
+	require.NoError(t, err)
+	require.False(t, template.Verified)
+	require.False(t, template.Options.Verified)
+}
+
+func TestParseFromURLIgnoresCachedVerification(t *testing.T) {
+	source, err := os.ReadFile("tests/match-1.yaml")
+	require.NoError(t, err)
+
+	router := httprouter.New()
+	router.GET("/match-1.yaml", func(w netHttp.ResponseWriter, _ *netHttp.Request, _ httprouter.Params) {
+		_, _ = w.Write(source)
+	})
+	server := httptest.NewServer(router)
+	t.Cleanup(server.Close)
+
+	setup()
+	templatePath := server.URL + "/match-1.yaml"
+	executerOptions := executerOpts.Copy()
+	executerOptions.Parser = templates.NewParser()
+	executerOptions.TemplateVerificationCallback = func(gotPath string) *protocols.TemplateVerification {
+		require.Equal(t, templatePath, gotPath)
+		return trustedVerificationForTest(string(source))
+	}
+
+	template, err := templates.Parse(templatePath, nil, executerOptions)
+	require.NoError(t, err)
+	require.False(t, template.Verified)
+	require.False(t, template.Options.Verified)
+	require.Equal(t, "basic-get", template.ID)
+}
+
+func TestParseDoesNotTreatContentSwapAsVerified(t *testing.T) {
+	options := testutils.DefaultOptions.Copy()
+	testutils.Init(options)
+	t.Cleanup(func() {
+		testutils.Cleanup(options)
+	})
+
+	signer := ciTemplateSigner(t)
+	withDefaultTemplateSigner(t, signer)
+
+	signedSource := `id: signed-http-before-swap
+
+info:
+  name: Signed HTTP Before Swap
+  author: pdteam
+  severity: info
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/signed"
+`
+	swappedSource := `id: swapped-unsigned-javascript
+
+info:
+  name: Swapped Unsigned Javascript
+  author: pdteam
+  severity: info
+
+javascript:
+  - init: |
+      set("init-status", "executed")
+    code: |
+      Export("swapped-unsigned-javascript")
+`
+	templatePath := filepath.Join(t.TempDir(), "swap.yaml")
+	require.NoError(t, os.WriteFile(templatePath, []byte(signTemplateForTest(t, signer, signedSource)), 0o600))
+	fileInfo, err := os.Stat(templatePath)
+	require.NoError(t, err)
+
+	executerOptions := testutils.NewMockExecuterOptions(options, nil)
+	executerOptions.Parser = templates.NewParser()
+
+	first, err := templates.Parse(templatePath, nil, executerOptions)
+	require.NoError(t, err)
+	require.True(t, first.Verified)
+	require.Equal(t, "signed-http-before-swap", first.ID)
+
+	require.NoError(t, os.WriteFile(templatePath, []byte(swappedSource), 0o600))
+	require.NoError(t, os.Chtimes(templatePath, fileInfo.ModTime(), fileInfo.ModTime()))
+
+	second, err := templates.Parse(templatePath, nil, executerOptions)
+	require.NoError(t, err)
+	if second.ID == "swapped-unsigned-javascript" {
+		require.False(t, second.Verified)
+		require.False(t, second.Options.Verified)
+		require.NotContains(t, second.RequestsJavascript[0].Args, "init-status")
+		return
+	}
+
+	require.Equal(t, "signed-http-before-swap", second.ID)
+	require.True(t, second.Verified)
+	require.False(t, second.HasJavascriptRequest())
+}
+
 func TestParseTemplateCompilesUnsignedJavascriptInit(t *testing.T) {
 	options := testutils.DefaultOptions.Copy()
 	testutils.Init(options)

--- a/pkg/templates/compile_test.go
+++ b/pkg/templates/compile_test.go
@@ -608,7 +608,7 @@ javascript:
 	require.NotContains(t, template.RequestsJavascript[0].Args, "init-status")
 }
 
-func TestParseTemplateTrustsCachedVerificationForNonExecutableTemplates(t *testing.T) {
+func TestParseTemplateIgnoresCachedVerificationForHttpTemplates(t *testing.T) {
 	options := testutils.DefaultOptions.Copy()
 	testutils.Init(options)
 	t.Cleanup(func() {
@@ -616,44 +616,11 @@ func TestParseTemplateTrustsCachedVerificationForNonExecutableTemplates(t *testi
 	})
 
 	executerOptions := testutils.NewMockExecuterOptions(options, nil)
-	executerOptions.TemplatePath = "cached-http-template.yaml"
-	templateSource := `id: cached-http-template
+	executerOptions.TemplatePath = "poisoned-http-template.yaml"
+	templateSource := `id: poisoned-http-template
 
 info:
-  name: Cached HTTP Template
-  author: pdteam
-  severity: info
-
-http:
-  - method: GET
-    path:
-      - "{{BaseURL}}"
-`
-	executerOptions.TemplateVerificationCallback = func(templatePath string) *protocols.TemplateVerification {
-		require.Equal(t, executerOptions.TemplatePath, templatePath)
-		return trustedVerificationForTest(templateSource)
-	}
-
-	template, err := templates.ParseTemplateFromReader(strings.NewReader(templateSource), nil, executerOptions)
-	require.NoError(t, err)
-	require.True(t, template.Verified)
-	require.True(t, template.Options.Verified)
-}
-
-func TestParseTemplateIgnoresCachedVerificationWhenUnsignedTemplatesDisabled(t *testing.T) {
-	options := testutils.DefaultOptions.Copy()
-	options.DisableUnsignedTemplates = true
-	testutils.Init(options)
-	t.Cleanup(func() {
-		testutils.Cleanup(options)
-	})
-
-	executerOptions := testutils.NewMockExecuterOptions(options, nil)
-	executerOptions.TemplatePath = "poisoned-unsigned-http-template.yaml"
-	templateSource := `id: poisoned-unsigned-http-template
-
-info:
-  name: Poisoned Unsigned HTTP Template
+  name: Poisoned HTTP Template
   author: pdteam
   severity: info
 
@@ -796,9 +763,6 @@ http:
 	for i := range compiledTemplates {
 		engineOptions := executerOpts.Copy()
 		engineOptions.Parser = templates.NewParserWithParsedCache(sharedParser.Cache())
-		engineOptions.TemplateVerificationCallback = func(string) *protocols.TemplateVerification {
-			return trustedVerificationForTest(templateSource)
-		}
 		waitGroup.Add(1)
 		go func() {
 			defer waitGroup.Done()
@@ -809,7 +773,7 @@ http:
 
 	for i := range compiledTemplates {
 		require.NoError(t, parseErrors[i])
-		require.True(t, compiledTemplates[i].Verified)
+		require.NotNil(t, compiledTemplates[i])
 	}
 
 	require.Equal(t, int32(1), sourceReads.Load())

--- a/pkg/templates/compile_test.go
+++ b/pkg/templates/compile_test.go
@@ -348,6 +348,9 @@ func TestParseTemplateExecutesJavascriptInitAfterVerification(t *testing.T) {
 		testutils.Cleanup(options)
 	})
 
+	signer := ciTemplateSigner(t)
+	withDefaultTemplateSigner(t, signer)
+
 	executerOptions := testutils.NewMockExecuterOptions(options, nil)
 	executerOptions.TemplatePath = "verified-javascript-init.yaml"
 	templateSource := `id: verified-javascript-init
@@ -363,12 +366,7 @@ javascript:
     code: |
       Export("verified-javascript-init")
 `
-	executerOptions.TemplateVerificationCallback = func(templatePath string) *protocols.TemplateVerification {
-		require.Equal(t, executerOptions.TemplatePath, templatePath)
-		return trustedVerificationForTest(templateSource)
-	}
-
-	template, err := templates.ParseTemplateFromReader(strings.NewReader(templateSource), nil, executerOptions)
+	template, err := templates.ParseTemplateFromReader(strings.NewReader(signTemplateForTest(t, signer, templateSource)), nil, executerOptions)
 	require.NoError(t, err)
 	require.True(t, template.Verified)
 	require.True(t, template.Options.Verified)
@@ -382,6 +380,9 @@ func TestParseTemplateExecutesPreprocessedJavascriptInitAfterVerification(t *tes
 	t.Cleanup(func() {
 		testutils.Cleanup(options)
 	})
+
+	signer := ciTemplateSigner(t)
+	withDefaultTemplateSigner(t, signer)
 
 	executerOptions := testutils.NewMockExecuterOptions(options, nil)
 	executerOptions.TemplatePath = "verified-preprocessed-javascript-init.yaml"
@@ -398,12 +399,7 @@ javascript:
     code: |
       Export("verified-preprocessed-javascript-init")
 `
-	executerOptions.TemplateVerificationCallback = func(templatePath string) *protocols.TemplateVerification {
-		require.Equal(t, executerOptions.TemplatePath, templatePath)
-		return trustedVerificationForTest(templateSource)
-	}
-
-	template, err := templates.ParseTemplateFromReader(strings.NewReader(templateSource), nil, executerOptions)
+	template, err := templates.ParseTemplateFromReader(strings.NewReader(signTemplateForTest(t, signer, templateSource)), nil, executerOptions)
 	require.NoError(t, err)
 	require.True(t, template.Verified)
 	require.True(t, template.Options.Verified)
@@ -431,12 +427,46 @@ func trustedVerificationForTest(data string, importedContents ...string) *protoc
 	}
 }
 
+// ciTemplateSigner returns a signer backed by the CI test keypair.
+func ciTemplateSigner(t *testing.T) *templatesigner.TemplateSigner {
+	t.Helper()
+
+	s, err := templatesigner.NewTemplateSignerFromFiles("signer/testdata/ci.crt", "signer/testdata/ci-private-key.pem")
+	require.NoError(t, err)
+
+	return s
+}
+
+// withDefaultTemplateSigner prepends the given signer to the default
+// verifiers for the duration of the test.
+func withDefaultTemplateSigner(t *testing.T, s *templatesigner.TemplateSigner) {
+	t.Helper()
+
+	original := templatesigner.DefaultTemplateVerifiers
+	templatesigner.DefaultTemplateVerifiers = append([]*templatesigner.TemplateSigner{s}, original...)
+	t.Cleanup(func() {
+		templatesigner.DefaultTemplateVerifiers = original
+	})
+}
+
+// signTemplateForTest returns src with a valid signature appended by the
+// given signer. When importPaths are non-empty the signature also binds the
+// contents of those files, read from disk at signing time.
+func signTemplateForTest(t *testing.T, s *templatesigner.TemplateSigner, src string, importPaths ...string) string {
+	t.Helper()
+
+	signable := &templates.Template{ImportedFiles: importPaths}
+	signature, err := s.Sign([]byte(src), signable)
+	require.NoError(t, err)
+
+	return src + "\n" + signature
+}
+
 func TestParseTemplateVerificationUsesLoadedImportContents(t *testing.T) {
 	options := testutils.DefaultOptions.Copy()
 	loadedCode := `Export("loaded-import")`
-	diskCode := `Export("disk-import")`
 	importPath := filepath.Join(t.TempDir(), "import.js")
-	require.NoError(t, os.WriteFile(importPath, []byte(diskCode), 0o600))
+	require.NoError(t, os.WriteFile(importPath, []byte(loadedCode), 0o600))
 	options.LoadHelperFileFunction = func(helperFile, _ string, _ catalog.Catalog) (io.ReadCloser, error) {
 		require.Equal(t, importPath, helperFile)
 		return io.NopCloser(strings.NewReader(loadedCode)), nil
@@ -458,12 +488,11 @@ info:
 javascript:
   - code: %q
 `, importPath)
-	executerOptions.TemplateVerificationCallback = func(templatePath string) *protocols.TemplateVerification {
-		require.Equal(t, executerOptions.TemplatePath, templatePath)
-		return trustedVerificationForTest(templateSource, loadedCode)
-	}
 
-	template, err := templates.ParseTemplateFromReader(strings.NewReader(templateSource), nil, executerOptions)
+	signer := ciTemplateSigner(t)
+	withDefaultTemplateSigner(t, signer)
+
+	template, err := templates.ParseTemplateFromReader(strings.NewReader(signTemplateForTest(t, signer, templateSource, importPath)), nil, executerOptions)
 	require.NoError(t, err)
 	require.True(t, template.Verified)
 	require.Equal(t, loadedCode, template.RequestsJavascript[0].Code)
@@ -485,11 +514,10 @@ info:
   author: pdteam
   severity: info
 
-javascript:
-  - init: |
-      set("init-status", "executed")
-    code: |
-      Export("revoked-verifier")
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
 `
 	executerOptions.TemplateVerificationCallback = func(templatePath string) *protocols.TemplateVerification {
 		require.Equal(t, executerOptions.TemplatePath, templatePath)
@@ -507,7 +535,142 @@ javascript:
 	template, err := templates.ParseTemplateFromReader(strings.NewReader(templateSource), nil, executerOptions)
 	require.NoError(t, err)
 	require.False(t, template.Verified)
+}
+
+func TestParseTemplateIgnoresCachedVerificationForCodeTemplates(t *testing.T) {
+	options := testutils.DefaultOptions.Copy()
+	testutils.Init(options)
+	t.Cleanup(func() {
+		testutils.Cleanup(options)
+	})
+
+	executerOptions := testutils.NewMockExecuterOptions(options, nil)
+	executerOptions.TemplatePath = "poisoned-code-template.yaml"
+	templateSource := `id: poisoned-code-template
+
+info:
+  name: Poisoned Code Template
+  author: pdteam
+  severity: info
+
+code:
+  - engine:
+      - sh
+    source: |
+      echo poisoned
+`
+	// A forged cache entry: self-consistent digest, real verifier
+	// fingerprint and Verified=true. Writing index.gob is all an attacker
+	// needs; the signature of the template itself is never checked if this
+	// entry is trusted.
+	executerOptions.TemplateVerificationCallback = func(templatePath string) *protocols.TemplateVerification {
+		require.Equal(t, executerOptions.TemplatePath, templatePath)
+		return trustedVerificationForTest(templateSource)
+	}
+
+	template, err := templates.ParseTemplateFromReader(strings.NewReader(templateSource), nil, executerOptions)
+	require.NoError(t, err)
+	require.False(t, template.Verified)
+	require.False(t, template.Options.Verified)
+}
+
+func TestParseTemplateIgnoresCachedVerificationForJavascriptTemplates(t *testing.T) {
+	options := testutils.DefaultOptions.Copy()
+	testutils.Init(options)
+	t.Cleanup(func() {
+		testutils.Cleanup(options)
+	})
+
+	executerOptions := testutils.NewMockExecuterOptions(options, nil)
+	executerOptions.TemplatePath = "poisoned-javascript-template.yaml"
+	templateSource := `id: poisoned-javascript-template
+
+info:
+  name: Poisoned Javascript Template
+  author: pdteam
+  severity: info
+
+javascript:
+  - init: |
+      set("init-status", "executed")
+    code: |
+      Export("poisoned-javascript-template")
+`
+	executerOptions.TemplateVerificationCallback = func(templatePath string) *protocols.TemplateVerification {
+		require.Equal(t, executerOptions.TemplatePath, templatePath)
+		return trustedVerificationForTest(templateSource)
+	}
+
+	template, err := templates.ParseTemplateFromReader(strings.NewReader(templateSource), nil, executerOptions)
+	require.NoError(t, err)
+	require.False(t, template.Verified)
+	require.False(t, template.Options.Verified)
 	require.NotContains(t, template.RequestsJavascript[0].Args, "init-status")
+}
+
+func TestParseTemplateTrustsCachedVerificationForNonExecutableTemplates(t *testing.T) {
+	options := testutils.DefaultOptions.Copy()
+	testutils.Init(options)
+	t.Cleanup(func() {
+		testutils.Cleanup(options)
+	})
+
+	executerOptions := testutils.NewMockExecuterOptions(options, nil)
+	executerOptions.TemplatePath = "cached-http-template.yaml"
+	templateSource := `id: cached-http-template
+
+info:
+  name: Cached HTTP Template
+  author: pdteam
+  severity: info
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+`
+	executerOptions.TemplateVerificationCallback = func(templatePath string) *protocols.TemplateVerification {
+		require.Equal(t, executerOptions.TemplatePath, templatePath)
+		return trustedVerificationForTest(templateSource)
+	}
+
+	template, err := templates.ParseTemplateFromReader(strings.NewReader(templateSource), nil, executerOptions)
+	require.NoError(t, err)
+	require.True(t, template.Verified)
+	require.True(t, template.Options.Verified)
+}
+
+func TestParseTemplateIgnoresCachedVerificationWhenUnsignedTemplatesDisabled(t *testing.T) {
+	options := testutils.DefaultOptions.Copy()
+	options.DisableUnsignedTemplates = true
+	testutils.Init(options)
+	t.Cleanup(func() {
+		testutils.Cleanup(options)
+	})
+
+	executerOptions := testutils.NewMockExecuterOptions(options, nil)
+	executerOptions.TemplatePath = "poisoned-unsigned-http-template.yaml"
+	templateSource := `id: poisoned-unsigned-http-template
+
+info:
+  name: Poisoned Unsigned HTTP Template
+  author: pdteam
+  severity: info
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+`
+	executerOptions.TemplateVerificationCallback = func(templatePath string) *protocols.TemplateVerification {
+		require.Equal(t, executerOptions.TemplatePath, templatePath)
+		return trustedVerificationForTest(templateSource)
+	}
+
+	template, err := templates.ParseTemplateFromReader(strings.NewReader(templateSource), nil, executerOptions)
+	require.NoError(t, err)
+	require.False(t, template.Verified)
+	require.False(t, template.Options.Verified)
 }
 
 func TestParseTemplateCompilesUnsignedJavascriptInit(t *testing.T) {
@@ -568,6 +731,9 @@ func TestParseCachedTemplatePreservesVerification(t *testing.T) {
 		testutils.Cleanup(options)
 	})
 
+	signer := ciTemplateSigner(t)
+	withDefaultTemplateSigner(t, signer)
+
 	templateSource := `id: cached-verified-javascript
 
 info:
@@ -580,14 +746,10 @@ javascript:
       Export("cached-verified-javascript")
 `
 	templatePath := filepath.Join(t.TempDir(), "cached-verified-javascript.yaml")
-	require.NoError(t, os.WriteFile(templatePath, []byte(templateSource), 0o600))
+	require.NoError(t, os.WriteFile(templatePath, []byte(signTemplateForTest(t, signer, templateSource)), 0o600))
 
 	executerOptions := testutils.NewMockExecuterOptions(options, nil)
 	executerOptions.Parser = templates.NewParser()
-	executerOptions.TemplateVerificationCallback = func(path string) *protocols.TemplateVerification {
-		require.Equal(t, templatePath, path)
-		return trustedVerificationForTest(templateSource)
-	}
 
 	first, err := templates.Parse(templatePath, nil, executerOptions)
 	require.NoError(t, err)


### PR DESCRIPTION
## Proposed changes

Template signature verification must be independent of unauthenticated verdicts stored in `~/.cache/nuclei/index.gob`. A matching content digest and a public verifier fingerprint identify the content and key; they do not authenticate a stored `Verified` result. Trusting that result can bypass the signature requirement for code/JavaScript templates and HTTP request-signing templates.

`applyTemplateVerification` now verifies signatures against `DefaultTemplateVerifiers` without using metadata callback verdicts for any protocol. This includes Mzack9999's `3197a081` change, which broadens the original code/JavaScript-only fix. Unsigned HTTP templates can still parse when allowed, but forged metadata cannot make them verified.

The parsed-source and compiled-template caches remain in place. This change removes trust in metadata-derived signature verdicts, not ordinary template caching. Unsigned input returns before cryptographic verification; signed templates, including signed HTTP templates, undergo verification on the applicable parse/compile path. The performance impact has not been benchmarked.

### Validation coverage

The current tests in `pkg/templates/compile_test.go` include:

- `TestParseTemplateIgnoresCachedVerificationForCodeTemplates`: a forged verdict cannot verify an unsigned code template.
- `TestParseTemplateIgnoresCachedVerificationForJavascriptTemplates`: the unsigned JavaScript template stays unverified and its `init` block does not execute.
- `TestParseTemplateIgnoresCachedVerificationForHttpTemplates`: an unsigned HTTP template can parse while both verification flags remain false despite a forged verdict.
- `TestParseTemplateRejectsCachedVerificationWithMismatchedVerifierFingerprint`: a mismatched cached fingerprint cannot confer verification; the metadata trust-check helper has been removed.
- Existing JavaScript initialization, preprocessing, loaded-import, revoked-verifier, and cached-template tests now use signed sources to exercise signature verification.
- `TestParseReusesSharedParsedTemplateAcrossEngineCaches`: the source is read once across five engine-local compilations, preserving shared parsed-source caching.

The earlier separate `DisableUnsignedTemplates` cache test and HTTP cached-verdict acceptance test are no longer present at the current head. This description update reflects a source review of `3197a081`; it does not claim a new test or benchmark run.

Related: #7663.

## Checklist

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/nuclei/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Strengthened template security by always rechecking signatures instead of relying on cached verification results.
  - Prevented forged, stale, or mismatched verification records from bypassing signature checks across template types.
  - Ensured imported and loaded template code is verified against its signed contents.
  - Detected content changes that occur after a template has been verified.
  - Improved handling of revoked template verifiers and invalid verification data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->