### PR TITLE
fix(stats): invalid percent on automatic scan

### DIFF
--- a/pkg/progress/progress.go
+++ b/pkg/progress/progress.go
@@ -198,8 +198,7 @@ func (p *StatsTicker) makePrintCallback() func(stats clistats.StatisticsClient) 
 			builder.WriteString(clistats.String(total))
 			builder.WriteRune(' ')
 			builder.WriteRune('(')
-			//nolint:gomnd // this is not a magic number
-			builder.WriteString(clistats.String(uint64(float64(requests) / float64(total) * 100.0)))
+			builder.WriteString(clistats.String(percentComplete(requests, total)))
 			builder.WriteRune('%')
 			builder.WriteRune(')')
 			builder.WriteRune('\n')
@@ -247,13 +246,16 @@ func metricsMap(stats clistats.StatisticsClient) map[string]interface{} {
 	errors, _ := stats.GetCounter("errors")
 	results["errors"] = clistats.String(errors)
 
-	var percentData float64
-	if total > 0 {
-		// nolint:gomnd // this is not a magic number
-		percentData = (float64(requests) * float64(100)) / float64(total)
-	}
-	results["percent"] = clistats.String(uint64(percentData))
+	results["percent"] = clistats.String(percentComplete(requests, total))
 	return results
+}
+
+func percentComplete(requests, total uint64) uint64 {
+	if total == 0 {
+		return 0
+	}
+	// nolint:gomnd // this is not a magic number
+	return uint64((float64(requests) * float64(100)) / float64(total))
 }
 
 // fmtDuration formats the duration for the time elapsed

--- a/pkg/progress/progress.go
+++ b/pkg/progress/progress.go
@@ -247,10 +247,12 @@ func metricsMap(stats clistats.StatisticsClient) map[string]interface{} {
 	errors, _ := stats.GetCounter("errors")
 	results["errors"] = clistats.String(errors)
 
-	// nolint:gomnd // this is not a magic number
-	percentData := (float64(requests) * float64(100)) / float64(total)
-	percent := clistats.String(uint64(percentData))
-	results["percent"] = percent
+	var percentData float64
+	if total > 0 {
+		// nolint:gomnd // this is not a magic number
+		percentData = (float64(requests) * float64(100)) / float64(total)
+	}
+	results["percent"] = clistats.String(uint64(percentData))
 	return results
 }
 

--- a/pkg/progress/progress_test.go
+++ b/pkg/progress/progress_test.go
@@ -84,6 +84,18 @@ func TestMetricsMapPercent(t *testing.T) {
 	}
 }
 
+func TestPrintCallbackZeroTotal(t *testing.T) {
+	ticker := &StatsTicker{}
+	stats := &statsClientSpy{
+		counters: map[string]uint64{"requests": 0, "total": 0},
+		statics:  map[string]interface{}{"startedAt": time.Now()},
+	}
+
+	out, ok := ticker.makePrintCallback()(stats).(string)
+	require.True(t, ok)
+	require.Contains(t, out, "(0%)")
+}
+
 type statsClientSpy struct {
 	periodicStatsRequested bool
 	started                bool

--- a/pkg/progress/progress_test.go
+++ b/pkg/progress/progress_test.go
@@ -46,9 +46,49 @@ func TestStatsTickerInit_registersPeriodicStatsOnly_whenIntervalIsPositive(t *te
 	}
 }
 
+func TestMetricsMapPercent(t *testing.T) {
+	tests := []struct {
+		name        string
+		requests    uint64
+		total       uint64
+		wantPercent string
+	}{
+		{
+			name:        "total is known",
+			requests:    50,
+			total:       200,
+			wantPercent: "25",
+		},
+		{
+			name:        "total is unknown",
+			requests:    80,
+			total:       0,
+			wantPercent: "0",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Given
+			stats := &statsClientSpy{
+				counters: map[string]uint64{"requests": test.requests, "total": test.total},
+				statics:  map[string]interface{}{"startedAt": time.Now().Add(-time.Second)},
+			}
+
+			// When
+			results := metricsMap(stats)
+
+			// Then
+			require.Equal(t, test.wantPercent, results["percent"])
+		})
+	}
+}
+
 type statsClientSpy struct {
 	periodicStatsRequested bool
 	started                bool
+	counters               map[string]uint64
+	statics                map[string]interface{}
 }
 
 func (s *statsClientSpy) Start() error {
@@ -62,16 +102,18 @@ func (s *statsClientSpy) Stop() error {
 
 func (s *statsClientSpy) AddCounter(string, uint64) {}
 
-func (s *statsClientSpy) GetCounter(string) (uint64, bool) {
-	return 0, false
+func (s *statsClientSpy) GetCounter(key string) (uint64, bool) {
+	value, ok := s.counters[key]
+	return value, ok
 }
 
 func (s *statsClientSpy) IncrementCounter(string, int) {}
 
 func (s *statsClientSpy) AddStatic(string, interface{}) {}
 
-func (s *statsClientSpy) GetStatic(string) (interface{}, bool) {
-	return nil, false
+func (s *statsClientSpy) GetStatic(key string) (interface{}, bool) {
+	value, ok := s.statics[key]
+	return value, ok
 }
 
 func (s *statsClientSpy) AddDynamic(string, clistats.DynamicCallback) {}

--- a/pkg/protocols/common/automaticscan/automaticscan.go
+++ b/pkg/protocols/common/automaticscan/automaticscan.go
@@ -13,12 +13,12 @@ import (
 	"github.com/logrusorgru/aurora/v4"
 	"github.com/pkg/errors"
 	"github.com/projectdiscovery/gologger"
-	"github.com/projectdiscovery/nuclei/v3/internal/tests/testutils"
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/config"
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/loader"
 	"github.com/projectdiscovery/nuclei/v3/pkg/core"
 	"github.com/projectdiscovery/nuclei/v3/pkg/input/provider"
 	"github.com/projectdiscovery/nuclei/v3/pkg/output"
+	"github.com/projectdiscovery/nuclei/v3/pkg/progress"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/contextargs"
 	"github.com/projectdiscovery/nuclei/v3/pkg/protocols/common/helpers/writer"
@@ -126,6 +126,9 @@ func (s *Service) Close() bool {
 // Execute automatic scan on each target with -bs host concurrency
 func (s *Service) Execute() error {
 	gologger.Info().Msgf("Executing Automatic scan on %d target[s]", s.target.Count())
+	if s.opts.Progress != nil {
+		s.opts.Progress.AddToTotal(int64(getRequestCount(s.techTemplates)) * s.target.Count())
+	}
 	// setup host concurrency
 	sg, err := syncutil.New(syncutil.WithSize(s.opts.Options.BulkSize))
 	if err != nil {
@@ -185,12 +188,21 @@ func (s *Service) executeAutomaticScanOnTarget(input *contextargs.MetaInput) {
 	gologger.Info().Msgf("Executing %d templates on %v", len(finalTemplates), input.Input)
 	eng := core.New(s.opts.Options)
 	execOptions := s.opts.Copy()
-	execOptions.Progress = &testutils.MockProgressClient{} // stats are not supported yet due to centralized logic and cannot be reinitialized
+	if s.opts.Progress != nil {
+		s.opts.Progress.AddToTotal(int64(getRequestCount(finalTemplates)))
+		execOptions.Progress = &sharedProgress{Progress: s.opts.Progress}
+	}
 	eng.SetExecuterOptions(execOptions)
 
 	tmp := eng.ExecuteScanWithOpts(context.Background(), finalTemplates, provider.NewSimpleInputProviderWithUrls(s.opts.Options.ExecutionId, input.Input), true)
 	s.hasResults.Store(tmp.Load())
 }
+
+type sharedProgress struct {
+	progress.Progress
+}
+
+func (p *sharedProgress) Init(hostCount int64, rulesCount int, requestCount int64) {}
 
 // getTagsUsingWappalyzer returns tags using wappalyzer by fingerprinting target
 // and utilizing the mapping data


### PR DESCRIPTION
`-as` never fed the progress client a request total, so `percent` divided by zero and `uint64(+Inf)` produced arch dependent garbage (2^63 on amd64, 2^64-1 on arm64).

- automatic scan now adds tech detection and per target template requests to the total, and reports into the shared progress client instead of a mock
- `metricsMap` guards the divide, matching the guard the text callback already had

Verified on a real `-as` run: `/metrics` went from `{"total":0,"percent":"18446744073709551615"}` to `{"total":2264,"percent":"94"}`.

The `/metrics` endpoint computes its own percent inside clistats, guarded separately in projectdiscovery/clistats#116.

Fixes #7722

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Progress percentages remain at zero when no requests have been processed, preventing invalid calculations.
  - Automatic scan progress accurately accounts for detection-template requests, including templates loaded during scanning.

- **Improvements**
  - Progress reporting is now consistent across text and JSON output.
  - Automatic scan execution provides clearer progress updates as work advances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->